### PR TITLE
Return shorter responses from the API when errors occur

### DIFF
--- a/metabrainz/api/decorators.py
+++ b/metabrainz/api/decorators.py
@@ -1,6 +1,6 @@
 from functools import wraps
 from flask import request
-from werkzeug.exceptions import BadRequest, Forbidden
+from werkzeug.wrappers import Response
 from metabrainz.model.token import Token
 from metabrainz.model.access_log import AccessLog
 
@@ -10,9 +10,9 @@ def token_required(f):
     def decorated(*args, **kwargs):
         access_token = request.args.get('token')
         if not access_token:
-            raise BadRequest("You need to provide an access token.")
+            return Response("You need to provide an access token!\n", status=400)
         if not Token.is_valid(access_token):
-            raise Forbidden("Provided access token is invalid.")
+            return Response("Provided access token is invalid!\n", status=403)
         return f(*args, **kwargs)
 
     return decorated

--- a/metabrainz/api/views.py
+++ b/metabrainz/api/views.py
@@ -2,7 +2,6 @@ from flask import Blueprint, jsonify, send_from_directory, current_app, render_t
 from flask.helpers import safe_join
 from werkzeug.wrappers import Response
 from werkzeug.urls import iri_to_uri
-from werkzeug.exceptions import NotFound
 from metabrainz.api.decorators import token_required, tracked
 from metabrainz.model.access_log import HOURLY_ALERT_THRESHOLD
 import logging
@@ -62,9 +61,8 @@ def last_replication_packets():
 def get_replication_packet(packet_number):
     directory = current_app.config['REPLICATION_PACKETS_DIR']
     filename = 'replication-%s.tar.bz2' % packet_number
-    path = safe_join(directory, filename)
-    if not os.path.isfile(path):
-        raise NotFound("Can't find specified replication packet.")
+    if not os.path.isfile(safe_join(directory, filename)):
+        return Response("Can't find specified replication packet!\n", status=404)
 
     if 'USE_NGINX_X_ACCEL' in current_app.config and current_app.config['USE_NGINX_X_ACCEL']:
         return _redirect_to_nginx('/internal/replication/%s' % filename)
@@ -83,9 +81,8 @@ def get_replication_packet(packet_number):
 def get_daily_replication_packet(packet_number):
     directory = current_app.config['REPLICATION_PACKETS_DIR'] + DAILY_SUBDIR
     filename = 'replication-daily-%s.tar.bz2' % packet_number
-    path = safe_join(directory, filename)
-    if not os.path.isfile(path):
-        raise NotFound("Can't find specified replication packet.")
+    if not os.path.isfile(safe_join(directory, filename)):
+        return Response("Can't find specified replication packet!\n", status=404)
 
     if 'USE_NGINX_X_ACCEL' in current_app.config and current_app.config['USE_NGINX_X_ACCEL']:
         return _redirect_to_nginx('/internal/replication%s/%s' % (DAILY_SUBDIR, filename))
@@ -104,9 +101,8 @@ def get_daily_replication_packet(packet_number):
 def get_weekly_replication_packet(packet_number):
     directory = current_app.config['REPLICATION_PACKETS_DIR'] + WEEKLY_SUBDIR
     filename = 'replication-weekly-%s.tar.bz2' % packet_number
-    path = safe_join(directory, filename)
-    if not os.path.isfile(path):
-        raise NotFound("Can't find specified replication packet.")
+    if not os.path.isfile(safe_join(directory, filename)):
+        return Response("Can't find specified replication packet!\n", status=404)
 
     if 'USE_NGINX_X_ACCEL' in current_app.config and current_app.config['USE_NGINX_X_ACCEL']:
         return _redirect_to_nginx('/internal/replication%s/%s' % (WEEKLY_SUBDIR, filename))


### PR DESCRIPTION
I think there's no need to transfer all our fancy HTML on default error pages to API users.