### PR TITLE
Fixed PayPal IPN endpoint

### DIFF
--- a/metabrainz/donations/paypal/views.py
+++ b/metabrainz/donations/paypal/views.py
@@ -22,7 +22,7 @@ def ipn():
 
     # Checking if data is legit
     paypal_url = PAYPAL_URL_PRIMARY if current_app.config['PAYMENT_PRODUCTION'] else PAYPAL_URL_SANDBOX
-    verify_args = chain(request.form.iteritems(), IPN_VERIFY_EXTRA_PARAMS)
+    verify_args = chain(IPN_VERIFY_EXTRA_PARAMS, request.form.iteritems())
     verify_string = '&'.join(('%s=%s' % (param, value) for param, value in verify_args))
     verification_response = requests.post(paypal_url, data=verify_string)
 

--- a/metabrainz/donations/paypal/views_test.py
+++ b/metabrainz/donations/paypal/views_test.py
@@ -49,9 +49,13 @@ class DonationsPayPalViewsTestCase(FlaskTestCase):
             'option_name2': 'contact',
             'option_selection2': 'yes',
         }
-        resp = self.client.post(url_for('donations_paypal.ipn'), data=ipn_data)
+        resp = self.client.post(
+            url_for('donations_paypal.ipn'),
+            headers=[('Content-Type', 'application/x-www-form-urlencoded')],
+            data=ipn_data,
+        )
         self.assert200(resp)
 
         # Donation should be in the DB now
         self.assertEqual(len(Donation.query.all()), 1)
-        self.assertEqual(Donation.query.all()[0].transaction_id, 'RANDOM-ID')
+        self.assertEqual(Donation.query.all()[0].transaction_id, u'RANDOM-ID')

--- a/metabrainz/model/donation_test.py
+++ b/metabrainz/model/donation_test.py
@@ -77,27 +77,27 @@ class DonationModelTestCase(FlaskTestCase):
     def test_process_paypal_ipn(self):
         # This is not a complete list:
         good_form = {
-            'first_name': 'Tester',
-            'last_name': 'Testing',
-            'custom': 'tester',  # MusicBrainz username
-            'payer_email': 'test@example.org',
+            'first_name': u'Tester',
+            'last_name': u'Testing',
+            'custom': u'tester',  # MusicBrainz username
+            'payer_email': u'test@example.org',
             'receiver_email': current_app.config['PAYPAL_PRIMARY_EMAIL'],
-            'business': 'donations@metabrainz.org',
+            'business': u'donations@metabrainz.org',
             'address_street': '1 Main St',
-            'address_city': 'San Jose',
-            'address_state': 'CA',
-            'address_country': 'United States',
-            'address_zip': '95131',
-            'mc_gross': '42.50',
-            'mc_fee': '1',
-            'txn_id': 'TEST1',
-            'payment_status': 'Completed',
+            'address_city': u'San Jose',
+            'address_state': u'CA',
+            'address_country': u'United States',
+            'address_zip': u'95131',
+            'mc_gross': u'42.50',
+            'mc_fee': u'1',
+            'txn_id': u'TEST1',
+            'payment_status': u'Completed',
 
             # Additional variables:
-            'option_name1': 'anonymous',
-            'option_selection1': 'yes',
-            'option_name2': 'contact',
-            'option_selection2': 'yes',
+            'option_name1': u'anonymous',
+            'option_selection1': u'yes',
+            'option_name2': u'contact',
+            'option_selection2': u'yes',
         }
         Donation.process_paypal_ipn(good_form)
         # Donation should be in the DB now


### PR DESCRIPTION
IPN endpoint should work better now. Though I still can't get my payments to go though in sandbox. Every single one is `pending`. `pending_reason` is set to `unilateral` which, [according to docs](https://developer.paypal.com/webapps/developer/docs/classic/ipn/integration-guide/IPNandPDTVariables/#id091EB04C0HS), means that payment was made to an email address that is not yet registered or confirmed. I can't find a solution to this.