### PR TITLE
Include external links in the carousel

### DIFF
--- a/metabrainz/templates/index/index.html
+++ b/metabrainz/templates/index/index.html
@@ -29,7 +29,7 @@
         <div class="item active">
           <img src="{{ url_for('static', filename='img/logos/musicbrainz.svg') }}" />
           <div class="caption">
-            <h2>MusicBrainz</h2>
+            <h2><a href="https://musicbrainz.org/">MusicBrainz</a></h2>
             <p>
               An open music encyclopedia that collects music metadata and makes it
               available to the public<br />
@@ -40,35 +40,35 @@
         <div class="item">
           <img src="{{ url_for('static', filename='img/logos/picard.svg') }}" />
           <div class="caption">
-            <h2>MusicBrainz Picard</h2>
+            <h2><a href="https://picard.musicbrainz.org/">MusicBrainz Picard</a></h2>
             <p>Cross-platform music tagger</p>
           </div>
         </div>
         <div class="item">
           <img src="{{ url_for('static', filename='img/logos/acousticbrainz.svg') }}" />
           <div class="caption">
-            <h2>AcousticBrainz</h2>
+            <h2><a href="http://acousticbrainz.org/">AcousticBrainz</a></h2>
             <p>Crowdsourced collection of acoustic information</p>
           </div>
         </div>
         <div class="item">
           <img src="{{ url_for('static', filename='img/logos/critiquebrainz.svg') }}" />
           <div class="caption">
-            <h2>CritiqueBrainz</h2>
+            <h2><a href="https://critiquebrainz.org/">CritiqueBrainz</a></h2>
             <p>Repository for Creative Commons licensed music reviews</p>
           </div>
         </div>
         <div class="item">
           <img src="{{ url_for('static', filename='img/logos/bookbrainz.svg') }}" />
           <div class="caption">
-            <h2>BookBrainz</h2>
+            <h2><a href="https://bookbrainz.org/">BookBrainz</a></h2>
             <p>An open encyclopedia which contains information about published literature</p>
           </div>
         </div>
         <div class="item">
           <img src="{{ url_for('static', filename='img/logos/coverartarchive.svg') }}" />
           <div class="caption">
-            <h2>Cover Art Archive</h2>
+            <h2><a href="https://coverartarchive.org/">Cover Art Archive</a></h2>
             <p>Repository of music cover art that is freely and easily accessible</p>
           </div>
         </div>


### PR DESCRIPTION
Note that the AcousticBrainz site is not accessible over TLS.