### PR TITLE
Link the supporter logos to the supporters page

### DIFF
--- a/metabrainz/templates/index/index.html
+++ b/metabrainz/templates/index/index.html
@@ -113,7 +113,7 @@
         {% for user in good_users %}
           <div class="col-sm-3 user">
             <span>
-              <a href="{{ url_for('index.sponsors') }}">
+              <a href="{{ url_for('users.supporters_list') }}">
                 <img src="{{ user.org_logo_url }}"/>
               </a>
             </span>


### PR DESCRIPTION
I always found it weird that clicking on one of the supporters lead to the list of sponsors, so change it.

Note: I didn't actually test this.