### PR TITLE
MEB-50: Redirecting about/customers to /supporters page

### DIFF
--- a/metabrainz/views.py
+++ b/metabrainz/views.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, render_template
+from flask import Blueprint, render_template, redirect, url_for
 from metabrainz.model.user import User
 
 index_bp = Blueprint('index', __name__)
@@ -49,3 +49,8 @@ def bad_customers():
 @index_bp.route('/privacy')
 def privacy_policy():
     return render_template('index/privacy.html')
+
+
+@index_bp.route('/about/customers.html')
+def about_customers_redirect():
+    return redirect(url_for('users.supporters_list') , 301)

--- a/metabrainz/views.py
+++ b/metabrainz/views.py
@@ -21,12 +21,12 @@ def about():
 @index_bp.route('/projects')
 def projects():
     return render_template('index/projects.html')
-    
+
 
 @index_bp.route('/team')
 def team():
     return render_template('index/team.html')
-    
+
 
 @index_bp.route('/contact')
 def contact():

--- a/metabrainz/views_test.py
+++ b/metabrainz/views_test.py
@@ -35,3 +35,7 @@ class IndexViewsTestCase(FlaskTestCase):
     def test_privacy_policy(self):
         response = self.client.get(url_for('index.privacy_policy'))
         self.assert200(response)
+
+    def test_about_customers(self):
+        response = self.client.get(url_for('index.about_customers_redirect'))
+        self.assertRedirects(response, url_for('users.supporters_list'))


### PR DESCRIPTION
/about/customers link is a dead link and it should be redirected to /supporters link 

Issue Link : https://tickets.metabrainz.org/browse/MEB-50 