### PR TITLE
MEB-81: Add #musicbrainz IRC channel to /contact

### DIFF
--- a/metabrainz/templates/index/contact.html
+++ b/metabrainz/templates/index/contact.html
@@ -75,14 +75,16 @@
   <h3>{{ _('IRC') }}</h3>
   <p>
     {{ _('The MetaBrainz/MusicBrainz team, as well as MusicBrainz users, hang out in the
-    <strong><a href="%(irc_url)s">#metabrainz</a></strong>
-    channel on IRC chat at irc.freenode.net. If you don\'t have an IRC client
+    <strong><a href="%(irc_url_mb)s">#musicbrainz</a></strong> and
+    <strong><a href="%(irc_url_meb)s">#metabrainz</a></strong>
+    channels on IRC chat at irc.freenode.net. If you don\'t have an IRC client
     installed, consider using this
     <a href="%(irc_webchat_url)s">webchat client</a>
     instead. Please feel free to browse the
     <a href="%(chatlogs_url)s">IRC log archives</a>.',
-    irc_url='irc://irc.freenode.net/metabrainz',
-    irc_webchat_url='https://webchat.freenode.net/?channels=metabrainz',
+    irc_url_mb='irc://irc.freenode.net/musicbrainz',
+    irc_url_meb='irc://irc.freenode.net/metabrainz',
+    irc_webchat_url='https://webchat.freenode.net/?channels=musicbrainz,metabrainz',
     chatlogs_url='http://chatlogs.metabrainz.org/') }}
   </p>
 


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/MEB-81

MusicBrainz.org links to metabrainz.org/contact for it's "Contact Us" link, but the page didn't actually reference the main IRC channel for MusicBrainz users.