### PR TITLE
Prevent literal <em> from being displayed

### DIFF
--- a/metabrainz/templates/payments/donate.html
+++ b/metabrainz/templates/payments/donate.html
@@ -124,7 +124,7 @@
     <h3>{{ _('Non-US Bank transfer') }}</h3>
     <p>{{ _('You can make a donation, or recurring donations, via bank transfer to the following IBAN:') }}</p>
     <p><em style="margin-left: 2em">ES39 0182 6536 7602 0155 8258 (BIC: BBVAESMMXXX)</em></p>
-    <p>{{ _('Please indicate your name and use the word %(donation_fixed_string)s in the description field.', donation_fixed_string='<em>DONATION</em>') }}</p>
+    <p>{{ _('Please indicate your name and use the word <em>%(donation_fixed_string)s</em> in the description field.', donation_fixed_string='DONATION') }}</p>
 
     <h3>{{ _('US Check') }}</h3>
     <p>{{ _('If you would like to donate using a check drawn on a US bank, please send them to:') }}</p>


### PR DESCRIPTION
I didn't test this.
I haven't done this in years.
I might have just broken everything.

Buyer beware.