### PR TITLE
Currency-related schema changes

### DIFF
--- a/admin/schema_updates/15.sql
+++ b/admin/schema_updates/15.sql
@@ -1,0 +1,15 @@
+BEGIN;
+
+CREATE TYPE payment_currency AS ENUM (
+  'usd',
+  'eur'
+);
+
+ALTER TABLE payment ADD COLUMN currency payment_currency;
+
+-- All existing payments were in USD, so we can just set them to that.
+UPDATE payment SET currency = 'usd';
+
+ALTER TABLE payment ALTER COLUMN currency SET NOT NULL;
+
+COMMIT;

--- a/admin/schema_updates/16.sql
+++ b/admin/schema_updates/16.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE payment ALTER COLUMN currency SET DEFAULT 'usd';
+
+COMMIT;

--- a/admin/sql/create_tables.sql
+++ b/admin/sql/create_tables.sql
@@ -76,6 +76,7 @@ CREATE TABLE payment (
   transaction_id   CHARACTER VARYING,
   amount           NUMERIC(11, 2)    NOT NULL,
   fee              NUMERIC(11, 2),
+  currency         payment_currency  NOT NULL,
   memo             CHARACTER VARYING,
   invoice_number   INTEGER
 );

--- a/admin/sql/create_tables.sql
+++ b/admin/sql/create_tables.sql
@@ -76,7 +76,7 @@ CREATE TABLE payment (
   transaction_id   CHARACTER VARYING,
   amount           NUMERIC(11, 2)    NOT NULL,
   fee              NUMERIC(11, 2),
-  currency         payment_currency  NOT NULL,
+  currency         payment_currency  NOT NULL DEFAULT 'usd',
   memo             CHARACTER VARYING,
   invoice_number   INTEGER
 );

--- a/admin/sql/create_types.sql
+++ b/admin/sql/create_types.sql
@@ -18,3 +18,8 @@ CREATE TYPE token_log_action_types AS ENUM (
   'deactivate',
   'create'
 );
+
+CREATE TYPE payment_currency AS ENUM (
+  'usd',
+  'eur'
+);

--- a/metabrainz/testing.py
+++ b/metabrainz/testing.py
@@ -60,5 +60,6 @@ class FlaskTestCase(TestCase):
     def drop_types(self):
         with db.engine.connect() as connection:
             connection.execute('DROP TYPE IF EXISTS payment_method_types CASCADE;')
+            connection.execute('DROP TYPE IF EXISTS payment_currency CASCADE;')
             connection.execute('DROP TYPE IF EXISTS state_types CASCADE;')
             connection.execute('DROP TYPE IF EXISTS token_log_action_types CASCADE;')


### PR DESCRIPTION
`15.sql` is already applied. `16.sql` is required to make payments function after changes are reverted (all payments would be `USD` by default just as they were before).