### PR TITLE
Retrieve name of the Sentry environment from Consul

### DIFF
--- a/consul_config.py.ctmpl
+++ b/consul_config.py.ctmpl
@@ -49,7 +49,8 @@ MUSICBRAINZ_CLIENT_ID = '''{{template "KEY" "musicbrainz/client_id"}}'''
 MUSICBRAINZ_CLIENT_SECRET = '''{{template "KEY" "musicbrainz/client_secret"}}'''
 
 LOG_SENTRY = {
-    'dsn': '''{{template "KEY" "sentry_dsn_private"}}''',
+    'dsn': '''{{template "KEY" "sentry/dsn_private"}}''',
+    'environment': '''{{template "KEY" "sentry/environment"}}''',
 }
 
 # reCAPTCHA (https://www.google.com/recaptcha/)


### PR DESCRIPTION
This allows configuring name of the environment for a deployed version of the MetaBrainz website. Error reports can then be filtered by environment name in the Sentry UI.