### PR TITLE
Code of Conduct, Privacy Policy and Social Contract consolidation

### DIFF
--- a/metabrainz/templates/index/code-of-conduct.html
+++ b/metabrainz/templates/index/code-of-conduct.html
@@ -45,4 +45,9 @@
     the <a href="https://musicbrainz.org/doc/Code_of_Conduct">MusicBrainz Code of Conduct</a>.
   </p>
 
+  <h1 class="page-title">{{ _('Automated Bots') }}</h1>
+  <p>
+    Bot authors should follow the <a href="https://musicbrainz.org/doc/Code_of_Conduct/Bots">dedicated code of conduct</a>.
+  </p>
+
 {% endblock %}

--- a/metabrainz/templates/index/code-of-conduct.html
+++ b/metabrainz/templates/index/code-of-conduct.html
@@ -1,0 +1,48 @@
+{% extends 'base.html' %}
+
+{% block title %}{{ _('Code of Conduct') }} - MetaBrainz Foundation{% endblock %}
+
+{% block content %}
+  <h1 class="page-title">{{ _('Code of Conduct') }}</h1>
+
+  <p>
+    This Code of Conduct describes how members of the MetaBrainz communities should interact and behave. The purpose is not so much to 
+    define a standard which everybody must follow, but to explicitly describe all the previously unwritten rules that make up good 
+    behavior in the MetaBrainz communities.
+  </p>
+
+  <ol>
+    <li>
+      Be polite. Remember that there's a real person on the receiving end of any communication. Treat people as you'd wish to be 
+      treated yourself.
+    </li>
+    <li>
+      Remember that everyone was new at some point and a polite nudge in the right direction is sometimes all that it takes to set 
+      them on the right path.
+    </li>
+
+    <li>
+      Don't get into flame wars, and try to remain as neutral as possible. Do not attack someone personally because you don't 
+      agree with them.
+    </li>
+    <li>
+      MetaBrainz projects have global communities. Be mindful and respectful of different languages, habits and cultures.
+    </li>
+    <li>
+      Share knowledge freely. New members should not be embarrassed for ignorance.
+    </li>
+    <li>
+      Respectfully suggest other options. Not everyone wants to reconfigure their directories, change their OS or switch players and formats.
+    </li>
+    <li>
+      Try not to pick fights by nit-picking other contributors. Asking for a source or reason (if not provided by the contributor in an 
+      a contribution) is OK; otherwise you can always submit your own edit to fix small errors or omissions. This is more productive.
+    </li>
+  </ol>
+
+  <p>
+    Each project may also define a Code of Conduct of its own that builds on the MetaBrainz social contract. For instance, have a look at 
+    the <a href="https://musicbrainz.org/doc/Code_of_Conduct">MusicBrainz Code of Conduct</a>.
+  </p>
+
+{% endblock %}

--- a/metabrainz/templates/index/code-of-conduct.html
+++ b/metabrainz/templates/index/code-of-conduct.html
@@ -35,19 +35,15 @@
       Respectfully suggest other options. Not everyone wants to reconfigure their directories, change their OS or switch players and formats.
     </li>
     <li>
-      Try not to pick fights by nit-picking other contributors. Asking for a source or reason (if not provided by the contributor in 
-      a contribution) is OK; otherwise you can always submit your own edit to fix small errors or omissions. This is more productive.
+      Try not to pick fights by <a href="http://www.merriam-webster.com/dictionary/nitpicking">nit-picking</a> other contributors. Asking for 
+      a source or reason (if not provided by the contributor in a contribution) is OK; otherwise you can always submit your own edit to fix 
+      small errors or omissions. This is more productive.
     </li>
   </ol>
 
   <p>
     Each project may also define a Code of Conduct of its own that builds on the MetaBrainz social contract. For instance, have a look at 
     the <a href="https://musicbrainz.org/doc/Code_of_Conduct">MusicBrainz Code of Conduct</a>.
-  </p>
-
-  <h1 class="page-title">{{ _('Automated Bots') }}</h1>
-  <p>
-    Bot authors should follow the <a href="https://musicbrainz.org/doc/Code_of_Conduct/Bots">dedicated code of conduct</a>.
   </p>
 
 {% endblock %}

--- a/metabrainz/templates/index/code-of-conduct.html
+++ b/metabrainz/templates/index/code-of-conduct.html
@@ -35,7 +35,7 @@
       Respectfully suggest other options. Not everyone wants to reconfigure their directories, change their OS or switch players and formats.
     </li>
     <li>
-      Try not to pick fights by nit-picking other contributors. Asking for a source or reason (if not provided by the contributor in an 
+      Try not to pick fights by nit-picking other contributors. Asking for a source or reason (if not provided by the contributor in 
       a contribution) is OK; otherwise you can always submit your own edit to fix small errors or omissions. This is more productive.
     </li>
   </ol>

--- a/metabrainz/templates/index/privacy.html
+++ b/metabrainz/templates/index/privacy.html
@@ -100,12 +100,12 @@
   <h3>{{ _('Account creation') }}</h3>
   <p>
     When creating an account with a MetaBrainz project you need to pick a unique username and choose a password, the username you pick is the 
-    only name associated with your account and will be what other MusicBrainz users know you as. You may optionally also tell us other 
-    information about yourself that will be displayed to other MusicBrainz users and the public.
+    only name associated with your account and will be what other MetaBrainz users know you as. You may optionally also tell us other 
+    information about yourself that will be displayed to other MetaBrainz users and the public.
   </p>
 
   <p>
-    Additionally, in order to edit the database you will need to provide a confirmed email address. This email address will be held in 
+    Additionally, in order to edit the databases you will need to provide a confirmed email address. This email address will be held in 
     confidence, the only method of revealing your email address to another user is if you choose to send a message to another 
     user and enable the option to "reveal my email address". Changing the email address stored with your account will require you to 
     verify the new address.
@@ -136,7 +136,7 @@
 
   <h2>{{ _('Third-party sites') }}</h2>
   <p>
-    Our code reviews are done on GitHub, which is not under the control of MusicBrainz. Participating in code reviews or other
+    Our code reviews are done on GitHub, which is not under the control of MetaBrainz. Participating in code reviews or other
     tasks carried out on GitHub are subject to <a href="https://help.github.com/articles/github-privacy-statement/">GitHub's privacy 
     policy</a>.
   </p>

--- a/metabrainz/templates/index/privacy.html
+++ b/metabrainz/templates/index/privacy.html
@@ -7,12 +7,144 @@
 
   <h2>{{ _('Summary') }}</h2>
   <p>
-    {{ _('The MetaBrainz Foundation will not collect any private information unless
-    you choose to donate to support the MusicBrainz project. Any personal
-    information you choose to provide during the donation process will not be
-    revealed to anyone else, unless you give us permission to list your name on
-    our donations page. We will not contact you unless you give us permission
-    to do so when you make a donation.') }}
+  <ol>
+    <li>
+      You do not have to provide any personal data to be able to browse the contents of the databases published by MetaBrainz.
+    </li>
+    <li>
+      You do not have to provide any personally-identifying information if you choose not to.
+    </li>
+    <li>
+      We will never reveal your email address on MetaBrainz controlled web sites.
+    </li>
+  </ol>
+  <p>
+    In order to get maximum value out of the MetaBrainz projects, you may want to create an account and log in. 
+    Doing so grants you the ability to: edit the databases, contribute your own data, communicate with other users, and keep track 
+    of recently released music from artists in your MusicBrainz collection. If you choose to create an account then the minimum we 
+    ask is that you: choose a unique username and password, use a web browser that accepts "session" cookies, and provide a verified 
+    email address.
+  </p>
+  <p>
+    If you do not create an account (or are not logged in) you will not have access to the above listed features, however, you will 
+    still have full access to browse and examine the database.
+  </p>
+
+  <h2>{{ _('Applicable to all users') }}</h2>
+
+  <h3>{{ _('Cookies') }}</h3>
+  <p>
+    We use two cookies that contain sensitive information:
+  </p>
+
+  <ol>
+    <li>
+      <b>remember_login</b>: If you choose the "Log in permanently" option when logging in to one of our sites; the cookie will be used to 
+      remember your login details.
+    </li>
+    <li>
+      <b>musicbrainz_server_session</b>: If you are logged into one of our sites, your current session ID is stored in this cookie.
+    </li>
+  </ol>
+
+  <p>
+    We may store boolean dynamic preference information in other cookies, but these do not contain any sensitive information.
+  </p>
+
+  <h3>{{ _('Web and FTP access logs') }}</h3>
+
+  <p>
+    In a practice similar to other web sites we keep logs of all web requests made against our servers. These logs include: your IP 
+    address, your browser's "User-Agent" string, and which page you requested. Aggregate information about web and FTP traffic is 
+    made available to the public via our site usage pages.
+  </p>
+
+  <h3>{{ _('Third-Party content') }}</h3>
+  <p>
+    Our project's web pages may load some third-party content. Some, but possibly not all sites are listed below:
+  </p>
+
+  <ol>
+    <li>
+      Cover art images: These are provided by the various cover art sites that have given MusicBrainz permission to do so. This means 
+      that the relevant site will know (if they want to) your IP address, User-Agent string, etc., and which MusicBrainz web page you 
+      were visiting (the one which included the cover art image).
+    </li>
+    <li>
+      Google Analytics: We use Google Analytics in our web pages to get a picture of who visits MusicBrainz. From these analytics we 
+      can set targets for supported browser versions, screen sizes and other useful information that we take into consideration when 
+      developing or improving features on our site. If you object to the use of Google Analytics, please consider blocking it in your 
+      browser.
+    </li>
+    <li>
+      AcoustID: Our fingerprints tab loads fingerprint information from acoustid.org.
+    </li>
+    <li>
+      reCAPTCHA: Our account creation page loads third party content in order to prevent spammers from creating accounts.
+    </li>
+  </ol>
+
+  <p>
+    The above information assumes that you are using "normal" web browser settings, whereby images are always loaded and HTTP referrer 
+    information is always sent.
+  </p>
+
+  <p>
+    It is impractical to constantly modify this privacy policy when MusicBrainz changes which third party content it utilizes. We will 
+    aim to use common sense, respect to our community and community review when adding more content from third party sites. We will also 
+    periodically review our policy to ensure that it remains current.
+  </p>
+
+  <h2>{{ _('Applicable to account holders') }}</h2>
+
+  <h3>{{ _('Account creation') }}</h3>
+  <p>
+    When creating an account with a MetaBrainz project you need to pick a unique username and choose a password, the username you pick is the 
+    only name associated with your account and will be what other MusicBrainz users know you as. You may optionally also tell us other 
+    information about yourself that will be displayed to other MusicBrainz users and the public.
+  </p>
+
+  <p>
+    Additionally, in order to edit the database you will need to provide a confirmed email address. This email address will be held in 
+    confidence, the only method of revealing your email address to another user is if you choose to send a message to another 
+    user and enable the option to "reveal my email address". Changing the email address stored with your account will require you to 
+    verify the new address.
+  </p>
+
+  <h3>{{ _('Edits and Notes') }}</h3>
+  <p>
+    If you make any changes to the a MetaBrainz project database, such as adding any data (including fingerprint submissions), the details 
+    of those changes will be visible to other logged-in users and the change will be associated with your username.
+  </p>
+
+  <h3>{{ _('Subscriptions on MusicBrainz') }}</h3>
+  <p>
+    As a logged-in user you can subscribe to one or more artists, labels, collections or other editors. The act of subscribing causes 
+    any edits made to (or by in the case of another editor) those entities to be emailed to you. By default, other users can see your 
+    list of subscriptions, however, you can opt out of this by editing the appropriate preference.
+  </p>
+
+  <p>
+    This does not provide "perfect" privacy though, in some cases it will be possible to infer information about the contents of your 
+    subscription list even though you have disallowed others from viewing that list directly. This imperfection arises because various 
+    parts of the system behave differently depending on whether or not an entity has any subscribers; also, the number of users 
+    subscribed to each artist is available via the artist pages. In the most extreme (possibly contrived) example, imagine that all 
+    users have their subscriptions set to "public", except for exactly one user whose list is "private". In that case, any discrepancy 
+    for a given artist between the shown list of subscribers and the total number of subscribers must be down to that one user. Thus, 
+    you can infer what artists are on that user's list.
+  </p>
+
+  <h2>{{ _('Third-party sites') }}</h2>
+  <p>
+    Our code reviews are done on GitHub, which is not under the control of MusicBrainz. Participating in code reviews or other
+    tasks carried out on GitHub are subject to <a href="https://help.github.com/articles/github-privacy-statement/">GitHub's privacy 
+    policy</a>.
+  </p>
+
+  <p>
+    The localization service we use for creating localized versions of the MusicBrainz site embeds embeds email addresses into 
+    translation files that will be checked into our git repositories. If you participate in translating at Transifex, your email 
+    address will be visible in our git repositories.
   </p>
 
   <h2>{{ _('MetaBrainz donors') }}</h2>
@@ -28,16 +160,11 @@
     donation, unless you chose to be anonymous during the donation process.') }}
   </p>
 
-  <h2>{{ _('Web and FTP access logs (all users)') }}</h2>
+  <h2>{{ _('Exceptions') }}</h2>
   <p>
-    {{ _('Like just about all web sites, we keep logs of all web requests made
-    against our servers. These logs include the usual stuff: your IP address,
-    your browser\'s "User-Agent" string, and which page you requested.') }}
+    Please note: Reasonable exceptions may apply to the above policy, for example to comply with applicable laws. The MetaBrainz 
+    server administrators (about five people in all) can of course see any information on the system they want to, but to be honest 
+    we're probably not interested enough to look.
   </p>
-  <p>
-    {{ _('Reasonable exceptions may apply to the above policy, for example to comply
-    with applicable laws. The MusicBrainz/MetaBrainz server administrators
-    (about three people in all) can of course see any information on the system
-    they want to, but to be honest they\'re probably not interested enough to look.') }}
-  </p>
+
 {% endblock %}

--- a/metabrainz/templates/index/privacy.html
+++ b/metabrainz/templates/index/privacy.html
@@ -142,7 +142,7 @@
   </p>
 
   <p>
-    The localization service we use for creating localized versions of the MusicBrainz site embeds embeds email addresses into 
+    The localization service we use for creating localized versions of the MetaBrainz sites embeds embeds email addresses into 
     translation files that will be checked into our git repositories. If you participate in translating at Transifex, your email 
     address will be visible in our git repositories.
   </p>

--- a/metabrainz/templates/index/privacy.html
+++ b/metabrainz/templates/index/privacy.html
@@ -27,7 +27,7 @@
   </p>
   <p>
     If you do not create an account (or are not logged in) you will not have access to the above listed features, however, you will 
-    still have full access to browse and examine the database.
+    still have full access to browse and examine the databases.
   </p>
 
   <h2>{{ _('Applicable to all users') }}</h2>
@@ -43,12 +43,12 @@
       remember your login details.
     </li>
     <li>
-      <b>musicbrainz_server_session</b>: If you are logged into one of our sites, your current session ID is stored in this cookie.
+      <b>musicbrainz_server_session, session, or connect.sid</b>: If you are logged into one of our sites, your current session ID is stored in this cookie.
     </li>
   </ol>
 
   <p>
-    We may store boolean dynamic preference information in other cookies, but these do not contain any sensitive information.
+    We may store dynamic preference information in other cookies, but these do not contain any sensitive information.
   </p>
 
   <h3>{{ _('Web and FTP access logs') }}</h3>
@@ -66,9 +66,9 @@
 
   <ol>
     <li>
-      Cover art images: These are provided by the various cover art sites that have given MusicBrainz permission to do so. This means 
-      that the relevant site will know (if they want to) your IP address, User-Agent string, etc., and which MusicBrainz web page you 
-      were visiting (the one which included the cover art image).
+      Cover art and other images: These are provided by the various cover art sites that have given MusicBrainz permission to do so and our own 
+      <a href="https://coverartarchive.org">Cover Art Archive</a>. This means that the relevant site will know (if they want to) your IP 
+      address, User-Agent string, etc., and which MusicBrainz web page you were visiting (the one which included the cover art image).
     </li>
     <li>
       Google Analytics: We use Google Analytics in our web pages to get a picture of who visits MusicBrainz. From these analytics we 
@@ -142,7 +142,7 @@
   </p>
 
   <p>
-    The localization service we use for creating localized versions of the MetaBrainz sites embeds embeds email addresses into 
+    The localization service we use for creating localized versions of the MetaBrainz sites embeds email addresses into 
     translation files that will be checked into our git repositories. If you participate in translating at Transifex, your email 
     address will be visible in our git repositories.
   </p>
@@ -162,9 +162,9 @@
 
   <h2>{{ _('Exceptions') }}</h2>
   <p>
-    Please note: Reasonable exceptions may apply to the above policy, for example to comply with applicable laws. The MetaBrainz 
+    <i><b>Please note</b>: Reasonable exceptions may apply to the above policy, for example to comply with applicable laws. The MetaBrainz 
     server administrators (about five people in all) can of course see any information on the system they want to, but to be honest 
-    we're probably not interested enough to look.
+    we're probably not interested enough to look.</i>
   </p>
 
 {% endblock %}

--- a/metabrainz/templates/index/privacy.html
+++ b/metabrainz/templates/index/privacy.html
@@ -85,8 +85,8 @@
   </ol>
 
   <p>
-    The above information assumes that you are using "normal" web browser settings, whereby images are always loaded and HTTP referrer 
-    information is always sent.
+    <i>The above information assumes that you are using "normal" web browser settings, whereby images are always loaded and HTTP referrer 
+    information is always sent.</i>
   </p>
 
   <p>
@@ -113,8 +113,8 @@
 
   <h3>{{ _('Edits and Notes') }}</h3>
   <p>
-    If you make any changes to the a MetaBrainz project database, such as adding any data (including fingerprint submissions), the details 
-    of those changes will be visible to other logged-in users and the change will be associated with your username.
+    If you make any changes to a MetaBrainz project database, such as adding any data, the details of those changes will be visible to 
+    other logged-in users and the change will be associated with your username.
   </p>
 
   <h3>{{ _('Subscriptions on MusicBrainz') }}</h3>

--- a/metabrainz/templates/index/social-contract.html
+++ b/metabrainz/templates/index/social-contract.html
@@ -13,16 +13,16 @@
 
   <ol>
     <li>
-      <b>MetaBrainz's projects will remain 100% free</b>: The development process will be open to the public by using public mailing lists, meetings 
-      open to interested parties, and open IRC channels. The client and server software will remain free and accessible under generally 
+      <b>MetaBrainz's projects will remain 100% free</b>: The development process will be open to the public by using our community forum, 
+      meetings open to interested parties, and open IRC channels. The client and server software will remain free and accessible under generally 
       accepted open licenses. The factual database content will be in the public domain and the non-factual database content will be released 
-      under a Creative Commons license. 
+      under Creative Commons licenses. 
     </li>
 
     <li>
       <b>We will give back to the web and free software community</b>: When we add extensions to MetaBrainz projects we will license them as free 
-      software or content. We will make the best system we can, so that our free encyclopedia will be widely distributed and used. We will 
-      feed back bug-fixes, improvements, user requests, etc. using public mailing lists and/or open meetings. 
+      software or content. We will make the best system we can, so that our open data projects will be widely distributed and used. We will 
+      feed back bug-fixes, improvements, user requests, etc. using our normal public communication channels.
     </li>
 
     <li>
@@ -39,11 +39,10 @@
     </li>
 
     <li>
-      <b>MetaBrainz is interested in all types of music/data</b>: MusicBrainz aims to collect information about all types of music. Published/unpublished, 
-      popular/fringe, western/non-western and human/non-human music should all be entered into MusicBrainz. MetaBrainz does not discriminate 
-      on sex, religion, race or controversial viewpoints. MetaBrainz does not prefer one type of metadata over another, which also means that 
-      MetaBrainz does not condemn or condone any of the music catalogued in the database. Editors and voters are expected to tolerate viewpoints 
-      that may differ from their own. 
+      <b>MetaBrainz projects are interested in all types of data/metadata</b>: Published/unpublished, popular/fringe, western/non-western and 
+      human/non-human music should all be captured by our projects. MetaBrainz does not discriminate on sex, religion, race or controversial viewpoints. 
+      MetaBrainz does not prefer one type of metadata over another, which also means that MetaBrainz does not condemn or condone any of the content catalogued 
+      in the database. Editors and voters are expected to tolerate viewpoints that may differ from their own. 
     </li>
 
     <li>

--- a/metabrainz/templates/index/social-contract.html
+++ b/metabrainz/templates/index/social-contract.html
@@ -1,0 +1,55 @@
+{% extends 'base.html' %}
+
+{% block title %}{{ _('Social Contract') }} - MetaBrainz Foundation{% endblock %}
+
+{% block content %}
+  <h1 class="page-title">{{ _('Social Contract') }}</h1>
+
+  <h3>{{ _('Our Social Contract') }}</h3>
+
+  <p>
+    This social contract defines the spirit underpinning MetaBrainz' projects and its community. This contract is not a legally binding 
+    contract; for legal information regarding products (including the MetaBrainz's Databases), please consult the license pages of 
+    the specific project.
+  </p>
+
+  <p>
+    MetaBrainz's projects will remain 100% free: The development process will be open to the public by using public mailing lists, meetings 
+    open to interested parties, and open IRC channels. The client and server software will remain free and accessible under generally 
+    accepted open licenses. The factual database content will be in the public domain and the non-factual database content will be released 
+    under a Creative Commons license. 
+  </p>
+
+  <p>
+    We will give back to the web and free software community: When we add extensions to MetaBrainz projects we will license them as free 
+    software or content. We will make the best system we can, so that our free encyclopedia will be widely distributed and used. We will 
+    feed back bug-fixes, improvements, user requests, etc. using public mailing lists and/or open meetings. 
+  </p>
+
+  <p>
+    We won't hide problems and policies: We will keep all MetaBrainz related discussions open for public view at all times, regardless 
+    of their content. All problems and policies related to MetaBrainz will be visible to all. 
+  </p>
+
+  <p>
+    Our priorities are our users, free content, and free software: We will be guided by the needs of our users, free content and software 
+    community. We will place their interests first in our priorities. We won't object to commercial use of our content, companies can use 
+    the work of our volunteers without any charge, but charging for the content itself is forbidden. We aim to follow the GPL in that 
+    "You may charge a fee for the physical act of transferring a copy, and you may at your option offer warranty protection in exchange 
+    for a fee." 
+  </p>
+
+  <p>
+    MetaBrainz is interested in all types of music/data: MusicBrainz aims to collect information about all types of music. Published/unpublished, 
+    popular/fringe, western/non-western and human/non-human music should all be entered into MusicBrainz. MetaBrainz/MusicBrainz does not discriminate 
+    on sex, religion, race or controversial viewpoints. MusicBrainz does not prefer one type of music over another, which also means that 
+    MetaBrainz does not condemn or condone any of the music catalogued in the database. Editors and voters are expected to tolerate viewpoints 
+    that may differ from their own. 
+  </p>
+
+  <p>
+    No warranty or liability for errors: There is no warranty for the content of the MetaBrainz databases or the software. It is provided 
+    "as is" without warranty of any kind for correctness or completeness. 
+  </p>
+
+{% endblock %}

--- a/metabrainz/templates/index/social-contract.html
+++ b/metabrainz/templates/index/social-contract.html
@@ -40,8 +40,8 @@
 
     <li>
       <b>MetaBrainz is interested in all types of music/data</b>: MusicBrainz aims to collect information about all types of music. Published/unpublished, 
-      popular/fringe, western/non-western and human/non-human music should all be entered into MusicBrainz. MetaBrainz/MusicBrainz does not discriminate 
-      on sex, religion, race or controversial viewpoints. MusicBrainz does not prefer one type of music over another, which also means that 
+      popular/fringe, western/non-western and human/non-human music should all be entered into MusicBrainz. MetaBrainz does not discriminate 
+      on sex, religion, race or controversial viewpoints. MetaBrainz does not prefer one type of metadata over another, which also means that 
       MetaBrainz does not condemn or condone any of the music catalogued in the database. Editors and voters are expected to tolerate viewpoints 
       that may differ from their own. 
     </li>

--- a/metabrainz/templates/index/social-contract.html
+++ b/metabrainz/templates/index/social-contract.html
@@ -5,51 +5,56 @@
 {% block content %}
   <h1 class="page-title">{{ _('Social Contract') }}</h1>
 
-  <h3>{{ _('Our Social Contract') }}</h3>
-
   <p>
     This social contract defines the spirit underpinning MetaBrainz' projects and its community. This contract is not a legally binding 
     contract; for legal information regarding products (including the MetaBrainz's Databases), please consult the license pages of 
     the specific project.
   </p>
 
-  <p>
-    MetaBrainz's projects will remain 100% free: The development process will be open to the public by using public mailing lists, meetings 
-    open to interested parties, and open IRC channels. The client and server software will remain free and accessible under generally 
-    accepted open licenses. The factual database content will be in the public domain and the non-factual database content will be released 
-    under a Creative Commons license. 
-  </p>
+  <ol>
+    <li>
+      <b>MetaBrainz's projects will remain 100% free</b>: The development process will be open to the public by using public mailing lists, meetings 
+      open to interested parties, and open IRC channels. The client and server software will remain free and accessible under generally 
+      accepted open licenses. The factual database content will be in the public domain and the non-factual database content will be released 
+      under a Creative Commons license. 
+    </li>
+
+    <li>
+      <b>We will give back to the web and free software community</b>: When we add extensions to MetaBrainz projects we will license them as free 
+      software or content. We will make the best system we can, so that our free encyclopedia will be widely distributed and used. We will 
+      feed back bug-fixes, improvements, user requests, etc. using public mailing lists and/or open meetings. 
+    </li>
+
+    <li>
+      <b>We won't hide problems and policies</b>: We will keep all MetaBrainz related discussions open for public view at all times, regardless 
+      of their content. All problems and policies related to MetaBrainz will be visible to all. 
+    </li>
+
+    <li>
+      Our priorities are our users, free content, and free software</b>: We will be guided by the needs of our users, free content and software 
+      community. We will place their interests first in our priorities. We won't object to commercial use of our content, companies can use 
+      the work of our volunteers without any charge, but charging for the content itself is forbidden. We aim to follow the GPL in that 
+      "You may charge a fee for the physical act of transferring a copy, and you may at your option offer warranty protection in exchange 
+      for a fee." 
+    </li>
+
+    <li>
+      <b>MetaBrainz is interested in all types of music/data</b>: MusicBrainz aims to collect information about all types of music. Published/unpublished, 
+      popular/fringe, western/non-western and human/non-human music should all be entered into MusicBrainz. MetaBrainz/MusicBrainz does not discriminate 
+      on sex, religion, race or controversial viewpoints. MusicBrainz does not prefer one type of music over another, which also means that 
+      MetaBrainz does not condemn or condone any of the music catalogued in the database. Editors and voters are expected to tolerate viewpoints 
+      that may differ from their own. 
+    </li>
+
+    <li>
+      <b>No warranty or liability for errors</b>: There is no warranty for the content of the MetaBrainz databases or the software. It is provided 
+      "as is" without warranty of any kind for correctness or completeness. 
+    </li>
+  </ol>
 
   <p>
-    We will give back to the web and free software community: When we add extensions to MetaBrainz projects we will license them as free 
-    software or content. We will make the best system we can, so that our free encyclopedia will be widely distributed and used. We will 
-    feed back bug-fixes, improvements, user requests, etc. using public mailing lists and/or open meetings. 
-  </p>
-
-  <p>
-    We won't hide problems and policies: We will keep all MetaBrainz related discussions open for public view at all times, regardless 
-    of their content. All problems and policies related to MetaBrainz will be visible to all. 
-  </p>
-
-  <p>
-    Our priorities are our users, free content, and free software: We will be guided by the needs of our users, free content and software 
-    community. We will place their interests first in our priorities. We won't object to commercial use of our content, companies can use 
-    the work of our volunteers without any charge, but charging for the content itself is forbidden. We aim to follow the GPL in that 
-    "You may charge a fee for the physical act of transferring a copy, and you may at your option offer warranty protection in exchange 
-    for a fee." 
-  </p>
-
-  <p>
-    MetaBrainz is interested in all types of music/data: MusicBrainz aims to collect information about all types of music. Published/unpublished, 
-    popular/fringe, western/non-western and human/non-human music should all be entered into MusicBrainz. MetaBrainz/MusicBrainz does not discriminate 
-    on sex, religion, race or controversial viewpoints. MusicBrainz does not prefer one type of music over another, which also means that 
-    MetaBrainz does not condemn or condone any of the music catalogued in the database. Editors and voters are expected to tolerate viewpoints 
-    that may differ from their own. 
-  </p>
-
-  <p>
-    No warranty or liability for errors: There is no warranty for the content of the MetaBrainz databases or the software. It is provided 
-    "as is" without warranty of any kind for correctness or completeness. 
+    Each project may also define a Social Contract of its own that builds on the MetaBrainz social contract. Please view the project's
+    documentation pages for more information.
   </p>
 
 {% endblock %}

--- a/metabrainz/templates/index/social-contract.html
+++ b/metabrainz/templates/index/social-contract.html
@@ -31,7 +31,7 @@
     </li>
 
     <li>
-      Our priorities are our users, free content, and free software</b>: We will be guided by the needs of our users, free content and software 
+      <b>Our priorities are our users, free content, and free software</b>: We will be guided by the needs of our users, free content and software 
       community. We will place their interests first in our priorities. We won't object to commercial use of our content, companies can use 
       the work of our volunteers without any charge, but charging for the content itself is forbidden. We aim to follow the GPL in that 
       "You may charge a fee for the physical act of transferring a copy, and you may at your option offer warranty protection in exchange 

--- a/metabrainz/templates/navbar.html
+++ b/metabrainz/templates/navbar.html
@@ -24,6 +24,7 @@
             <li><a href="{{ url_for('index.projects') }}">{{ _('Projects') }}</a></li>
             <li><a href="{{ url_for('index.team') }}">{{ _('Team') }}</a></li>
             <li><a href="{{ url_for('index.social_contract') }}">{{ _('Social Contract') }}</a></li>
+            <li><a href="{{ url_for('index.code_of_conduct') }}">{{ _('Code of Conduct') }}</a></li>
           </ul>
         </li>
         <li><a href="{{ url_for('users.supporters_list') }}">{{ _('Supporters') }}</a></li>

--- a/metabrainz/templates/navbar.html
+++ b/metabrainz/templates/navbar.html
@@ -23,7 +23,7 @@
             <li><a href="{{ url_for('index.about') }}">{{ _('The Foundation') }}</a></li>
             <li><a href="{{ url_for('index.projects') }}">{{ _('Projects') }}</a></li>
             <li><a href="{{ url_for('index.team') }}">{{ _('Team') }}</a></li>
-            <li><a href="{{ url_for('index.socialcontract') }}">{{ _('Social Contract') }}</a></li>
+            <li><a href="{{ url_for('index.social_contract') }}">{{ _('Social Contract') }}</a></li>
           </ul>
         </li>
         <li><a href="{{ url_for('users.supporters_list') }}">{{ _('Supporters') }}</a></li>

--- a/metabrainz/templates/navbar.html
+++ b/metabrainz/templates/navbar.html
@@ -25,6 +25,7 @@
             <li><a href="{{ url_for('index.team') }}">{{ _('Team') }}</a></li>
             <li><a href="{{ url_for('index.social_contract') }}">{{ _('Social Contract') }}</a></li>
             <li><a href="{{ url_for('index.code_of_conduct') }}">{{ _('Code of Conduct') }}</a></li>
+            <li><a href="{{ url_for('index.privacy_policy') }}">{{ _('Privacy Policy') }}</a></li>
           </ul>
         </li>
         <li><a href="{{ url_for('users.supporters_list') }}">{{ _('Supporters') }}</a></li>

--- a/metabrainz/templates/navbar.html
+++ b/metabrainz/templates/navbar.html
@@ -23,6 +23,7 @@
             <li><a href="{{ url_for('index.about') }}">{{ _('The Foundation') }}</a></li>
             <li><a href="{{ url_for('index.projects') }}">{{ _('Projects') }}</a></li>
             <li><a href="{{ url_for('index.team') }}">{{ _('Team') }}</a></li>
+            <li><a href="{{ url_for('index.socialcontract') }}">{{ _('Social Contract') }}</a></li>
           </ul>
         </li>
         <li><a href="{{ url_for('users.supporters_list') }}">{{ _('Supporters') }}</a></li>

--- a/metabrainz/views.py
+++ b/metabrainz/views.py
@@ -47,6 +47,11 @@ def social_contract():
     return render_template('index/social-contract.html')
 
 
+@index_bp.route('/code-of-conduct')
+def code_of_conduct():
+    return render_template('index/code-of-conduct.html')
+
+
 @index_bp.route('/sponsors')
 def sponsors():
     return render_template('index/sponsors.html')

--- a/metabrainz/views.py
+++ b/metabrainz/views.py
@@ -42,9 +42,10 @@ def contact():
     return render_template('index/contact.html', ad_deadline=ad_deadline)
 
 
-@index_bp.route('/socialcontract')
-def contract():
-    return render_template('index/socialcontract.html')
+@index_bp.route('/social-contract')
+def social_contract():
+    return render_template('index/social-contract.html')
+
 
 @index_bp.route('/sponsors')
 def sponsors():

--- a/metabrainz/views.py
+++ b/metabrainz/views.py
@@ -42,6 +42,10 @@ def contact():
     return render_template('index/contact.html', ad_deadline=ad_deadline)
 
 
+@index_bp.route('/socialcontract')
+def contract():
+    return render_template('index/socialcontract.html')
+
 @index_bp.route('/sponsors')
 def sponsors():
     return render_template('index/sponsors.html')

--- a/metabrainz/views_test.py
+++ b/metabrainz/views_test.py
@@ -13,6 +13,10 @@ class IndexViewsTestCase(FlaskTestCase):
         response = self.client.get(url_for('index.contact'))
         self.assert200(response)
 
+    def test_socialcontract(self):
+        response = self.client.get(url_for('index.socialcontract'))
+        self.assert200(response)
+
     def test_about(self):
         response = self.client.get(url_for('index.about'))
         self.assert200(response)

--- a/metabrainz/views_test.py
+++ b/metabrainz/views_test.py
@@ -13,6 +13,10 @@ class IndexViewsTestCase(FlaskTestCase):
         response = self.client.get(url_for('index.contact'))
         self.assert200(response)
 
+    def test_code_of_conduct(self):
+        response = self.client.get(url_for('index.code_of_conduct'))
+        self.assert200(response)
+
     def test_socialcontract(self):
         response = self.client.get(url_for('index.socialcontract'))
         self.assert200(response)


### PR DESCRIPTION
This RP attempts to move the MusicBrainz specific privacy policy/CoC/social contract and create a MetaBrainz umbrella version of each of those. Making one policy that covers all of our projects is unrealistic, so the goal it to have the general points that are common to all projects under the MetaBrainz version of these documents. This can be seen in the Code of Conduct now and I suspect that as we flesh out the PP and social contract we may want project specific extensions in the future.

Code of Conduct:

Parts of the MusicBrainz Code of Conduct move to MetaBrainz at https://test.metabrainz.org/code-of-conduct and the MB CoC gets edited to: https://wiki.musicbrainz.org/Code_of_Conduct

Privacy Policy:

The PP on MB moves to http://metabrainz.org/privacy and gets an update: https://test.metabrainz.org/privacy . Once this is released, the MB version should redirect to the MeB version.

Social contract:

It moves to metabrainz.org and once it is deployed we will need a redirect:
redirect https://musicbrainz.org/doc/Social_Contract -> https://test.metabrainz.org/social-contract

