### PR TITLE
Document incremental JSON dumps API, remove daily/weekly packets

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,6 @@ It must have the following structure:
 ```
 ./data/replication_packets/
     - hourly replication packets
-
-./data/replication_packets/daily/
-    - daily replication packets
-
-./data/replication_packets/weekly/
-    - weekly replication packets
 ```
 
 ### Startup

--- a/default_config.py
+++ b/default_config.py
@@ -10,9 +10,7 @@ SQLALCHEMY_TRACK_MODIFICATIONS = False
 
 
 # REPLICATION PACKETS
-# Hourly replication packets must be located in this directory. Daily
-# replication packets must be located in subdirectory called "daily"
-# in REPLICATION_PACKETS_DIR. Weekly packets in subdirectory "weekly".
+# Hourly replication packets must be located in this directory.
 REPLICATION_PACKETS_DIR = "/data/replication_packets"
 JSON_DUMPS_DIR = "/data/json_dumps"
 

--- a/metabrainz/api/views/musicbrainz.py
+++ b/metabrainz/api/views/musicbrainz.py
@@ -16,9 +16,6 @@ MIMETYPE_ARCHIVE_BZ2 = 'application/x-tar-bz2'
 MIMETYPE_ARCHIVE_XZ = 'application/x-xz'
 MIMETYPE_SIGNATURE = 'text/plain'
 
-DAILY_SUBDIR = 'daily'
-WEEKLY_SUBDIR = 'weekly'
-
 # These durations are used to create nagios compatible status codes so we can monitor
 # the replication packet stream.
 MAX_PACKET_AGE_WARNING = 60 * 60 * 2  # 4 hours
@@ -96,14 +93,6 @@ def replication_info():
             current_app.config['REPLICATION_PACKETS_DIR'],
             "replication-[0-9]+.tar.bz2$"
         ),
-        'last_packet_daily': _get_last_packet_name(
-            os.path.join(current_app.config['REPLICATION_PACKETS_DIR'], DAILY_SUBDIR),
-            "replication-daily-[0-9]+.tar.bz2$"
-        ),
-        'last_packet_weekly': _get_last_packet_name(
-            os.path.join(current_app.config['REPLICATION_PACKETS_DIR'], WEEKLY_SUBDIR),
-            "replication-weekly-[0-9]+.tar.bz2$"
-        ),
     })
 
 
@@ -132,64 +121,6 @@ def replication_hourly_signature(packet_number):
 
     if 'USE_NGINX_X_ACCEL' in current_app.config and current_app.config['USE_NGINX_X_ACCEL']:
         return _redirect_to_nginx(os.path.join(NGINX_INTERNAL_LOCATION, filename))
-    else:
-        return send_from_directory(directory, filename, mimetype=MIMETYPE_SIGNATURE)
-
-
-@api_musicbrainz_bp.route('/replication-daily-<int:packet_number>.tar.bz2')
-@token_required
-@tracked
-def replication_daily(packet_number):
-    directory = os.path.join(current_app.config['REPLICATION_PACKETS_DIR'], DAILY_SUBDIR)
-    filename = 'replication-daily-%s.tar.bz2' % packet_number
-    if not os.path.isfile(safe_join(directory, filename)):
-        return Response("Can't find specified replication packet!\n", status=404)
-
-    if 'USE_NGINX_X_ACCEL' in current_app.config and current_app.config['USE_NGINX_X_ACCEL']:
-        return _redirect_to_nginx(os.path.join(NGINX_INTERNAL_LOCATION, DAILY_SUBDIR, filename))
-    else:
-        return send_from_directory(directory, filename, mimetype=MIMETYPE_ARCHIVE_BZ2)
-
-
-@api_musicbrainz_bp.route('/replication-daily-<int:packet_number>.tar.bz2.asc')
-@token_required
-def replication_daily_signature(packet_number):
-    directory = os.path.join(current_app.config['REPLICATION_PACKETS_DIR'], DAILY_SUBDIR)
-    filename = 'replication-daily-%s.tar.bz2.asc' % packet_number
-    if not os.path.isfile(safe_join(directory, filename)):
-        return Response("Can't find signature for a specified replication packet!\n", status=404)
-
-    if 'USE_NGINX_X_ACCEL' in current_app.config and current_app.config['USE_NGINX_X_ACCEL']:
-        return _redirect_to_nginx(os.path.join(NGINX_INTERNAL_LOCATION, DAILY_SUBDIR, filename))
-    else:
-        return send_from_directory(directory, filename, mimetype=MIMETYPE_SIGNATURE)
-
-
-@api_musicbrainz_bp.route('/replication-weekly-<int:packet_number>.tar.bz2')
-@token_required
-@tracked
-def replication_weekly(packet_number):
-    directory = os.path.join(current_app.config['REPLICATION_PACKETS_DIR'], WEEKLY_SUBDIR)
-    filename = 'replication-weekly-%s.tar.bz2' % packet_number
-    if not os.path.isfile(safe_join(directory, filename)):
-        return Response("Can't find specified replication packet!\n", status=404)
-
-    if 'USE_NGINX_X_ACCEL' in current_app.config and current_app.config['USE_NGINX_X_ACCEL']:
-        return _redirect_to_nginx(os.path.join(NGINX_INTERNAL_LOCATION, WEEKLY_SUBDIR, filename))
-    else:
-        return send_from_directory(directory, filename, mimetype=MIMETYPE_ARCHIVE_BZ2)
-
-
-@api_musicbrainz_bp.route('/replication-weekly-<int:packet_number>.tar.bz2.asc')
-@token_required
-def replication_weekly_signature(packet_number):
-    directory = os.path.join(current_app.config['REPLICATION_PACKETS_DIR'], WEEKLY_SUBDIR)
-    filename = 'replication-weekly-%s.tar.bz2.asc' % packet_number
-    if not os.path.isfile(safe_join(directory, filename)):
-        return Response("Can't find signature for a specified replication packet!\n", status=404)
-
-    if 'USE_NGINX_X_ACCEL' in current_app.config and current_app.config['USE_NGINX_X_ACCEL']:
-        return _redirect_to_nginx(os.path.join(NGINX_INTERNAL_LOCATION, WEEKLY_SUBDIR, filename))
     else:
         return send_from_directory(directory, filename, mimetype=MIMETYPE_SIGNATURE)
 

--- a/metabrainz/api/views/musicbrainz.py
+++ b/metabrainz/api/views/musicbrainz.py
@@ -140,6 +140,19 @@ def json_dump(packet_number, entity_name):
     return send_from_directory(directory, filename, mimetype=MIMETYPE_ARCHIVE_XZ)
 
 
+@api_musicbrainz_bp.route('/json-dumps/json-dump-<int:packet_number>/<entity_name>.tar.xz.asc')
+@token_required
+@tracked
+def json_dump_signature(packet_number, entity_name):
+    """Endpoint that provides access to the JSON dump signature files.
+    """
+    directory = os.path.join(current_app.config['JSON_DUMPS_DIR'], "json-dump-%s" % packet_number)
+    filename = '%s.tar.xz.asc' % entity_name
+    if not os.path.isfile(safe_join(directory, filename)):
+        return Response("Can't find signature for the specified JSON dump!", status=404)
+    return send_from_directory(directory, filename, mimetype=MIMETYPE_SIGNATURE)
+
+
 def _redirect_to_nginx(location):
     """This creates an internal redirection to a specified location.
 

--- a/metabrainz/api/views/musicbrainz_test.py
+++ b/metabrainz/api/views/musicbrainz_test.py
@@ -1,5 +1,4 @@
 from metabrainz.testing import FlaskTestCase
-from metabrainz.api.views.musicbrainz import DAILY_SUBDIR, WEEKLY_SUBDIR
 from metabrainz.model.token import Token
 from flask import url_for, current_app
 import tempfile
@@ -12,8 +11,6 @@ class MusicBrainzViewsTestCase(FlaskTestCase):
     def setUp(self):
         super(MusicBrainzViewsTestCase, self).setUp()
         current_app.config['REPLICATION_PACKETS_DIR'] = self.path = tempfile.mkdtemp()
-        os.mkdir(os.path.join(self.path, DAILY_SUBDIR))
-        os.mkdir(os.path.join(self.path, WEEKLY_SUBDIR))
         self.token = Token.generate_token(owner_id=None)
 
     def tearDown(self):
@@ -28,33 +25,21 @@ class MusicBrainzViewsTestCase(FlaskTestCase):
         self.assert200(resp)
         self.assertEquals(resp.json, {
             'last_packet': None,
-            'last_packet_daily': None,
-            'last_packet_weekly': None,
         })
 
         open(os.path.join(self.path, 'replication-1.tar.bz2'), 'a').close()
-        open(os.path.join(self.path, DAILY_SUBDIR, 'replication-daily-1.tar.bz2'), 'a').close()
-        open(os.path.join(self.path, WEEKLY_SUBDIR, 'replication-weekly-1.tar.bz2'), 'a').close()
         resp = self.client.get(url_for('api_musicbrainz.replication_info', token=self.token))
         self.assert200(resp)
         self.assertEquals(resp.json, {
             'last_packet': 'replication-1.tar.bz2',
-            'last_packet_daily': 'replication-daily-1.tar.bz2',
-            'last_packet_weekly': 'replication-weekly-1.tar.bz2',
         })
 
         open(os.path.join(self.path, 'replication-99999.tar.bz2'), 'a').close()
         open(os.path.join(self.path, 'replication-100000.tar.bz2'), 'a').close()
-        open(os.path.join(self.path, DAILY_SUBDIR, 'replication-daily-99999.tar.bz2'), 'a').close()
-        open(os.path.join(self.path, DAILY_SUBDIR, 'replication-daily-100000.tar.bz2'), 'a').close()
-        open(os.path.join(self.path, WEEKLY_SUBDIR, 'replication-weekly-99999.tar.bz2'), 'a').close()
-        open(os.path.join(self.path, WEEKLY_SUBDIR, 'replication-weekly-100000.tar.bz2'), 'a').close()
         resp = self.client.get(url_for('api_musicbrainz.replication_info', token=self.token))
         self.assert200(resp)
         self.assertEquals(resp.json, {
             'last_packet': 'replication-100000.tar.bz2',
-            'last_packet_daily': 'replication-daily-100000.tar.bz2',
-            'last_packet_weekly': 'replication-weekly-100000.tar.bz2',
         })
 
     def test_replication_check(self):
@@ -94,35 +79,3 @@ class MusicBrainzViewsTestCase(FlaskTestCase):
 
         open(os.path.join(self.path, 'replication-1.tar.bz2.asc'), 'a').close()
         self.assert200(self.client.get(url_for('api_musicbrainz.replication_hourly_signature', packet_number=1, token=self.token)))
-
-    def test_replication_daily(self):
-        self.assert400(self.client.get(url_for('api_musicbrainz.replication_daily', packet_number=1)))
-        self.assert403(self.client.get(url_for('api_musicbrainz.replication_daily', packet_number=1, token='fake')))
-        self.assert404(self.client.get(url_for('api_musicbrainz.replication_daily', packet_number=1, token=self.token)))
-
-        open(os.path.join(self.path, DAILY_SUBDIR, 'replication-daily-1.tar.bz2'), 'a').close()
-        self.assert200(self.client.get(url_for('api_musicbrainz.replication_daily', packet_number=1, token=self.token)))
-
-    def test_replication_daily_signature(self):
-        self.assert400(self.client.get(url_for('api_musicbrainz.replication_daily_signature', packet_number=1)))
-        self.assert403(self.client.get(url_for('api_musicbrainz.replication_daily_signature', packet_number=1, token='fake')))
-        self.assert404(self.client.get(url_for('api_musicbrainz.replication_daily_signature', packet_number=1, token=self.token)))
-
-        open(os.path.join(self.path, DAILY_SUBDIR, 'replication-daily-1.tar.bz2.asc'), 'a').close()
-        self.assert200(self.client.get(url_for('api_musicbrainz.replication_daily_signature', packet_number=1, token=self.token)))
-
-    def test_replication_weekly(self):
-        self.assert400(self.client.get(url_for('api_musicbrainz.replication_weekly', packet_number=1)))
-        self.assert403(self.client.get(url_for('api_musicbrainz.replication_weekly', packet_number=1, token='fake')))
-        self.assert404(self.client.get(url_for('api_musicbrainz.replication_weekly', packet_number=1, token=self.token)))
-
-        open(os.path.join(self.path, WEEKLY_SUBDIR, 'replication-weekly-1.tar.bz2'), 'a').close()
-        self.assert200(self.client.get(url_for('api_musicbrainz.replication_weekly', packet_number=1, token=self.token)))
-
-    def test_replication_weekly_signature(self):
-        self.assert400(self.client.get(url_for('api_musicbrainz.replication_weekly_signature', packet_number=1)))
-        self.assert403(self.client.get(url_for('api_musicbrainz.replication_weekly_signature', packet_number=1, token='fake')))
-        self.assert404(self.client.get(url_for('api_musicbrainz.replication_weekly_signature', packet_number=1, token=self.token)))
-
-        open(os.path.join(self.path, WEEKLY_SUBDIR, 'replication-weekly-1.tar.bz2.asc'), 'a').close()
-        self.assert200(self.client.get(url_for('api_musicbrainz.replication_weekly_signature', packet_number=1, token=self.token)))

--- a/metabrainz/templates/api/info.html
+++ b/metabrainz/templates/api/info.html
@@ -63,5 +63,8 @@
     <p>
       {{ _('Each dump contains a file named <code>mbdump/&lt;ENTITY_NAME&gt;</code>. This file must be read line-by-line; each line contains one changed entity in JSON format.') }}
     </p>
+    <p>
+      {{ _('As with replication packets, you can obtain a file signature by replacing <code>.tar.xz</code> with <code>.tar.xz.asc</code>.') }}
+    </p>
   </div>
 {% endblock %}

--- a/metabrainz/templates/api/info.html
+++ b/metabrainz/templates/api/info.html
@@ -13,33 +13,12 @@
     </em>
 
     <h2>{{ _('MusicBrainz Live Data Feed') }}</h2>
-    <p>{{ _('There are three endpoints for fetching replication packets:') }}</p>
+    <p>{{ _('There are two endpoints for fetching live data:') }}</p>
+
+    <h3>{{ _('Hourly Replication Packets') }}</h3>
     <p>
-      <strong>{{ _('Hourly:') }}</strong>
       <code>
         GET {{ url_for('api_musicbrainz.replication_hourly',
-                       _external=True, _scheme=config.PREFERRED_URL_SCHEME,
-                       packet_number=42, token="TOKEN")
-                  | replace("42", "<PACKET_NUMBER>")
-                  | replace("TOKEN", "<ACCESS_TOKEN>")
-            }}
-      </code>
-    </p>
-    <p>
-      <strong>{{ _('Daily:') }}</strong>
-      <code>
-        GET {{ url_for('api_musicbrainz.replication_daily',
-                       _external=True, _scheme=config.PREFERRED_URL_SCHEME,
-                       packet_number=42, token="TOKEN")
-                  | replace("42", "<PACKET_NUMBER>")
-                  | replace("TOKEN", "<ACCESS_TOKEN>")
-            }}
-      </code>
-    </p>
-    <p>
-      <strong>{{ _('Weekly:') }}</strong>
-      <code>
-        GET {{ url_for('api_musicbrainz.replication_weekly',
                        _external=True, _scheme=config.PREFERRED_URL_SCHEME,
                        packet_number=42, token="TOKEN")
                   | replace("42", "<PACKET_NUMBER>")
@@ -52,15 +31,37 @@
       <code>.tar.bz2</code> with <code>.asc</code>.') }}
     </p>
     <p>
-      {{ _('You can find the latest replication packet numbers from this endpoint:') }}<br />
+      {{ _('You can find the latest replication packet number from this endpoint:') }}<br />
       <code>
         GET {{ url_for('api_musicbrainz.replication_info',
                        _external=True, _scheme=config.PREFERRED_URL_SCHEME,
                        token="TOKEN")
                   | replace("TOKEN", "<ACCESS_TOKEN>")
             }}
-        </code>
+      </code>
     </p>
 
+    <h3>{{ _('Hourly Incremental JSON Dumps') }}</h3>
+    <p>
+      <code>
+        GET {{ url_for('api_musicbrainz.json_dump',
+                       _external=True, _scheme=config.PREFERRED_URL_SCHEME,
+                       packet_number=42, entity_name="ENTITY_NAME",
+                       token="TOKEN")
+                  | replace("42", "<PACKET_NUMBER>")
+                  | replace("ENTITY_NAME", "<ENTITY_NAME>")
+                  | replace("TOKEN", "<ACCESS_TOKEN>")
+            }}
+      </code>
+    </p>
+    <p>
+      {{ _('The JSON dumps are partitioned by entity type. <code>&lt;ENTITY_NAME&gt;</code> can be one of: area, artist, event, instrument, label, place, recording, release, release-group, series, or work.') }}
+    </p>
+    <p>
+      {{ _('It’s possible that a JSON dump for a particular entity type doesn’t exist if no entities of that type have changed in a given hour.') }}
+    </p>
+    <p>
+      {{ _('Each dump contains a file named <code>mbdump/&lt;ENTITY_NAME&gt;</code>. This file must be read line-by-line; each line contains one changed entity in JSON format.') }}
+    </p>
   </div>
 {% endblock %}

--- a/metabrainz/templates/api/info.html
+++ b/metabrainz/templates/api/info.html
@@ -28,7 +28,7 @@
     </p>
     <p>
       {{ _('It is possible to get a signature for each replication packet. Just replace
-      <code>.tar.bz2</code> with <code>.asc</code>.') }}
+      <code>.tar.bz2</code> with <code>.tar.bz2.asc</code>.') }}
     </p>
     <p>
       {{ _('You can find the latest replication packet number from this endpoint:') }}<br />


### PR DESCRIPTION
<img width="600" alt="json-dump-api" src="https://user-images.githubusercontent.com/1056556/38475310-e7c5aa16-3b6c-11e8-9361-a66942b58d8e.png">

The daily/weekly packets haven't been updating since some time in 2016, and I recall @mayhem giving the OK to only support hourly ones, but lemme know if you'd still like to document/include them in the API.