### PR TITLE
Add note about registration requirement for IRC

### DIFF
--- a/metabrainz/templates/index/contact.html
+++ b/metabrainz/templates/index/contact.html
@@ -102,6 +102,18 @@
     chatlogs_url='http://chatlogs.metabrainz.org/') }}
   </p>
 
+  <p>
+    {{ _('<strong>Note:</strong> Due to an
+    <a href="%(spam_attack_url)s">on-going spam attack on the IRC network we use</a>
+    we temporarily require people to
+    <a href="%(irc_registration_url)s">register on the network</a>
+    to be able to talk in our channels. Please follow
+    <a href="%(irc_registration_url)s">the guide on how to register</a>
+    and feel free to contact us by other means if you have issues or questions regarding this.',
+    spam_attack_url='https://freenode.net/news/spambot-attack',
+    irc_registration_url='https://freenode.net/kb/answer/registration') }}
+  </p>
+
   <h3>{{ _('Mailing address') }}</h3>
   <p>
     MetaBrainz Foundation<br/>


### PR DESCRIPTION
This can hopefully be reverted soon enough, but whether the channels are in `+r` or `+zq $~a` mode people will need to register to talk in the channels. The spam attack has been going for a month now, so let's be up front about the current reality.

(This is mostly a copy/paste of the note I added on the wiki page: <https://wiki.musicbrainz.org/index.php?title=Communication%2FIRC&type=revision&diff=72851&oldid=72850>)