### PR TITLE
 MEB-100: Add a new datasets page

### DIFF
--- a/metabrainz/static/css/main.less
+++ b/metabrainz/static/css/main.less
@@ -387,3 +387,29 @@ h1.page-title, h2.page-title {
 table.finances td:nth-child(2) {
   text-align: right;
 }
+
+// Datasets page
+#data {
+  .dataset {
+    .clearfix;
+    padding-bottom: 20px;
+    span.name {
+      font-weight: bold;
+      color: @orange;
+    }
+    img.logo {
+      width: 120px;
+      .pull-left;
+      margin-right: 10px;
+      margin-top: 15px;
+    }
+    .info {
+      @media (min-width: @grid-float-breakpoint) {
+        margin-left: 142px;
+      }
+      ul.links {
+        .list-unstyled;
+      }
+    }
+  }
+}

--- a/metabrainz/static/css/main.less
+++ b/metabrainz/static/css/main.less
@@ -417,6 +417,7 @@ table.finances td:nth-child(2) {
     }
   }
 }
+}
 
 @media (max-width: 400px) {
   #data {

--- a/metabrainz/templates/base.html
+++ b/metabrainz/templates/base.html
@@ -48,6 +48,7 @@
               <div class="title"><a href="{{ url_for('index.about') }}">{{ _('Foundation') }}</a></div>
               <ul>
                 <li><a href="{{ url_for('index.projects') }}">{{ _('Projects') }}</a></li>
+                <li><a href="{{ url_for('index.datasets') }}">{{ _('Datasets') }}</a></li>
                 <li><a href="{{ url_for('index.team') }}">{{ _('Team') }}</a></li>
                 <li><a href="{{ url_for('index.shop') }}">{{ _('Shop') }}</a></li>
               </ul>

--- a/metabrainz/templates/index/datasets.html
+++ b/metabrainz/templates/index/datasets.html
@@ -1,0 +1,112 @@
+{% extends 'base.html' %}
+
+{% block title %}{{ _('Datasets') }} - MetaBrainz Foundation{% endblock %}
+
+{% block content %}
+  <h1 class="page-title">{{ _('The MetaBrainz Datasets') }}</h1>
+
+  <p>
+    The MetaBrainz Foundation provides free, open access to various types of useful data
+    gathered and verified by volunteers. Here, we list and describe the various datasets we maintain.
+  </p>
+
+  <div id="data">
+
+    <div class="dataset">
+      <img class="logo" src="{{ url_for('static', filename='img/projects/musicbrainz.svg') }}" alt="MusicBrainz logo" />
+      <div class="info">
+        <h4><span class="name">MusicBrainz Data Dumps</span></h4>
+        <p>
+          The MusicBrainz Database is built on the PostgreSQL relational database engine and
+          contains all of MusicBrainz' music metadata. This data includes information about
+          artists, release groups, releases, recordings, works, and labels, as well as the many
+          relationships between them. The database also contains a full history of all the
+          changes that the MusicBrainz community has made to the data.
+        </p>
+        <p>
+          MetaBrainz provides full database exports of the MusicBrainz database updated regularly
+          and also provides the possibility of keeping in sync with the main MusicBrainz database via
+          the <a href="safjkla">Live Data Feed</a>. The MusicBrainz data dumps can be found on the
+          <a href="http://ftp.musicbrainz.org/pub/musicbrainz/data/fullexport/">MusicBrainz FTP Server</a>
+          and more information on the contents of the various dump files can be found in the
+          <a href="https://musicbrainz.org/doc/MusicBrainz_Database/Download">MusicBrainz documentation</a>.
+        </p>
+      </div>
+    </div>
+
+    <div class="dataset">
+      <img class="logo" src="{{ url_for('static', filename='img/projects/musicbrainz.svg') }}" alt="MusicBrainz logo" />
+      <div class="info">
+        <h4><span class="name">MusicBrainz JSON Dumps</span></h4>
+        <p>
+          MetaBrainz also provides access to the music metadata in the MusicBrainz database in the easily
+          consumable format of JSON documents. These JSON dumps can be downloaded from the
+          <a href="http://ftp.musicbrainz.org/pub/musicbrainz/data/json-dumps/">MusicBrainz FTP Server</a>.
+          These dumps are <a href="https://creativecommons.org/share-your-work/public-domain/cc0/">CC0 licensed</a>
+          but we ask <a href="{{ url_for('users.account_type') }}">commercial users</a> to
+          <a href="{{ url_for('users.account_type') }}">support us</a> in order to help fund the creation and
+          maintenance of these datasets.
+        </p>
+      </div>
+    </div>
+
+    <div class="dataset">
+      <img class="logo" src="{{ url_for('static', filename='img/projects/listenbrainz.svg') }}" alt="ListenBrainz logo" />
+      <div class="info">
+        <h4><span class="name">ListenBrainz Data Dumps</span></h4>
+        <p>
+          The <a href="https://listenbrainz.org">ListenBrainz</a> project serves as an archive for users to store their music listening history.
+          This incredibly useful dataset can be used for the creation of new music recommendation engines.
+          The MetaBrainz Foundation provides data dumps containing over a 100 million listens in the ListenBrainz
+          database. We also provide access to a live feed of the ListenBrainz data on Google's BigQuery service.
+        </p>
+        <p>
+          The ListenBrainz project creates new data dumps every two weeks, on the 1st and 15th of every month.
+          These data dumps are <a href="https://creativecommons.org/share-your-work/public-domain/cc0/">CC0 licensed</a>
+          and can be downloaded from the <a href="http://ftp.musicbrainz.org/pub/musicbrainz/listenbrainz/fullexport/">MusicBrainz FTP Server</a>.
+          For more information, please visit the <a href="https://listenbrainz.org">ListenBrainz website</a>
+          and the <a href="https://listenbrainz.readthedocs.io/en/latest/dev/listenbrainz-dumps.html">ListenBrainz data dumps documentation</a>.
+        </p>
+      </div>
+    </div>
+
+    <div class="dataset">
+      <img class="logo" src="{{ url_for('static', filename='img/projects/acousticbrainz.svg') }}" alt="AcousticBrainz logo" />
+      <div class="info">
+        <h4><span class="name">AcousticBrainz Data Dumps</span></h4>
+        <p>
+          The <a href="https://acousticbrainz.org">AcousticBrainz</a> project aims to crowd source acoustic information for all music in the
+          world and to make it available to the public. This acoustic information describes the
+          acoustic characteristics of music and includes low-level spectral information and
+          information for genres, moods, keys, scales and much more.
+        </p>
+        <p>
+          The MetaBrainz Foundation provides dumps of the data in the AcousticBrainz database regularly.
+          These dumps are seperated into low-level and high-level archives, each containing different types
+          of information about music. A download of the full AcousticBrainz database dump is also provided.
+          For more information, please visit the <a href="http://acousticbrainz.org/download">AcousticBrainz
+          downloads page</a>.
+        </p>
+      </div>
+    </div>
+
+    <div class="dataset">
+      <img class="logo" src="{{ url_for('static', filename='img/projects/critiquebrainz.svg') }}" alt="CritiqueBrainz logo" />
+      <div class="info">
+        <h4><span class="name">CritiqueBrainz Data Dumps</span></h4>
+        <p>
+          <a href="https://critiquebrainz.org">CritiqueBrainz</a> is a repository for Creative Commons licensed music reviews. It fills the gap
+          between the factual music metadata in the MusicBrainz database and opinions about music of music
+          critics and listeners by providing a platform that archives Creative Commons licensed reviews.
+        </p>
+        <p>
+          The MetaBrainz foundation provides full dumps of the CritiqueBrainz database
+          as well as JSON dumps containing reviews in a more easily consumable format.
+          These datasets are updated every day and can be downloaded from the
+          <a href="ftp://ftp.musicbrainz.org/pub/musicbrainz/critiquebrainz/">MusicBrainz FTP Server</a>.
+        </p>
+      </div>
+    </div>
+
+  </div>
+{% endblock %}

--- a/metabrainz/templates/index/datasets.html
+++ b/metabrainz/templates/index/datasets.html
@@ -5,11 +5,12 @@
 {% block content %}
   <h1 class="page-title">{{ _('The MetaBrainz Datasets') }}</h1>
 
-  <p> We ask <a href="{{ url_for('users.account_type') }}">commercial users</a> to <a href="{{ url_for('users.account_type') }}">support us</a> in order to help fund the creation and maintenance of these datasets. </p>
-
-<p>
-  The MetaBrainz Foundation provides free, open access to various types of useful data gathered and verified by volunteers. Here, we list and describe the various datasets we maintain.
-</p>
+  <p> 
+    We ask <a href="{{ url_for('users.account_type') }}">commercial users</a> to <a href="{{ url_for('users.account_type') }}">
+    support us</a> in order to help fund the creation and maintenance of these datasets. 
+    The MetaBrainz Foundation provides free, open access to various types of useful data gathered and verified by volunteers. 
+    Here, we list and describe the various datasets we maintain.
+  </p>
 <div id="data">
   <div class="column">
     <div class="dataset">
@@ -17,12 +18,16 @@
       <div class="info">
         <h4><span class="name">MusicBrainz Data Dumps</span></h4>
         <p>
-          The MusicBrainz Database is built on the PostgreSQL relational database engine and contains all of MusicBrainz' music metadata. This data includes but is not limited to artists, releases, labels and the relationships between them. In addition, there is
-          a full history of all the changes that the MusicBrainz community has made to the data.
+          The MusicBrainz Database is built on the PostgreSQL relational database engine and contains all of MusicBrainz' 
+          music metadata. This data includes but is not limited to artists, releases, labels and the relationships between them.
+          In addition, there is a full history of all the changes that the MusicBrainz community has made to the data.
         </p>
         <p>
-          MetaBrainz provides full database exports of the MusicBrainz database updated regularly and can be kept in sync with the main MusicBrainz database via the <a href="safjkla">Live Data Feed</a>. The MusicBrainz data dumps can be found on the
-          <a href="http://ftp.musicbrainz.org/pub/musicbrainz/data/fullexport/">MusicBrainz FTP Server</a> and more information on the contents of the various dump files can be found in the <a href="https://musicbrainz.org/doc/MusicBrainz_Database/Download">MusicBrainz documentation</a>.
+          MetaBrainz provides full database exports of the MusicBrainz database updated regularly and can be kept in sync 
+          with the main MusicBrainz database via the <a href="safjkla">Live Data Feed</a>. 
+          The MusicBrainz data dumps can be found on the <a href="http://ftp.musicbrainz.org/pub/musicbrainz/data/fullexport/">
+          MusicBrainz FTP Server</a> and more information on the contents of the various dump files can be found in the 
+          <a href="https://musicbrainz.org/doc/MusicBrainz_Database/Download">MusicBrainz documentation</a>.
         </p>
       </div>
     </div>
@@ -31,8 +36,10 @@
       <div class="info">
         <h4><span class="name">MusicBrainz JSON</span></h4>
         <p>
-          MetaBrainz also provides access to the music metadata in the MusicBrainz database in the easily consumable format of JSON documents. These JSON dumps can be downloaded from the
-          <a href="http://ftp.musicbrainz.org/pub/musicbrainz/data/json-dumps/">MusicBrainz FTP Server</a>. These dumps are <a href="https://creativecommons.org/share-your-work/public-domain/cc0/">CC0 licensed</a> but we ask <a href="{{ url_for('users.account_type') }}">commercial users</a>          to
+          MetaBrainz also provides access to the music metadata in the MusicBrainz database in the easily consumable format of JSON documents. 
+          These JSON dumps can be downloaded from the <a href="http://ftp.musicbrainz.org/pub/musicbrainz/data/json-dumps/">
+          MusicBrainz FTP Server</a>. These dumps are <a href="https://creativecommons.org/share-your-work/public-domain/cc0/">
+          CC0 licensed</a> but we ask <a href="{{ url_for('users.account_type') }}">commercial users</a> to
           <a href="{{ url_for('users.account_type') }}">support us</a> in order to help fund the creation and maintenance of these datasets.
         </p>
       </div>
@@ -42,12 +49,18 @@
       <div class="info">
         <h4><span class="name">ListenBrainz</span></h4>
         <p>
-          The <a href="https://listenbrainz.org">ListenBrainz</a> project serves as an archive where users can store their music listening history. This dataset can be used to create new music recommendation engines. The provided data dumps contains over
-          a 100 million listens in the ListenBrainz database. Also provided is access to a live feed of the ListenBrainz data on Google's BigQuery service.
+          The <a href="https://listenbrainz.org">ListenBrainz</a> project serves as an archive where users can store their music listening history. 
+          This dataset can be used to create new music recommendation engines. The provided data dumps contains over
+          a 100 million listens in the ListenBrainz database. 
+          Also provided is access to a live feed of the ListenBrainz data on Google's BigQuery service.
         </p>
         <p>
-          The ListenBrainz project creates new data dumps every two weeks, on the 1st and 15th of every month. These data dumps are <a href="https://creativecommons.org/share-your-work/public-domain/cc0/">CC0 licensed</a> and can be downloaded from the
-          <a href="http://ftp.musicbrainz.org/pub/musicbrainz/listenbrainz/fullexport/">MusicBrainz FTP Server</a>. For more information, please visit the <a href="https://listenbrainz.org">ListenBrainz website</a> and the <a href="https://listenbrainz.readthedocs.io/en/latest/dev/listenbrainz-dumps.html">ListenBrainz data dumps documentation</a>.
+          The ListenBrainz project creates new data dumps every two weeks, on the 1st and 15th of every month. 
+          These data dumps are <a href="https://creativecommons.org/share-your-work/public-domain/cc0/">CC0 licensed</a> 
+          and can be downloaded from the <a href="http://ftp.musicbrainz.org/pub/musicbrainz/listenbrainz/fullexport/">
+          MusicBrainz FTP Server</a>. For more information, please visit the <a href="https://listenbrainz.org">
+          ListenBrainz website</a> and the <a href="https://listenbrainz.readthedocs.io/en/latest/dev/listenbrainz-dumps.html">
+          ListenBrainz data dumps documentation</a>.
         </p>
       </div>
     </div>
@@ -58,12 +71,15 @@
       <div class="info">
         <h4><span class="name">AcousticBrainz</span></h4>
         <p>
-          The <a href="https://acousticbrainz.org">AcousticBrainz</a> project aims to crowdsource acoustic information for all music globally and make it available publicly. This information describes the acoustic characteristics of music, includes low-level
+          The <a href="https://acousticbrainz.org">AcousticBrainz</a> project aims to crowdsource acoustic information for all music globally and make it available publicly. 
+          This information describes the acoustic characteristics of music, includes low-level
           spectral information as well as information for genres, moods, keys, scales and much more.
         </p>
         <p>
-          The MetaBrainz Foundation provides dumps of the data in the AcousticBrainz database regularly. These dumps are seperated into low-level and high-level archives, each containing different types of information about music. A download of the full AcousticBrainz
-          database dump is also provided. For more information, please visit the <a href="http://acousticbrainz.org/download">AcousticBrainz downloads page</a>.
+          The MetaBrainz Foundation provides dumps of the data in the AcousticBrainz database regularly. 
+          These dumps are seperated into low-level and high-level archives, each containing different types of information about music. 
+          A download of the full AcousticBrainz database dump is also provided. 
+          For more information, please visit the <a href="http://acousticbrainz.org/download">AcousticBrainz downloads page</a>.
         </p>
       </div>
     </div>

--- a/metabrainz/templates/index/datasets.html
+++ b/metabrainz/templates/index/datasets.html
@@ -5,108 +5,82 @@
 {% block content %}
   <h1 class="page-title">{{ _('The MetaBrainz Datasets') }}</h1>
 
-  <p>
-    The MetaBrainz Foundation provides free, open access to various types of useful data
-    gathered and verified by volunteers. Here, we list and describe the various datasets we maintain.
-  </p>
+  <p> We ask <a href="{{ url_for('users.account_type') }}">commercial users</a> to <a href="{{ url_for('users.account_type') }}">support us</a> in order to help fund the creation and maintenance of these datasets. </p>
 
-  <div id="data">
-
+<p>
+  The MetaBrainz Foundation provides free, open access to various types of useful data gathered and verified by volunteers. Here, we list and describe the various datasets we maintain.
+</p>
+<div id="data">
+  <div class="column">
     <div class="dataset">
       <img class="logo" src="{{ url_for('static', filename='img/projects/musicbrainz.svg') }}" alt="MusicBrainz logo" />
       <div class="info">
         <h4><span class="name">MusicBrainz Data Dumps</span></h4>
         <p>
-          The MusicBrainz Database is built on the PostgreSQL relational database engine and
-          contains all of MusicBrainz' music metadata. This data includes information about
-          artists, release groups, releases, recordings, works, and labels, as well as the many
-          relationships between them. The database also contains a full history of all the
-          changes that the MusicBrainz community has made to the data.
+          The MusicBrainz Database is built on the PostgreSQL relational database engine and contains all of MusicBrainz' music metadata. This data includes but is not limited to artists, releases, labels and the relationships between them. In addition, there is
+          a full history of all the changes that the MusicBrainz community has made to the data.
         </p>
         <p>
-          MetaBrainz provides full database exports of the MusicBrainz database updated regularly
-          and also provides the possibility of keeping in sync with the main MusicBrainz database via
-          the <a href="safjkla">Live Data Feed</a>. The MusicBrainz data dumps can be found on the
-          <a href="http://ftp.musicbrainz.org/pub/musicbrainz/data/fullexport/">MusicBrainz FTP Server</a>
-          and more information on the contents of the various dump files can be found in the
-          <a href="https://musicbrainz.org/doc/MusicBrainz_Database/Download">MusicBrainz documentation</a>.
+          MetaBrainz provides full database exports of the MusicBrainz database updated regularly and can be kept in sync with the main MusicBrainz database via the <a href="safjkla">Live Data Feed</a>. The MusicBrainz data dumps can be found on the
+          <a href="http://ftp.musicbrainz.org/pub/musicbrainz/data/fullexport/">MusicBrainz FTP Server</a> and more information on the contents of the various dump files can be found in the <a href="https://musicbrainz.org/doc/MusicBrainz_Database/Download">MusicBrainz documentation</a>.
         </p>
       </div>
     </div>
-
     <div class="dataset">
       <img class="logo" src="{{ url_for('static', filename='img/projects/musicbrainz.svg') }}" alt="MusicBrainz logo" />
       <div class="info">
-        <h4><span class="name">MusicBrainz JSON Dumps</span></h4>
+        <h4><span class="name">MusicBrainz JSON</span></h4>
         <p>
-          MetaBrainz also provides access to the music metadata in the MusicBrainz database in the easily
-          consumable format of JSON documents. These JSON dumps can be downloaded from the
-          <a href="http://ftp.musicbrainz.org/pub/musicbrainz/data/json-dumps/">MusicBrainz FTP Server</a>.
-          These dumps are <a href="https://creativecommons.org/share-your-work/public-domain/cc0/">CC0 licensed</a>
-          but we ask <a href="{{ url_for('users.account_type') }}">commercial users</a> to
-          <a href="{{ url_for('users.account_type') }}">support us</a> in order to help fund the creation and
-          maintenance of these datasets.
+          MetaBrainz also provides access to the music metadata in the MusicBrainz database in the easily consumable format of JSON documents. These JSON dumps can be downloaded from the
+          <a href="http://ftp.musicbrainz.org/pub/musicbrainz/data/json-dumps/">MusicBrainz FTP Server</a>. These dumps are <a href="https://creativecommons.org/share-your-work/public-domain/cc0/">CC0 licensed</a> but we ask <a href="{{ url_for('users.account_type') }}">commercial users</a>          to
+          <a href="{{ url_for('users.account_type') }}">support us</a> in order to help fund the creation and maintenance of these datasets.
         </p>
       </div>
     </div>
-
     <div class="dataset">
       <img class="logo" src="{{ url_for('static', filename='img/projects/listenbrainz.svg') }}" alt="ListenBrainz logo" />
       <div class="info">
-        <h4><span class="name">ListenBrainz Data Dumps</span></h4>
+        <h4><span class="name">ListenBrainz</span></h4>
         <p>
-          The <a href="https://listenbrainz.org">ListenBrainz</a> project serves as an archive for users to store their music listening history.
-          This incredibly useful dataset can be used for the creation of new music recommendation engines.
-          The MetaBrainz Foundation provides data dumps containing over a 100 million listens in the ListenBrainz
-          database. We also provide access to a live feed of the ListenBrainz data on Google's BigQuery service.
+          The <a href="https://listenbrainz.org">ListenBrainz</a> project serves as an archive where users can store their music listening history. This dataset can be used to create new music recommendation engines. The provided data dumps contains over
+          a 100 million listens in the ListenBrainz database. Also provided is access to a live feed of the ListenBrainz data on Google's BigQuery service.
         </p>
         <p>
-          The ListenBrainz project creates new data dumps every two weeks, on the 1st and 15th of every month.
-          These data dumps are <a href="https://creativecommons.org/share-your-work/public-domain/cc0/">CC0 licensed</a>
-          and can be downloaded from the <a href="http://ftp.musicbrainz.org/pub/musicbrainz/listenbrainz/fullexport/">MusicBrainz FTP Server</a>.
-          For more information, please visit the <a href="https://listenbrainz.org">ListenBrainz website</a>
-          and the <a href="https://listenbrainz.readthedocs.io/en/latest/dev/listenbrainz-dumps.html">ListenBrainz data dumps documentation</a>.
+          The ListenBrainz project creates new data dumps every two weeks, on the 1st and 15th of every month. These data dumps are <a href="https://creativecommons.org/share-your-work/public-domain/cc0/">CC0 licensed</a> and can be downloaded from the
+          <a href="http://ftp.musicbrainz.org/pub/musicbrainz/listenbrainz/fullexport/">MusicBrainz FTP Server</a>. For more information, please visit the <a href="https://listenbrainz.org">ListenBrainz website</a> and the <a href="https://listenbrainz.readthedocs.io/en/latest/dev/listenbrainz-dumps.html">ListenBrainz data dumps documentation</a>.
         </p>
       </div>
     </div>
-
+  </div>
+  <div class="column">
     <div class="dataset">
       <img class="logo" src="{{ url_for('static', filename='img/projects/acousticbrainz.svg') }}" alt="AcousticBrainz logo" />
       <div class="info">
-        <h4><span class="name">AcousticBrainz Data Dumps</span></h4>
+        <h4><span class="name">AcousticBrainz</span></h4>
         <p>
-          The <a href="https://acousticbrainz.org">AcousticBrainz</a> project aims to crowd source acoustic information for all music in the
-          world and to make it available to the public. This acoustic information describes the
-          acoustic characteristics of music and includes low-level spectral information and
-          information for genres, moods, keys, scales and much more.
+          The <a href="https://acousticbrainz.org">AcousticBrainz</a> project aims to crowdsource acoustic information for all music globally and make it available publicly. This information describes the acoustic characteristics of music, includes low-level
+          spectral information as well as information for genres, moods, keys, scales and much more.
         </p>
         <p>
-          The MetaBrainz Foundation provides dumps of the data in the AcousticBrainz database regularly.
-          These dumps are seperated into low-level and high-level archives, each containing different types
-          of information about music. A download of the full AcousticBrainz database dump is also provided.
-          For more information, please visit the <a href="http://acousticbrainz.org/download">AcousticBrainz
-          downloads page</a>.
+          The MetaBrainz Foundation provides dumps of the data in the AcousticBrainz database regularly. These dumps are seperated into low-level and high-level archives, each containing different types of information about music. A download of the full AcousticBrainz
+          database dump is also provided. For more information, please visit the <a href="http://acousticbrainz.org/download">AcousticBrainz downloads page</a>.
         </p>
       </div>
     </div>
-
     <div class="dataset">
       <img class="logo" src="{{ url_for('static', filename='img/projects/critiquebrainz.svg') }}" alt="CritiqueBrainz logo" />
       <div class="info">
-        <h4><span class="name">CritiqueBrainz Data Dumps</span></h4>
+        <h4><span class="name">CritiqueBrainz</span></h4>
         <p>
-          <a href="https://critiquebrainz.org">CritiqueBrainz</a> is a repository for Creative Commons licensed music reviews. It fills the gap
-          between the factual music metadata in the MusicBrainz database and opinions about music of music
-          critics and listeners by providing a platform that archives Creative Commons licensed reviews.
+          <a href="https://critiquebrainz.org">CritiqueBrainz</a> is a repository for Creative Commons licensed music reviews. It fills the gap between the factual music metadata in the MusicBrainz database and opinions about music from music critics
+          and listeners by providing a platform that archives Creative Commons licensed reviews.
         </p>
         <p>
-          The MetaBrainz foundation provides full dumps of the CritiqueBrainz database
-          as well as JSON dumps containing reviews in a more easily consumable format.
-          These datasets are updated every day and can be downloaded from the
+          The MetaBrainz foundation provides full dumps of the CritiqueBrainz database as well as JSON dumps containing reviews in an easily consumable format. These datasets are updated every day and can be downloaded from the
           <a href="ftp://ftp.musicbrainz.org/pub/musicbrainz/critiquebrainz/">MusicBrainz FTP Server</a>.
         </p>
       </div>
     </div>
-
   </div>
+</div>
 {% endblock %}

--- a/metabrainz/templates/navbar.html
+++ b/metabrainz/templates/navbar.html
@@ -22,6 +22,7 @@
           <ul class="dropdown-menu" role="menu">
             <li><a href="{{ url_for('index.about') }}">{{ _('The Foundation') }}</a></li>
             <li><a href="{{ url_for('index.projects') }}">{{ _('Projects') }}</a></li>
+            <li><a href="{{ url_for('index.datasets') }}">{{ _('Datasets') }}</a></li>
             <li><a href="{{ url_for('index.team') }}">{{ _('Team') }}</a></li>
             <li><a href="{{ url_for('index.shop') }}">{{ _('Shop') }}</a></li>
           </ul>

--- a/metabrainz/views.py
+++ b/metabrainz/views.py
@@ -1,4 +1,4 @@
-import datetime 
+import datetime
 from flask import Blueprint, render_template, redirect, url_for
 from metabrainz.model.user import User
 
@@ -34,7 +34,7 @@ def contact():
     # Dear intelligent people who hate advertisers:
     #   No, we have no plans to add advertising, SEO, or software monetization to any of our pages.
     #   We are sick of being constantly harassed by advertisers, so we are giving them a place
-    #   to send their proposals to. We're never going to read them. We're never going to respond to 
+    #   to send their proposals to. We're never going to read them. We're never going to respond to
     #   any of the proposals. And the deadline will always be extended to next month. :)
     today = datetime.date.today()
     today += datetime.timedelta(31)
@@ -88,3 +88,8 @@ def about_customers_redirect():
 @index_bp.route('/shop')
 def shop():
     return render_template('index/shop.html')
+
+
+@index_bp.route('/datasets')
+def datasets():
+    return render_template('index/datasets.html')

--- a/metabrainz/views_test.py
+++ b/metabrainz/views_test.py
@@ -61,8 +61,10 @@ class IndexViewsTestCase(FlaskTestCase):
         self.assert200(resp)
         self.assertIn('flDebug', str(resp.data))
 
-
     def test_shop(self):
         response = self.client.get(url_for('index.shop'))
         self.assert200(response)
 
+    def test_datasets(self):
+        response = self.client.get(url_for('index.datasets'))
+        self.assert200(response)


### PR DESCRIPTION
The following changes have been made: 

1. Created a two column layout
2. Made the logos a bit smaller
3. Made the text flow around the logos
4. Streamlined the headings -- there is a lot of duplication -- not each heading needs to have the "Data Dumps" in.
5. Streamlined the descriptions 
6. Added a nice catch all commercial use statement at the top, with basically this sentiment: "we ask commercial users to support us in order to help fund the creation and maintenance of these datasets."
