### PR TITLE
Fix minor typographical errors etc. in GDPR, Privacy policies

### DIFF
--- a/metabrainz/templates/index/gdpr.html
+++ b/metabrainz/templates/index/gdpr.html
@@ -87,7 +87,7 @@
   <p>
     The ListenBrainz project differs in that the Listens (metadata about what music you have listened to) are stored on our servers 
     and <a href="https://listenbrainz.org/data">made available to the public</a>. We believe Listens to be personally identifying 
-    data and furthermore we have goals of creating open source recommendation engines with this data, which is becomes processing the 
+    data and furthermore we have goals of creating open source recommendation engines with this data, which involves processing the 
     user’s data. These two points are fundamental goals of the ListenBrainz project and we do not see a reasonable way to reach another 
     compromise position.
   </p>
@@ -113,7 +113,7 @@
   <p>
     The final point to restriction of processing is that we used to gather aggregate statistics about our web traffic (mostly to identify 
     which browsers our sites need to support) in Google Analytics. Google Analytics has always been a contentious service in the eyes 
-    of our community, so we decided to stop using the service and implement the minor feature of browsers analysis on our own servers at 
+    of our community, so we decided to stop using the service and implement the minor feature of browser analysis on our own servers at 
     a later point in time.
   </p>
   <p>
@@ -121,7 +121,7 @@
   </p>
   <ul>
      <li>
-       <a href="https://listenbrainz.org/login">Disclaimer for ListenBrainz
+       <a href="https://listenbrainz.org/login">Disclaimer for ListenBrainz</a>
      </li>
      <li>
        <a href="https://tickets.metabrainz.org/projects/LB/issues/LB-355">Delete Listens from BigQuery data</a>, 

--- a/metabrainz/templates/index/privacy.html
+++ b/metabrainz/templates/index/privacy.html
@@ -61,7 +61,7 @@
 
   <h3>{{ _('Third-Party content') }}</h3>
   <p>
-    Our project's web pages may load some third-party content. Some, but possibly not all sites are listed below:
+    Our projects' web pages may load some third-party content. Some, but possibly not all sites are listed below:
   </p>
 
   <ol>


### PR DESCRIPTION
***Not** part of the Google Code-in (GCI) competition*

This is just a quick pull request to fix some minor typos in the GDPR Compliance Policy and the Privacy Policy.

Related to #338 but I don't think any of our changes overlap

The changes include:
- Adding a closing `</a>` tag
- Substituting "which is becomes processing" for "which involves processing"
- Substituting "the minor feature of browsers analysis" for "browser" (no 's')
- Substituting "Our project's web pages" for "Our projects' web pages" (note position of apostrophe) because Metabrainz has many projects, each of which have their own web pages

I just also wanted to raise some other very minor points (not addressed by this PR):
- Some of the lines in the file have a trailing space, but others don't
- The spelling of some important words isn't standardised. Example: "personally-identifiable" (hyphenated) in privacy policy; "personally identifiable" (not hyphenated) in GDPR
- Is the "User-Agent" header (as referenced by the privacy policy) still collected after you phased out Google Analytics? (This just seems to conflict with my reading of the GDPR compliance policy -- though I appreciate you aren't constantly updating the privacy policy after every little change to which third parties are involved)