### PR TITLE
Add GitHub Sponsors to other ways to donate

### DIFF
--- a/metabrainz/templates/payments/donate.html
+++ b/metabrainz/templates/payments/donate.html
@@ -145,6 +145,10 @@
     <p>{{ _('If you use Flattr to donate to your favourite projects, you can click below to Flattr MetaBrainz:') }}</p>
     <p><a href="https://flattr.com/profile/metabrainz ">https://flattr.com/profile/metabrainz</a></p>
 
+    <h3>GitHub</h3>
+    <p>{{ _('If you use GitHub to sponsor your favourite projects, you can click below to Sponsor @metabrainz on GitHub Sponsors:') }}</p>
+    <p><a href="https://github.com/sponsors/metabrainz">https://github.com/sponsors/metabrainz</a></p>
+
   </div>
 {% endblock %}
 


### PR DESCRIPTION
Reciprocally, a link should be added from <https://github.com/sponsors/metabrainz> to <https://metabrainz.org/donate>.