### PR TITLE
Upgrade pip, brainzutils and pin package versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update \
                         libssl-dev \
      && rm -rf /var/lib/apt/lists/*
 COPY requirements.txt /code/
-RUN pip3 install pip==20.2.4
+RUN pip3 install pip==21.0.1
 RUN pip install --no-cache-dir -r requirements.txt
 RUN pip install --no-cache-dir uWSGI==2.0.15
 

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -20,7 +20,7 @@ RUN apt-get update \
                         libssl-dev \
      && rm -rf /var/lib/apt/lists/*
 COPY requirements.txt /code/
-RUN pip3 install pip==20.2.4
+RUN pip3 install pip==21.0.1
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . /code/

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -21,7 +21,7 @@ RUN mkdir /code
 WORKDIR /code
 
 COPY requirements.txt /code/
-RUN pip3 install pip==20.2.4
+RUN pip3 install pip==21.0.1
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . /code/

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -13,7 +13,7 @@ RUN apt-get update \
                         wget \
      && rm -rf /var/lib/apt/lists/*
 
-ENV DOCKERIZE_VERSION v0.2.0
+ENV DOCKERIZE_VERSION v0.6.1
 RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
     && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/metabrainz/brainzutils-python.git@v1.15.0
+git+https://github.com/metabrainz/brainzutils-python.git@v1.16.1
 click==6.7
 Werkzeug==1.0.1
 Flask-Admin==1.5.7
@@ -21,3 +21,16 @@ python-quickbooks==0.8.4
 intuit-oauth==1.2.3
 email_validator==1.0.5
 idna==2.7
+
+Flask==1.1.2
+Jinja2==2.11.2
+Flask-DebugToolbar==0.11.0
+Flask-UUID==0.2
+raven[flask]==6.10.0
+certifi
+redis==3.5.3
+msgpack-python==0.5.6
+requests==2.23.0
+SQLAlchemy==1.3.16
+mbdata==25.0.4
+sqlalchemy-dst==1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Flask-Babel==2.0.0
 Flask-Login==0.4.1
 Flask-SQLAlchemy==2.4.0
 Flask-Testing==0.8.1
--e git://github.com/maxcountryman/flask-uploads.git@f66d7dc93e68#egg=Flask_Uploads
+git+git://github.com/maxcountryman/flask-uploads.git@f66d7dc93e68#egg=Flask_Uploads
 Flask-WTF==0.14.3
 psycopg2==2.8.6
 pytest-cov==2.11.0
@@ -21,7 +21,6 @@ python-quickbooks==0.8.4
 intuit-oauth==1.2.3
 email_validator==1.0.5
 idna==2.7
-
 Flask==1.1.2
 Jinja2==2.11.2
 Flask-DebugToolbar==0.11.0


### PR DESCRIPTION
Upgrade to the latest version of pip and brainzutils. BU now uses open-ended versions, hence we pin all the versions here. The change in how flask_uploads dependency is specified has been made to avoid errors in the development mode.