### PR TITLE
Downgrade lessc to v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/metabrainz/metabrainz.org.git"
   },
   "dependencies": {
-    "less": "4.1.1",
+    "less": "3.13.1",
     "less-plugin-clean-css": "1.5.1"
   },
   "private": true


### PR DESCRIPTION
lessc v4 has suddenly started to err while building the Docker image. See https://gist.github.com/mayhem/afbd5da10f003013044a8b7e704fcd7d . I think this might be the issue https://github.com/less/less.js/issues/3608 we are facing. That still doesn't explain why it worked the last time. Anyways, downgrade to v3 for now.