### PR TITLE
Update nicks of team members as on Libera.Chat

### DIFF
--- a/metabrainz/templates/index/team.html
+++ b/metabrainz/templates/index/team.html
@@ -160,7 +160,7 @@
           {{ _('Born in Canada and raised in France, Nicolas now lives in Barcelona, Spain.') }}
         </p>
         <ul class="links">
-          <li><strong>IRC:</strong> Mr_Monkey</li>
+          <li><strong>IRC:</strong> monkey</li>
           <li><strong>GitHub:</strong> <a href="https://github.com/monkeydo">MonkeyDo</a></li>
         </ul>
       </div>
@@ -205,7 +205,7 @@
           CritiqueBrainz projects. He also spends a lot of time on the AcousticBrainz and ListenBrainz projects.') }}
         </p>
         <ul class="links">
-          <li><strong>IRC:</strong> _lucifer</li>
+          <li><strong>IRC:</strong> lucifer</li>
           <li><strong>GitHub:</strong> <a href="https://github.com/amCap1712">amCap1712</a></li>
         </ul>
       </div>
@@ -224,7 +224,7 @@
           When not staring at a screen, Param plays some chess and tries to listen to new music.') }}
         </p>
         <ul class="links">
-          <li><strong>IRC:</strong> iliekcomputers</li>
+          <li><strong>IRC:</strong> param</li>
           <li><strong>GitHub:</strong> <a href="https://github.com/paramsingh">paramsingh</a></li>
           <li><strong>Last.fm:</strong> <a href="http://www.last.fm/user/singhparam">singhparam</a></li>
           <li><strong>ListenBrainz:</strong> <a href="https://listenbrainz.org/user/iliekcomputers">iliekcomputers</a></li>


### PR DESCRIPTION
These are the new nicks of some of the team members on Libera.Chat. Will keep updating as the remaining members move to the new network,