### PR TITLE
Add actions workflows

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,4 @@
+template: |
+  ## What’s Changed
+
+  $CHANGES

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -1,0 +1,37 @@
+name: Build and publish image to Docker Hub
+
+on:
+  release:
+    types: [published]
+
+jobs:
+
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      # Github stores the current tag in an enviroment variable (GITHUB_REF) in the format /refs/tags/TAG_NAME.
+      # Using shell parameter expansion, we extract the TAG_NAME. Also, it seems we cannot use shell tricks
+      # directly in the with block, so doing it in a separate step and then fetching its output when needed.
+    - name: Get the tag name
+      id: get_tag
+      run: echo ::set-output name=TAG::${GITHUB_REF/refs\/tags\//}
+
+    - name: Docker Setup Buildx
+      uses: docker/setup-buildx-action@v1.3.0
+
+    - name: Docker Login
+      uses: docker/login-action@v1.9.0
+      with:
+        username: ${{ secrets.DOCKER_HUB_USERNAME }}
+        password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+
+    - name: Build and push Docker images
+      uses: docker/build-push-action@v2.4.0
+      with:
+        build-args: GIT_COMMIT_SHA=${{ github.sha }}
+        cache-from: metabrainz/metabrainz:cache
+        cache-to: metabrainz/metabrainz:cache
+        push: true
+        tags: metabrainz/metabrainz:${{ steps.get_tag.outputs.TAG }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,16 @@
+name: Release Drafter
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,3 +30,9 @@ jobs:
 
     - name: Run tests
       run: ./test.sh
+
+    - name: Publish Unit Test Results
+      uses: EnricoMi/publish-unit-test-result-action@v1.11
+      if: ${{ always() }}
+      with:
+        files: reports/tests.xml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,32 @@
+name: MetaBrainz Tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ '*' ]
+
+jobs:
+
+  test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Create configuration file
+      run: cp config.py.sample config.py
+
+    - name: Login to Docker Hub
+      run: echo ${{ secrets.DOCKER_HUB_PASSWORD }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
+      continue-on-error: true
+
+    - name: Pull docker images
+      run: docker-compose -f docker/docker-compose.test.yml pull
+
+    - uses: satackey/action-docker-layer-caching@v0.0.11
+      continue-on-error: true
+
+    - name: Run tests
+      run: ./test.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Create configuration file
-      run: cp config.py.sample config.py
+      run: cp config.py.example config.py
 
     - name: Login to Docker Hub
       run: echo ${{ secrets.DOCKER_HUB_PASSWORD }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -27,6 +27,4 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY . /code/
 
 CMD dockerize -wait tcp://db_test:5432 -timeout 60s \
-    py.test --junitxml=/data/test_report.xml \
-            --cov-report xml:/data/coverage.xml \
-            --cov-report html:/data/coverage-html
+    py.test --junitxml=reports/tests.xml

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -6,6 +6,8 @@ services:
     build:
       context: ..
       dockerfile: ./docker/Dockerfile.test
+    volumes:
+      - ..:/code:z
     depends_on:
       - db_test
       - redis

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -7,7 +7,7 @@ services:
       context: ..
       dockerfile: ./docker/Dockerfile.test
     volumes:
-      - ..:/code:z
+      - ..:/code
     depends_on:
       - db_test
       - redis

--- a/test.sh
+++ b/test.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
-
-docker-compose -f docker/docker-compose.test.yml up --build --remove-orphans
+docker-compose -f docker/docker-compose.test.yml up -d --build --remove-orphans db_test redis
+docker-compose -f docker/docker-compose.test.yml run --rm  web_test
+RET=$?
+docker-compose -f docker/docker-compose.test.yml down
+exit $RET


### PR DESCRIPTION
Adding action workflows for building production images, running tests and creating release notes. We are now moving to a date based tag and release as in other *Brainz. We should also remove the Jenkins job after merging this.