### PR TITLE
Validate integer query params

### DIFF
--- a/metabrainz/admin/views.py
+++ b/metabrainz/admin/views.py
@@ -20,6 +20,8 @@ import uuid
 import json
 import socket
 
+from metabrainz.utils import get_int_query_param
+
 
 class HomeView(AdminIndexView):
 
@@ -193,7 +195,7 @@ class CommercialUsersView(AdminBaseView):
 
     @expose('/')
     def index(self):
-        page = int(request.args.get('page', default=1))
+        page = get_int_query_param('page', default=1)
         if page < 1:
             return redirect(url_for('.index'))
         limit = 20
@@ -207,7 +209,7 @@ class PaymentsView(AdminBaseView):
 
     @expose('/')
     def list(self):
-        page = int(request.args.get('page', default=1))
+        page = get_int_query_param('page', default=1)
         is_donation_arg = request.args.get('is_donation')
         if is_donation_arg == "True":
             is_donation = True
@@ -283,12 +285,7 @@ class StatsView(AdminBaseView):
 
     @expose('/top-ips/')
     def top_ips(self):
-
-        days = 7
-        try:
-            days = int(request.args.get('days'))
-        except:
-            pass
+        days = get_int_query_param('days', default=7)
 
         non_commercial, commercial = AccessLog.top_ips(limit=100, days=days)
 
@@ -302,15 +299,9 @@ class StatsView(AdminBaseView):
             days=days
         )
 
-
     @expose('/top-tokens/')
     def top_tokens(self):
-
-        days = 7
-        try:
-            days = int(request.args.get('days'))
-        except:
-            pass
+        days = get_int_query_param('days', default=7)
 
         non_commercial, commercial = AccessLog.top_tokens(limit=100, days=days)
         return self.render(
@@ -323,7 +314,7 @@ class StatsView(AdminBaseView):
 
     @expose('/token-log')
     def token_log(self):
-        page = int(request.args.get('page', default=1))
+        page = get_int_query_param('page', default=1)
         if page < 1:
             return redirect(url_for('.token_log'))
         limit = 20

--- a/metabrainz/payments/views.py
+++ b/metabrainz/payments/views.py
@@ -10,6 +10,8 @@ import requests
 from requests.exceptions import RequestException
 from werkzeug.exceptions import BadRequest
 
+from metabrainz.utils import get_int_query_param
+
 payments_bp = Blueprint('payments', __name__)
 
 
@@ -47,7 +49,7 @@ def payment(currency):
 
 @payments_bp.route('/donors')
 def donors():
-    page = int(request.args.get('page', default=1))
+    page = get_int_query_param('page', default=1)
     if page < 1:
         return redirect(url_for('.donors'))
     limit = 30

--- a/metabrainz/utils.py
+++ b/metabrainz/utils.py
@@ -4,6 +4,8 @@ import random
 import string
 import subprocess
 
+from flask import request
+
 
 def reformat_datetime(value, format='%x %X %Z'):
     return value.strftime(format)
@@ -29,3 +31,10 @@ def build_url(base, additional_params=None):
         (url.scheme, url.netloc, url.path, url.params,
          urlencode(query_params), url.fragment)
     )
+
+
+def get_int_query_param(key, default):
+    try:
+        return int(request.args.get(key, default=default))
+    except ValueError:
+        return default

--- a/metabrainz/utils.py
+++ b/metabrainz/utils.py
@@ -33,7 +33,16 @@ def build_url(base, additional_params=None):
     )
 
 
-def get_int_query_param(key, default):
+def get_int_query_param(key: str, default: int):
+    """ Get an integer query parameter from the current request
+        Args:
+            key: the key whose value to retrieve
+            default: the value to return in case the param is missing
+             or not a valid integer
+        Returns:
+            the value of query param if its available and a valid integer,
+             else the default value
+    """
     try:
         return int(request.args.get(key, default=default))
     except ValueError:


### PR DESCRIPTION
and use the default value instead if param is not a valid integer

A bunch of errors related to this showed up in sentry, hence fixing it.