### PR TITLE
Simplify stripe keys configuration

### DIFF
--- a/config.py.example
+++ b/config.py.example
@@ -38,15 +38,9 @@ STRIPE_KEYS = {
     "PUBLISHABLE": "",
     "WEBHOOK_SECRET": ""
 }
-STRIPE_TEST_KEYS = {
-    "SECRET": "",
-    "PUBLISHABLE": "",
-    "WEBHOOK_SECRET": ""
-}
 
 # if developing payment integration locally, change this to your localhost url
 SERVER_BASE_URL = "https://metabrainz.org"
-
 
 
 # REDIS

--- a/consul_config.py.ctmpl
+++ b/consul_config.py.ctmpl
@@ -39,14 +39,9 @@ PAYPAL_ACCOUNT_IDS = {
 PAYPAL_BUSINESS = '''{{template "KEY" "payments/paypal/business_email"}}'''
 
 STRIPE_KEYS = {
-    "SECRET": '''{{template "KEY" "payments/stripe/prod/secret"}}''',
-    "PUBLISHABLE": '''{{template "KEY" "payments/stripe/prod/publishable"}}''',
-    "WEBHOOK_SECRET": '''{{template "KEY" "payments/stripe/prod/webhook_secret"}}''',
-}
-STRIPE_TEST_KEYS = {
-    "SECRET": '''{{template "KEY" "payments/stripe/test/secret"}}''',
-    "PUBLISHABLE": '''{{template "KEY" "payments/stripe/test/publishable"}}''',
-    "WEBHOOK_SECRET": '''{{template "KEY" "payments/stripe/test/webhook_secret"}}''',
+    "SECRET": '''{{template "KEY" "payments/stripe/secret"}}''',
+    "PUBLISHABLE": '''{{template "KEY" "payments/stripe/publishable"}}''',
+    "WEBHOOK_SECRET": '''{{template "KEY" "payments/stripe/webhook_secret"}}''',
 }
 
 # MusicBrainz Base URL must have a trailing slash.

--- a/metabrainz/__init__.py
+++ b/metabrainz/__init__.py
@@ -156,10 +156,7 @@ def create_app(debug=None, config_path = None):
     if app.config["QUICKBOOKS_CLIENT_ID"]:
         admin.add_view(QuickBooksView(name='Invoices', endpoint="quickbooks/", category='Quickbooks'))
 
-    if app.config["PAYMENT_PRODUCTION"]:
-        stripe.api_key = app.config["STRIPE_KEYS"]["SECRET"]
-    else:
-        stripe.api_key = app.config["STRIPE_TEST_KEYS"]["SECRET"]
+    stripe.api_key = app.config["STRIPE_KEYS"]["SECRET"]
 
     return app
 

--- a/metabrainz/payments/stripe/views.py
+++ b/metabrainz/payments/stripe/views.py
@@ -65,10 +65,7 @@ def pay():
 def webhook():
     payload = request.data
     sig_header = request.headers.get("Stripe-Signature")
-    if current_app.config["PAYMENT_PRODUCTION"]:
-        webhook_secret = current_app.config["STRIPE_KEYS"]["WEBHOOK_SECRET"]
-    else:
-        webhook_secret = current_app.config["STRIPE_TEST_KEYS"]["WEBHOOK_SECRET"]
+    webhook_secret = current_app.config["STRIPE_KEYS"]["WEBHOOK_SECRET"]
 
     try:
         event = stripe.Webhook.construct_event(payload, sig_header, webhook_secret)

--- a/metabrainz/payments/views.py
+++ b/metabrainz/payments/views.py
@@ -16,11 +16,7 @@ payments_bp = Blueprint('payments', __name__)
 @payments_bp.route('/donate')
 def donate():
     """Regular donation page."""
-    if current_app.config['PAYMENT_PRODUCTION']:
-        stripe_public_key = current_app.config['STRIPE_KEYS']['PUBLISHABLE']
-    else:
-        stripe_public_key = current_app.config['STRIPE_TEST_KEYS']['PUBLISHABLE']
-
+    stripe_public_key = current_app.config['STRIPE_KEYS']['PUBLISHABLE']
     return render_template('payments/donate.html', form=DonationForm(),
                            stripe_public_key=stripe_public_key)
 
@@ -37,10 +33,7 @@ def payment(currency):
     currency = currency.lower()
     if currency not in SUPPORTED_CURRENCIES:
         return redirect('.payment_selector')
-    if current_app.config['PAYMENT_PRODUCTION']:
-        stripe_public_key = current_app.config['STRIPE_KEYS']['PUBLISHABLE']
-    else:
-        stripe_public_key = current_app.config['STRIPE_TEST_KEYS']['PUBLISHABLE']
+    stripe_public_key = current_app.config['STRIPE_KEYS']['PUBLISHABLE']
     return render_template('payments/payment.html', form=PaymentForm(), currency=currency,
                            stripe_public_key=stripe_public_key)
 


### PR DESCRIPTION
We don't need a STRIPE_KEYS and another STRIPE_TEST_KEYS. Just keep one and put the keys you are using there. For consul config this means, that test.meb config contains the test keys only while the prod one uses live keys only.