### PR TITLE
Subscriptions using Stripe

### DIFF
--- a/metabrainz/model/payment.py
+++ b/metabrainz/model/payment.py
@@ -334,9 +334,9 @@ class Payment(db.Model):
 
         transaction = charge["balance_transaction"]
         currency = transaction["currency"].lower()
-        # if currency not in SUPPORTED_CURRENCIES:
-        #     current_app.logger.warning("Unsupported currency: ", session["currency"])
-        #     return
+        if currency not in SUPPORTED_CURRENCIES:
+            current_app.logger.warning("Unsupported currency: ", transaction["currency"])
+            return
 
         new_donation = cls(
             first_name=details["name"],

--- a/metabrainz/templates/payments/donate.html
+++ b/metabrainz/templates/payments/donate.html
@@ -192,9 +192,8 @@
         // This function disables or enables payment buttons depending on what
         // features they support.
 
-        // We don't support recurring payments via Stripe. Payments in EUR are
-        // also not supported currently.
-        if ($('#recurring-flag').is(":checked") || selectedCurrency === CURRENCY.Euro) {
+        // We don't support payments in EUR via Stripe currently.
+        if (selectedCurrency === CURRENCY.Euro) {
           buttons.stripe.attr('disabled', 'disabled');
         } else {
           buttons.stripe.removeAttr('disabled');
@@ -231,13 +230,6 @@
         } else {
           console.error("Unknown currency:", this.value)
         }
-        updateButtonState();
-      });
-
-      /////////////
-      // RECURRENCE
-      /////////////
-      $('#recurring-flag').change(function() {
         updateButtonState();
       });
 


### PR DESCRIPTION
The current implementation is able to create subscriptions but not cancel them. Cancelling stripe subscriptions requires us to store the donor's stripe customer id. This means that we'll need auth for stripe recurring subscriptions. Otherwise, we cannot be sure that a user's subscription is not messed up with by someone else. Before we go ahead to implement this, we should consider if this added complexoty is worth it.