### PR TITLE
Pin WTForms version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ Flask-SQLAlchemy==2.4.0
 Flask-Testing==0.8.1
 git+git://github.com/maxcountryman/flask-uploads.git@f66d7dc93e68#egg=Flask_Uploads
 Flask-WTF==0.14.3
+WTForms==2.3.3
 psycopg2-binary==2.8.6
 pytest-cov==2.11.0
 pytest==6.2.1


### PR DESCRIPTION
WTForms 3.* moves arounds some fields so imports need to be updated, possible Flask-WTF may need to be updated as well to be compatible with it. For now, pin the latest 2.* version.