### PR TITLE
Link CoC to conflict policy doc

### DIFF
--- a/metabrainz/templates/index/code-of-conduct.html
+++ b/metabrainz/templates/index/code-of-conduct.html
@@ -61,7 +61,10 @@
 
   <p>
     Each project may also define a Code of Conduct of its own that builds on the MetaBrainz social contract. For instance, have a look at
-    the <a href="https://musicbrainz.org/doc/Code_of_Conduct">MusicBrainz Code of Conduct</a>.
+    the <a href="https://musicbrainz.org/doc/Code_of_Conduct">MusicBrainz Code of Conduct</a>. Should you encounter a Code of Conduct violation
+    and want to find out how we deal with infractions, please take a look at our
+    <a href="https://metabrainz.org/conflict-policy">conflict resolution policy</a>.
+
   </p>
 
 {% endblock %}


### PR DESCRIPTION
It makes sense to have a straight link from "how to behave" to "what do we do if someone does not".

Mirrors https://github.com/metabrainz/.github/pull/4