### PR TITLE
Improve the clarity of the Privacy Policy exemption

### DIFF
--- a/metabrainz/templates/index/privacy.html
+++ b/metabrainz/templates/index/privacy.html
@@ -157,9 +157,9 @@
   <h2>{{ _('Exceptions') }}</h2>
   <p>
     <i><b>Please note</b>: Reasonable exceptions may apply to the above policy, for example to comply with applicable laws.
-    Also, members of the MetaBrainz team and other personnel contracted to provide services to MetaBrainz may have access
-    to our infrastructure and we can see any information we want to, but all of us are bound by non-disclosure clauses
-    in our contracts that prevent us from making any of that information available to others.</i>
+    Also, members of the MetaBrainz team and other personnel contracted to provide services to MetaBrainz may have access to
+    our infrastructure and could therefore view any information they wanted to. However all personnel are contractually bound
+    by non-disclosure clauses which prevent them from making any such information available to others.
   </p>
 
   <h2>{{ _('Privacy/GDPR Representative') }}</h2>

--- a/metabrainz/templates/index/privacy.html
+++ b/metabrainz/templates/index/privacy.html
@@ -158,7 +158,7 @@
   <p>
     <i><b>Please note</b>: Reasonable exceptions may apply to the above policy, for example to comply with applicable laws.
     Also, members of the MetaBrainz team and other personnel contracted to provide services to MetaBrainz may have access to
-    our infrastructure and could therefore view any information they wanted to. However all personnel are contractually bound
+    our infrastructure and could therefore view any information contained therein. However all personnel are contractually bound
     by non-disclosure clauses which prevent them from making any such information available to others.
   </p>
 

--- a/metabrainz/templates/index/privacy.html
+++ b/metabrainz/templates/index/privacy.html
@@ -156,9 +156,10 @@
 
   <h2>{{ _('Exceptions') }}</h2>
   <p>
-    <i><b>Please note</b>: Reasonable exceptions may apply to the above policy, for example to comply with applicable laws. The MetaBrainz 
-    server administrators (about five people in all) can of course see any information on the system they want to, but to be honest 
-    we're probably not interested enough to look.</i>
+    <i><b>Please note</b>: Reasonable exceptions may apply to the above policy, for example to comply with applicable laws.
+    Also, members of the MetaBrainz team and other personnel contracted to provide services to MetaBrainz may have access
+    to our infrastructure and we can see any information we want to, but all of us are bound by non-disclosure clauses
+    in our contracts that prevent us from making any of that information available to others.</i>
   </p>
 
   <h2>{{ _('Privacy/GDPR Representative') }}</h2>


### PR DESCRIPTION
The existent privacy policy is a little flippant and not very clear about who may actually have access to our infrastructure. This PR aims to clear this up.