### PR TITLE
Support fetching replication v2 packets

### DIFF
--- a/metabrainz/api/views/musicbrainz_test.py
+++ b/metabrainz/api/views/musicbrainz_test.py
@@ -73,6 +73,14 @@ class MusicBrainzViewsTestCase(FlaskTestCase):
         open(os.path.join(self.path, 'replication-1.tar.bz2'), 'a').close()
         self.assert200(self.client.get(url_for('api_musicbrainz.replication_hourly', packet_number=1, token=self.token)))
 
+    def test_replication_hourly_v2(self):
+        self.assert400(self.client.get(url_for('api_musicbrainz.replication_hourly_v2', packet_number=1)))
+        self.assert403(self.client.get(url_for('api_musicbrainz.replication_hourly_v2', packet_number=1, token='fake')))
+        self.assert404(self.client.get(url_for('api_musicbrainz.replication_hourly_v2', packet_number=1, token=self.token)))
+
+        open(os.path.join(self.path, 'replication-1-v2.tar.bz2'), 'a').close()
+        self.assert200(self.client.get(url_for('api_musicbrainz.replication_hourly_v2', packet_number=1, token=self.token)))
+
     def test_replication_hourly_signature(self):
         self.assert400(self.client.get(url_for('api_musicbrainz.replication_hourly_signature', packet_number=1)))
         self.assert403(self.client.get(url_for('api_musicbrainz.replication_hourly_signature', packet_number=1, token='fake')))
@@ -80,6 +88,14 @@ class MusicBrainzViewsTestCase(FlaskTestCase):
 
         open(os.path.join(self.path, 'replication-1.tar.bz2.asc'), 'a').close()
         self.assert200(self.client.get(url_for('api_musicbrainz.replication_hourly_signature', packet_number=1, token=self.token)))
+
+    def test_replication_hourly_signature_v2(self):
+        self.assert400(self.client.get(url_for('api_musicbrainz.replication_hourly_signature_v2', packet_number=1)))
+        self.assert403(self.client.get(url_for('api_musicbrainz.replication_hourly_signature_v2', packet_number=1, token='fake')))
+        self.assert404(self.client.get(url_for('api_musicbrainz.replication_hourly_signature_v2', packet_number=1, token=self.token)))
+
+        open(os.path.join(self.path, 'replication-1-v2.tar.bz2.asc'), 'a').close()
+        self.assert200(self.client.get(url_for('api_musicbrainz.replication_hourly_signature_v2', packet_number=1, token=self.token)))
 
     def test_json_dump(self):
         self.assert400(self.client.get(url_for('api_musicbrainz.json_dump', packet_number=1, entity_name='artist')))


### PR DESCRIPTION
Since the last schema change, MB now generates dbmirror2 replication packets, which exist in the same volume and have a '-v2' suffix after the packet number.

This commit adds initial support for fetching such packets to help me test them with replication and JSON dumps.

For now I just made it so that you fetch them how they're named on disk (with '-v2' suffix) but we could alternatively add an API subpath like /api/musicbrainz/v2/ if that's desirable.