### PR TITLE
Bump sentry-sdk from 0.20.3 to 1.14.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ pytz==2022.7.1
 rauth==0.7.3
 redis==3.5.3
 reportlab==3.6.12
-requests==2.23.0
+requests==2.28.2
 sentry-sdk[flask]==1.14.0
 six==1.15.0
 SQLAlchemy==1.4.18

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ rauth==0.7.3
 redis==3.5.3
 reportlab==3.6.12
 requests==2.23.0
-sentry-sdk[flask]==0.20.3
+sentry-sdk[flask]==1.14.0
 six==1.15.0
 SQLAlchemy==1.4.18
 sqlalchemy-dst>=1.0.1


### PR DESCRIPTION
to resolve CVE.