### PR TITLE
Fix dataset cards layout

### DIFF
--- a/metabrainz/static/css/main.less
+++ b/metabrainz/static/css/main.less
@@ -391,7 +391,7 @@ table.finances td:nth-child(2) {
 // Datasets page
 .dataset-card {
     background: #eee;
-    height: 16em;
+    min-height: 16em;
     filter: drop-shadow(0px 4px 4px fade(#000, 25%));
     border: 1px solid #e0e0e0;
     border-radius: 5px;
@@ -416,6 +416,17 @@ table.finances td:nth-child(2) {
         color: #eb743b;
         font-weight: bold;
     }
+}
+.dataset-flex-container{
+  display: flex;
+  align-items: stretch;
+  gap: 2em;
+  flex-wrap: wrap;
+  .dataset-card {
+    flex:1;
+    flex-basis: 455px; // replicate the behavior of col-md-6
+    margin: 0;
+  }
 }
 
 

--- a/metabrainz/templates/index/datasets.html
+++ b/metabrainz/templates/index/datasets.html
@@ -26,112 +26,100 @@
     </div>
   </div>
 
-  <div class="row">
+  <div class="dataset-flex-container">
 
-    <div class="col-md-6">
-      <div class="dataset-card">
-        <div class="dataset-card-logo">
-          <a href="/datasets/postgres-dumps#musicbrainz">
-            <img class="logo" src="{{ url_for('static', filename='img/projects/musicbrainz.svg') }}" alt="MusicBrainz logo" />
-          </a>
-        </div>
-        <div class="dataset-card-text">
-            <h4>
-              <a href="/datasets/postgres-dumps#musicbrainz">
-                <span class="dataset-card-heading">MusicBrainz PostgreSQL Data</span>
-              </a>
-            </h4>
-            <p>
-              This data dump includes all public portions of the data from our MusicBrainz project.
-              All artists, releases, recordings, labels and the relationships between them, and
-              much more data, including everything needed to run your own copy of MusicBrainz is
-              included.
-            </p>
-            <p>
-              <a href="/datasets/postgres-dumps#musicbrainz">Read more...</a>
-            </p>
-        </div>
+    <div class="dataset-card">
+      <div class="dataset-card-logo">
+        <a href="/datasets/postgres-dumps#musicbrainz">
+          <img class="logo" src="{{ url_for('static', filename='img/projects/musicbrainz.svg') }}" alt="MusicBrainz logo" />
+        </a>
+      </div>
+      <div class="dataset-card-text">
+          <h4>
+            <a href="/datasets/postgres-dumps#musicbrainz">
+              <span class="dataset-card-heading">MusicBrainz PostgreSQL Data</span>
+            </a>
+          </h4>
+          <p>
+            This data dump includes all public portions of the data from our MusicBrainz project.
+            All artists, releases, recordings, labels and the relationships between them, and
+            much more data, including everything needed to run your own copy of MusicBrainz is
+            included.
+          </p>
+          <p>
+            <a href="/datasets/postgres-dumps#musicbrainz">Read more...</a>
+          </p>
       </div>
     </div>
 
-    <div class="col-md-6">
-      <div class="dataset-card">
-        <div class="dataset-card-logo">
-          <a href="/datasets/postgres-dumps#musicbrainz-json">
-            <img class="logo" src="{{ url_for('static', filename='img/projects/musicbrainz.svg') }}" alt="MusicBrainz logo" />
-          </a>
-        </div>
-        <div class="dataset-card-text">
-            <h4>
-              <a href="/datasets/postgres-dumps#musicbrainz-json">
-                <span class="dataset-card-heading">MusicBrainz JSON Data</span>
-              </a>
-            </h4>
-            <p>
-              We also provide the MusicBrainz data in the easily consumable format of JSON documents. If you
-              simply cannot work with PostgreSQL or you prefer to work with a document oriented data store, then this
-              data dump is for you.
-            </p>
-            <p>
-              <a href="/datasets/postgres-dumps#musicbrainz-json">Read more...</a>
-            </p>
-        </div>
+    <div class="dataset-card">
+      <div class="dataset-card-logo">
+        <a href="/datasets/postgres-dumps#musicbrainz-json">
+          <img class="logo" src="{{ url_for('static', filename='img/projects/musicbrainz.svg') }}" alt="MusicBrainz logo" />
+        </a>
+      </div>
+      <div class="dataset-card-text">
+          <h4>
+            <a href="/datasets/postgres-dumps#musicbrainz-json">
+              <span class="dataset-card-heading">MusicBrainz JSON Data</span>
+            </a>
+          </h4>
+          <p>
+            We also provide the MusicBrainz data in the easily consumable format of JSON documents. If you
+            simply cannot work with PostgreSQL or you prefer to work with a document oriented data store, then this
+            data dump is for you.
+          </p>
+          <p>
+            <a href="/datasets/postgres-dumps#musicbrainz-json">Read more...</a>
+          </p>
+      </div>
+    </div
+
+    <div class="dataset-card">
+      <div class="dataset-card-logo">
+        <a href="/datasets/postgres-dumps#listenbrainz">
+          <img class="logo" src="{{ url_for('static', filename='img/projects/listenbrainz.svg') }}" alt="ListenBrainz logo" />
+        </a>
+      </div>
+      <div class="dataset-card-text">
+          <h4>
+            <a href="/datasets/postgres-dumps#listenbrainz">
+              <span class="dataset-card-heading">ListenBrainz PostgreSQL Data</span>
+            </a>
+          </h4>
+          <p>
+            ListenBrainz collects user listening information and creates insights for its users
+            about their own listening habits, as well as providing various tools for discovering new
+            music. All of this data, indexed against MusicBrainz, is available for
+            download.
+          </p>
+          <p>
+            <a href="/datasets/postgres-dumps#listenbrainz">Read more...</a>
+          </p>
       </div>
     </div>
 
-  </div>
-
-  <div class="row">
-
-    <div class="col-md-6">
-      <div class="dataset-card">
-        <div class="dataset-card-logo">
-          <a href="/datasets/postgres-dumps#listenbrainz">
-            <img class="logo" src="{{ url_for('static', filename='img/projects/listenbrainz.svg') }}" alt="ListenBrainz logo" />
-          </a>
-        </div>
-        <div class="dataset-card-text">
-            <h4>
-              <a href="/datasets/postgres-dumps#listenbrainz">
-                <span class="dataset-card-heading">ListenBrainz PostgreSQL Data</span>
-              </a>
-            </h4>
-            <p>
-              ListenBrainz collects user listening information and creates insights for its users
-              about their own listening habits, as well as providing various tools for discovering new
-              music. All of this data, indexed against MusicBrainz, is available for
-              download.
-            </p>
-            <p>
-              <a href="/datasets/postgres-dumps#listenbrainz">Read more...</a>
-            </p>
-        </div>
+    <div class="dataset-card">
+      <div class="dataset-card-logo">
+        <a href="/datasets/postgres-dumps#critiquebrainz">
+          <img class="logo" src="{{ url_for('static', filename='img/projects/critiquebrainz.svg') }}" alt="CritiqueBrainz logo" />
+        </a>
       </div>
-    </div>
-
-    <div class="col-md-6">
-      <div class="dataset-card">
-        <div class="dataset-card-logo">
-          <a href="/datasets/postgres-dumps#critiquebrainz">
-            <img class="logo" src="{{ url_for('static', filename='img/projects/critiquebrainz.svg') }}" alt="CritiqueBrainz logo" />
-          </a>
-        </div>
-        <div class="dataset-card-text">
-            <h4>
-              <a href="/datasets/postgres-dumps#critiquebrainz">
-                <span class="dataset-card-heading">CritiqueBrainz PostgreSQL Data</span>
-              </a>
-            </h4>
-            <p>
-              The <a href="https://critiquebrainz.org">CritiqueBrainz project</a> collects user reviews of music and
-              books, based on the data of the <a href="https://musicbrainz.org">MusicBrainz</a> and
-              <a href="https://bookbrainz.org">BookBrainz</a> projects. All of the reviews and everything
-              necessary to run your own copy of CritiqueBrainz is included in these data dumps.
-            </p>
-            <p>
-              <a href="/datasets/postgres-dumps#critiquebrainz">Read more...</a>
-            </p>
-        </div>
+      <div class="dataset-card-text">
+          <h4>
+            <a href="/datasets/postgres-dumps#critiquebrainz">
+              <span class="dataset-card-heading">CritiqueBrainz PostgreSQL Data</span>
+            </a>
+          </h4>
+          <p>
+            The <a href="https://critiquebrainz.org">CritiqueBrainz project</a> collects user reviews of music and
+            books, based on the data of the <a href="https://musicbrainz.org">MusicBrainz</a> and
+            <a href="https://bookbrainz.org">BookBrainz</a> projects. All of the reviews and everything
+            necessary to run your own copy of CritiqueBrainz is included in these data dumps.
+          </p>
+          <p>
+            <a href="/datasets/postgres-dumps#critiquebrainz">Read more...</a>
+          </p>
       </div>
     </div>
 
@@ -148,56 +136,52 @@
     </div>
   </div>
 
-  <div class="row">
+  <div class="dataset-flex-container">
 
-    <div class="col-md-6">
-      <div class="dataset-card">
-        <div class="dataset-card-logo">
-          <a href="/datasets/derived-dumps#canonical">
-            <img class="logo" src="{{ url_for('static', filename='img/projects/musicbrainz.svg') }}" alt="MusicBrainz logo" />
-          </a>
-        </div>
-        <div class="dataset-card-text">
-            <h4>
-              <a href="/datasets/derived-dumps#canonical">
-                <span class="dataset-card-heading">MusicBrainz Canonical Data Dumps</span>
-              </a>
-            </h4>
-            <p>
-              These dumps contain canonical MusicBrainz data, which makes it easier to reason about the core
-              metadata in MusicBrainz, providing one single record for each musical recording and release in
-              the database. This dataset is useful for matching data to or from MusicBrainz.
-            </p>
-            <p>
-              <a href="/datasets/derived-dumps#canonical">Read more...</a>
-            </p>
-        </div>
+    <div class="dataset-card">
+      <div class="dataset-card-logo">
+        <a href="/datasets/derived-dumps#canonical">
+          <img class="logo" src="{{ url_for('static', filename='img/projects/musicbrainz.svg') }}" alt="MusicBrainz logo" />
+        </a>
+      </div>
+      <div class="dataset-card-text">
+          <h4>
+            <a href="/datasets/derived-dumps#canonical">
+              <span class="dataset-card-heading">MusicBrainz Canonical Data Dumps</span>
+            </a>
+          </h4>
+          <p>
+            These dumps contain canonical MusicBrainz data, which makes it easier to reason about the core
+            metadata in MusicBrainz, providing one single record for each musical recording and release in
+            the database. This dataset is useful for matching data to or from MusicBrainz.
+          </p>
+          <p>
+            <a href="/datasets/derived-dumps#canonical">Read more...</a>
+          </p>
       </div>
     </div>
 
-    <div class="col-md-6">
-      <div class="dataset-card">
-        <div class="dataset-card-logo">
-          <a href="/datasets/derived-dumps#mhld">
-            <img class="logo" src="{{ url_for('static', filename='img/projects/listenbrainz.svg') }}" alt="ListenBrainz logo" />
-          </a>
-        </div>
-        <div class="dataset-card-text">
-            <h4>
-              <a href="/datasets/derived-dumps#mhld">
-                <span class="dataset-card-heading">MHLD+ Data Dump</span>
-              </a>
-            </h4>
-            <p>
-                The Music Listening Histories Dataset collects a large number of music listening
-                events assembled from more than 27 billion time-stamped logs extracted from Last.fm.
-                Using the MusicBrainz canonical data, we cleaned up errors in the data
-                in order to provide an improved version of this dataset.
-            </p>
-            <p>
-              <a href="/datasets/derived-dumps#mhld">Read more...</a>
-            </p>
-        </div>
+    <div class="dataset-card">
+      <div class="dataset-card-logo">
+        <a href="/datasets/derived-dumps#mhld">
+          <img class="logo" src="{{ url_for('static', filename='img/projects/listenbrainz.svg') }}" alt="ListenBrainz logo" />
+        </a>
+      </div>
+      <div class="dataset-card-text">
+          <h4>
+            <a href="/datasets/derived-dumps#mhld">
+              <span class="dataset-card-heading">MHLD+ Data Dump</span>
+            </a>
+          </h4>
+          <p>
+              The Music Listening Histories Dataset collects a large number of music listening
+              events assembled from more than 27 billion time-stamped logs extracted from Last.fm.
+              Using the MusicBrainz canonical data, we cleaned up errors in the data
+              in order to provide an improved version of this dataset.
+          </p>
+          <p>
+            <a href="/datasets/derived-dumps#mhld">Read more...</a>
+          </p>
       </div>
     </div>
 

--- a/metabrainz/templates/index/datasets.html
+++ b/metabrainz/templates/index/datasets.html
@@ -26,7 +26,7 @@
     </div>
   </div>
 
-  <div class="dataset-flex-container">
+  <div class="row dataset-flex-container">
 
     <div class="dataset-card">
       <div class="dataset-card-logo">
@@ -73,7 +73,7 @@
             <a href="/datasets/postgres-dumps#musicbrainz-json">Read more...</a>
           </p>
       </div>
-    </div
+    </div>
 
     <div class="dataset-card">
       <div class="dataset-card-logo">
@@ -136,7 +136,7 @@
     </div>
   </div>
 
-  <div class="dataset-flex-container">
+  <div class="row dataset-flex-container">
 
     <div class="dataset-card">
       <div class="dataset-card-logo">


### PR DESCRIPTION
On mobile, the fixed height css of the dataset page cards becomes an issue and text overlaps outside the cards.
![image](https://user-images.githubusercontent.com/6179856/236482463-c41a1424-c9cc-4dca-ae6c-f1bc42726707.png)


Using flexbox instead (because flexbox is the answer to all my problems) we can make the cards extend to be the same height as their neighbors, but also have that height be dynamic.