### PR TITLE
Archive annual reports

### DIFF
--- a/metabrainz/reports/annual_reports/files/2018/content.html
+++ b/metabrainz/reports/annual_reports/files/2018/content.html
@@ -1,0 +1,29 @@
+<h2>Archive notice</h2>
+
+<p>
+Annual reports from 2006 to 2017 are still available for history.
+There was no annual report in this form before 2006.
+Since 2018, no annual report has been produced as it was too much overhead for one person.
+Most of the information it was gathering is nowadays available as follows:
+</p>
+
+<ul>
+  <li>
+    <b>Year in review:</b>
+    Most major announcements are published on our
+    <a href="https://blog.metabrainz.org/">blog</a>.
+    Some minor annoucements are made during our
+    <a href="https://community.metabrainz.org/tag/metabrainz-meeting-notes">weekly meetings</a>.
+  </li>
+  <li>
+    <b>Finances:</b>
+    The same level of transparency is achieved through our
+    <a href="/finances/">financial reports</a>.
+  </li>
+  <li>
+    <b>Top MusicBrainz contributors:</b>
+    Annual statistics are no longer computed,
+    but weekly statistics and overall statistics are available from
+    <a href="https://musicbrainz.org/statistics/editors">MusicBrainz Database statistics</a>.
+  </li>
+</ul>

--- a/metabrainz/reports/annual_reports/files/2018/content.html
+++ b/metabrainz/reports/annual_reports/files/2018/content.html
@@ -1,7 +1,7 @@
 <h2>Archive notice</h2>
 
 <p>
-Annual reports from 2006 to 2017 are still available for history.
+Annual reports from 2006 to 2017 are still available for the record.
 There was no annual report in this form before 2006.
 Since 2018, no annual report has been produced as it was too much overhead for one person.
 Most of the information it was gathering is nowadays available as follows:

--- a/metabrainz/reports/annual_reports/files/2018/content.html
+++ b/metabrainz/reports/annual_reports/files/2018/content.html
@@ -1,10 +1,9 @@
 <h2>Archive notice</h2>
 
 <p>
-Annual reports from 2006 to 2017 are still available for the record.
-There was no annual report in this form before 2006.
-Since 2018, no annual report has been produced as there wasn’t enough interest into it.
-Most of the information it was gathering is nowadays available as follows:
+Annual reports from 2006 to 2017 are still available for the record. There was no annual report in this
+form before 2006 and since 2018, no annual reports have been produced as almost no one has shown interest
+in them. Most of the information it was gathering is nowadays available on the following resources:
 </p>
 
 <ul>

--- a/metabrainz/reports/annual_reports/files/2018/content.html
+++ b/metabrainz/reports/annual_reports/files/2018/content.html
@@ -3,7 +3,7 @@
 <p>
 Annual reports from 2006 to 2017 are still available for the record.
 There was no annual report in this form before 2006.
-Since 2018, no annual report has been produced as it was too much overhead for one person.
+Since 2018, no annual report has been produced as there wasn’t enough interest into it.
 Most of the information it was gathering is nowadays available as follows:
 </p>
 

--- a/metabrainz/templates/base.html
+++ b/metabrainz/templates/base.html
@@ -64,7 +64,7 @@
             <div class="col-sm-2">
               <div class="title"><a href="{{ url_for('financial_reports.index') }}">{{ _('Finances') }}</a></div>
               <ul>
-                <li><a href="{{ url_for('annual_reports.index') }}">{{ _('Annual Reports') }}</a></li>
+                <li><a href="{{ url_for('annual_reports.index') }}">{{ _('Archived Annual Reports') }}</a></li>
                 <li><a href="{{ url_for('payments.donors') }}">{{ _('Donors') }}</a></li>
                 <li><a href="{{ url_for('index.sponsors') }}">{{ _('Sponsors') }}</a></li>
                 <li><a href="{{ url_for('supporters.supporters_list') }}">{{ _('Supporters') }}</a></li>

--- a/metabrainz/templates/navbar.html
+++ b/metabrainz/templates/navbar.html
@@ -44,7 +44,7 @@
         <li class="dropdown">
           <a class="dropdown-toggle" data-toggle="dropdown" href="#">{{ _('Reports ') }}<span class="caret"></span></a>
           <ul class="dropdown-menu" role="menu">
-            <li><a href="{{ url_for('annual_reports.index') }}">{{ _('Annual Reports') }}</a></li>
+            <li><a href="{{ url_for('annual_reports.index') }}">{{ _('Archived Annual Reports') }}</a></li>
             <li><a href="{{ url_for('financial_reports.index') }}">{{ _('Financial Reports') }}</a></li>
             <li><a href="{{ url_for('payments.donors') }}">{{ _('Donors') }}</a></li>
           </ul>

--- a/metabrainz/templates/reports/annual_reports/view.html
+++ b/metabrainz/templates/reports/annual_reports/view.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% block title %}{{ _('Annual Report') }} {{ year }} - MetaBrainz Foundation{% endblock %}
 {% block content %}
-  <h1 class="page-title">{{ _('Annual Reports') }}</h1>
+  <h1 class="page-title">{{ _('Archived Annual Reports') }}</h1>
 
   <ul class="nav nav-pills">
     {% for current_year in all_years %}


### PR DESCRIPTION
It follows the comments to the pull request #412 (to replace it).

- Add archive notice to annual reports
- Reword the menu item “Annual Reports” (and same strings) as “Archived Annual Reports”