### PR TITLE
Pin urllib3==1.26.16 to fix actions build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,5 +35,6 @@ six==1.16.0
 SQLAlchemy==1.4.18
 sqlalchemy-dst>=1.0.1
 stripe==2.60.0
+urllib3==1.26.16
 Werkzeug==2.3.3
 WTForms==2.3.3


### PR DESCRIPTION
urllib3 2.0 requires newer versions of OpenSSL on the OS. For now, pin an older version.