### PR TITLE
Update privacy policy for switching to Weblate

### DIFF
--- a/metabrainz/templates/index/privacy.html
+++ b/metabrainz/templates/index/privacy.html
@@ -136,9 +136,10 @@
   </p>
 
   <p>
-    The localization service we use for creating localized versions of the MetaBrainz sites embeds email addresses into 
-    translation files that will be checked into our git repositories. If you participate in translating at Transifex, your email 
-    address will be visible in our git repositories.
+    Our translations platform is provided and hosted by Weblate, which has a data processing agreement with MetaBrainz.
+    Participating in translations is subject to <a href="https://translations.metabrainz.org/legal/">dedicated legal terms</a>.
+    Any translations you make will be submitted to our Git repositories and publicly associated with your username;
+    if you so choose, you can also publicly associate them with your own verified email address.
   </p>
 
   <h2>{{ _('MetaBrainz donors') }}</h2>


### PR DESCRIPTION
Additionally explain that the default email address is a no-reply since this behavior depends on the settings for our Weblate instance and thus this is not specified in the generic Weblate page for legal terms.