### PR TITLE
Remove caching from tests action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,12 +22,6 @@ jobs:
       run: echo ${{ secrets.DOCKER_HUB_PASSWORD }} | docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
       continue-on-error: true
 
-    - name: Pull docker images
-      run: docker-compose -f docker/docker-compose.test.yml pull
-
-    - uses: satackey/action-docker-layer-caching@v0.0.11
-      continue-on-error: true
-
     - name: Run tests
       run: ./test.sh
 


### PR DESCRIPTION
Running with docker image caching is slower than downloading the image from docker hub itself.