### PR TITLE
Non-commercial donate link was broken

### DIFF
--- a/metabrainz/templates/users/account-type.html
+++ b/metabrainz/templates/users/account-type.html
@@ -21,8 +21,8 @@
     research project, please sign up as a commercial user using the non-profit tier below. If you are a
     non-profit with more than 10 employees/contractors, or a pre-revenue start-up and expect to have
     revenue in the future, please sign up with a commercial account - see below for more details.
-    Please <a href="%(donate_url)s">consider making a donation</a> to support
-    our efforts!', donate_url=url_for('payments.donate')) }}
+    Please <a href="{{ url_for('payments.donate') }}">consider making a donation</a> to support
+    our efforts!
   </p>
 
   <p class="text-center">


### PR DESCRIPTION
![image](https://github.com/metabrainz/metabrainz.org/assets/38532/bc66c59d-8ef3-44b4-8763-f5362180468f)

This fixes the syntax which appears to have gotten broken 6 years ago during 12246c6