### PR TITLE
Update CI test results workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,9 @@ jobs:
   test:
 
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      pull-requests: write
 
     steps:
     - uses: actions/checkout@v2
@@ -26,7 +29,7 @@ jobs:
       run: ./test.sh
 
     - name: Publish Unit Test Results
-      uses: EnricoMi/publish-unit-test-result-action@v1.11
+      uses: EnricoMi/publish-unit-test-result-action@v2
       if: ${{ always() }}
       with:
         files: reports/tests.xml


### PR DESCRIPTION
Essentially applying the same changes as in https://github.com/metabrainz/critiquebrainz/pull/495 since I believe the workflow was copied from CB.
I noticed this test workflow has been consistently failing* even thought the testing step succeeds. The action that is supposed to publish the test results is failing due to permissions issues.

I'm now adding the required permissions to allow the workflow to write checks and comments on pull requests, as well as updating to a newer version of the action.

* see failures like so: https://github.com/metabrainz/metabrainz.org/actions/runs/6574602419/job/17898828849#step:7:31