### PR TITLE
Clarify Privacy Policy about web API

### DIFF
--- a/metabrainz/templates/index/privacy.html
+++ b/metabrainz/templates/index/privacy.html
@@ -54,8 +54,8 @@
   <h3>{{ _('Web and FTP access logs') }}</h3>
 
   <p>
-    In a practice similar to other web sites we keep logs of all web requests made against our servers. These logs include: your IP 
-    address, your browser's "User-Agent" string, and which page you requested. Aggregate information about web and FTP traffic is 
+    In a practice similar to other web sites (and APIs) we keep logs of all web requests made against our servers. These logs include: your IP
+    address, your browser's (or API client's) "User-Agent" string, and which page (or API endpoint) you requested with which parameters. Aggregate information about web and FTP traffic is
     made available to the public via our site usage pages.
   </p>
 


### PR DESCRIPTION
Two small updates to our [Privacy Policy](https://metabrainz.org/privacy):

1. It explicitly mentions web API calls in the paragraph about server logs. It comes after a [user’s question on IRC](https://chatlogs.metabrainz.org/libera/metabrainz/msg/5250667/).
2. <del>It drops FTP as we don’t use it anymore, datasets now have to be downloaded from web servers through HTTPS even though `ftp` remains in a couple of subdomain names for now.</del>