### PR TITLE
Fixing small wording mess

### DIFF
--- a/metabrainz/templates/index/gdpr.html
+++ b/metabrainz/templates/index/gdpr.html
@@ -87,7 +87,7 @@
   <p>
     The ListenBrainz project differs in that the Listens (metadata about what music you have listened to) are stored on our servers
     and <a href="https://listenbrainz.org/data">made available to the public</a>. We believe Listens to be personally identifying
-    data and furthermore, we have goals of creating open source recommendation engines with this data, which is becomes processing the
+    data and furthermore, we have goals of creating open source recommendation engines with this data, which involves processing the
     user’s data. These two points are fundamental goals of the ListenBrainz project and we do not see a reasonable way to reach another
     compromise position.
   </p>


### PR DESCRIPTION
"which is becomes" is clearly wrong, but I wasn't sure "which is" or "which becomes" was a lot better, so changing to "which involves". Reported at support.