### PR TITLE
Upgrade python, consul-template, uWSGI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON_BASE_IMAGE_VERSION=3.11-20221221
+ARG PYTHON_BASE_IMAGE_VERSION=3.11-20231006
 ARG NODE_VERSION=18-alpine
 FROM metabrainz/python:$PYTHON_BASE_IMAGE_VERSION as metabrainz-base
 
@@ -83,7 +83,7 @@ RUN npm run build:prod
 ###########################################
 FROM metabrainz-base as metabrainz-prod
 
-RUN pip install --no-cache-dir uWSGI==2.0.22
+RUN pip install --no-cache-dir uWSGI==2.0.23
 
 COPY ./docker/prod/consul-template-uwsgi.conf /etc/
 

--- a/docker/prod/consul-template-uwsgi.conf
+++ b/docker/prod/consul-template-uwsgi.conf
@@ -4,8 +4,8 @@ template {
 }
 
 exec {
-    command = "uwsgi /etc/uwsgi/uwsgi.ini"
-    splay = "30s"
+    command = ["uwsgi", "/etc/uwsgi/uwsgi.ini"]
+    splay = "5s"
     reload_signal = "SIGHUP"
     kill_signal = "SIGTERM"
     kill_timeout = "30s"

--- a/docker/prod/uwsgi.ini
+++ b/docker/prod/uwsgi.ini
@@ -1,4 +1,6 @@
 [uwsgi]
+uid = www-data
+gid = www-data
 master = true
 socket = 0.0.0.0:13031
 module = metabrainz
@@ -11,5 +13,4 @@ log-x-forwarded-for=true
 disable-logging = true
 ; quit uwsgi if the python app fails to load
 need-app = true
-; when uwsgi gets a sighup, quit completely and let runit restart us
-exit-on-reload = true
+die-on-term = true


### PR DESCRIPTION
We fixed the `bind(): Address already in use [core/socket.c line 769]` error using `exit-on-reload = true` in uWSGI configuration. However, this prevents graceful reloading.

I did some further investigation as noted in metabrainz/artwork-redirect#46 and have a better fix in mind now.

For the command field in exec block of consul template configuration, use array format. This executes the command directly without spawning a shell wrapper or setting a process group id. Both of which will interfere with forwarding signals to the uWSGI process.

This also needs a newer version of consul-template. So upgrading to a newer base image.