### PR TITLE
MEB-143: Update projects page v2

### DIFF
--- a/frontend/css/main.less
+++ b/frontend/css/main.less
@@ -214,8 +214,8 @@ h1.page-title, h2.page-title {
 }
 
 // Projects page
-#projects {
-  #projects-list > div {
+.projects {
+  .projects-list > div {
     padding: 10px;
     .clearfix;
     .logo-container {

--- a/metabrainz/templates/index/projects.html
+++ b/metabrainz/templates/index/projects.html
@@ -97,7 +97,6 @@
           </p>
         </div>
       </div>
-
     </div>
 
   </div>
@@ -105,8 +104,8 @@
   <h1 class="page-title">{{ _('Past Projects') }}</h1>
   <div id="projects">
 
-        <div id="projects-list" class="row">
-          <div class="col-md-6">
+    <div id="projects-list" class="row">
+      <div class="col-md-6">
         <div class="logo-container">
           <a href="https://acousticbrainz.org/">
             <img src="{{ url_for('static', filename='img/projects/acousticbrainz.svg') }}" alt="AcousticBrainz logo">
@@ -123,7 +122,7 @@
         </div>
       </div>
 
-          <div class="col-md-6">
+      <div class="col-md-6">
         <div class="logo-container">
           <a href="https://messybrainz.org/">
             <img src="{{ url_for('static', filename='img/projects/messybrainz.svg') }}" alt="MessyBrainz logo">
@@ -138,9 +137,8 @@
           </p>
         </div>
       </div>
-
     </div>
 
   </div>
-    
+
 {% endblock %}

--- a/metabrainz/templates/index/projects.html
+++ b/metabrainz/templates/index/projects.html
@@ -70,23 +70,6 @@
 
       <div class="col-md-6">
         <div class="logo-container">
-          <a href="https://acousticbrainz.org/">
-            <img src="{{ url_for('static', filename='img/projects/acousticbrainz.svg') }}" alt="AcousticBrainz logo">
-          </a>
-        </div>
-        <div>
-          <span class="title">{{ _('AcousticBrainz') }}</span>
-          <p>
-            {{ _('<a href="%(ab_url)s">AcousticBrainz</a> crowd sources acoustic information for all music in
-            the world and makes it available to the public. It is a joint effort with
-            <a href="%(mtg_url)s">Music Technology Group</a> at <a href="%(upf_url)s">Universitat Pompeu Fabra</a>
-            in Barcelona.', ab_url='https://acousticbrainz.org/', mtg_url='http://www.mtg.upf.edu/', upf_url='https://www.upf.edu/') }}
-          </p>
-        </div>
-      </div>
-
-      <div class="col-md-6">
-        <div class="logo-container">
           <a href="https://bookbrainz.org/">
             <img src="{{ url_for('static', filename='img/projects/bookbrainz.svg') }}" alt="BookBrainz logo">
           </a>
@@ -115,7 +98,32 @@
         </div>
       </div>
 
-      <div class="col-md-6">
+    </div>
+
+  </div>
+
+  <h1 class="page-title">{{ _('Past Projects') }}</h1>
+  <div id="projects">
+
+        <div id="projects-list" class="row">
+          <div class="col-md-6">
+        <div class="logo-container">
+          <a href="https://acousticbrainz.org/">
+            <img src="{{ url_for('static', filename='img/projects/acousticbrainz.svg') }}" alt="AcousticBrainz logo">
+          </a>
+        </div>
+        <div>
+          <span class="title">{{ _('AcousticBrainz') }}</span>
+          <p>
+            {{ _('<a href="%(ab_url)s">AcousticBrainz</a> crowd sourced acoustic information for all music in
+            the world and made it available to the public. It was a joint effort with
+            <a href="%(mtg_url)s">Music Technology Group</a> at <a href="%(upf_url)s">Universitat Pompeu Fabra</a>
+            in Barcelona.', ab_url='https://acousticbrainz.org/', mtg_url='http://www.mtg.upf.edu/', upf_url='https://www.upf.edu/') }}
+          </p>
+        </div>
+      </div>
+
+          <div class="col-md-6">
         <div class="logo-container">
           <a href="https://messybrainz.org/">
             <img src="{{ url_for('static', filename='img/projects/messybrainz.svg') }}" alt="MessyBrainz logo">
@@ -125,11 +133,14 @@
           <span class="title">{{ _('MessyBrainz') }}</span>
           <p>
             {{ _('<a href="%(messybrainz_url)s">MessyBrainz</a> identifies unclean metadata, and where possible,
-            links it to stable MusicBrainz identifiers. MessyBrainz is currently being used for AcousticBrainz and ListenBrainz.', messybrainz_url='https://messybrainz.org/') }}
+            links it to stable MusicBrainz identifiers. MessyBrainz was used for AcousticBrainz and is still being
+            used in ListenBrainz.', messybrainz_url='https://messybrainz.org/') }}
           </p>
         </div>
       </div>
+
     </div>
 
   </div>
+    
 {% endblock %}

--- a/metabrainz/templates/index/projects.html
+++ b/metabrainz/templates/index/projects.html
@@ -101,7 +101,7 @@
 
   </div>
 
-  <h1 class="page-title">{{ _('Past Projects') }}</h1>
+  <h2>{{ _('Past Projects') }}</h2>
   <div class="projects">
 
     <div class="projects-list row">

--- a/metabrainz/templates/index/projects.html
+++ b/metabrainz/templates/index/projects.html
@@ -4,9 +4,9 @@
 
 {% block content %}
   <h1 class="page-title">{{ _('MetaBrainz Projects') }}</h1>
-  <div id="projects">
+  <div class="projects">
 
-    <div id="projects-list" class="row">
+    <div class="projects-list row">
       <div class="col-md-6">
         <div class="logo-container">
           <a href="https://musicbrainz.org/">
@@ -102,9 +102,9 @@
   </div>
 
   <h1 class="page-title">{{ _('Past Projects') }}</h1>
-  <div id="projects">
+  <div class="projects">
 
-    <div id="projects-list" class="row">
+    <div class="projects-list row">
       <div class="col-md-6">
         <div class="logo-container">
           <a href="https://acousticbrainz.org/">


### PR DESCRIPTION
Remove AcousticBrainz and MessyBrainz from:
https://metabrainz.org/projects

This pull moves them to a 'Past Projects' section instead of removing them, as suggested by yvanzo in: https://github.com/metabrainz/metabrainz.org/pull/449