### PR TITLE
MEB-163: Update the docs for cancelling payments

### DIFF
--- a/metabrainz/templates/payments/cancel_recurring.html
+++ b/metabrainz/templates/payments/cancel_recurring.html
@@ -6,16 +6,20 @@
   <h1 class="page-title">{{ _('Cancelling recurring payments') }}</h1>
 
   <p>
-    {{ _('In case you want to cancel recurring donation (payment) that you set up before,
-    you\'ll need to go to a service which you used to pay.') }}
+    {{ _('If you want to cancel a recurring donation (payment) that you have set up:') }}
   </p>
-
-  <p>
-    {{ _('Here are links to more information:') }}
-    <strong>
-      <ul>
-        <li><a href="https://www.paypal.com/selfhelp/article/FAQ2058">PayPal</a></li>
-      </ul>
-    </strong>
-  </p>
+ 
+  <ul>
+    <li>
+      {{ _('For Stripe, we will cancel your donation manually. 
+      Please <a href="%(contact_url)s">contact us</a>, indicating the name
+      on the card used to set up the payment.',
+      contact_url=url_for('index.contact')) }}
+    </li>
+    <li>
+      {{ _('For PayPal, you will need to cancel from their site.
+      See <a href="%(paypal_cancel_url)s">their documentation</a>.',
+      paypal_cancel_url='https://www.paypal.com/us/cshelp/article/what-is-an-automatic-payment-and-how-do-i-update-or-cancel-one-help240') }}
+    </li>
+  </ul>
 {% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,6 @@ intuit-oauth==1.2.5
 itsdangerous==2.1.2
 Jinja2==3.1.4
 MarkupSafe==2.1.5
-mbdata==26.0.1
 msgpack==0.5.6
 psycopg2-binary==2.9.7
 pytest==8.1.1


### PR DESCRIPTION
This had a PayPal link which, as far as I can tell, was meant to dispute one-off payments (so, not what we wanted at all), and it didn't mention what to do for Stripe payments (our primary choice at the moment) at all.

Updated the PayPal link to one that is at least about cancelling automatic payments (it's from PayPal US but I'd hope a similar process applies elsewhere), and mentioned that users should contact us if they want their Stripe payment cancelled.

Tested locally, seems to work fine.