### PR TITLE
Add script to copy musicbrainz row ids for payment table

### DIFF
--- a/metabrainz/supporter/copy_mb_row_ids.py
+++ b/metabrainz/supporter/copy_mb_row_ids.py
@@ -7,14 +7,14 @@ from metabrainz import db
 mb_db_conn = "postgresql://musicbrainz_ro@10.2.2.25:65437/musicbrainz_db"
 
 
-def copy_row_ids():
-    current_app.logger.info("Beginning to update emails for users...")
+def copy_row_ids_for_table(table_name, fetch_query, update_query):
+    current_app.logger.info(f"Beginning to update emails for {table_name}")
     connection = db.engine.raw_connection()
     try:
         with (connection.cursor() as cursor,
               psycopg2.connect(mb_db_conn) as mb_connection,
               mb_connection.cursor() as mb_curs):
-            cursor.execute("SELECT musicbrainz_id FROM supporter")
+            cursor.execute(fetch_query)
             editor_ids = [(row[0],) for row in cursor.fetchall()]
             current_app.logger.info("Fetched musicbrainz ids from MeB.")
 
@@ -30,17 +30,32 @@ def copy_row_ids():
             editors = [(r[0], r[1]) for r in results]
             current_app.logger.info("Fetched editor emails from MusicBrainz.")
 
-            query = """
-                UPDATE supporter s
-                   SET musicbrainz_row_id = t.musicbrainz_row_id
-                  FROM (VALUES %s) AS t(musicbrainz_row_id, musicbrainz_id)
-                WHERE s.musicbrainz_id = t.musicbrainz_id
-            """
-            execute_values(cursor, query, editors)
-            current_app.logger.info("Updated row ids of supporters.")
+            execute_values(cursor, update_query, editors)
+            current_app.logger.info(f"Updated row ids of {table_name}.")
         connection.commit()
     except psycopg2.errors.OperationalError:
-        current_app.logger.error("Error while updating emails of MetaBrainz supporters", exc_info=True)
+        current_app.logger.error(f"Error while updating musicbrainz row ids in {table_name}", exc_info=True)
         connection.rollback()
     finally:
         connection.close()
+
+
+def copy_row_ids():
+    supporter_fetch_query = "SELECT musicbrainz_id FROM supporter"
+    supporter_update_query = """
+        UPDATE supporter s
+           SET musicbrainz_row_id = t.musicbrainz_row_id
+          FROM (VALUES %s) AS t(musicbrainz_row_id, musicbrainz_id)
+        WHERE s.musicbrainz_id = t.musicbrainz_id
+    """
+
+    payment_fetch_query = "SELECT DISTINCT editor_name FROM payment WHERE editor_name IS NOT NULL"
+    payment_update_query = """
+        UPDATE payment p
+           SET editor_id = t.musicbrainz_row_id
+          FROM (VALUES %s) AS t(musicbrainz_row_id, musicbrainz_id)
+         WHERE p.editor_name = t.musicbrainz_id
+    """
+
+    copy_row_ids_for_table("supporter", supporter_fetch_query, supporter_update_query)
+    copy_row_ids_for_table("payment", payment_fetch_query, payment_update_query)


### PR DESCRIPTION
An earlier iteration of updating musicbrainz row ids in payment table (#480) depending on the editor making the donation being present in the supporter table. However on running it in production, this didn't turn out to be the case. Hence, update the script to directly copy row ids from MusicBrainz.