### PR TITLE
Fetch musicbrainz_row_id from MB for non-supporters

### DIFF
--- a/config.py.example
+++ b/config.py.example
@@ -7,6 +7,7 @@ SECRET_KEY = "CHANGE_THIS"
 
 # DATABASE
 SQLALCHEMY_DATABASE_URI = "postgresql://metabrainz:metabrainz@db:5432/metabrainz"
+SQLALCHEMY_DATABASE_URI = ""
 SQLALCHEMY_TRACK_MODIFICATIONS = False
 
 POSTGRES_ADMIN_URI = "postgresql://postgres:postgres@db/postgres"

--- a/consul_config.py.ctmpl
+++ b/consul_config.py.ctmpl
@@ -16,6 +16,7 @@ DEBUG = False
 {{if service "pgbouncer-master"}}
 {{with index (service "pgbouncer-master") 0}}
 SQLALCHEMY_DATABASE_URI = "postgresql://{{template "KEY" "postgresql/username"}}:{{template "KEY" "postgresql/password"}}@{{.Address}}:{{.Port}}/{{template "KEY" "postgresql/db_name"}}"
+SQLALCHEMY_MUSICBRAINZ_URI = 'postgresql://musicbrainz_ro@{{.Address}}:{{.Port}}/musicbrainz_db'
 {{end}}
 {{end}}
 

--- a/metabrainz/__init__.py
+++ b/metabrainz/__init__.py
@@ -92,6 +92,9 @@ def create_app(debug=None, config_path=None):
     # Database
     from metabrainz import db
     db.init_db_engine(app.config["SQLALCHEMY_DATABASE_URI"])
+    if app.config.get("SQLALCHEMY_MUSICBRAINZ_URI", None):
+        db.init_mb_db_engine(app.config["SQLALCHEMY_MUSICBRAINZ_URI"])
+
     from metabrainz import model
     model.db.init_app(app)
 

--- a/metabrainz/db/__init__.py
+++ b/metabrainz/db/__init__.py
@@ -4,10 +4,17 @@ from sqlalchemy.pool import NullPool
 
 engine: sqlalchemy.engine.Engine = None
 
+mb_engine: sqlalchemy.engine.Engine = None
+
 
 def init_db_engine(connect_str):
     global engine
     engine = create_engine(connect_str, poolclass=NullPool)
+
+
+def init_mb_db_engine(connect_str):
+    global mb_engine
+    mb_engine = create_engine(connect_str, poolclass=NullPool)
 
 
 def run_sql_script(sql_file_path):


### PR DESCRIPTION
A supporter account is not required for donations, hence fallback to checking MB db for musicbrainz_row_id if the specified editor_name is not associated with a supporter.