### PR TITLE
Replacing "IRC" with "Chat" or "ChatBrainz"

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,14 +128,14 @@ web# ./node_modules/.bin/lessc ./metabrainz/static/fonts/font_awesome/less/font-
 
 Once you have built and started all the services as mentioned above, run:
 
-`$ ./develop.sh manage extract_strings`
+`$ ./develop.sh manage extract-strings`
 
 ### Compiling the strings
 
 The POT files are compiled automatically every time the services are built, but in case you make any changes to the POT files
 and want to compile the translation files again, run:
 
-`$ ./develop.sh manage compile_translations`
+`$ ./develop.sh manage compile-translations`
 
 
 ## Testing

--- a/metabrainz/babel.cfg
+++ b/metabrainz/babel.cfg
@@ -1,3 +1,2 @@
 [python: **.py]
 [jinja2: **/templates/**.html]
-extensions=jinja2.ext.autoescape,jinja2.ext.with_

--- a/metabrainz/messages.pot
+++ b/metabrainz/messages.pot
@@ -1,62 +1,54 @@
 # Translations template for PROJECT.
-# Copyright (C) 2017 ORGANIZATION
+# Copyright (C) 2024 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
 #
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-01-27 14:44+0100\n"
+"POT-Creation-Date: 2024-10-29 09:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.3.4\n"
+"Generated-By: Babel 2.16.0\n"
 
-#: metabrainz/payments/forms.py:9
-msgid "You need to specify amount!"
-msgstr ""
-
-#: metabrainz/payments/forms.py:21
-msgid "You need to specify invoice number!"
-msgstr ""
-
-#: metabrainz/payments/views.py:105
+#: metabrainz/payments/views.py:155
 msgid ""
 "Thank you for making a donation to the MetaBrainz Foundation. Your "
 "support is greatly appreciated! It may take some time before your "
 "donation appears in the list due to processing delays."
 msgstr ""
 
-#: metabrainz/payments/views.py:112
+#: metabrainz/payments/views.py:162
 msgid ""
 "Thank you for making a payment to the MetaBrainz Foundation. Your support"
 " is greatly appreciated!"
 msgstr ""
 
-#: metabrainz/payments/views.py:123
+#: metabrainz/payments/views.py:173
 msgid ""
 "We're sorry to see that you won't be donating today. We hope that you'll "
 "change your mind!"
 msgstr ""
 
-#: metabrainz/payments/views.py:129
+#: metabrainz/payments/views.py:179
 msgid ""
 "We're sorry to see that you won't be paying today. We hope that you'll "
 "change your mind!"
 msgstr ""
 
-#: metabrainz/payments/views.py:143
+#: metabrainz/payments/views.py:193
 msgid ""
 "We're sorry, but it appears we've run into an error and can't process "
 "your donation."
 msgstr ""
 
-#: metabrainz/payments/views.py:149
+#: metabrainz/payments/views.py:199
 msgid ""
 "We're sorry, but it appears we've run into an error and can't process "
 "your payment."
@@ -66,90 +58,314 @@ msgstr ""
 msgid "Requested annual report was not found."
 msgstr ""
 
-#: metabrainz/templates/base.html:48
+#: metabrainz/supporter/forms.py:26
+#, python-format
+msgid "'%(value)s' is not a valid choice for this field"
+msgstr ""
+
+#: metabrainz/supporter/forms.py:41
+msgid "Contact name is required!"
+msgstr ""
+
+#: metabrainz/supporter/forms.py:42
+msgid "Email address is required!"
+msgstr ""
+
+#: metabrainz/supporter/forms.py:44
+msgid ""
+"Can you please tell us more about the project in which you'd like to use "
+"our data? Do you plan to self host the data or use our APIs?"
+msgstr ""
+
+#: metabrainz/supporter/forms.py:46
+msgid "Please, tell us how you (will) use our data."
+msgstr ""
+
+#: metabrainz/supporter/forms.py:47
+msgid "Please, limit usage description to 500 characters."
+msgstr ""
+
+#: metabrainz/supporter/forms.py:50
+msgid "You need to accept the agreement!"
+msgstr ""
+
+#: metabrainz/supporter/forms.py:70
+msgid "Organization name"
+msgstr ""
+
+#: metabrainz/supporter/forms.py:71
+msgid "You need to specify the name of your organization."
+msgstr ""
+
+#: metabrainz/supporter/forms.py:73
+msgid "Organization description"
+msgstr ""
+
+#: metabrainz/supporter/forms.py:74
+msgid "You need to provide description of your organization."
+msgstr ""
+
+#: metabrainz/supporter/forms.py:77
+msgid "Website URL"
+msgstr ""
+
+#: metabrainz/supporter/forms.py:78
+msgid "You need to specify website of the organization."
+msgstr ""
+
+#: metabrainz/supporter/forms.py:80
+msgid "Logo image URL"
+msgstr ""
+
+#: metabrainz/supporter/forms.py:81
+msgid "API URL"
+msgstr ""
+
+#: metabrainz/supporter/forms.py:83
+msgid "Street"
+msgstr ""
+
+#: metabrainz/supporter/forms.py:84
+msgid "You need to specify street."
+msgstr ""
+
+#: metabrainz/supporter/forms.py:86
+msgid "City"
+msgstr ""
+
+#: metabrainz/supporter/forms.py:87
+msgid "You need to specify city."
+msgstr ""
+
+#: metabrainz/supporter/forms.py:89
+msgid "State / Province"
+msgstr ""
+
+#: metabrainz/supporter/forms.py:90
+msgid "You need to specify state/province."
+msgstr ""
+
+#: metabrainz/supporter/forms.py:92
+msgid "Postcode"
+msgstr ""
+
+#: metabrainz/supporter/forms.py:93
+msgid "You need to specify postcode."
+msgstr ""
+
+#: metabrainz/supporter/forms.py:95
+msgid "Country"
+msgstr ""
+
+#: metabrainz/supporter/forms.py:96
+msgid "You need to specify country."
+msgstr ""
+
+#: metabrainz/supporter/forms.py:104
+msgid "Name"
+msgstr ""
+
+#: metabrainz/supporter/forms.py:105
+msgid "Contact name field is empty."
+msgstr ""
+
+#: metabrainz/supporter/forms.py:107
+msgid "Email"
+msgstr ""
+
+#: metabrainz/supporter/forms.py:109
+msgid "Email field is not a valid email address."
+msgstr ""
+
+#: metabrainz/supporter/forms.py:110
+msgid "Contact email field is empty."
+msgstr ""
+
+#: metabrainz/supporter/views.py:55
+msgid "Can't find tier with a specified ID."
+msgstr ""
+
+#: metabrainz/supporter/views.py:69 metabrainz/supporter/views.py:75
+msgid "Please select account type to sign up."
+msgstr ""
+
+#: metabrainz/supporter/views.py:92
+msgid "You need to choose support tier before signing up!"
+msgstr ""
+
+#: metabrainz/supporter/views.py:102
+msgid "You need to choose existing tier before signing up!"
+msgstr ""
+
+#: metabrainz/supporter/views.py:121
+msgid ""
+"Custom amount must be more than threshold amountfor selected tier or "
+"equal to it!"
+msgstr ""
+
+#: metabrainz/supporter/views.py:156
+msgid ""
+"Thanks for signing up! Your application will be reviewed soon. We will "
+"send you updates via email."
+msgstr ""
+
+#: metabrainz/supporter/views.py:173 metabrainz/supporter/views.py:243
+msgid ""
+"Failed to send welcome email to you. We are looking into it. Sorry for "
+"inconvenience!"
+msgstr ""
+
+#: metabrainz/supporter/views.py:178 metabrainz/supporter/views.py:248
+msgid "You already have a MetaBrainz account!"
+msgstr ""
+
+#: metabrainz/supporter/views.py:232
+msgid "Thanks for signing up!"
+msgstr ""
+
+#: metabrainz/supporter/views.py:278 metabrainz/supporter/views.py:286
+msgid "Login failed!"
+msgstr ""
+
+#: metabrainz/supporter/views.py:281
+msgid "Authorization code is missing!"
+msgstr ""
+
+#: metabrainz/supporter/views.py:357
+msgid "Can't generate new token unless account is active."
+msgstr ""
+
+#: metabrainz/templates/base.html:44
 msgid "Foundation"
 msgstr ""
 
-#: metabrainz/templates/base.html:50 metabrainz/templates/index/projects.html:3
+#: metabrainz/templates/base.html:46 metabrainz/templates/index/projects.html:3
 #: metabrainz/templates/navbar.html:24
 msgid "Projects"
 msgstr ""
 
-#: metabrainz/templates/base.html:51 metabrainz/templates/index/team.html:3
+#: metabrainz/templates/base.html:47 metabrainz/templates/index/datasets.html:3
+#: metabrainz/templates/index/datasets/derived-dumps.html:3
+#: metabrainz/templates/index/datasets/postgres-dumps.html:3
 #: metabrainz/templates/navbar.html:25
+msgid "Datasets"
+msgstr ""
+
+#: metabrainz/templates/base.html:48 metabrainz/templates/index/team.html:3
+#: metabrainz/templates/navbar.html:26
 msgid "Team"
 msgstr ""
 
-#: metabrainz/templates/base.html:52 metabrainz/templates/index/sponsors.html:3
-#: metabrainz/templates/index/sponsors.html:6
-#: metabrainz/templates/index/sponsors.html:20
-#: metabrainz/templates/navbar.html:29
-msgid "Sponsors"
+#: metabrainz/templates/base.html:49 metabrainz/templates/navbar.html:27
+msgid "Shop"
 msgstr ""
 
-#: metabrainz/templates/base.html:53 metabrainz/templates/navbar.html:28
-#: metabrainz/templates/users/supporters-list.html:3
-#: metabrainz/templates/users/supporters-list.html:6
-msgid "Supporters"
+#: metabrainz/templates/base.html:53
+msgid "Policies"
 msgstr ""
 
-#: metabrainz/templates/base.html:54 metabrainz/templates/index/privacy.html:6
+#: metabrainz/templates/base.html:55
+#: metabrainz/templates/index/social-contract.html:3
+#: metabrainz/templates/index/social-contract.html:6
+#: metabrainz/templates/navbar.html:34
+msgid "Social Contract"
+msgstr ""
+
+#: metabrainz/templates/base.html:56
+#: metabrainz/templates/index/code-of-conduct.html:3
+#: metabrainz/templates/index/code-of-conduct.html:16
+#: metabrainz/templates/navbar.html:35
+msgid "Code of Conduct"
+msgstr ""
+
+#: metabrainz/templates/base.html:57 metabrainz/templates/index/privacy.html:6
+#: metabrainz/templates/navbar.html:36
 msgid "Privacy Policy"
 msgstr ""
 
-#: metabrainz/templates/base.html:58
+#: metabrainz/templates/base.html:61
 #: metabrainz/templates/reports/financial_reports/index.html:3
 #: metabrainz/templates/reports/financial_reports/index.html:6
 msgid "Finances"
 msgstr ""
 
-#: metabrainz/templates/base.html:60 metabrainz/templates/navbar.html:33
+#: metabrainz/templates/base.html:63 metabrainz/templates/navbar.html:47
 #: metabrainz/templates/reports/annual_reports/view.html:4
-msgid "Annual Reports"
+msgid "Archived Annual Reports"
 msgstr ""
 
-#: metabrainz/templates/base.html:61 metabrainz/templates/navbar.html:35
+#: metabrainz/templates/base.html:64 metabrainz/templates/navbar.html:49
 #: metabrainz/templates/payments/donors.html:6
 msgid "Donors"
 msgstr ""
 
-#: metabrainz/templates/base.html:65
-msgid "Users"
+#: metabrainz/templates/base.html:65 metabrainz/templates/index/sponsors.html:3
+#: metabrainz/templates/index/sponsors.html:6
+#: metabrainz/templates/index/sponsors.html:20
+#: metabrainz/templates/navbar.html:43
+msgid "Sponsors"
 msgstr ""
 
-#: metabrainz/templates/base.html:68
+#: metabrainz/templates/base.html:66 metabrainz/templates/base.html:70
+#: metabrainz/templates/navbar.html:42
+#: metabrainz/templates/supporters/supporters-list.html:3
+#: metabrainz/templates/supporters/supporters-list.html:6
+msgid "Supporters"
+msgstr ""
+
+#: metabrainz/templates/base.html:73 metabrainz/templates/navbar.html:60
 msgid "Sign in"
 msgstr ""
 
-#: metabrainz/templates/base.html:70 metabrainz/templates/navbar.html:53
+#: metabrainz/templates/base.html:75 metabrainz/templates/navbar.html:68
 msgid "Sign out"
 msgstr ""
 
-#: metabrainz/templates/base.html:72
+#: metabrainz/templates/base.html:77
 msgid "Access your account"
 msgstr ""
 
-#: metabrainz/templates/base.html:73
+#: metabrainz/templates/base.html:78
 msgid "API"
 msgstr ""
 
-#: metabrainz/templates/base.html:78
+#: metabrainz/templates/base.html:83
 msgid "Contact us"
 msgstr ""
 
-#: metabrainz/templates/base.html:80
+#: metabrainz/templates/base.html:85
+#: metabrainz/templates/index/contact.html:105
 msgid "Blog"
 msgstr ""
 
-#: metabrainz/templates/base.html:81
-msgid "Twitter"
+#: metabrainz/templates/base.html:86 metabrainz/templates/index/contact.html:90
+msgid "Chat"
 msgstr ""
 
-#: metabrainz/templates/base.html:86
+#: metabrainz/templates/base.html:87
+#: metabrainz/templates/index/contact.html:106
+msgid "Twitter/X"
+msgstr ""
+
+#: metabrainz/templates/base.html:88
+#: metabrainz/templates/index/contact.html:107
+msgid "Mastodon"
+msgstr ""
+
+#: metabrainz/templates/base.html:89
+#: metabrainz/templates/index/contact.html:108
+msgid "Bluesky"
+msgstr ""
+
+#: metabrainz/templates/base.html:90
+#: metabrainz/templates/index/contact.html:109
+msgid "Instagram"
+msgstr ""
+
+#: metabrainz/templates/base.html:95
 #, python-format
 msgid ""
-"Sponsored by <a href=\"%(google_url)s\">Google</a>,\n"
-"            <a href=\"%(osuosl_url)s\">OSUOSL</a> and\n"
+"Sponsored by <a href=\"%(google_url)s\">Google</a> and\n"
 "            <a href=\"%(sponsors_url)s\">others&hellip;</a>"
 msgstr ""
 
@@ -165,30 +381,37 @@ msgstr ""
 msgid "The Foundation"
 msgstr ""
 
-#: metabrainz/templates/navbar.html:31
-msgid "Reports "
+#: metabrainz/templates/navbar.html:32
+msgid "Policies "
 msgstr ""
 
-#: metabrainz/templates/navbar.html:34
-msgid "Financial Reports"
+#: metabrainz/templates/index/conflict-policy.html:2
+#: metabrainz/templates/index/conflict-policy.html:12
+#: metabrainz/templates/navbar.html:37
+msgid "Conflict Resolution Policy"
 msgstr ""
 
 #: metabrainz/templates/navbar.html:38
-msgid "Donate"
+msgid "GDPR Compliance"
 msgstr ""
 
 #: metabrainz/templates/navbar.html:45
-#: metabrainz/templates/users/account-type.html:65
-#: metabrainz/templates/users/account-type.html:111
-#: metabrainz/templates/users/mb-signup.html:3
-#: metabrainz/templates/users/mb-signup.html:6
-#: metabrainz/templates/users/signup-commercial.html:3
-#: metabrainz/templates/users/signup-non-commercial.html:3
-#: metabrainz/templates/users/signup-non-commercial.html:87
-msgid "Sign up"
+msgid "Reports "
+msgstr ""
+
+#: metabrainz/templates/navbar.html:48
+msgid "Financial Reports"
 msgstr ""
 
 #: metabrainz/templates/navbar.html:52
+msgid "Donate"
+msgstr ""
+
+#: metabrainz/templates/navbar.html:59
+msgid "Register"
+msgstr ""
+
+#: metabrainz/templates/navbar.html:67
 msgid "Your profile"
 msgstr ""
 
@@ -208,30 +431,53 @@ msgid "MusicBrainz Live Data Feed"
 msgstr ""
 
 #: metabrainz/templates/api/info.html:16
-msgid "There are three endpoints for fetching replication packets:"
+msgid "There are two endpoints for fetching live data:"
 msgstr ""
 
 #: metabrainz/templates/api/info.html:18
-msgid "Hourly:"
+msgid "Hourly Replication Packets"
 msgstr ""
 
-#: metabrainz/templates/api/info.html:29
-msgid "Daily:"
-msgstr ""
-
-#: metabrainz/templates/api/info.html:40
-msgid "Weekly:"
-msgstr ""
-
-#: metabrainz/templates/api/info.html:51
+#: metabrainz/templates/api/info.html:30
 msgid ""
 "It is possible to get a signature for each replication packet. Just "
 "replace\n"
-"      <code>.tar.bz2</code> with <code>.asc</code>."
+"      <code>.tar.bz2</code> with <code>.tar.bz2.asc</code>."
 msgstr ""
 
-#: metabrainz/templates/api/info.html:55
-msgid "You can find the latest replication packet numbers from this endpoint:"
+#: metabrainz/templates/api/info.html:34
+msgid "You can find the latest replication packet number from this endpoint:"
+msgstr ""
+
+#: metabrainz/templates/api/info.html:44
+msgid "Hourly Incremental JSON Dumps"
+msgstr ""
+
+#: metabrainz/templates/api/info.html:58
+msgid ""
+"The JSON dumps are partitioned by entity type. "
+"<code>&lt;ENTITY_NAME&gt;</code> can be one of: area, artist, event, "
+"instrument, label, place, recording, release, release-group, series, or "
+"work."
+msgstr ""
+
+#: metabrainz/templates/api/info.html:61
+msgid ""
+"It’s possible that a JSON dump for a particular entity type doesn’t exist"
+" if no entities of that type have changed in a given hour."
+msgstr ""
+
+#: metabrainz/templates/api/info.html:64
+msgid ""
+"Each dump contains a file named <code>mbdump/&lt;ENTITY_NAME&gt;</code>. "
+"This file must be read line-by-line; each line contains one changed "
+"entity in JSON format."
+msgstr ""
+
+#: metabrainz/templates/api/info.html:67
+msgid ""
+"As with replication packets, you can obtain a file signature by replacing"
+" <code>.tar.xz</code> with <code>.tar.xz.asc</code>."
 msgstr ""
 
 #: metabrainz/templates/errors/base.html:8
@@ -242,60 +488,80 @@ msgstr ""
 msgid "About"
 msgstr ""
 
-#: metabrainz/templates/index/about.html:6
+#: metabrainz/templates/index/about.html:8
 msgid "About the MetaBrainz Foundation"
 msgstr ""
 
-#: metabrainz/templates/index/about.html:11
-msgid ""
-"The MetaBrainz Foundation is a 501(c)(3) tax-exempt non-profit founded in"
-"\n"
-"        December 2004 and based in San Luis Obispo, California, that "
-"believes in\n"
-"        free, open access to data."
-msgstr ""
-
-#: metabrainz/templates/index/about.html:16
-msgid ""
-"The MetaBrainz Foundation has been set up to build community maintained\n"
-"        databases and make them available in the public domain or under "
-"Creative\n"
-"        Commons licenses. Our data is mostly gathered by volunteers, and "
-"verified\n"
-"        by a voting system to make sure it is consistent and correct. All"
-"\n"
-"        non-commercial use is free, but commercial users are asked to pay"
-" for\n"
-"        regular updates of the data in order to help fund the project. We"
-"\n"
-"        encourage all data users to contribute to the data gathering "
-"process so\n"
-"        that our data can be as comprehensive as possible."
-msgstr ""
-
-#: metabrainz/templates/index/about.html:26
+#: metabrainz/templates/index/about.html:13
 #, python-format
 msgid ""
-"The MetaBrainz Foundation believes in <a "
-"href=\"%(financial_reports_url)s\">\n"
-"        transparent finances</a> and has several <a "
-"href=\"%(supporters_url)s\">\n"
-"        commercial supporters</a> who pay for timely and convenient "
-"access to\n"
-"        data. The MetaBrainz Foundation is also supported by a number of\n"
-"        <a href=\"%(sponsors_url)s\">sponsors</a> who provide\n"
-"        funds in order for the foundation to accomplish its goals."
+"The MetaBrainz Foundation is a global community creating and maintaining"
+" \n"
+"        an open encyclopedia of music and arts metadata. Beginning as a "
+"resource for music \n"
+"        collectors we currently establish collaborations between "
+"volunteers, artists, and \n"
+"        industry leaders. Since it’s founding it has grown into a global "
+"community of \n"
+"        <a href=\"%(editors_url)s\">hundreds of thousands of editors</a>\n"
+"        collaborating together to build and maintain the MetaBrainz "
+"comprehensive datasets."
 msgstr ""
 
-#: metabrainz/templates/index/about.html:42
+#: metabrainz/templates/index/about.html:22
+#, python-format
+msgid ""
+"The foundation works within a balanced ecosystem of contributions to the "
+"datasets \n"
+"        and community and the utilization of the datasets. We encourage "
+"all data supporters to participate\n"
+"        in the data gathering, editing and peer review processes so that "
+"our data can be as comprehensive\n"
+"        as possible. Each entity is assigned a permanent \n"
+"        <a href=\"%(mbid_url)s\">MBID (MusicBrainz Identifier)</a>\n"
+"        in order to facilitate the creation of a reliable and unambiguous"
+" universal lingua franca for music data. \n"
+"        MBID’s have opened the possibility of boundless search queries, "
+"exceeding the seven traditional \n"
+"        identifiers for music data and truly putting knowledge at one's "
+"fingertips. Our community aggregated\n"
+"        data sets are verified and edited by a global voting system to "
+"ensure the data is consistent and correct.\n"
+"        We collect information about as many different styles and types "
+"of arts and music as possible \n"
+"        and do not discriminate when compiling data."
+msgstr ""
+
+#: metabrainz/templates/index/about.html:36
+#, python-format
+msgid ""
+"The foundation was founded in 2004 by Robert Kaye, in San Luis Obispo, "
+"California and is a \n"
+"        501(c)(3) tax-exempt non-profit. <a "
+"href=\"%(supporters_url)s\">Commercial supporters</a> are asked to "
+"contribute\n"
+"        financially in order to help fund our family of projects, and "
+"give back to our community to keep our \n"
+"        ecosystem healthy. Non-commercial use of our data remains free, "
+"and we are committed to keeping it free to utilize. \n"
+"        We are also supported by donations and a number of <a "
+"href=\"%(sponsors_url)s\">sponsors</a> who provide \n"
+"        funds in order for the foundation to continue to accomplish "
+"various project goals. The MetaBrainz \n"
+"        Foundation believes in <a "
+"href=\"%(financial_reports_url)s\">transparent finances,</a> which are "
+"published quarterly."
+msgstr ""
+
+#: metabrainz/templates/index/about.html:49
 msgid "Board of Directors"
 msgstr ""
 
-#: metabrainz/templates/index/about.html:43
+#: metabrainz/templates/index/about.html:50
 msgid "Our board of directors consists of:"
 msgstr ""
 
-#: metabrainz/templates/index/about.html:45
+#: metabrainz/templates/index/about.html:52
 #, python-format
 msgid ""
 "Director Nick Ashton-Hart, Executive Director of the <a "
@@ -303,35 +569,28 @@ msgid ""
 "Alliance</a>"
 msgstr ""
 
-#: metabrainz/templates/index/about.html:46
+#: metabrainz/templates/index/about.html:53
 #, python-format
 msgid ""
-"Director <a href=\"%(paul_url)s\">Paul Bennun</a> of <a "
-"href=\"%(somethin_else_url)s\">Somethin' Else</a>"
+"Director <a href=\"%(paul_url)s\">Paul Bennun</a> is the Chief Content "
+"Officer at <a href=\"%(kcrw_url)s\">KCRW</a>, Los Angeles"
 msgstr ""
 
-#: metabrainz/templates/index/about.html:47
+#: metabrainz/templates/index/about.html:54
 #, python-format
 msgid ""
 "Director <a href=\"%(cory_url)s\">Cory Doctorow</a>, Sci-Fi author and "
 "editor of the <a href=\"%(boing_url)s\">Boing Boing</a> weblog"
 msgstr ""
 
-#: metabrainz/templates/index/about.html:48
-#, python-format
-msgid ""
-"Director <a href=\"%(sophie_url)s\">Sophie Goossens</a> of <a "
-"href=\"%(ab_url)s\">August &amp; Debouzy</a>"
-msgstr ""
-
-#: metabrainz/templates/index/about.html:49
+#: metabrainz/templates/index/about.html:55
 #, python-format
 msgid ""
 "Director <a href=\"%(matthew_url)s\">Matthew Hawn</a> of <a "
 "href=\"%(audio_net_url)s\">Audio Network</a>"
 msgstr ""
 
-#: metabrainz/templates/index/about.html:50
+#: metabrainz/templates/index/about.html:56
 #, python-format
 msgid ""
 "Director &amp; Treasurer <a href=\"%(rassami_url)s\">Rassami Hok "
@@ -339,59 +598,43 @@ msgid ""
 "series</a> put on by <a href=\"%(two_pears_url)s\">2 Pears</a>"
 msgstr ""
 
-#: metabrainz/templates/index/about.html:51
+#: metabrainz/templates/index/about.html:57
 #, python-format
 msgid ""
 "Executive Director <a href=\"%(mayhem_url)s\">Robert Kaye</a> of the "
 "MetaBrainz Foundation"
 msgstr ""
 
-#: metabrainz/templates/index/about.html:52
-#, python-format
-msgid ""
-"Secretary <a href=\"%(freso_url)s\">Frederik “Freso” S. Olesen</a>, "
-"Community Manager of the MetaBrainz Foundation"
-msgstr ""
-
-#: metabrainz/templates/index/about.html:55
-msgid "Our directors emeritus include:"
-msgstr ""
-
 #: metabrainz/templates/index/about.html:58
 #, python-format
 msgid ""
-"Director Emeritus <a href=\"%(lessig_url)s\">Lawrence Lessig</a> of the "
-"<a href=\"%(berkman_url)s\">Berkman Center for Internet and Society</a> "
-"and <a href=\"%(cc_url)s\">Creative Commons</a>"
+"Director <a href=\"%(hazel_url)s\">Hazel Savage</a> of <a "
+"href=\"%(soundcloud)s\">SoundCloud</a>"
 msgstr ""
 
-#: metabrainz/templates/index/about.html:59
+#: metabrainz/templates/index/about.html:60
+#: metabrainz/templates/index/about.html:69
 #, python-format
 msgid ""
-"Director Emeritus <a href=\"%(joi_url)s\">Joichi Ito</a> of <a "
-"href=\"%(neoteny_url)s\">Neoteny Co. Ltd.</a>"
+"Secretary <a href=\"%(reo_url)s\">Nicolás Tamargo</a>, Junior Software "
+"Engineer at MetaBrainz Foundation"
 msgstr ""
 
-#: metabrainz/templates/index/about.html:62
+#: metabrainz/templates/index/about.html:64
 msgid "Officers"
 msgstr ""
 
-#: metabrainz/templates/index/about.html:63
+#: metabrainz/templates/index/about.html:65
 msgid "The officers of this company are:"
 msgstr ""
 
-#: metabrainz/templates/index/about.html:65
+#: metabrainz/templates/index/about.html:67
 msgid "President Robert Kaye"
 msgstr ""
 
-#: metabrainz/templates/index/about.html:66
+#: metabrainz/templates/index/about.html:68
 #, python-format
 msgid "Treasurer <a href=\"%(rassami_url)s\">Rassami Hok Ljungberg</a>"
-msgstr ""
-
-#: metabrainz/templates/index/about.html:67
-#, python-format
-msgid "Secretary <a href=\"%(freso_url)s\">Frederik “Freso” S. Olesen</a>"
 msgstr ""
 
 #: metabrainz/templates/index/bad-customers.html:3
@@ -399,7 +642,7 @@ msgid "Bad customers"
 msgstr ""
 
 #: metabrainz/templates/index/bad-customers.html:8
-msgid "Our not-so-favorite commercial data users"
+msgid "Our not-so-favorite commercial data supporters"
 msgstr ""
 
 #: metabrainz/templates/index/bad-customers.html:11
@@ -445,7 +688,7 @@ msgid "Nice!!"
 msgstr ""
 
 #: metabrainz/templates/index/bad-customers.html:54
-msgid "There are currently no not-so-favorite commercial data users!"
+msgid "There are currently no not-so-favorite commercial data supporters!"
 msgstr ""
 
 #: metabrainz/templates/index/bad-customers.html:56
@@ -453,6 +696,15 @@ msgid ""
 "... either that, or maybe we're working to convince some companies to do "
 "the\n"
 "          \"right thing\"... :)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:14
+#: metabrainz/templates/index/gdpr.html:8
+msgid "Introduction"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:55
+msgid "Reporting and Response"
 msgstr ""
 
 #: metabrainz/templates/index/contact.html:3
@@ -470,7 +722,7 @@ msgid ""
 "Found a broken link or something that doesn't work as you expect it to? "
 "You can report issues in our\n"
 "    <a href=\"%(bug_tracker_url)s\">bug tracker</a>, or let us know on "
-"IRC or\n"
+"our chat or\n"
 "    by email. Contact details are provided below. Please include details "
 "such as what happened, what you expected\n"
 "    to happen, and the URLs of any pages involved."
@@ -526,54 +778,85 @@ msgid ""
 msgstr ""
 
 #: metabrainz/templates/index/contact.html:40
-msgid "Contact details"
+msgid "Advertising requests"
 msgstr ""
 
 #: metabrainz/templates/index/contact.html:42
+msgid ""
+"We are currently evaluating our overall online advertising strategy. We "
+"are evaluating advertising, traffic optimization,\n"
+"    search engine optimization and software monitization technologies. If"
+" you provide these professional services, please provide a detailed\n"
+"    deck of your comprehensive services to the following email address. "
+"<em>Please respect our other non-media teams and do not contact us \n"
+"    regarding these services on any other of our email addresses. We will"
+" disregard the entirety of your submissions if you contact us any other "
+"way!</em>"
+msgstr ""
+
+#: metabrainz/templates/index/contact.html:52
+#, python-format
+msgid "Please submit your proposals before 17:00 PST on %(ad_deadline)s."
+msgstr ""
+
+#: metabrainz/templates/index/contact.html:54
+msgid "Contact details"
+msgstr ""
+
+#: metabrainz/templates/index/contact.html:56
 msgid "Please do not contact us with the following topics:"
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:44
+#: metabrainz/templates/index/contact.html:58
 msgid ""
 "We cannot license any of the music listed in MusicBrainz, since we have "
 "neither the music itself nor the\n"
 "        rights to license the music."
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:46
+#: metabrainz/templates/index/contact.html:60
 msgid "We are not distributing any of the music listed in MusicBrainz."
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:47
+#: metabrainz/templates/index/contact.html:61
 msgid ""
-"We are not interested in your advertising, SEO optimization, or software "
-"monetization services. Please\n"
-"        do not offer us <b>any</b> services!"
+"For inquiries about advertising, SEO optimization, or software "
+"monetization services, please see above!"
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:53
+#: metabrainz/templates/index/contact.html:62
+msgid "Please do not offer us <b>any</b> other services! We are not interested."
+msgstr ""
+
+#: metabrainz/templates/index/contact.html:63
+msgid ""
+"Please do not contact us about any job openings, we do not hire people "
+"who are not part of our community."
+msgstr ""
+
+#: metabrainz/templates/index/contact.html:68
 msgid ""
 "If you disregard this agreement and contact us about one of the\n"
 "      disallowed topics, we reserve the right to make fun of you."
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:58
+#: metabrainz/templates/index/contact.html:73
 msgid "E-mail us"
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:60
+#: metabrainz/templates/index/contact.html:75
 msgid "I agree with the rules above, show me the email address"
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:63
+#: metabrainz/templates/index/contact.html:78
 msgid "You can reach the MetaBrainz staff directly at the following address:"
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:69
+#: metabrainz/templates/index/contact.html:84
 msgid "Forums"
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:71
+#: metabrainz/templates/index/contact.html:86
 #, python-format
 msgid ""
 "Please come ask your questions at our <a "
@@ -581,26 +864,64 @@ msgid ""
 "    answer any questions you may have."
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:75
-msgid "IRC"
-msgstr ""
-
-#: metabrainz/templates/index/contact.html:77
+#: metabrainz/templates/index/contact.html:92
 #, python-format
 msgid ""
-"The MetaBrainz/MusicBrainz team, as well as MusicBrainz users, hang out "
-"in the\n"
-"    <strong><a href=\"%(irc_url)s\">#metabrainz</a></strong>\n"
-"    channel on IRC chat at irc.libera.chat. If you don't have an IRC "
-"client\n"
-"    installed, consider using this\n"
-"    <a href=\"%(irc_webchat_url)s\">webchat client</a>\n"
-"    instead. Please feel free to browse the\n"
-"    <a href=\"%(chatlogs_url)s\">IRC log archives</a>."
+"The MetaBrainz/MusicBrainz/ListenBrainz team and community hang out\n"
+"    on our Matrix, IRC and Discord channels. Visit the\n"
+"    <a href=\"%(chatbrainz_url)s\">ChatBrainz</a>\n"
+"    page and join the chat. You can also browse the\n"
+"    <a href=\"%(chatlogs_url)s\">chat log archives</a>."
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:89
+#: metabrainz/templates/index/contact.html:101
+msgid "Social media"
+msgstr ""
+
+#: metabrainz/templates/index/contact.html:103
+msgid "You can follow us on these social channels:"
+msgstr ""
+
+#: metabrainz/templates/index/contact.html:113
 msgid "Mailing address"
+msgstr ""
+
+#: metabrainz/templates/index/datasets.html:9
+msgid "The MetaBrainz Datasets"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:3
+#: metabrainz/templates/index/gdpr.html:6
+msgid "GDPR Compliance Statement"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:37
+msgid "Right to be forgotten"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:77
+msgid "Restriction of processing"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:110
+msgid "Right to data portability / exporting your data"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:150
+msgid "Right to rectification"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:165
+msgid "Right to be informed"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:188
+msgid "Right to access"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:198
+#: metabrainz/templates/index/privacy.html:166
+msgid "Privacy/GDPR Representative"
 msgstr ""
 
 #: metabrainz/templates/index/index.html:6
@@ -623,62 +944,58 @@ msgid ""
 "        by peer review to ensure it is consistent and correct. All\n"
 "        <a href=\"%(account_type_url)s\">non-commercial use</a> of this "
 "data is free,\n"
-"        but <a href=\"%(account_type_url)s\">commercial users</a> are "
-"asked to\n"
+"        but <a href=\"%(account_type_url)s\">commercial supporters</a> "
+"are asked to\n"
 "        <a href=\"%(account_type_url)s\">support us</a> in order to help "
 "fund the\n"
-"        project. We encourage all data users to contribute to the data "
-"gathering process so\n"
+"        project. We encourage all data supporters to contribute to the "
+"data gathering process so\n"
 "        that our data can be as comprehensive as possible."
 msgstr ""
 
-#: metabrainz/templates/index/index.html:34
+#: metabrainz/templates/index/index.html:38
 msgid ""
 "An open music encyclopedia that collects music metadata and makes it\n"
 "              available to the public"
 msgstr ""
 
-#: metabrainz/templates/index/index.html:36
+#: metabrainz/templates/index/index.html:40
 #, python-format
 msgid ""
 "Sign up to use the <a href=\"%(account_type_url)s\">Live Data "
 "Feed</a></em>"
 msgstr ""
 
-#: metabrainz/templates/index/index.html:45
+#: metabrainz/templates/index/index.html:49
 msgid "A cross-platform music tagger"
 msgstr ""
 
-#: metabrainz/templates/index/index.html:53
-msgid "A crowdsourced collection of acoustic information"
-msgstr ""
-
-#: metabrainz/templates/index/index.html:61
-msgid "An open record of user listening habits"
-msgstr ""
-
-#: metabrainz/templates/index/index.html:69
-msgid "A repository for Creative Commons licensed music reviews"
-msgstr ""
-
-#: metabrainz/templates/index/index.html:77
+#: metabrainz/templates/index/index.html:57
 msgid "An open encyclopedia which contains information about published literature"
 msgstr ""
 
-#: metabrainz/templates/index/index.html:85
+#: metabrainz/templates/index/index.html:65
+msgid "An open record of user listening habits"
+msgstr ""
+
+#: metabrainz/templates/index/index.html:73
+msgid "A repository for Creative Commons licensed music and book reviews"
+msgstr ""
+
+#: metabrainz/templates/index/index.html:81
 msgid "A repository of music cover art that is freely and easily accessible"
 msgstr ""
 
-#: metabrainz/templates/index/index.html:92
+#: metabrainz/templates/index/index.html:88
 #: metabrainz/templates/payments/donors.html:66
 msgid "Previous"
 msgstr ""
 
-#: metabrainz/templates/index/index.html:96
+#: metabrainz/templates/index/index.html:92
 msgid "Next"
 msgstr ""
 
-#: metabrainz/templates/index/index.html:103
+#: metabrainz/templates/index/index.html:99
 #, python-format
 msgid ""
 "The MetaBrainz Foundation believes in <a "
@@ -694,7 +1011,7 @@ msgid ""
 "        who make use of our data sets."
 msgstr ""
 
-#: metabrainz/templates/index/index.html:137
+#: metabrainz/templates/index/index.html:133
 #, python-format
 msgid ""
 "Unfortunately, some companies listed below use data we provide without "
@@ -704,7 +1021,7 @@ msgid ""
 "        <a href=\"%(account_type_url)s\">sign up</a>!"
 msgstr ""
 
-#: metabrainz/templates/index/index.html:160
+#: metabrainz/templates/index/index.html:156
 #, python-format
 msgid ""
 "To get more information about the foundation, go to the\n"
@@ -719,26 +1036,47 @@ msgstr ""
 msgid "Summary"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:10
-msgid ""
-"The MetaBrainz Foundation will not collect any private information unless"
-"\n"
-"    you choose to donate to support the MusicBrainz project. Any personal"
-"\n"
-"    information you choose to provide during the donation process will "
-"not be\n"
-"    revealed to anyone else, unless you give us permission to list your "
-"name on\n"
-"    our donations page. We will not contact you unless you give us "
-"permission\n"
-"    to do so when you make a donation."
+#: metabrainz/templates/index/privacy.html:33
+msgid "Applicable to all supporters"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:18
+#: metabrainz/templates/index/privacy.html:35
+msgid "Cookies"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:54
+msgid "Web and FTP access logs"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:62
+msgid "Third-Party content"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:92
+msgid "Applicable to account holders"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:94
+msgid "Account creation"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:108
+msgid "Edits and Notes"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:114
+msgid "Subscriptions on MusicBrainz"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:131
+msgid "Third-party sites"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:145
 msgid "MetaBrainz donors"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:20
+#: metabrainz/templates/index/privacy.html:147
 msgid ""
 "When you make a donation to the MetaBrainz Foundation, we are legally\n"
 "    required to collect your personal information and keep it in our "
@@ -748,7 +1086,7 @@ msgid ""
 "    information to anyone else, ever."
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:26
+#: metabrainz/templates/index/privacy.html:153
 msgid ""
 "We believe in transparent finances, which means that we list all "
 "donations\n"
@@ -758,28 +1096,8 @@ msgid ""
 "process."
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:31
-msgid "Web and FTP access logs (all users)"
-msgstr ""
-
-#: metabrainz/templates/index/privacy.html:33
-msgid ""
-"Like just about all web sites, we keep logs of all web requests made\n"
-"    against our servers. These logs include the usual stuff: your IP "
-"address,\n"
-"    your browser's \"User-Agent\" string, and which page you requested."
-msgstr ""
-
-#: metabrainz/templates/index/privacy.html:38
-msgid ""
-"Reasonable exceptions may apply to the above policy, for example to "
-"comply\n"
-"    with applicable laws. The MusicBrainz/MetaBrainz server "
-"administrators\n"
-"    (about three people in all) can of course see any information on the "
-"system\n"
-"    they want to, but to be honest they're probably not interested enough"
-" to look."
+#: metabrainz/templates/index/privacy.html:158
+msgid "Exceptions"
 msgstr ""
 
 #: metabrainz/templates/index/projects.html:6
@@ -830,33 +1148,17 @@ msgstr ""
 #: metabrainz/templates/index/projects.html:65
 #, python-format
 msgid ""
-"<a href=\"%(cb_url)s\">CritiqueBrainz</a> fills the gap between music "
-"critics and raw data by\n"
+"<a href=\"%(cb_url)s\">CritiqueBrainz</a> fills the gap between music and"
+" book critics and raw data by\n"
 "            providing a platform created for the sole purpose of Creative"
 " Commons licensed reviews."
 msgstr ""
 
 #: metabrainz/templates/index/projects.html:78
-msgid "AcousticBrainz"
-msgstr ""
-
-#: metabrainz/templates/index/projects.html:80
-#, python-format
-msgid ""
-"<a href=\"%(ab_url)s\">AcousticBrainz</a> crowd sources acoustic "
-"information for all music in\n"
-"            the world and makes it available to the public. It is a joint"
-" effort with\n"
-"            <a href=\"%(mtg_url)s\">Music Technology Group</a> at <a "
-"href=\"%(upf_url)s\">Universitat Pompeu Fabra</a>\n"
-"            in Barcelona."
-msgstr ""
-
-#: metabrainz/templates/index/projects.html:95
 msgid "BookBrainz"
 msgstr ""
 
-#: metabrainz/templates/index/projects.html:97
+#: metabrainz/templates/index/projects.html:80
 #, python-format
 msgid ""
 "<a href=\"%(bb_url)s\">BookBrainz</a> is an online encyclopedia "
@@ -865,11 +1167,11 @@ msgid ""
 "publication ever written."
 msgstr ""
 
-#: metabrainz/templates/index/projects.html:110
+#: metabrainz/templates/index/projects.html:93
 msgid "ListenBrainz"
 msgstr ""
 
-#: metabrainz/templates/index/projects.html:112
+#: metabrainz/templates/index/projects.html:95
 #, python-format
 msgid ""
 "<a href=\"%(lb_url)s\">ListenBrainz</a> is an open source music website "
@@ -878,17 +1180,43 @@ msgid ""
 " used for building open music recommendation systems."
 msgstr ""
 
-#: metabrainz/templates/index/projects.html:125
+#: metabrainz/templates/index/projects.html:104
+msgid "Past Projects"
+msgstr ""
+
+#: metabrainz/templates/index/projects.html:115
+msgid "AcousticBrainz"
+msgstr ""
+
+#: metabrainz/templates/index/projects.html:117
+#, python-format
+msgid ""
+"<a href=\"%(ab_url)s\">AcousticBrainz</a> crowd sourced acoustic "
+"information for all music in\n"
+"            the world and made it available to the public. It was a joint"
+" effort with\n"
+"            <a href=\"%(mtg_url)s\">Music Technology Group</a> at <a "
+"href=\"%(upf_url)s\">Universitat Pompeu Fabra</a>\n"
+"            in Barcelona."
+msgstr ""
+
+#: metabrainz/templates/index/projects.html:132
 msgid "MessyBrainz"
 msgstr ""
 
-#: metabrainz/templates/index/projects.html:127
+#: metabrainz/templates/index/projects.html:134
 #, python-format
 msgid ""
 "<a href=\"%(messybrainz_url)s\">MessyBrainz</a> identifies unclean "
 "metadata, and where possible,\n"
-"            links it to stable MusicBrainz identifiers. MessyBrainz is "
-"currently being used for AcousticBrainz and ListenBrainz."
+"            links it to stable MusicBrainz identifiers. MessyBrainz was "
+"used for AcousticBrainz and is still being\n"
+"            used in ListenBrainz."
+msgstr ""
+
+#: metabrainz/templates/index/shop.html:3
+#: metabrainz/templates/index/shop.html:6
+msgid "MetaBrainz Shop"
 msgstr ""
 
 #: metabrainz/templates/index/sponsors.html:9
@@ -918,38 +1246,10 @@ msgstr ""
 msgid ""
 "<b><a href=\"%(google_url)s\">Google</a></b> has been an extremely "
 "supportive\n"
-"        sponsor. They've donated over <b>$320,000</b>."
+"        sponsor. They've donated over <b>$500,000!</b>"
 msgstr ""
 
 #: metabrainz/templates/index/sponsors.html:34
-#, python-format
-msgid ""
-"The <b><a href=\"%(osuosl_url)s\">OSU Open Source Lab</a></b> hosts the "
-"FTP\n"
-"        mirror server that handles the distribution of the\n"
-"        <a href=\"%(mb_db_url)s\">MusicBrainz Database</a>\n"
-"        and virtual machines, thus saving us considerable load and "
-"bandwidth costs."
-msgstr ""
-
-#: metabrainz/templates/index/sponsors.html:44
-#, python-format
-msgid ""
-"<b><a href=\"%(dotsrc_url)s\">DotSrc</a></b> hosts an\n"
-"        <a href=\"%(mb_ftp_url)s\">EU mirror of our FTP site</a>.\n"
-"        This gives better download speeds of our large data sets for "
-"users in Europe."
-msgstr ""
-
-#: metabrainz/templates/index/sponsors.html:53
-#, python-format
-msgid ""
-"<b><a href=\"%(layer42_url)s\">Layer42</a></b> generously hosts a test "
-"server for\n"
-"        us, free of charge!"
-msgstr ""
-
-#: metabrainz/templates/index/sponsors.html:61
 #, python-format
 msgid ""
 "<b><a href=\"%(github_url)s\">GitHub</a></b> provides us with a free "
@@ -957,19 +1257,11 @@ msgid ""
 "        account for hosting our sysadmin repositories."
 msgstr ""
 
-#: metabrainz/templates/index/sponsors.html:69
-#, python-format
-msgid ""
-"<b><a href=\"%(pipedrive_url)s\">Pipedrive</a></b> provides us with a "
-"free\n"
-"        account to help keep track of commercial users and supporters."
-msgstr ""
-
-#: metabrainz/templates/index/sponsors.html:76
+#: metabrainz/templates/index/sponsors.html:42
 msgid "Special thanks"
 msgstr ""
 
-#: metabrainz/templates/index/sponsors.html:78
+#: metabrainz/templates/index/sponsors.html:44
 msgid ""
 "In our past, we've had a lot of people support us with many different "
 "levels of support:\n"
@@ -980,7 +1272,7 @@ msgid ""
 "    who have made a big difference for us."
 msgstr ""
 
-#: metabrainz/templates/index/sponsors.html:84
+#: metabrainz/templates/index/sponsors.html:50
 #, python-format
 msgid ""
 "Richard Jones of <a href=\"%(last_fm_url)s\">Last.fm fame</a> donated "
@@ -1001,7 +1293,7 @@ msgid ""
 " of our non-profit status."
 msgstr ""
 
-#: metabrainz/templates/index/sponsors.html:100
+#: metabrainz/templates/index/sponsors.html:66
 msgid ""
 "Thanks to everyone who has helped make the MetaBrainz Foundation what it "
 "is today!"
@@ -1039,11 +1331,13 @@ msgid ""
 msgstr ""
 
 #: metabrainz/templates/index/team.html:26
-msgid "He lives in Barcelona, Spain."
+msgid "Originally from Germany, he now lives in Barcelona, Spain."
 msgstr ""
 
 #: metabrainz/templates/index/team.html:39
-msgid "<span class=\"name\">Michael Wiencek</span> &mdash; Senior Developer"
+msgid ""
+"<span class=\"name\">Michael Wiencek</span> &mdash; Senior Software "
+"Engineer"
 msgstr ""
 
 #: metabrainz/templates/index/team.html:41
@@ -1060,91 +1354,37 @@ msgstr ""
 
 #: metabrainz/templates/index/team.html:57
 msgid ""
-"<span class=\"name\">Frederik “Freso” S. Olesen</span> &mdash; Community "
-"Manager"
+"<span class=\"name\">Nicolás Tamargo</span> &mdash; Style Leader/Customer"
+" Support/Community Manager/Software Engineer"
 msgstr ""
 
 #: metabrainz/templates/index/team.html:59
 #, python-format
 msgid ""
-"Hired in the fall of 2015 as the MetaBrainz Community Manager, Freso is "
-"in charge of most of the public communication\n"
-"          channels (IRC, forums, blog, etc.) and various community "
-"projects (like the Google Code-in). He has been a\n"
-"          <a href=\"%(mb_freso_url)s\">MusicBrainz contributor since "
-"2006</a> and an open source enthusiast for\n"
-"          even longer."
+"Nicolás started (and still moonlights as) a hardcore editor, because he "
+"just likes\n"
+"          organizing data that much. He was eventually offered the style "
+"leader position, in which\n"
+"          he helps the community decide how all the data should be "
+"organized. Later he was put in\n"
+"          charge of answering any support issues, and finally started to "
+"actually write code to\n"
+"          fix those complaints (and sometimes, to be honest, to cause new"
+" ones!).\n"
+"          When he's not actively working for MetaBrainz, he's busy <a "
+"href=\"%(mb_editors_url)s\">editing MusicBrainz</a>\n"
+"          or traveling around trying to watch some wildlife."
 msgstr ""
 
-#: metabrainz/templates/index/team.html:65
-#, python-format
-msgid ""
-"On the rare occasions that he is not found in front of a monitor of some "
-"sort, Freso can be found\n"
-"          <a href=\"%(mb_freso_artist)s\">playing music</a> or (far more "
-"commonly)\n"
-"          dancing to it. He has even taught some dance classes and "
-"workshops in\n"
-"          <a href=\"%(bboy_url)s\">b-boying</a>!"
+#: metabrainz/templates/index/team.html:68
+msgid "Originally from Spain, he now lives in Tartu, Estonia."
 msgstr ""
 
-#: metabrainz/templates/index/team.html:73
-msgid ""
-"Freso was born and raised in Copenhagen, Denmark but has recently moved "
-"to Barcelona to be closer to the rest of\n"
-"          the MetaBrainz team."
-msgstr ""
-
-#: metabrainz/templates/index/team.html:87
-msgid ""
-"<span class=\"name\">Nicolás Tamargo</span> &mdash; Style Leader/Customer"
-" Support"
-msgstr ""
-
-#: metabrainz/templates/index/team.html:89
-#, python-format
-msgid ""
-"Nicolás is the leader of everything style-related in MusicBrainz (all "
-"except for fashion), and is in charge of\n"
-"          answering (or delegating!) support requests. When he's not "
-"actively working for MetaBrainz, he's busy\n"
-"          <a href=\"%(mb_editors_url)s\">editing MusicBrainz</a>, "
-"devouring ice cream, and following\n"
-"          the <a href=\"%(tartu_url)s\">world's best football team</a> "
-"around the country."
-msgstr ""
-
-#: metabrainz/templates/index/team.html:96
-msgid "He lives in Tartu, Estonia."
-msgstr ""
-
-#: metabrainz/templates/index/team.html:108
-msgid "<span class=\"name\">Roman Tsukanov</span> &mdash; Software Engineer"
-msgstr ""
-
-#: metabrainz/templates/index/team.html:110
-#, python-format
-msgid ""
-"Roman first became associated with MetaBrainz through Google Summer of "
-"Code program, where he was instrumental\n"
-"          in the birth of <a href=\"%(cb_url)s\">CritiqueBrainz</a>. He "
-"wrote the updated MetaBrainz\n"
-"          website. Currently works on MusicBrainz, AcousticBrainz, and "
-"other projects."
-msgstr ""
-
-#: metabrainz/templates/index/team.html:115
-msgid ""
-"Roman joined the MetaBrainz team as a software engineer in 2015. He "
-"currently lives and studies music technology\n"
-"          in Barcelona, Spain."
-msgstr ""
-
-#: metabrainz/templates/index/team.html:129
+#: metabrainz/templates/index/team.html:81
 msgid "<span class=\"name\">Laurent Monin</span> &mdash; System Administrator"
 msgstr ""
 
-#: metabrainz/templates/index/team.html:131
+#: metabrainz/templates/index/team.html:83
 msgid ""
 "A zealous music devotee, Laurent Monin first stumbled upon MusicBrainz "
 "and Picard in attempts to codify his vast\n"
@@ -1154,7 +1394,7 @@ msgid ""
 "system administrator since 1998."
 msgstr ""
 
-#: metabrainz/templates/index/team.html:136
+#: metabrainz/templates/index/team.html:88
 #, python-format
 msgid ""
 "With his extensive repertoire of skills and passions, Laurent has "
@@ -1168,78 +1408,199 @@ msgid ""
 "France."
 msgstr ""
 
-#: metabrainz/templates/index/team.html:153
-msgid "<span class=\"name\">Elizabeth Bigger</span> &mdash; Supporter Catalyst"
+#: metabrainz/templates/index/team.html:105
+msgid "<span class=\"name\">Yvan Rivierre</span> &mdash; Software Engineer"
 msgstr ""
 
-#: metabrainz/templates/index/team.html:155
+#: metabrainz/templates/index/team.html:107
 msgid ""
-"Elizabeth lives in Barcelona, Spain and joined the MetaBrainz team to "
-"manage the relationships with our \n"
-"          supporters. When not working for MetaBrainz, Elizabeth enjoys "
-"researching and developing computational textiles and\n"
-"          attending the International Symposium of Wearable Computing. "
-"She continuously struggles to find balance between her \n"
-"          cheese obsession, tinkering with power tools and learning the "
-"art of weaving."
+"Yvan is a software engineer for MusicBrainz and comes from Nancy, France."
+" Initially he discovered MusicBrainz\n"
+"          as a simple user, then started to edit it, then reported "
+"issues, then fixed issues reported by others, and got hired\n"
+"          in the end. Besides that, he casually plays music, listens to "
+"music, eats music, … music, for an healthy way of life."
+msgstr ""
+
+#: metabrainz/templates/index/team.html:120
+msgid ""
+"<span class=\"name\">Nicolas Pelletier</span> &mdash; BookBrainz Lead,  "
+"Software Engineer & Graphic Designer"
+msgstr ""
+
+#: metabrainz/templates/index/team.html:122
+msgid ""
+"Nicolas comes from a graphic design background, but was always a computer"
+" and electronics tinkerer at heart.\n"
+"          He followed his curiosity into the land of development never to"
+" return again. He has always had a passion for music\n"
+"          and books, and enjoyed working on MetaBrainz projects so much "
+"he eventually joined the team."
+msgstr ""
+
+#: metabrainz/templates/index/team.html:127
+msgid ""
+"In his free time, Nicolas likes to go rock climbing, hence the nickname, "
+"and designing and building structures."
+msgstr ""
+
+#: metabrainz/templates/index/team.html:130
+msgid ""
+"Born in Canada and raised in France, Nicolas now lives in Barcelona, "
+"Spain."
+msgstr ""
+
+#: metabrainz/templates/index/team.html:146
+msgid ""
+"<span class=\"name\">Kartik Ohri</span> &mdash; "
+"ListenBrainz/CritiqueBrainz/Android App Lead &amp; Junior Software "
+"Engineer"
+msgstr ""
+
+#: metabrainz/templates/index/team.html:148
+msgid ""
+"Kartik joined the MetaBrainz community during Google Code-In 2018 and "
+"since then there has been\n"
+"          no looking back. Now as a contractor for MetaBrainz, Kartik "
+"leads the development of the MusicBrainz Android App and\n"
+"          CritiqueBrainz projects. He also spends a lot of time on the "
+"AcousticBrainz and ListenBrainz projects."
 msgstr ""
 
 #: metabrainz/templates/index/team.html:166
+msgid "<span class=\"name\">Adam James</span> &mdash; System Administrator"
+msgstr ""
+
+#: metabrainz/templates/index/team.html:168
+msgid ""
+"Adam is a system administrator and occasional developer with over 15 "
+"years experience in Linux and Open Source\n"
+"          software. A huge music lover, he became an active MusicBrainz "
+"editor whilst organising his digital music collection,\n"
+"\t  which led to his involvement in the MetaBrainz community.\n"
+"\t  Adam's time is being provided on a pro-bono basis by <a "
+"href=\"https://www.transitiv.co.uk\">Transitiv Technologies</a>,\n"
+"\t  where he is a consultant and technical director."
+msgstr ""
+
+#: metabrainz/templates/index/team.html:189
+msgid ""
+"<span class=\"name\">Simon Hartman</span> &mdash; Design, UX Consultant &"
+" Social Media Jockey"
+msgstr ""
+
+#: metabrainz/templates/index/team.html:191
+msgid ""
+"Simon has been contributing data and complaints about UX and design to "
+"MusicBrainz since 2009.\n"
+"          In 2022 he started complaining about UX and design in an "
+"official capacity. He lives in New Zealand\n"
+"          and has 15 years experience across various graphic "
+"design/comms/marketing roles."
+msgstr ""
+
+#: metabrainz/templates/index/team.html:210
+msgid "<span class=\"name\">Ansh Goyal</span> &mdash; Junior Software Engineer"
+msgstr ""
+
+#: metabrainz/templates/index/team.html:212
+msgid ""
+"Ansh is a Software Engineer and is based in New Delhi, India. He joined "
+"MetaBrainz as a Google Summer of Code student in 2022 and has been a part"
+" of the community since then.\n"
+"          He started contributing to CritiqueBrainz and BookBrainz and is"
+" now also working on ListenBrainz.\n"
+"          In his leisure moments, Ansh enjoys binge-watching movies and "
+"listening to music."
+msgstr ""
+
+#: metabrainz/templates/index/team.html:224
 msgid "Voluntary Project Leaders"
 msgstr ""
 
-#: metabrainz/templates/index/team.html:171
-msgid "<span class=\"name\">Ben Ockmore</span> &mdash; BookBrainz"
+#: metabrainz/templates/index/team.html:233
+msgid "<span class=\"name\">Akshat Tiwari</span> &mdash; Junior Software Engineer"
 msgstr ""
 
-#: metabrainz/templates/index/team.html:173
+#: metabrainz/templates/index/team.html:235
+msgid ""
+"Akshat started contributing to the MusicBrainz Android App out of love "
+"for the project and after dwelling\n"
+"          on the variety of projects MetaBrainz operates, he decided to "
+"focus on the MusicBrainz project.\n"
+"          He was accepted as a Google Summer of Code student and is now a"
+" contractor for MetaBrainz, where\n"
+"          he focuses on the improvement of the MusicBrainz user interface"
+" and user experience.\n"
+"          \n"
+"          Akshat has always been fascinated by the creativity of people. "
+"He resides in New Delhi, India."
+msgstr ""
+
+#: metabrainz/templates/index/team.html:252
+msgid ""
+"<span class=\"name\">Param Singh</span> &mdash; Former ListenBrainz team "
+"leader"
+msgstr ""
+
+#: metabrainz/templates/index/team.html:254
+msgid ""
+"Param is a software engineer and the former leader of the ListenBrainz "
+"project. Param\n"
+"          joined MetaBrainz as a Google Summer of Code student in 2017 "
+"and has been part of MetaBrainz since then.\n"
+"          Param loves both programming and music a lot, so MetaBrainz was"
+" love at first sight for him.\n"
+"          When not staring at a screen, Param plays some chess and tries "
+"to listen to new music."
+msgstr ""
+
+#: metabrainz/templates/index/team.html:275
+msgid ""
+"<span class=\"name\">David \"drsaunde\" Saunders</span> &mdash; "
+"MusicBrainz Areas"
+msgstr ""
+
+#: metabrainz/templates/index/team.html:277
 #, python-format
 msgid ""
-"Ben is one of the two project leads and the main programmer for <a "
-"href=\"%(bb_url)s\">BookBrainz</a>,\n"
-"          a volunteer project doing for books what MusicBrainz does for "
-"music. He started programming C++ 9 years ago, and now\n"
-"          knows Python and Node.js too, although he is currently studying"
-" for a degree in Electronics Engineering at the\n"
-"          <a href=\"%(surrey_url)s\"> University of Surrey</a>. Ben has "
-"been editing MusicBrainz for the past 4 years,\n"
-"          attending the last three summits, and has contributed code to<a"
-" href=\"%(mutagen_url)s\">\n"
-"          mutagen</a> and <a href=\"%(beets_url)s\">beets</a> besides "
-"BookBrainz."
+"David is in charge of adding new areas to MusicBrainz when they're "
+"requested by the community. He\n"
+"          has been active in MusicBrainz for over a decade, and is one of"
+" the few editors to have surpassed the one\n"
+"          million edits mark. A proud Canadian, when he's not in "
+"MusicBrainz, he is often enjoying some of his\n"
+"          favourite things, such as <a href=\"%(thc_url)s\">THC</a>, <a "
+"href=\"%(tfc_url)s\">TFC</a>,\n"
+"          <a href=\"%(cts_url)s\">CTS</a> & <a "
+"href=\"%(gnt_url)s\">GnT's</a>,\n"
+"          as well as cheering for the Toronto Raptors."
 msgstr ""
 
-#: metabrainz/templates/index/team.html:185
-#, python-format
+#: metabrainz/templates/index/team.html:302
+msgid "<span class=\"name\">Akira Holm</span> &mdash; MusicBrainz Instruments"
+msgstr ""
+
+#: metabrainz/templates/index/team.html:304
 msgid ""
-"In his spare time, Ben likes to design quadrotors,\n"
-"          <a href=\"%(race_surrey_url)s\"> racing cars</a>,\n"
-"          artificial intelligence, <a "
-"href=\"%(opengrow_url)s\">vegetation simulators</a> and music\n"
-"          software. However, none of them are finished yet!"
+"ApeKattQuest or MonkeyPython has been a MusicBrainz editor since 2004, "
+"and\n"
+"          is in charge of adding and improving the musical instruments in"
+" MusicBrainz (the very unseriously-named,\n"
+"          yet quite important \"Instrument Inserter\" position). When not"
+" looking all over the internet (and the library!)\n"
+"          for instrument data, his other hobbies include playing games, "
+"listening to all sorts of different music, Lupin \n"
+"          III, colouring, and collecting all sorts of things, from "
+"stickers and stamps to bottlecaps."
 msgstr ""
 
-#: metabrainz/templates/index/team.html:202
-msgid "<span class=\"name\">Sean Burke</span> &mdash; BookBrainz"
+#: metabrainz/templates/index/datasets/download.html:3
+msgid "Download Datasets"
 msgstr ""
 
-#: metabrainz/templates/index/team.html:204
-#, python-format
-msgid ""
-"Sean is the other of the two project leaders for <a "
-"href=\"%(bb_url)s\">BookBrainz</a>. He speaks\n"
-"          Irish and is currently trying to learn to play the bodhrán."
-msgstr ""
-
-#: metabrainz/templates/index/team.html:215
-msgid "<span class=\"name\">Alastair Porter</span> &mdash; AcousticBrainz"
-msgstr ""
-
-#: metabrainz/templates/index/team.html:217
-#, python-format
-msgid ""
-"Alastair is the project leader for <a "
-"href=\"%(ab_url)s\">AcousticBrainz</a>."
+#: metabrainz/templates/index/datasets/signup.html:3
+msgid "Please sign up"
 msgstr ""
 
 #: metabrainz/templates/oauth/prompt.html:4
@@ -1268,14 +1629,23 @@ msgid "Cancelling recurring payments"
 msgstr ""
 
 #: metabrainz/templates/payments/cancel_recurring.html:9
-msgid ""
-"In case you want to cancel recurring donation (payment) that you set up "
-"before,\n"
-"    you'll need to go to a service which you used to pay."
+msgid "If you want to cancel a recurring donation (payment) that you have set up:"
 msgstr ""
 
 #: metabrainz/templates/payments/cancel_recurring.html:14
-msgid "Here are links to more information:"
+#, python-format
+msgid ""
+"For Stripe, we will cancel your donation manually. \n"
+"      Please <a href=\"%(contact_url)s\">contact us</a>, indicating the "
+"name\n"
+"      on the card used to set up the payment."
+msgstr ""
+
+#: metabrainz/templates/payments/cancel_recurring.html:20
+#, python-format
+msgid ""
+"For PayPal, you will need to cancel from their site.\n"
+"      See <a href=\"%(paypal_cancel_url)s\">their documentation</a>."
 msgstr ""
 
 #: metabrainz/templates/payments/donate.html:3
@@ -1330,11 +1700,11 @@ msgid ""
 msgstr ""
 
 #: metabrainz/templates/payments/donate.html:39
-#: metabrainz/templates/payments/payment.html:36
+#: metabrainz/templates/payments/payment.html:18
 msgid "Amount"
 msgstr ""
 
-#: metabrainz/templates/payments/donate.html:46
+#: metabrainz/templates/payments/donate.html:54
 #, python-format
 msgid ""
 "If you would like to make a large donation, please contact us at\n"
@@ -1342,35 +1712,35 @@ msgid ""
 "            before you do."
 msgstr ""
 
-#: metabrainz/templates/payments/donate.html:57
+#: metabrainz/templates/payments/donate.html:65
 msgid "I want this to be a recurring monthly donation"
 msgstr ""
 
-#: metabrainz/templates/payments/donate.html:65
+#: metabrainz/templates/payments/donate.html:73
 msgid "MusicBrainz username"
 msgstr ""
 
-#: metabrainz/templates/payments/donate.html:74
+#: metabrainz/templates/payments/donate.html:82
 msgid "Email me about future fundraising events"
 msgstr ""
 
-#: metabrainz/templates/payments/donate.html:75
+#: metabrainz/templates/payments/donate.html:83
 msgid "This will be very seldom"
 msgstr ""
 
-#: metabrainz/templates/payments/donate.html:83
+#: metabrainz/templates/payments/donate.html:91
 msgid "I would like this donation to be anonymous"
 msgstr ""
 
-#: metabrainz/templates/payments/donate.html:84
+#: metabrainz/templates/payments/donate.html:92
 msgid "Your name won't appear in the donors list"
 msgstr ""
 
-#: metabrainz/templates/payments/donate.html:92
+#: metabrainz/templates/payments/donate.html:100
 msgid "Donate with Credit Card"
 msgstr ""
 
-#: metabrainz/templates/payments/donate.html:108
+#: metabrainz/templates/payments/donate.html:113
 #, python-format
 msgid ""
 "The personal information provided to the MetaBrainz Foundation during the"
@@ -1381,76 +1751,70 @@ msgid ""
 "        privacy policy</a>."
 msgstr ""
 
-#: metabrainz/templates/payments/donate.html:117
+#: metabrainz/templates/payments/donate.html:122
 #, python-format
 msgid ""
 "To find out how to cancel recurring donations take a look at\n"
 "        <a href=\"%(cancel_recurring_url)s\">this page</a>."
 msgstr ""
 
-#: metabrainz/templates/payments/donate.html:122
+#: metabrainz/templates/payments/donate.html:127
 msgid "Other ways to donate"
 msgstr ""
 
-#: metabrainz/templates/payments/donate.html:124
-#: metabrainz/templates/payments/payment.html:100
+#: metabrainz/templates/payments/donate.html:130
+msgid ""
+"If you use GitHub to sponsor your favourite projects, you can click below"
+" to Sponsor @metabrainz on GitHub Sponsors:"
+msgstr ""
+
+#: metabrainz/templates/payments/donate.html:133
+#: metabrainz/templates/payments/payment_base.html:29
 msgid "Non-US Bank transfer"
 msgstr ""
 
-#: metabrainz/templates/payments/donate.html:125
+#: metabrainz/templates/payments/donate.html:134
 msgid ""
 "You can make a donation, or recurring donations, via bank transfer to the"
 " following IBAN:"
 msgstr ""
 
-#: metabrainz/templates/payments/donate.html:127
+#: metabrainz/templates/payments/donate.html:136
 #, python-format
 msgid ""
-"Please indicate your name and use the word %(donation_fixed_string)s in "
-"the description field."
+"Please indicate your name and use the word "
+"<em>%(donation_fixed_string)s</em> in the description field."
 msgstr ""
 
-#: metabrainz/templates/payments/donate.html:129
-#: metabrainz/templates/payments/payment.html:105
+#: metabrainz/templates/payments/donate.html:138
 msgid "US Check"
 msgstr ""
 
-#: metabrainz/templates/payments/donate.html:130
+#: metabrainz/templates/payments/donate.html:139
 msgid ""
-"If you would like to donate using a check drawn on a US bank, please send"
-" them to:"
+"Due to the increased unreliability of the US Postal Service we have "
+"stopped accepting paper checks. Sorry!"
 msgstr ""
 
-#: metabrainz/templates/payments/donate.html:137
-#: metabrainz/templates/payments/payment.html:113
-msgid "Please make checks payable to the <strong>MetaBrainz Foundation</strong>."
-msgstr ""
-
-#: metabrainz/templates/payments/donate.html:140
-msgid ""
-"If you use Flattr to donate to your favourite projects, you can click "
-"below to Flattr MetaBrainz:"
-msgstr ""
-
-#: metabrainz/templates/payments/donate.html:215
+#: metabrainz/templates/payments/donate.html:234
 msgid ""
 "Enter your MusicBrainz username to have Picard/MusicBrainz stop nagging "
 "you"
 msgstr ""
 
-#: metabrainz/templates/payments/donate.html:230
+#: metabrainz/templates/payments/donate.html:249
 msgid "MusicBrainz is currently unavailable."
 msgstr ""
 
-#: metabrainz/templates/payments/donate.html:231
+#: metabrainz/templates/payments/donate.html:250
 msgid "Please, make sure that your username is correct."
 msgstr ""
 
-#: metabrainz/templates/payments/donate.html:233
+#: metabrainz/templates/payments/donate.html:252
 msgid "Your donation will be associated with this account."
 msgstr ""
 
-#: metabrainz/templates/payments/donate.html:235
+#: metabrainz/templates/payments/donate.html:254
 msgid "We can't find this account. Please, make sure it's correct"
 msgstr ""
 
@@ -1491,22 +1855,69 @@ msgstr ""
 msgid "First"
 msgstr ""
 
-#: metabrainz/templates/payments/payment.html:3
 #: metabrainz/templates/payments/payment.html:7
+#, python-format
+msgid ""
+"<b>Be careful!</b> This is a development version of the website. Do NOT\n"
+"      use your real credit card credentials! If you want to send an "
+"actual\n"
+"      payment, go to <a href=\"%(mb_url)s\">metabrainz.org</a>."
+msgstr ""
+
+#: metabrainz/templates/payments/payment.html:31
+#, python-format
+msgid ""
+"If you would like to make a large payment, please contact us at\n"
+"          <a href=\"%(mail_link)s\">payments@metabrainz.org</a>\n"
+"          before you do."
+msgstr ""
+
+#: metabrainz/templates/payments/payment.html:39
+msgid "Invoice number"
+msgstr ""
+
+#: metabrainz/templates/payments/payment.html:48
+msgid "Make this a recurring monthly payment"
+msgstr ""
+
+#: metabrainz/templates/payments/payment.html:57
+msgid "Pay with Credit Card"
+msgstr ""
+
+#: metabrainz/templates/payments/payment.html:71
+#, python-format
+msgid ""
+"The personal information provided to the MetaBrainz Foundation during the"
+"\n"
+"      payment process will not be shared with anyone. For more "
+"information,\n"
+"      please take a look at our <a href=\"%(privacy_policy_url)s\">\n"
+"      privacy policy</a>."
+msgstr ""
+
+#: metabrainz/templates/payments/payment.html:80
+#, python-format
+msgid ""
+"To find out how to cancel recurring payments take a look at\n"
+"      <a href=\"%(cancel_recurring_url)s\">this page</a>."
+msgstr ""
+
+#: metabrainz/templates/payments/payment_base.html:3
+#: metabrainz/templates/payments/payment_base.html:7
 msgid "Make a Payment"
 msgstr ""
 
-#: metabrainz/templates/payments/payment.html:10
+#: metabrainz/templates/payments/payment_base.html:10
 #, python-format
 msgid ""
-"<b>This page is for organizations!</b> Payments made here will not show "
-"up\n"
-"      in the list of donations. If you want to make a donation instead, "
-"go to\n"
-"      <a href=\"%(donate_url)s\">donation page</a>."
+"<b>This page is for organizations that are supporters of the MetaBrainz "
+"Foundation to make payments\n"
+"      to us!</b> Payments made here will not be considered as donations. "
+"If you want to make a donation\n"
+"      instead, go to <a href=\"%(donate_url)s\">donation page</a>."
 msgstr ""
 
-#: metabrainz/templates/payments/payment.html:16
+#: metabrainz/templates/payments/payment_base.html:16
 msgid ""
 "Your payments will be used to operate projects of the MetaBrainz "
 "Foundation. This includes paying\n"
@@ -1515,80 +1926,57 @@ msgid ""
 "      salary for MetaBrainz employees."
 msgstr ""
 
-#: metabrainz/templates/payments/payment.html:21
+#: metabrainz/templates/payments/payment_base.html:21
 #, python-format
 msgid ""
 "<p>Where has your contribution gone? See our <a "
 "href=\"%(financial_reports_url)s\">transparent finances</a>.</p>"
 msgstr ""
 
-#: metabrainz/templates/payments/payment.html:25
-#, python-format
-msgid ""
-"<b>Be careful!</b> This is a development version of the website. Do NOT\n"
-"        use your real credit card credentials! If you want to send an "
-"actual\n"
-"        payment, go to <a href=\"%(mb_url)s\">metabrainz.org</a>."
-msgstr ""
-
-#: metabrainz/templates/payments/payment.html:43
-#, python-format
-msgid ""
-"If you would like to make a large payment, please contact us at\n"
-"            <a href=\"%(mail_link)s\">payments@metabrainz.org</a>\n"
-"            before you do."
-msgstr ""
-
-#: metabrainz/templates/payments/payment.html:51
-msgid "Invoice number"
-msgstr ""
-
-#: metabrainz/templates/payments/payment.html:60
-msgid "Make this a recurring monthly payment"
-msgstr ""
-
-#: metabrainz/templates/payments/payment.html:68
-msgid "Pay with Credit Card"
-msgstr ""
-
-#: metabrainz/templates/payments/payment.html:84
-#, python-format
-msgid ""
-"The personal information provided to the MetaBrainz Foundation during the"
-"\n"
-"        payment process will not be shared with anyone. For more "
-"information,\n"
-"        please take a look at our <a href=\"%(privacy_policy_url)s\">\n"
-"        privacy policy</a>."
-msgstr ""
-
-#: metabrainz/templates/payments/payment.html:93
-#, python-format
-msgid ""
-"To find out how to cancel recurring payments take a look at\n"
-"        <a href=\"%(cancel_recurring_url)s\">this page</a>."
-msgstr ""
-
-#: metabrainz/templates/payments/payment.html:98
+#: metabrainz/templates/payments/payment_base.html:27
 msgid "Other ways to pay"
 msgstr ""
 
-#: metabrainz/templates/payments/payment.html:101
+#: metabrainz/templates/payments/payment_base.html:30
 msgid ""
 "You can make a payment, or recurring payments, via bank transfer to the "
 "following IBAN:"
 msgstr ""
 
-#: metabrainz/templates/payments/payment.html:103
+#: metabrainz/templates/payments/payment_base.html:32
 msgid ""
 "Please specify the invoice number(s) you are paying in the description "
 "field of the transfer."
 msgstr ""
 
-#: metabrainz/templates/payments/payment.html:106
-msgid ""
-"If you would like to pay us using a check drawn on a US bank, please send"
-" them to:"
+#: metabrainz/templates/payments/payment_selector.html:7
+msgid "Please, select a currency that you want to use for payment:"
+msgstr ""
+
+#: metabrainz/templates/payments/payment_selector.html:8
+msgid "United States dollar"
+msgstr ""
+
+#: metabrainz/templates/payments/payment_selector.html:9
+msgid "USD"
+msgstr ""
+
+#: metabrainz/templates/payments/payment_selector.html:10
+msgid "Euro"
+msgstr ""
+
+#: metabrainz/templates/payments/payment_selector.html:11
+msgid "EUR"
+msgstr ""
+
+#: metabrainz/templates/quickbooks/index.html:3
+#: metabrainz/templates/quickbooks/index.html:7
+msgid "Create Invoices"
+msgstr ""
+
+#: metabrainz/templates/quickbooks/login.html:3
+#: metabrainz/templates/quickbooks/login.html:7
+msgid "Login to Quickbooks"
 msgstr ""
 
 #: metabrainz/templates/reports/annual_reports/view.html:2
@@ -1636,658 +2024,706 @@ msgstr ""
 #: metabrainz/templates/reports/financial_reports/index.html:31
 msgid ""
 "We attempt to publish our balance sheets within the first week of the "
-"succeeding month, or as close to that as possible."
+"succeeding quarter, or as close to that as possible."
 msgstr ""
 
-#: metabrainz/templates/reports/financial_reports/index.html:35
-#: metabrainz/templates/reports/financial_reports/index.html:64
+#: metabrainz/templates/reports/financial_reports/index.html:36
+#: metabrainz/templates/reports/financial_reports/index.html:55
+#: metabrainz/templates/reports/financial_reports/index.html:76
+#: metabrainz/templates/reports/financial_reports/index.html:96
+#: metabrainz/templates/reports/financial_reports/index.html:116
+#: metabrainz/templates/reports/financial_reports/index.html:136
+#: metabrainz/templates/reports/financial_reports/index.html:157
+#: metabrainz/templates/reports/financial_reports/index.html:181
+#: metabrainz/templates/reports/financial_reports/index.html:199
+#: metabrainz/templates/reports/financial_reports/index.html:228
+#: metabrainz/templates/reports/financial_reports/index.html:257
+#: metabrainz/templates/reports/financial_reports/index.html:286
+#: metabrainz/templates/reports/financial_reports/index.html:315
+#: metabrainz/templates/reports/financial_reports/index.html:344
+#: metabrainz/templates/reports/financial_reports/index.html:373
+#: metabrainz/templates/reports/financial_reports/index.html:402
+#: metabrainz/templates/reports/financial_reports/index.html:431
+#: metabrainz/templates/reports/financial_reports/index.html:460
+msgid "Quarterly reports"
+msgstr ""
+
+#: metabrainz/templates/reports/financial_reports/index.html:38
+#: metabrainz/templates/reports/financial_reports/index.html:40
+#: metabrainz/templates/reports/financial_reports/index.html:42
+#: metabrainz/templates/reports/financial_reports/index.html:52
+#: metabrainz/templates/reports/financial_reports/index.html:57
+#: metabrainz/templates/reports/financial_reports/index.html:59
+#: metabrainz/templates/reports/financial_reports/index.html:61
+#: metabrainz/templates/reports/financial_reports/index.html:63
+#: metabrainz/templates/reports/financial_reports/index.html:73
+#: metabrainz/templates/reports/financial_reports/index.html:78
+#: metabrainz/templates/reports/financial_reports/index.html:80
+#: metabrainz/templates/reports/financial_reports/index.html:82
+#: metabrainz/templates/reports/financial_reports/index.html:84
 #: metabrainz/templates/reports/financial_reports/index.html:93
+#: metabrainz/templates/reports/financial_reports/index.html:98
+#: metabrainz/templates/reports/financial_reports/index.html:100
+#: metabrainz/templates/reports/financial_reports/index.html:102
+#: metabrainz/templates/reports/financial_reports/index.html:104
+#: metabrainz/templates/reports/financial_reports/index.html:113
+#: metabrainz/templates/reports/financial_reports/index.html:118
+#: metabrainz/templates/reports/financial_reports/index.html:120
 #: metabrainz/templates/reports/financial_reports/index.html:122
+#: metabrainz/templates/reports/financial_reports/index.html:124
+#: metabrainz/templates/reports/financial_reports/index.html:133
+#: metabrainz/templates/reports/financial_reports/index.html:138
+#: metabrainz/templates/reports/financial_reports/index.html:140
+#: metabrainz/templates/reports/financial_reports/index.html:142
+#: metabrainz/templates/reports/financial_reports/index.html:144
+#: metabrainz/templates/reports/financial_reports/index.html:154
+#: metabrainz/templates/reports/financial_reports/index.html:159
+#: metabrainz/templates/reports/financial_reports/index.html:161
+#: metabrainz/templates/reports/financial_reports/index.html:163
+#: metabrainz/templates/reports/financial_reports/index.html:165
+#: metabrainz/templates/reports/financial_reports/index.html:178
+#: metabrainz/templates/reports/financial_reports/index.html:183
+#: metabrainz/templates/reports/financial_reports/index.html:185
+#: metabrainz/templates/reports/financial_reports/index.html:187
+#: metabrainz/templates/reports/financial_reports/index.html:189
+#: metabrainz/templates/reports/financial_reports/index.html:197
+#: metabrainz/templates/reports/financial_reports/index.html:201
+#: metabrainz/templates/reports/financial_reports/index.html:202
+#: metabrainz/templates/reports/financial_reports/index.html:203
+#: metabrainz/templates/reports/financial_reports/index.html:204
+#: metabrainz/templates/reports/financial_reports/index.html:208
+#: metabrainz/templates/reports/financial_reports/index.html:209
+#: metabrainz/templates/reports/financial_reports/index.html:210
+#: metabrainz/templates/reports/financial_reports/index.html:211
+#: metabrainz/templates/reports/financial_reports/index.html:212
+#: metabrainz/templates/reports/financial_reports/index.html:213
+#: metabrainz/templates/reports/financial_reports/index.html:214
+#: metabrainz/templates/reports/financial_reports/index.html:215
+#: metabrainz/templates/reports/financial_reports/index.html:216
+#: metabrainz/templates/reports/financial_reports/index.html:217
+#: metabrainz/templates/reports/financial_reports/index.html:218
+#: metabrainz/templates/reports/financial_reports/index.html:219
+#: metabrainz/templates/reports/financial_reports/index.html:226
+#: metabrainz/templates/reports/financial_reports/index.html:230
+#: metabrainz/templates/reports/financial_reports/index.html:231
+#: metabrainz/templates/reports/financial_reports/index.html:232
+#: metabrainz/templates/reports/financial_reports/index.html:233
+#: metabrainz/templates/reports/financial_reports/index.html:237
+#: metabrainz/templates/reports/financial_reports/index.html:238
+#: metabrainz/templates/reports/financial_reports/index.html:239
+#: metabrainz/templates/reports/financial_reports/index.html:240
+#: metabrainz/templates/reports/financial_reports/index.html:241
+#: metabrainz/templates/reports/financial_reports/index.html:242
+#: metabrainz/templates/reports/financial_reports/index.html:243
+#: metabrainz/templates/reports/financial_reports/index.html:244
+#: metabrainz/templates/reports/financial_reports/index.html:245
+#: metabrainz/templates/reports/financial_reports/index.html:246
+#: metabrainz/templates/reports/financial_reports/index.html:247
+#: metabrainz/templates/reports/financial_reports/index.html:248
+#: metabrainz/templates/reports/financial_reports/index.html:255
+#: metabrainz/templates/reports/financial_reports/index.html:259
+#: metabrainz/templates/reports/financial_reports/index.html:260
+#: metabrainz/templates/reports/financial_reports/index.html:261
+#: metabrainz/templates/reports/financial_reports/index.html:262
+#: metabrainz/templates/reports/financial_reports/index.html:266
+#: metabrainz/templates/reports/financial_reports/index.html:267
+#: metabrainz/templates/reports/financial_reports/index.html:268
+#: metabrainz/templates/reports/financial_reports/index.html:269
+#: metabrainz/templates/reports/financial_reports/index.html:270
+#: metabrainz/templates/reports/financial_reports/index.html:271
+#: metabrainz/templates/reports/financial_reports/index.html:272
+#: metabrainz/templates/reports/financial_reports/index.html:273
+#: metabrainz/templates/reports/financial_reports/index.html:274
+#: metabrainz/templates/reports/financial_reports/index.html:275
+#: metabrainz/templates/reports/financial_reports/index.html:276
+#: metabrainz/templates/reports/financial_reports/index.html:277
+#: metabrainz/templates/reports/financial_reports/index.html:284
+#: metabrainz/templates/reports/financial_reports/index.html:288
+#: metabrainz/templates/reports/financial_reports/index.html:289
+#: metabrainz/templates/reports/financial_reports/index.html:290
+#: metabrainz/templates/reports/financial_reports/index.html:291
+#: metabrainz/templates/reports/financial_reports/index.html:295
+#: metabrainz/templates/reports/financial_reports/index.html:296
+#: metabrainz/templates/reports/financial_reports/index.html:297
+#: metabrainz/templates/reports/financial_reports/index.html:298
+#: metabrainz/templates/reports/financial_reports/index.html:299
+#: metabrainz/templates/reports/financial_reports/index.html:300
+#: metabrainz/templates/reports/financial_reports/index.html:301
+#: metabrainz/templates/reports/financial_reports/index.html:302
+#: metabrainz/templates/reports/financial_reports/index.html:303
+#: metabrainz/templates/reports/financial_reports/index.html:304
+#: metabrainz/templates/reports/financial_reports/index.html:305
+#: metabrainz/templates/reports/financial_reports/index.html:306
+#: metabrainz/templates/reports/financial_reports/index.html:313
+#: metabrainz/templates/reports/financial_reports/index.html:317
+#: metabrainz/templates/reports/financial_reports/index.html:318
+#: metabrainz/templates/reports/financial_reports/index.html:319
+#: metabrainz/templates/reports/financial_reports/index.html:320
+#: metabrainz/templates/reports/financial_reports/index.html:324
+#: metabrainz/templates/reports/financial_reports/index.html:325
+#: metabrainz/templates/reports/financial_reports/index.html:326
+#: metabrainz/templates/reports/financial_reports/index.html:327
+#: metabrainz/templates/reports/financial_reports/index.html:328
+#: metabrainz/templates/reports/financial_reports/index.html:329
+#: metabrainz/templates/reports/financial_reports/index.html:330
+#: metabrainz/templates/reports/financial_reports/index.html:331
+#: metabrainz/templates/reports/financial_reports/index.html:332
+#: metabrainz/templates/reports/financial_reports/index.html:333
+#: metabrainz/templates/reports/financial_reports/index.html:334
+#: metabrainz/templates/reports/financial_reports/index.html:335
+#: metabrainz/templates/reports/financial_reports/index.html:342
+#: metabrainz/templates/reports/financial_reports/index.html:346
+#: metabrainz/templates/reports/financial_reports/index.html:347
+#: metabrainz/templates/reports/financial_reports/index.html:348
+#: metabrainz/templates/reports/financial_reports/index.html:349
+#: metabrainz/templates/reports/financial_reports/index.html:353
+#: metabrainz/templates/reports/financial_reports/index.html:354
+#: metabrainz/templates/reports/financial_reports/index.html:355
+#: metabrainz/templates/reports/financial_reports/index.html:356
+#: metabrainz/templates/reports/financial_reports/index.html:357
+#: metabrainz/templates/reports/financial_reports/index.html:358
+#: metabrainz/templates/reports/financial_reports/index.html:359
+#: metabrainz/templates/reports/financial_reports/index.html:360
+#: metabrainz/templates/reports/financial_reports/index.html:361
+#: metabrainz/templates/reports/financial_reports/index.html:362
+#: metabrainz/templates/reports/financial_reports/index.html:363
+#: metabrainz/templates/reports/financial_reports/index.html:364
+#: metabrainz/templates/reports/financial_reports/index.html:371
+#: metabrainz/templates/reports/financial_reports/index.html:375
+#: metabrainz/templates/reports/financial_reports/index.html:376
+#: metabrainz/templates/reports/financial_reports/index.html:377
+#: metabrainz/templates/reports/financial_reports/index.html:378
+#: metabrainz/templates/reports/financial_reports/index.html:382
+#: metabrainz/templates/reports/financial_reports/index.html:383
+#: metabrainz/templates/reports/financial_reports/index.html:384
+#: metabrainz/templates/reports/financial_reports/index.html:385
+#: metabrainz/templates/reports/financial_reports/index.html:386
+#: metabrainz/templates/reports/financial_reports/index.html:387
+#: metabrainz/templates/reports/financial_reports/index.html:388
+#: metabrainz/templates/reports/financial_reports/index.html:389
+#: metabrainz/templates/reports/financial_reports/index.html:390
+#: metabrainz/templates/reports/financial_reports/index.html:391
+#: metabrainz/templates/reports/financial_reports/index.html:392
+#: metabrainz/templates/reports/financial_reports/index.html:393
+#: metabrainz/templates/reports/financial_reports/index.html:400
+#: metabrainz/templates/reports/financial_reports/index.html:404
+#: metabrainz/templates/reports/financial_reports/index.html:405
+#: metabrainz/templates/reports/financial_reports/index.html:406
+#: metabrainz/templates/reports/financial_reports/index.html:407
+#: metabrainz/templates/reports/financial_reports/index.html:411
+#: metabrainz/templates/reports/financial_reports/index.html:412
+#: metabrainz/templates/reports/financial_reports/index.html:413
+#: metabrainz/templates/reports/financial_reports/index.html:414
+#: metabrainz/templates/reports/financial_reports/index.html:415
+#: metabrainz/templates/reports/financial_reports/index.html:416
+#: metabrainz/templates/reports/financial_reports/index.html:417
+#: metabrainz/templates/reports/financial_reports/index.html:418
+#: metabrainz/templates/reports/financial_reports/index.html:419
+#: metabrainz/templates/reports/financial_reports/index.html:420
+#: metabrainz/templates/reports/financial_reports/index.html:421
+#: metabrainz/templates/reports/financial_reports/index.html:422
+#: metabrainz/templates/reports/financial_reports/index.html:429
+#: metabrainz/templates/reports/financial_reports/index.html:433
+#: metabrainz/templates/reports/financial_reports/index.html:434
+#: metabrainz/templates/reports/financial_reports/index.html:435
+#: metabrainz/templates/reports/financial_reports/index.html:436
+#: metabrainz/templates/reports/financial_reports/index.html:440
+#: metabrainz/templates/reports/financial_reports/index.html:441
+#: metabrainz/templates/reports/financial_reports/index.html:442
+#: metabrainz/templates/reports/financial_reports/index.html:443
+#: metabrainz/templates/reports/financial_reports/index.html:444
+#: metabrainz/templates/reports/financial_reports/index.html:445
+#: metabrainz/templates/reports/financial_reports/index.html:446
+#: metabrainz/templates/reports/financial_reports/index.html:447
+#: metabrainz/templates/reports/financial_reports/index.html:448
+#: metabrainz/templates/reports/financial_reports/index.html:449
+#: metabrainz/templates/reports/financial_reports/index.html:450
+#: metabrainz/templates/reports/financial_reports/index.html:451
+#: metabrainz/templates/reports/financial_reports/index.html:458
+#: metabrainz/templates/reports/financial_reports/index.html:462
+#: metabrainz/templates/reports/financial_reports/index.html:463
+#: metabrainz/templates/reports/financial_reports/index.html:464
+#: metabrainz/templates/reports/financial_reports/index.html:465
+#: metabrainz/templates/reports/financial_reports/index.html:469
+#: metabrainz/templates/reports/financial_reports/index.html:470
+#: metabrainz/templates/reports/financial_reports/index.html:471
+#: metabrainz/templates/reports/financial_reports/index.html:472
+#: metabrainz/templates/reports/financial_reports/index.html:473
+#: metabrainz/templates/reports/financial_reports/index.html:474
+#: metabrainz/templates/reports/financial_reports/index.html:475
+#: metabrainz/templates/reports/financial_reports/index.html:476
+#: metabrainz/templates/reports/financial_reports/index.html:477
+#: metabrainz/templates/reports/financial_reports/index.html:478
+#: metabrainz/templates/reports/financial_reports/index.html:479
+#: metabrainz/templates/reports/financial_reports/index.html:480
+#: metabrainz/templates/reports/financial_reports/index.html:487
+#: metabrainz/templates/reports/financial_reports/index.html:509
+msgid "profit &amp; loss"
+msgstr ""
+
+#: metabrainz/templates/reports/financial_reports/index.html:39
+#: metabrainz/templates/reports/financial_reports/index.html:41
+#: metabrainz/templates/reports/financial_reports/index.html:43
+#: metabrainz/templates/reports/financial_reports/index.html:51
+#: metabrainz/templates/reports/financial_reports/index.html:58
+#: metabrainz/templates/reports/financial_reports/index.html:60
+#: metabrainz/templates/reports/financial_reports/index.html:62
+#: metabrainz/templates/reports/financial_reports/index.html:64
+#: metabrainz/templates/reports/financial_reports/index.html:72
+#: metabrainz/templates/reports/financial_reports/index.html:79
+#: metabrainz/templates/reports/financial_reports/index.html:81
+#: metabrainz/templates/reports/financial_reports/index.html:83
+#: metabrainz/templates/reports/financial_reports/index.html:85
+#: metabrainz/templates/reports/financial_reports/index.html:92
+#: metabrainz/templates/reports/financial_reports/index.html:99
+#: metabrainz/templates/reports/financial_reports/index.html:101
+#: metabrainz/templates/reports/financial_reports/index.html:103
+#: metabrainz/templates/reports/financial_reports/index.html:105
+#: metabrainz/templates/reports/financial_reports/index.html:112
+#: metabrainz/templates/reports/financial_reports/index.html:119
+#: metabrainz/templates/reports/financial_reports/index.html:121
+#: metabrainz/templates/reports/financial_reports/index.html:123
+#: metabrainz/templates/reports/financial_reports/index.html:125
+#: metabrainz/templates/reports/financial_reports/index.html:132
+#: metabrainz/templates/reports/financial_reports/index.html:139
+#: metabrainz/templates/reports/financial_reports/index.html:141
+#: metabrainz/templates/reports/financial_reports/index.html:143
+#: metabrainz/templates/reports/financial_reports/index.html:145
+#: metabrainz/templates/reports/financial_reports/index.html:153
+#: metabrainz/templates/reports/financial_reports/index.html:160
+#: metabrainz/templates/reports/financial_reports/index.html:162
+#: metabrainz/templates/reports/financial_reports/index.html:164
+#: metabrainz/templates/reports/financial_reports/index.html:166
+#: metabrainz/templates/reports/financial_reports/index.html:177
+#: metabrainz/templates/reports/financial_reports/index.html:184
+#: metabrainz/templates/reports/financial_reports/index.html:186
+#: metabrainz/templates/reports/financial_reports/index.html:188
+#: metabrainz/templates/reports/financial_reports/index.html:190
+#: metabrainz/templates/reports/financial_reports/index.html:196
+#: metabrainz/templates/reports/financial_reports/index.html:208
+#: metabrainz/templates/reports/financial_reports/index.html:209
+#: metabrainz/templates/reports/financial_reports/index.html:210
+#: metabrainz/templates/reports/financial_reports/index.html:211
+#: metabrainz/templates/reports/financial_reports/index.html:212
+#: metabrainz/templates/reports/financial_reports/index.html:213
+#: metabrainz/templates/reports/financial_reports/index.html:214
+#: metabrainz/templates/reports/financial_reports/index.html:215
+#: metabrainz/templates/reports/financial_reports/index.html:216
+#: metabrainz/templates/reports/financial_reports/index.html:217
+#: metabrainz/templates/reports/financial_reports/index.html:218
+#: metabrainz/templates/reports/financial_reports/index.html:219
+#: metabrainz/templates/reports/financial_reports/index.html:225
+#: metabrainz/templates/reports/financial_reports/index.html:237
+#: metabrainz/templates/reports/financial_reports/index.html:238
+#: metabrainz/templates/reports/financial_reports/index.html:239
+#: metabrainz/templates/reports/financial_reports/index.html:240
+#: metabrainz/templates/reports/financial_reports/index.html:241
+#: metabrainz/templates/reports/financial_reports/index.html:242
+#: metabrainz/templates/reports/financial_reports/index.html:243
+#: metabrainz/templates/reports/financial_reports/index.html:244
+#: metabrainz/templates/reports/financial_reports/index.html:245
+#: metabrainz/templates/reports/financial_reports/index.html:246
+#: metabrainz/templates/reports/financial_reports/index.html:247
+#: metabrainz/templates/reports/financial_reports/index.html:248
+#: metabrainz/templates/reports/financial_reports/index.html:254
+#: metabrainz/templates/reports/financial_reports/index.html:266
+#: metabrainz/templates/reports/financial_reports/index.html:267
+#: metabrainz/templates/reports/financial_reports/index.html:268
+#: metabrainz/templates/reports/financial_reports/index.html:269
+#: metabrainz/templates/reports/financial_reports/index.html:270
+#: metabrainz/templates/reports/financial_reports/index.html:271
+#: metabrainz/templates/reports/financial_reports/index.html:272
+#: metabrainz/templates/reports/financial_reports/index.html:273
+#: metabrainz/templates/reports/financial_reports/index.html:274
+#: metabrainz/templates/reports/financial_reports/index.html:275
+#: metabrainz/templates/reports/financial_reports/index.html:276
+#: metabrainz/templates/reports/financial_reports/index.html:277
+#: metabrainz/templates/reports/financial_reports/index.html:283
+#: metabrainz/templates/reports/financial_reports/index.html:295
+#: metabrainz/templates/reports/financial_reports/index.html:296
+#: metabrainz/templates/reports/financial_reports/index.html:297
+#: metabrainz/templates/reports/financial_reports/index.html:298
+#: metabrainz/templates/reports/financial_reports/index.html:299
+#: metabrainz/templates/reports/financial_reports/index.html:300
+#: metabrainz/templates/reports/financial_reports/index.html:301
+#: metabrainz/templates/reports/financial_reports/index.html:302
+#: metabrainz/templates/reports/financial_reports/index.html:303
+#: metabrainz/templates/reports/financial_reports/index.html:304
+#: metabrainz/templates/reports/financial_reports/index.html:305
+#: metabrainz/templates/reports/financial_reports/index.html:306
+#: metabrainz/templates/reports/financial_reports/index.html:312
+#: metabrainz/templates/reports/financial_reports/index.html:324
+#: metabrainz/templates/reports/financial_reports/index.html:325
+#: metabrainz/templates/reports/financial_reports/index.html:326
+#: metabrainz/templates/reports/financial_reports/index.html:327
+#: metabrainz/templates/reports/financial_reports/index.html:328
+#: metabrainz/templates/reports/financial_reports/index.html:329
+#: metabrainz/templates/reports/financial_reports/index.html:330
+#: metabrainz/templates/reports/financial_reports/index.html:331
+#: metabrainz/templates/reports/financial_reports/index.html:332
+#: metabrainz/templates/reports/financial_reports/index.html:333
+#: metabrainz/templates/reports/financial_reports/index.html:334
+#: metabrainz/templates/reports/financial_reports/index.html:335
+#: metabrainz/templates/reports/financial_reports/index.html:341
+#: metabrainz/templates/reports/financial_reports/index.html:353
+#: metabrainz/templates/reports/financial_reports/index.html:354
+#: metabrainz/templates/reports/financial_reports/index.html:355
+#: metabrainz/templates/reports/financial_reports/index.html:356
+#: metabrainz/templates/reports/financial_reports/index.html:357
+#: metabrainz/templates/reports/financial_reports/index.html:358
+#: metabrainz/templates/reports/financial_reports/index.html:359
+#: metabrainz/templates/reports/financial_reports/index.html:360
+#: metabrainz/templates/reports/financial_reports/index.html:361
+#: metabrainz/templates/reports/financial_reports/index.html:362
+#: metabrainz/templates/reports/financial_reports/index.html:363
+#: metabrainz/templates/reports/financial_reports/index.html:364
+#: metabrainz/templates/reports/financial_reports/index.html:370
+#: metabrainz/templates/reports/financial_reports/index.html:382
+#: metabrainz/templates/reports/financial_reports/index.html:383
+#: metabrainz/templates/reports/financial_reports/index.html:384
+#: metabrainz/templates/reports/financial_reports/index.html:385
+#: metabrainz/templates/reports/financial_reports/index.html:386
+#: metabrainz/templates/reports/financial_reports/index.html:387
+#: metabrainz/templates/reports/financial_reports/index.html:388
+#: metabrainz/templates/reports/financial_reports/index.html:389
+#: metabrainz/templates/reports/financial_reports/index.html:390
+#: metabrainz/templates/reports/financial_reports/index.html:391
+#: metabrainz/templates/reports/financial_reports/index.html:392
+#: metabrainz/templates/reports/financial_reports/index.html:393
+#: metabrainz/templates/reports/financial_reports/index.html:399
+#: metabrainz/templates/reports/financial_reports/index.html:411
+#: metabrainz/templates/reports/financial_reports/index.html:412
+#: metabrainz/templates/reports/financial_reports/index.html:413
+#: metabrainz/templates/reports/financial_reports/index.html:414
+#: metabrainz/templates/reports/financial_reports/index.html:415
+#: metabrainz/templates/reports/financial_reports/index.html:416
+#: metabrainz/templates/reports/financial_reports/index.html:417
+#: metabrainz/templates/reports/financial_reports/index.html:418
+#: metabrainz/templates/reports/financial_reports/index.html:419
+#: metabrainz/templates/reports/financial_reports/index.html:420
+#: metabrainz/templates/reports/financial_reports/index.html:421
+#: metabrainz/templates/reports/financial_reports/index.html:422
+#: metabrainz/templates/reports/financial_reports/index.html:428
+#: metabrainz/templates/reports/financial_reports/index.html:440
+#: metabrainz/templates/reports/financial_reports/index.html:441
+#: metabrainz/templates/reports/financial_reports/index.html:442
+#: metabrainz/templates/reports/financial_reports/index.html:443
+#: metabrainz/templates/reports/financial_reports/index.html:444
+#: metabrainz/templates/reports/financial_reports/index.html:445
+#: metabrainz/templates/reports/financial_reports/index.html:446
+#: metabrainz/templates/reports/financial_reports/index.html:447
+#: metabrainz/templates/reports/financial_reports/index.html:448
+#: metabrainz/templates/reports/financial_reports/index.html:449
+#: metabrainz/templates/reports/financial_reports/index.html:450
+#: metabrainz/templates/reports/financial_reports/index.html:451
+#: metabrainz/templates/reports/financial_reports/index.html:457
+#: metabrainz/templates/reports/financial_reports/index.html:469
+#: metabrainz/templates/reports/financial_reports/index.html:470
+#: metabrainz/templates/reports/financial_reports/index.html:471
+#: metabrainz/templates/reports/financial_reports/index.html:472
+#: metabrainz/templates/reports/financial_reports/index.html:473
+#: metabrainz/templates/reports/financial_reports/index.html:474
+#: metabrainz/templates/reports/financial_reports/index.html:475
+#: metabrainz/templates/reports/financial_reports/index.html:476
+#: metabrainz/templates/reports/financial_reports/index.html:477
+#: metabrainz/templates/reports/financial_reports/index.html:478
+#: metabrainz/templates/reports/financial_reports/index.html:479
+#: metabrainz/templates/reports/financial_reports/index.html:480
+#: metabrainz/templates/reports/financial_reports/index.html:486
+#: metabrainz/templates/reports/financial_reports/index.html:508
+msgid "balance sheet"
+msgstr ""
+
+#: metabrainz/templates/reports/financial_reports/index.html:49
+#: metabrainz/templates/reports/financial_reports/index.html:70
+#: metabrainz/templates/reports/financial_reports/index.html:90
+#: metabrainz/templates/reports/financial_reports/index.html:110
+#: metabrainz/templates/reports/financial_reports/index.html:130
 #: metabrainz/templates/reports/financial_reports/index.html:151
-#: metabrainz/templates/reports/financial_reports/index.html:180
+#: metabrainz/templates/reports/financial_reports/index.html:175
+#: metabrainz/templates/reports/financial_reports/index.html:194
+#: metabrainz/templates/reports/financial_reports/index.html:223
+#: metabrainz/templates/reports/financial_reports/index.html:252
+#: metabrainz/templates/reports/financial_reports/index.html:281
+#: metabrainz/templates/reports/financial_reports/index.html:310
+#: metabrainz/templates/reports/financial_reports/index.html:339
+#: metabrainz/templates/reports/financial_reports/index.html:368
+#: metabrainz/templates/reports/financial_reports/index.html:397
+#: metabrainz/templates/reports/financial_reports/index.html:426
+#: metabrainz/templates/reports/financial_reports/index.html:455
+#: metabrainz/templates/reports/financial_reports/index.html:484
+#: metabrainz/templates/reports/financial_reports/index.html:506
+msgid "Year end reports"
+msgstr ""
+
+#: metabrainz/templates/reports/financial_reports/index.html:206
+#: metabrainz/templates/reports/financial_reports/index.html:235
+#: metabrainz/templates/reports/financial_reports/index.html:264
+#: metabrainz/templates/reports/financial_reports/index.html:293
+#: metabrainz/templates/reports/financial_reports/index.html:322
+#: metabrainz/templates/reports/financial_reports/index.html:351
+#: metabrainz/templates/reports/financial_reports/index.html:380
+#: metabrainz/templates/reports/financial_reports/index.html:409
+#: metabrainz/templates/reports/financial_reports/index.html:438
+#: metabrainz/templates/reports/financial_reports/index.html:467
+msgid "Monthly reports"
+msgstr ""
+
+#: metabrainz/templates/reports/financial_reports/index.html:208
+#: metabrainz/templates/reports/financial_reports/index.html:237
+#: metabrainz/templates/reports/financial_reports/index.html:266
+#: metabrainz/templates/reports/financial_reports/index.html:295
+#: metabrainz/templates/reports/financial_reports/index.html:324
+#: metabrainz/templates/reports/financial_reports/index.html:353
+#: metabrainz/templates/reports/financial_reports/index.html:382
+#: metabrainz/templates/reports/financial_reports/index.html:411
+#: metabrainz/templates/reports/financial_reports/index.html:440
+#: metabrainz/templates/reports/financial_reports/index.html:469
+#: metabrainz/templates/reports/financial_reports/index.html:491
+#: metabrainz/templates/reports/financial_reports/index.html:513
+#: metabrainz/templates/reports/financial_reports/index.html:529
+msgid "December"
+msgstr ""
+
 #: metabrainz/templates/reports/financial_reports/index.html:209
 #: metabrainz/templates/reports/financial_reports/index.html:238
 #: metabrainz/templates/reports/financial_reports/index.html:267
 #: metabrainz/templates/reports/financial_reports/index.html:296
 #: metabrainz/templates/reports/financial_reports/index.html:325
-#: metabrainz/templates/reports/financial_reports/index.html:347
-msgid "Year end reports"
+#: metabrainz/templates/reports/financial_reports/index.html:354
+#: metabrainz/templates/reports/financial_reports/index.html:383
+#: metabrainz/templates/reports/financial_reports/index.html:412
+#: metabrainz/templates/reports/financial_reports/index.html:441
+#: metabrainz/templates/reports/financial_reports/index.html:470
+#: metabrainz/templates/reports/financial_reports/index.html:492
+#: metabrainz/templates/reports/financial_reports/index.html:514
+msgid "November"
 msgstr ""
 
-#: metabrainz/templates/reports/financial_reports/index.html:37
-#: metabrainz/templates/reports/financial_reports/index.html:49
-#: metabrainz/templates/reports/financial_reports/index.html:50
-#: metabrainz/templates/reports/financial_reports/index.html:51
-#: metabrainz/templates/reports/financial_reports/index.html:52
-#: metabrainz/templates/reports/financial_reports/index.html:53
-#: metabrainz/templates/reports/financial_reports/index.html:54
-#: metabrainz/templates/reports/financial_reports/index.html:55
-#: metabrainz/templates/reports/financial_reports/index.html:56
-#: metabrainz/templates/reports/financial_reports/index.html:57
-#: metabrainz/templates/reports/financial_reports/index.html:58
-#: metabrainz/templates/reports/financial_reports/index.html:59
-#: metabrainz/templates/reports/financial_reports/index.html:60
-#: metabrainz/templates/reports/financial_reports/index.html:66
-#: metabrainz/templates/reports/financial_reports/index.html:78
-#: metabrainz/templates/reports/financial_reports/index.html:79
-#: metabrainz/templates/reports/financial_reports/index.html:80
-#: metabrainz/templates/reports/financial_reports/index.html:81
-#: metabrainz/templates/reports/financial_reports/index.html:82
-#: metabrainz/templates/reports/financial_reports/index.html:83
-#: metabrainz/templates/reports/financial_reports/index.html:84
-#: metabrainz/templates/reports/financial_reports/index.html:85
-#: metabrainz/templates/reports/financial_reports/index.html:86
-#: metabrainz/templates/reports/financial_reports/index.html:87
-#: metabrainz/templates/reports/financial_reports/index.html:88
-#: metabrainz/templates/reports/financial_reports/index.html:89
-#: metabrainz/templates/reports/financial_reports/index.html:95
-#: metabrainz/templates/reports/financial_reports/index.html:107
-#: metabrainz/templates/reports/financial_reports/index.html:108
-#: metabrainz/templates/reports/financial_reports/index.html:109
-#: metabrainz/templates/reports/financial_reports/index.html:110
-#: metabrainz/templates/reports/financial_reports/index.html:111
-#: metabrainz/templates/reports/financial_reports/index.html:112
-#: metabrainz/templates/reports/financial_reports/index.html:113
-#: metabrainz/templates/reports/financial_reports/index.html:114
-#: metabrainz/templates/reports/financial_reports/index.html:115
-#: metabrainz/templates/reports/financial_reports/index.html:116
-#: metabrainz/templates/reports/financial_reports/index.html:117
-#: metabrainz/templates/reports/financial_reports/index.html:118
-#: metabrainz/templates/reports/financial_reports/index.html:124
-#: metabrainz/templates/reports/financial_reports/index.html:136
-#: metabrainz/templates/reports/financial_reports/index.html:137
-#: metabrainz/templates/reports/financial_reports/index.html:138
-#: metabrainz/templates/reports/financial_reports/index.html:139
-#: metabrainz/templates/reports/financial_reports/index.html:140
-#: metabrainz/templates/reports/financial_reports/index.html:141
-#: metabrainz/templates/reports/financial_reports/index.html:142
-#: metabrainz/templates/reports/financial_reports/index.html:143
-#: metabrainz/templates/reports/financial_reports/index.html:144
-#: metabrainz/templates/reports/financial_reports/index.html:145
-#: metabrainz/templates/reports/financial_reports/index.html:146
-#: metabrainz/templates/reports/financial_reports/index.html:147
-#: metabrainz/templates/reports/financial_reports/index.html:153
-#: metabrainz/templates/reports/financial_reports/index.html:165
-#: metabrainz/templates/reports/financial_reports/index.html:166
-#: metabrainz/templates/reports/financial_reports/index.html:167
-#: metabrainz/templates/reports/financial_reports/index.html:168
-#: metabrainz/templates/reports/financial_reports/index.html:169
-#: metabrainz/templates/reports/financial_reports/index.html:170
-#: metabrainz/templates/reports/financial_reports/index.html:171
-#: metabrainz/templates/reports/financial_reports/index.html:172
-#: metabrainz/templates/reports/financial_reports/index.html:173
-#: metabrainz/templates/reports/financial_reports/index.html:174
-#: metabrainz/templates/reports/financial_reports/index.html:175
-#: metabrainz/templates/reports/financial_reports/index.html:176
-#: metabrainz/templates/reports/financial_reports/index.html:182
-#: metabrainz/templates/reports/financial_reports/index.html:194
-#: metabrainz/templates/reports/financial_reports/index.html:195
-#: metabrainz/templates/reports/financial_reports/index.html:196
-#: metabrainz/templates/reports/financial_reports/index.html:197
-#: metabrainz/templates/reports/financial_reports/index.html:198
-#: metabrainz/templates/reports/financial_reports/index.html:199
-#: metabrainz/templates/reports/financial_reports/index.html:200
-#: metabrainz/templates/reports/financial_reports/index.html:201
-#: metabrainz/templates/reports/financial_reports/index.html:202
-#: metabrainz/templates/reports/financial_reports/index.html:203
-#: metabrainz/templates/reports/financial_reports/index.html:204
-#: metabrainz/templates/reports/financial_reports/index.html:205
+#: metabrainz/templates/reports/financial_reports/index.html:210
+#: metabrainz/templates/reports/financial_reports/index.html:239
+#: metabrainz/templates/reports/financial_reports/index.html:268
+#: metabrainz/templates/reports/financial_reports/index.html:297
+#: metabrainz/templates/reports/financial_reports/index.html:326
+#: metabrainz/templates/reports/financial_reports/index.html:355
+#: metabrainz/templates/reports/financial_reports/index.html:384
+#: metabrainz/templates/reports/financial_reports/index.html:413
+#: metabrainz/templates/reports/financial_reports/index.html:442
+#: metabrainz/templates/reports/financial_reports/index.html:471
+#: metabrainz/templates/reports/financial_reports/index.html:493
+#: metabrainz/templates/reports/financial_reports/index.html:515
+msgid "October"
+msgstr ""
+
 #: metabrainz/templates/reports/financial_reports/index.html:211
-#: metabrainz/templates/reports/financial_reports/index.html:223
-#: metabrainz/templates/reports/financial_reports/index.html:224
-#: metabrainz/templates/reports/financial_reports/index.html:225
-#: metabrainz/templates/reports/financial_reports/index.html:226
-#: metabrainz/templates/reports/financial_reports/index.html:227
-#: metabrainz/templates/reports/financial_reports/index.html:228
-#: metabrainz/templates/reports/financial_reports/index.html:229
-#: metabrainz/templates/reports/financial_reports/index.html:230
-#: metabrainz/templates/reports/financial_reports/index.html:231
-#: metabrainz/templates/reports/financial_reports/index.html:232
-#: metabrainz/templates/reports/financial_reports/index.html:233
-#: metabrainz/templates/reports/financial_reports/index.html:234
 #: metabrainz/templates/reports/financial_reports/index.html:240
-#: metabrainz/templates/reports/financial_reports/index.html:252
-#: metabrainz/templates/reports/financial_reports/index.html:253
-#: metabrainz/templates/reports/financial_reports/index.html:254
-#: metabrainz/templates/reports/financial_reports/index.html:255
-#: metabrainz/templates/reports/financial_reports/index.html:256
-#: metabrainz/templates/reports/financial_reports/index.html:257
-#: metabrainz/templates/reports/financial_reports/index.html:258
-#: metabrainz/templates/reports/financial_reports/index.html:259
-#: metabrainz/templates/reports/financial_reports/index.html:260
-#: metabrainz/templates/reports/financial_reports/index.html:261
-#: metabrainz/templates/reports/financial_reports/index.html:262
-#: metabrainz/templates/reports/financial_reports/index.html:263
 #: metabrainz/templates/reports/financial_reports/index.html:269
-#: metabrainz/templates/reports/financial_reports/index.html:281
-#: metabrainz/templates/reports/financial_reports/index.html:282
-#: metabrainz/templates/reports/financial_reports/index.html:283
-#: metabrainz/templates/reports/financial_reports/index.html:284
-#: metabrainz/templates/reports/financial_reports/index.html:285
-#: metabrainz/templates/reports/financial_reports/index.html:286
-#: metabrainz/templates/reports/financial_reports/index.html:287
-#: metabrainz/templates/reports/financial_reports/index.html:288
-#: metabrainz/templates/reports/financial_reports/index.html:289
-#: metabrainz/templates/reports/financial_reports/index.html:290
-#: metabrainz/templates/reports/financial_reports/index.html:291
-#: metabrainz/templates/reports/financial_reports/index.html:292
 #: metabrainz/templates/reports/financial_reports/index.html:298
-#: metabrainz/templates/reports/financial_reports/index.html:310
-#: metabrainz/templates/reports/financial_reports/index.html:311
-#: metabrainz/templates/reports/financial_reports/index.html:312
-#: metabrainz/templates/reports/financial_reports/index.html:313
-#: metabrainz/templates/reports/financial_reports/index.html:314
-#: metabrainz/templates/reports/financial_reports/index.html:315
-#: metabrainz/templates/reports/financial_reports/index.html:316
-#: metabrainz/templates/reports/financial_reports/index.html:317
-#: metabrainz/templates/reports/financial_reports/index.html:318
-#: metabrainz/templates/reports/financial_reports/index.html:319
-#: metabrainz/templates/reports/financial_reports/index.html:320
-#: metabrainz/templates/reports/financial_reports/index.html:321
 #: metabrainz/templates/reports/financial_reports/index.html:327
-#: metabrainz/templates/reports/financial_reports/index.html:349
-msgid "balance sheet"
+#: metabrainz/templates/reports/financial_reports/index.html:356
+#: metabrainz/templates/reports/financial_reports/index.html:385
+#: metabrainz/templates/reports/financial_reports/index.html:414
+#: metabrainz/templates/reports/financial_reports/index.html:443
+#: metabrainz/templates/reports/financial_reports/index.html:472
+#: metabrainz/templates/reports/financial_reports/index.html:494
+#: metabrainz/templates/reports/financial_reports/index.html:516
+msgid "September"
 msgstr ""
 
-#: metabrainz/templates/reports/financial_reports/index.html:38
-#: metabrainz/templates/reports/financial_reports/index.html:42
-#: metabrainz/templates/reports/financial_reports/index.html:43
-#: metabrainz/templates/reports/financial_reports/index.html:44
-#: metabrainz/templates/reports/financial_reports/index.html:45
-#: metabrainz/templates/reports/financial_reports/index.html:49
-#: metabrainz/templates/reports/financial_reports/index.html:50
-#: metabrainz/templates/reports/financial_reports/index.html:51
-#: metabrainz/templates/reports/financial_reports/index.html:52
-#: metabrainz/templates/reports/financial_reports/index.html:53
-#: metabrainz/templates/reports/financial_reports/index.html:54
-#: metabrainz/templates/reports/financial_reports/index.html:55
-#: metabrainz/templates/reports/financial_reports/index.html:56
-#: metabrainz/templates/reports/financial_reports/index.html:57
-#: metabrainz/templates/reports/financial_reports/index.html:58
-#: metabrainz/templates/reports/financial_reports/index.html:59
-#: metabrainz/templates/reports/financial_reports/index.html:60
-#: metabrainz/templates/reports/financial_reports/index.html:67
-#: metabrainz/templates/reports/financial_reports/index.html:71
-#: metabrainz/templates/reports/financial_reports/index.html:72
-#: metabrainz/templates/reports/financial_reports/index.html:73
-#: metabrainz/templates/reports/financial_reports/index.html:74
-#: metabrainz/templates/reports/financial_reports/index.html:78
-#: metabrainz/templates/reports/financial_reports/index.html:79
-#: metabrainz/templates/reports/financial_reports/index.html:80
-#: metabrainz/templates/reports/financial_reports/index.html:81
-#: metabrainz/templates/reports/financial_reports/index.html:82
-#: metabrainz/templates/reports/financial_reports/index.html:83
-#: metabrainz/templates/reports/financial_reports/index.html:84
-#: metabrainz/templates/reports/financial_reports/index.html:85
-#: metabrainz/templates/reports/financial_reports/index.html:86
-#: metabrainz/templates/reports/financial_reports/index.html:87
-#: metabrainz/templates/reports/financial_reports/index.html:88
-#: metabrainz/templates/reports/financial_reports/index.html:89
-#: metabrainz/templates/reports/financial_reports/index.html:96
-#: metabrainz/templates/reports/financial_reports/index.html:100
-#: metabrainz/templates/reports/financial_reports/index.html:101
-#: metabrainz/templates/reports/financial_reports/index.html:102
-#: metabrainz/templates/reports/financial_reports/index.html:103
-#: metabrainz/templates/reports/financial_reports/index.html:107
-#: metabrainz/templates/reports/financial_reports/index.html:108
-#: metabrainz/templates/reports/financial_reports/index.html:109
-#: metabrainz/templates/reports/financial_reports/index.html:110
-#: metabrainz/templates/reports/financial_reports/index.html:111
-#: metabrainz/templates/reports/financial_reports/index.html:112
-#: metabrainz/templates/reports/financial_reports/index.html:113
-#: metabrainz/templates/reports/financial_reports/index.html:114
-#: metabrainz/templates/reports/financial_reports/index.html:115
-#: metabrainz/templates/reports/financial_reports/index.html:116
-#: metabrainz/templates/reports/financial_reports/index.html:117
-#: metabrainz/templates/reports/financial_reports/index.html:118
-#: metabrainz/templates/reports/financial_reports/index.html:125
-#: metabrainz/templates/reports/financial_reports/index.html:129
-#: metabrainz/templates/reports/financial_reports/index.html:130
-#: metabrainz/templates/reports/financial_reports/index.html:131
-#: metabrainz/templates/reports/financial_reports/index.html:132
-#: metabrainz/templates/reports/financial_reports/index.html:136
-#: metabrainz/templates/reports/financial_reports/index.html:137
-#: metabrainz/templates/reports/financial_reports/index.html:138
-#: metabrainz/templates/reports/financial_reports/index.html:139
-#: metabrainz/templates/reports/financial_reports/index.html:140
-#: metabrainz/templates/reports/financial_reports/index.html:141
-#: metabrainz/templates/reports/financial_reports/index.html:142
-#: metabrainz/templates/reports/financial_reports/index.html:143
-#: metabrainz/templates/reports/financial_reports/index.html:144
-#: metabrainz/templates/reports/financial_reports/index.html:145
-#: metabrainz/templates/reports/financial_reports/index.html:146
-#: metabrainz/templates/reports/financial_reports/index.html:147
-#: metabrainz/templates/reports/financial_reports/index.html:154
-#: metabrainz/templates/reports/financial_reports/index.html:158
-#: metabrainz/templates/reports/financial_reports/index.html:159
-#: metabrainz/templates/reports/financial_reports/index.html:160
-#: metabrainz/templates/reports/financial_reports/index.html:161
-#: metabrainz/templates/reports/financial_reports/index.html:165
-#: metabrainz/templates/reports/financial_reports/index.html:166
-#: metabrainz/templates/reports/financial_reports/index.html:167
-#: metabrainz/templates/reports/financial_reports/index.html:168
-#: metabrainz/templates/reports/financial_reports/index.html:169
-#: metabrainz/templates/reports/financial_reports/index.html:170
-#: metabrainz/templates/reports/financial_reports/index.html:171
-#: metabrainz/templates/reports/financial_reports/index.html:172
-#: metabrainz/templates/reports/financial_reports/index.html:173
-#: metabrainz/templates/reports/financial_reports/index.html:174
-#: metabrainz/templates/reports/financial_reports/index.html:175
-#: metabrainz/templates/reports/financial_reports/index.html:176
-#: metabrainz/templates/reports/financial_reports/index.html:183
-#: metabrainz/templates/reports/financial_reports/index.html:187
-#: metabrainz/templates/reports/financial_reports/index.html:188
-#: metabrainz/templates/reports/financial_reports/index.html:189
-#: metabrainz/templates/reports/financial_reports/index.html:190
-#: metabrainz/templates/reports/financial_reports/index.html:194
-#: metabrainz/templates/reports/financial_reports/index.html:195
-#: metabrainz/templates/reports/financial_reports/index.html:196
-#: metabrainz/templates/reports/financial_reports/index.html:197
-#: metabrainz/templates/reports/financial_reports/index.html:198
-#: metabrainz/templates/reports/financial_reports/index.html:199
-#: metabrainz/templates/reports/financial_reports/index.html:200
-#: metabrainz/templates/reports/financial_reports/index.html:201
-#: metabrainz/templates/reports/financial_reports/index.html:202
-#: metabrainz/templates/reports/financial_reports/index.html:203
-#: metabrainz/templates/reports/financial_reports/index.html:204
-#: metabrainz/templates/reports/financial_reports/index.html:205
 #: metabrainz/templates/reports/financial_reports/index.html:212
-#: metabrainz/templates/reports/financial_reports/index.html:216
-#: metabrainz/templates/reports/financial_reports/index.html:217
-#: metabrainz/templates/reports/financial_reports/index.html:218
-#: metabrainz/templates/reports/financial_reports/index.html:219
-#: metabrainz/templates/reports/financial_reports/index.html:223
-#: metabrainz/templates/reports/financial_reports/index.html:224
-#: metabrainz/templates/reports/financial_reports/index.html:225
-#: metabrainz/templates/reports/financial_reports/index.html:226
-#: metabrainz/templates/reports/financial_reports/index.html:227
-#: metabrainz/templates/reports/financial_reports/index.html:228
-#: metabrainz/templates/reports/financial_reports/index.html:229
-#: metabrainz/templates/reports/financial_reports/index.html:230
-#: metabrainz/templates/reports/financial_reports/index.html:231
-#: metabrainz/templates/reports/financial_reports/index.html:232
-#: metabrainz/templates/reports/financial_reports/index.html:233
-#: metabrainz/templates/reports/financial_reports/index.html:234
 #: metabrainz/templates/reports/financial_reports/index.html:241
-#: metabrainz/templates/reports/financial_reports/index.html:245
-#: metabrainz/templates/reports/financial_reports/index.html:246
-#: metabrainz/templates/reports/financial_reports/index.html:247
-#: metabrainz/templates/reports/financial_reports/index.html:248
-#: metabrainz/templates/reports/financial_reports/index.html:252
-#: metabrainz/templates/reports/financial_reports/index.html:253
-#: metabrainz/templates/reports/financial_reports/index.html:254
-#: metabrainz/templates/reports/financial_reports/index.html:255
-#: metabrainz/templates/reports/financial_reports/index.html:256
-#: metabrainz/templates/reports/financial_reports/index.html:257
-#: metabrainz/templates/reports/financial_reports/index.html:258
-#: metabrainz/templates/reports/financial_reports/index.html:259
-#: metabrainz/templates/reports/financial_reports/index.html:260
-#: metabrainz/templates/reports/financial_reports/index.html:261
-#: metabrainz/templates/reports/financial_reports/index.html:262
-#: metabrainz/templates/reports/financial_reports/index.html:263
 #: metabrainz/templates/reports/financial_reports/index.html:270
-#: metabrainz/templates/reports/financial_reports/index.html:274
-#: metabrainz/templates/reports/financial_reports/index.html:275
-#: metabrainz/templates/reports/financial_reports/index.html:276
-#: metabrainz/templates/reports/financial_reports/index.html:277
-#: metabrainz/templates/reports/financial_reports/index.html:281
-#: metabrainz/templates/reports/financial_reports/index.html:282
-#: metabrainz/templates/reports/financial_reports/index.html:283
-#: metabrainz/templates/reports/financial_reports/index.html:284
-#: metabrainz/templates/reports/financial_reports/index.html:285
-#: metabrainz/templates/reports/financial_reports/index.html:286
-#: metabrainz/templates/reports/financial_reports/index.html:287
-#: metabrainz/templates/reports/financial_reports/index.html:288
-#: metabrainz/templates/reports/financial_reports/index.html:289
-#: metabrainz/templates/reports/financial_reports/index.html:290
-#: metabrainz/templates/reports/financial_reports/index.html:291
-#: metabrainz/templates/reports/financial_reports/index.html:292
 #: metabrainz/templates/reports/financial_reports/index.html:299
-#: metabrainz/templates/reports/financial_reports/index.html:303
-#: metabrainz/templates/reports/financial_reports/index.html:304
-#: metabrainz/templates/reports/financial_reports/index.html:305
-#: metabrainz/templates/reports/financial_reports/index.html:306
-#: metabrainz/templates/reports/financial_reports/index.html:310
-#: metabrainz/templates/reports/financial_reports/index.html:311
-#: metabrainz/templates/reports/financial_reports/index.html:312
-#: metabrainz/templates/reports/financial_reports/index.html:313
-#: metabrainz/templates/reports/financial_reports/index.html:314
-#: metabrainz/templates/reports/financial_reports/index.html:315
-#: metabrainz/templates/reports/financial_reports/index.html:316
-#: metabrainz/templates/reports/financial_reports/index.html:317
-#: metabrainz/templates/reports/financial_reports/index.html:318
-#: metabrainz/templates/reports/financial_reports/index.html:319
-#: metabrainz/templates/reports/financial_reports/index.html:320
-#: metabrainz/templates/reports/financial_reports/index.html:321
 #: metabrainz/templates/reports/financial_reports/index.html:328
-#: metabrainz/templates/reports/financial_reports/index.html:350
-msgid "profit &amp; loss"
+#: metabrainz/templates/reports/financial_reports/index.html:357
+#: metabrainz/templates/reports/financial_reports/index.html:386
+#: metabrainz/templates/reports/financial_reports/index.html:415
+#: metabrainz/templates/reports/financial_reports/index.html:444
+#: metabrainz/templates/reports/financial_reports/index.html:473
+#: metabrainz/templates/reports/financial_reports/index.html:495
+#: metabrainz/templates/reports/financial_reports/index.html:517
+msgid "August"
 msgstr ""
 
-#: metabrainz/templates/reports/financial_reports/index.html:40
-#: metabrainz/templates/reports/financial_reports/index.html:69
-#: metabrainz/templates/reports/financial_reports/index.html:98
-#: metabrainz/templates/reports/financial_reports/index.html:127
-#: metabrainz/templates/reports/financial_reports/index.html:156
-#: metabrainz/templates/reports/financial_reports/index.html:185
+#: metabrainz/templates/reports/financial_reports/index.html:213
+#: metabrainz/templates/reports/financial_reports/index.html:242
+#: metabrainz/templates/reports/financial_reports/index.html:271
+#: metabrainz/templates/reports/financial_reports/index.html:300
+#: metabrainz/templates/reports/financial_reports/index.html:329
+#: metabrainz/templates/reports/financial_reports/index.html:358
+#: metabrainz/templates/reports/financial_reports/index.html:387
+#: metabrainz/templates/reports/financial_reports/index.html:416
+#: metabrainz/templates/reports/financial_reports/index.html:445
+#: metabrainz/templates/reports/financial_reports/index.html:474
+#: metabrainz/templates/reports/financial_reports/index.html:496
+#: metabrainz/templates/reports/financial_reports/index.html:518
+msgid "July"
+msgstr ""
+
 #: metabrainz/templates/reports/financial_reports/index.html:214
 #: metabrainz/templates/reports/financial_reports/index.html:243
 #: metabrainz/templates/reports/financial_reports/index.html:272
 #: metabrainz/templates/reports/financial_reports/index.html:301
-msgid "Quarterly reports"
-msgstr ""
-
-#: metabrainz/templates/reports/financial_reports/index.html:47
-#: metabrainz/templates/reports/financial_reports/index.html:76
-#: metabrainz/templates/reports/financial_reports/index.html:105
-#: metabrainz/templates/reports/financial_reports/index.html:134
-#: metabrainz/templates/reports/financial_reports/index.html:163
-#: metabrainz/templates/reports/financial_reports/index.html:192
-#: metabrainz/templates/reports/financial_reports/index.html:221
-#: metabrainz/templates/reports/financial_reports/index.html:250
-#: metabrainz/templates/reports/financial_reports/index.html:279
-#: metabrainz/templates/reports/financial_reports/index.html:308
-msgid "Monthly reports"
-msgstr ""
-
-#: metabrainz/templates/reports/financial_reports/index.html:49
-#: metabrainz/templates/reports/financial_reports/index.html:78
-#: metabrainz/templates/reports/financial_reports/index.html:107
-#: metabrainz/templates/reports/financial_reports/index.html:136
-#: metabrainz/templates/reports/financial_reports/index.html:165
-#: metabrainz/templates/reports/financial_reports/index.html:194
-#: metabrainz/templates/reports/financial_reports/index.html:223
-#: metabrainz/templates/reports/financial_reports/index.html:252
-#: metabrainz/templates/reports/financial_reports/index.html:281
-#: metabrainz/templates/reports/financial_reports/index.html:310
-#: metabrainz/templates/reports/financial_reports/index.html:332
-#: metabrainz/templates/reports/financial_reports/index.html:354
-#: metabrainz/templates/reports/financial_reports/index.html:370
-msgid "December"
-msgstr ""
-
-#: metabrainz/templates/reports/financial_reports/index.html:50
-#: metabrainz/templates/reports/financial_reports/index.html:79
-#: metabrainz/templates/reports/financial_reports/index.html:108
-#: metabrainz/templates/reports/financial_reports/index.html:137
-#: metabrainz/templates/reports/financial_reports/index.html:166
-#: metabrainz/templates/reports/financial_reports/index.html:195
-#: metabrainz/templates/reports/financial_reports/index.html:224
-#: metabrainz/templates/reports/financial_reports/index.html:253
-#: metabrainz/templates/reports/financial_reports/index.html:282
-#: metabrainz/templates/reports/financial_reports/index.html:311
-#: metabrainz/templates/reports/financial_reports/index.html:333
-#: metabrainz/templates/reports/financial_reports/index.html:355
-msgid "November"
-msgstr ""
-
-#: metabrainz/templates/reports/financial_reports/index.html:51
-#: metabrainz/templates/reports/financial_reports/index.html:80
-#: metabrainz/templates/reports/financial_reports/index.html:109
-#: metabrainz/templates/reports/financial_reports/index.html:138
-#: metabrainz/templates/reports/financial_reports/index.html:167
-#: metabrainz/templates/reports/financial_reports/index.html:196
-#: metabrainz/templates/reports/financial_reports/index.html:225
-#: metabrainz/templates/reports/financial_reports/index.html:254
-#: metabrainz/templates/reports/financial_reports/index.html:283
-#: metabrainz/templates/reports/financial_reports/index.html:312
-#: metabrainz/templates/reports/financial_reports/index.html:334
-#: metabrainz/templates/reports/financial_reports/index.html:356
-msgid "October"
-msgstr ""
-
-#: metabrainz/templates/reports/financial_reports/index.html:52
-#: metabrainz/templates/reports/financial_reports/index.html:81
-#: metabrainz/templates/reports/financial_reports/index.html:110
-#: metabrainz/templates/reports/financial_reports/index.html:139
-#: metabrainz/templates/reports/financial_reports/index.html:168
-#: metabrainz/templates/reports/financial_reports/index.html:197
-#: metabrainz/templates/reports/financial_reports/index.html:226
-#: metabrainz/templates/reports/financial_reports/index.html:255
-#: metabrainz/templates/reports/financial_reports/index.html:284
-#: metabrainz/templates/reports/financial_reports/index.html:313
-#: metabrainz/templates/reports/financial_reports/index.html:335
-#: metabrainz/templates/reports/financial_reports/index.html:357
-msgid "September"
-msgstr ""
-
-#: metabrainz/templates/reports/financial_reports/index.html:53
-#: metabrainz/templates/reports/financial_reports/index.html:82
-#: metabrainz/templates/reports/financial_reports/index.html:111
-#: metabrainz/templates/reports/financial_reports/index.html:140
-#: metabrainz/templates/reports/financial_reports/index.html:169
-#: metabrainz/templates/reports/financial_reports/index.html:198
-#: metabrainz/templates/reports/financial_reports/index.html:227
-#: metabrainz/templates/reports/financial_reports/index.html:256
-#: metabrainz/templates/reports/financial_reports/index.html:285
-#: metabrainz/templates/reports/financial_reports/index.html:314
-#: metabrainz/templates/reports/financial_reports/index.html:336
-#: metabrainz/templates/reports/financial_reports/index.html:358
-msgid "August"
-msgstr ""
-
-#: metabrainz/templates/reports/financial_reports/index.html:54
-#: metabrainz/templates/reports/financial_reports/index.html:83
-#: metabrainz/templates/reports/financial_reports/index.html:112
-#: metabrainz/templates/reports/financial_reports/index.html:141
-#: metabrainz/templates/reports/financial_reports/index.html:170
-#: metabrainz/templates/reports/financial_reports/index.html:199
-#: metabrainz/templates/reports/financial_reports/index.html:228
-#: metabrainz/templates/reports/financial_reports/index.html:257
-#: metabrainz/templates/reports/financial_reports/index.html:286
-#: metabrainz/templates/reports/financial_reports/index.html:315
-#: metabrainz/templates/reports/financial_reports/index.html:337
+#: metabrainz/templates/reports/financial_reports/index.html:330
 #: metabrainz/templates/reports/financial_reports/index.html:359
-msgid "July"
-msgstr ""
-
-#: metabrainz/templates/reports/financial_reports/index.html:55
-#: metabrainz/templates/reports/financial_reports/index.html:84
-#: metabrainz/templates/reports/financial_reports/index.html:113
-#: metabrainz/templates/reports/financial_reports/index.html:142
-#: metabrainz/templates/reports/financial_reports/index.html:171
-#: metabrainz/templates/reports/financial_reports/index.html:200
-#: metabrainz/templates/reports/financial_reports/index.html:229
-#: metabrainz/templates/reports/financial_reports/index.html:258
-#: metabrainz/templates/reports/financial_reports/index.html:287
-#: metabrainz/templates/reports/financial_reports/index.html:316
-#: metabrainz/templates/reports/financial_reports/index.html:338
-#: metabrainz/templates/reports/financial_reports/index.html:360
+#: metabrainz/templates/reports/financial_reports/index.html:388
+#: metabrainz/templates/reports/financial_reports/index.html:417
+#: metabrainz/templates/reports/financial_reports/index.html:446
+#: metabrainz/templates/reports/financial_reports/index.html:475
+#: metabrainz/templates/reports/financial_reports/index.html:497
+#: metabrainz/templates/reports/financial_reports/index.html:519
 msgid "June"
 msgstr ""
 
-#: metabrainz/templates/reports/financial_reports/index.html:56
-#: metabrainz/templates/reports/financial_reports/index.html:85
-#: metabrainz/templates/reports/financial_reports/index.html:114
-#: metabrainz/templates/reports/financial_reports/index.html:143
-#: metabrainz/templates/reports/financial_reports/index.html:172
-#: metabrainz/templates/reports/financial_reports/index.html:201
-#: metabrainz/templates/reports/financial_reports/index.html:230
-#: metabrainz/templates/reports/financial_reports/index.html:259
-#: metabrainz/templates/reports/financial_reports/index.html:288
-#: metabrainz/templates/reports/financial_reports/index.html:317
-#: metabrainz/templates/reports/financial_reports/index.html:339
-#: metabrainz/templates/reports/financial_reports/index.html:361
+#: metabrainz/templates/reports/financial_reports/index.html:215
+#: metabrainz/templates/reports/financial_reports/index.html:244
+#: metabrainz/templates/reports/financial_reports/index.html:273
+#: metabrainz/templates/reports/financial_reports/index.html:302
+#: metabrainz/templates/reports/financial_reports/index.html:331
+#: metabrainz/templates/reports/financial_reports/index.html:360
+#: metabrainz/templates/reports/financial_reports/index.html:389
+#: metabrainz/templates/reports/financial_reports/index.html:418
+#: metabrainz/templates/reports/financial_reports/index.html:447
+#: metabrainz/templates/reports/financial_reports/index.html:476
+#: metabrainz/templates/reports/financial_reports/index.html:498
+#: metabrainz/templates/reports/financial_reports/index.html:520
 msgid "May"
 msgstr ""
 
-#: metabrainz/templates/reports/financial_reports/index.html:57
-#: metabrainz/templates/reports/financial_reports/index.html:86
-#: metabrainz/templates/reports/financial_reports/index.html:115
-#: metabrainz/templates/reports/financial_reports/index.html:144
-#: metabrainz/templates/reports/financial_reports/index.html:173
-#: metabrainz/templates/reports/financial_reports/index.html:202
-#: metabrainz/templates/reports/financial_reports/index.html:231
-#: metabrainz/templates/reports/financial_reports/index.html:260
-#: metabrainz/templates/reports/financial_reports/index.html:289
-#: metabrainz/templates/reports/financial_reports/index.html:318
-#: metabrainz/templates/reports/financial_reports/index.html:340
-#: metabrainz/templates/reports/financial_reports/index.html:362
+#: metabrainz/templates/reports/financial_reports/index.html:216
+#: metabrainz/templates/reports/financial_reports/index.html:245
+#: metabrainz/templates/reports/financial_reports/index.html:274
+#: metabrainz/templates/reports/financial_reports/index.html:303
+#: metabrainz/templates/reports/financial_reports/index.html:332
+#: metabrainz/templates/reports/financial_reports/index.html:361
+#: metabrainz/templates/reports/financial_reports/index.html:390
+#: metabrainz/templates/reports/financial_reports/index.html:419
+#: metabrainz/templates/reports/financial_reports/index.html:448
+#: metabrainz/templates/reports/financial_reports/index.html:477
+#: metabrainz/templates/reports/financial_reports/index.html:499
+#: metabrainz/templates/reports/financial_reports/index.html:521
 msgid "April"
 msgstr ""
 
-#: metabrainz/templates/reports/financial_reports/index.html:58
-#: metabrainz/templates/reports/financial_reports/index.html:87
-#: metabrainz/templates/reports/financial_reports/index.html:116
-#: metabrainz/templates/reports/financial_reports/index.html:145
-#: metabrainz/templates/reports/financial_reports/index.html:174
-#: metabrainz/templates/reports/financial_reports/index.html:203
-#: metabrainz/templates/reports/financial_reports/index.html:232
-#: metabrainz/templates/reports/financial_reports/index.html:261
-#: metabrainz/templates/reports/financial_reports/index.html:290
-#: metabrainz/templates/reports/financial_reports/index.html:319
-#: metabrainz/templates/reports/financial_reports/index.html:341
-#: metabrainz/templates/reports/financial_reports/index.html:363
+#: metabrainz/templates/reports/financial_reports/index.html:217
+#: metabrainz/templates/reports/financial_reports/index.html:246
+#: metabrainz/templates/reports/financial_reports/index.html:275
+#: metabrainz/templates/reports/financial_reports/index.html:304
+#: metabrainz/templates/reports/financial_reports/index.html:333
+#: metabrainz/templates/reports/financial_reports/index.html:362
+#: metabrainz/templates/reports/financial_reports/index.html:391
+#: metabrainz/templates/reports/financial_reports/index.html:420
+#: metabrainz/templates/reports/financial_reports/index.html:449
+#: metabrainz/templates/reports/financial_reports/index.html:478
+#: metabrainz/templates/reports/financial_reports/index.html:500
+#: metabrainz/templates/reports/financial_reports/index.html:522
 msgid "March"
 msgstr ""
 
-#: metabrainz/templates/reports/financial_reports/index.html:59
-#: metabrainz/templates/reports/financial_reports/index.html:88
-#: metabrainz/templates/reports/financial_reports/index.html:117
-#: metabrainz/templates/reports/financial_reports/index.html:146
-#: metabrainz/templates/reports/financial_reports/index.html:175
-#: metabrainz/templates/reports/financial_reports/index.html:204
-#: metabrainz/templates/reports/financial_reports/index.html:233
-#: metabrainz/templates/reports/financial_reports/index.html:262
-#: metabrainz/templates/reports/financial_reports/index.html:291
-#: metabrainz/templates/reports/financial_reports/index.html:320
-#: metabrainz/templates/reports/financial_reports/index.html:342
-#: metabrainz/templates/reports/financial_reports/index.html:364
+#: metabrainz/templates/reports/financial_reports/index.html:218
+#: metabrainz/templates/reports/financial_reports/index.html:247
+#: metabrainz/templates/reports/financial_reports/index.html:276
+#: metabrainz/templates/reports/financial_reports/index.html:305
+#: metabrainz/templates/reports/financial_reports/index.html:334
+#: metabrainz/templates/reports/financial_reports/index.html:363
+#: metabrainz/templates/reports/financial_reports/index.html:392
+#: metabrainz/templates/reports/financial_reports/index.html:421
+#: metabrainz/templates/reports/financial_reports/index.html:450
+#: metabrainz/templates/reports/financial_reports/index.html:479
+#: metabrainz/templates/reports/financial_reports/index.html:501
+#: metabrainz/templates/reports/financial_reports/index.html:523
 msgid "February"
 msgstr ""
 
-#: metabrainz/templates/reports/financial_reports/index.html:60
-#: metabrainz/templates/reports/financial_reports/index.html:89
-#: metabrainz/templates/reports/financial_reports/index.html:118
-#: metabrainz/templates/reports/financial_reports/index.html:147
-#: metabrainz/templates/reports/financial_reports/index.html:176
-#: metabrainz/templates/reports/financial_reports/index.html:205
-#: metabrainz/templates/reports/financial_reports/index.html:234
-#: metabrainz/templates/reports/financial_reports/index.html:263
-#: metabrainz/templates/reports/financial_reports/index.html:292
-#: metabrainz/templates/reports/financial_reports/index.html:321
-#: metabrainz/templates/reports/financial_reports/index.html:343
-#: metabrainz/templates/reports/financial_reports/index.html:365
+#: metabrainz/templates/reports/financial_reports/index.html:219
+#: metabrainz/templates/reports/financial_reports/index.html:248
+#: metabrainz/templates/reports/financial_reports/index.html:277
+#: metabrainz/templates/reports/financial_reports/index.html:306
+#: metabrainz/templates/reports/financial_reports/index.html:335
+#: metabrainz/templates/reports/financial_reports/index.html:364
+#: metabrainz/templates/reports/financial_reports/index.html:393
+#: metabrainz/templates/reports/financial_reports/index.html:422
+#: metabrainz/templates/reports/financial_reports/index.html:451
+#: metabrainz/templates/reports/financial_reports/index.html:480
+#: metabrainz/templates/reports/financial_reports/index.html:502
+#: metabrainz/templates/reports/financial_reports/index.html:524
 msgid "January"
 msgstr ""
 
-#: metabrainz/templates/reports/financial_reports/index.html:330
-#: metabrainz/templates/reports/financial_reports/index.html:352
+#: metabrainz/templates/reports/financial_reports/index.html:489
+#: metabrainz/templates/reports/financial_reports/index.html:511
 msgid "Monthly balance sheets"
 msgstr ""
 
-#: metabrainz/templates/users/account-type.html:3
+#: metabrainz/templates/supporters/account-type.html:3
 msgid "Support"
 msgstr ""
 
-#: metabrainz/templates/users/account-type.html:6
+#: metabrainz/templates/supporters/account-type.html:6
 msgid "Support us"
 msgstr ""
 
-#: metabrainz/templates/users/account-type.html:9
-#, python-format
-msgid ""
-"For commercial use of our data or to get access to the\n"
-"    <a href=\"%(mb_data_feed)s\">MusicBrainz Live Data Feed</a>,\n"
-"    please choose between non-commercial and commercial use below. You "
-"will need a\n"
-"    <a href=\"%(mb_register_url)s\">MusicBrainz account</a> with a "
-"verified email address to sign-up."
-msgstr ""
-
-#: metabrainz/templates/users/account-type.html:16
-msgid ""
-"<strong>Open source developers and non-profits</strong>: Please sign up "
-"as a\n"
-"    commercial user using the free non-profit tier below. This allows us "
-"to give you credit\n"
-"    for your open source project or your non-profit."
-msgstr ""
-
-#: metabrainz/templates/users/account-type.html:21
+#: metabrainz/templates/supporters/account-type.html:16
 msgid "Non-commercial / Personal"
 msgstr ""
 
-#: metabrainz/templates/users/account-type.html:24
-#, python-format
-msgid ""
-"Non-commercial use includes personal use of our data sets and use by "
-"companies that\n"
-"    don't anticipate earning more than $500 in a given year. If you are a"
-" pre-revenue\n"
-"    start-up and expect to have more than $500 of revenue in the future, "
-"please sign up\n"
-"    with a commercial account &mdash; see below for more details. Please\n"
-"    <a href=\"%(donate_url)s\">consider making a donation</a> to support\n"
-"    our efforts!"
-msgstr ""
-
-#: metabrainz/templates/users/account-type.html:34
-#: metabrainz/templates/users/signup-non-commercial.html:25
+#: metabrainz/templates/supporters/account-type.html:30
 msgid "Non-commercial"
 msgstr ""
 
-#: metabrainz/templates/users/account-type.html:37
-#: metabrainz/templates/users/signup-commercial.html:25
+#: metabrainz/templates/supporters/account-type.html:33
 msgid "Commercial"
 msgstr ""
 
-#: metabrainz/templates/users/account-type.html:40
-msgid ""
-"If you are a company with more than $500 income in a year, please select "
-"a support\n"
-"    tier below that fits your current situation. We welcome working with "
-"companies that\n"
-"    are just getting started and we're happy for your support for "
-"MetaBrainz to grow as\n"
-"    you grow. If you would like to use our data, but are not ready to "
-"state this publicly\n"
-"    yet, please sign up for the <em>Stealth start up</em> tier; we will "
-"keep your\n"
-"    data-usage confidential and contact you to discuss your future plans."
-msgstr ""
-
-#: metabrainz/templates/users/account-type.html:59
-#: metabrainz/templates/users/account-type.html:106
-#: metabrainz/templates/users/signup-commercial.html:29
+#: metabrainz/templates/supporters/account-type.html:55
+#: metabrainz/templates/supporters/account-type.html:102
 #, python-format
 msgid "$%(tier_price)s/month and up"
 msgstr ""
 
-#: metabrainz/templates/users/account-type.html:63
-#: metabrainz/templates/users/account-type.html:109
+#: metabrainz/templates/supporters/account-type.html:59
+#: metabrainz/templates/supporters/account-type.html:105
 msgid "More info"
 msgstr ""
 
-#: metabrainz/templates/users/account-type.html:79
-msgid "Some of our Unicorn members"
+#: metabrainz/templates/supporters/account-type.html:61
+#: metabrainz/templates/supporters/account-type.html:107
+#: metabrainz/templates/supporters/mb-signup.html:3
+#: metabrainz/templates/supporters/mb-signup.html:6
+#: metabrainz/templates/supporters/signup-commercial.html:3
+#: metabrainz/templates/supporters/signup-non-commercial.html:3
+msgid "Sign up"
 msgstr ""
 
-#: metabrainz/templates/users/account-type.html:90
-msgid "See all our supporters"
-msgstr ""
-
-#: metabrainz/templates/users/account-type.html:96
+#: metabrainz/templates/supporters/account-type.html:71
 msgid "View all tiers"
 msgstr ""
 
-#: metabrainz/templates/users/account-type.html:117
+#: metabrainz/templates/supporters/account-type.html:79
+msgid "Some of our Unicorn members"
+msgstr ""
+
+#: metabrainz/templates/supporters/account-type.html:90
+msgid "See all our supporters"
+msgstr ""
+
+#: metabrainz/templates/supporters/account-type.html:113
 msgid "View featured tiers"
 msgstr ""
 
-#: metabrainz/templates/users/account-type.html:124
+#: metabrainz/templates/supporters/account-type.html:120
 #, python-format
 msgid ""
 "If you are not sure which tier to pick, please\n"
 "      <a href=\"%(contact_url)s\">contact us</a>."
 msgstr ""
 
-#: metabrainz/templates/users/bad-standing.html:3
-#: metabrainz/templates/users/bad-standing.html:6
+#: metabrainz/templates/supporters/bad-standing.html:3
+#: metabrainz/templates/supporters/bad-standing.html:6
 msgid "Bad standing"
 msgstr ""
 
-#: metabrainz/templates/users/bad-standing.html:8
+#: metabrainz/templates/supporters/bad-standing.html:8
 msgid ""
 "Companies that are in <i>bad standing</i> have previously agreed to "
 "support\n"
@@ -2295,20 +2731,20 @@ msgid ""
 "  payments by more than 60 days."
 msgstr ""
 
-#: metabrainz/templates/users/mb-login.html:3
-#: metabrainz/templates/users/mb-login.html:6
+#: metabrainz/templates/supporters/mb-login.html:3
+#: metabrainz/templates/supporters/mb-login.html:6
 msgid "Log in"
 msgstr ""
 
-#: metabrainz/templates/users/mb-login.html:8
+#: metabrainz/templates/supporters/mb-login.html:8
 msgid "To log in you need to have a MusicBrainz account."
 msgstr ""
 
-#: metabrainz/templates/users/mb-login.html:13
+#: metabrainz/templates/supporters/mb-login.html:13
 msgid "Log in with MusicBrainz"
 msgstr ""
 
-#: metabrainz/templates/users/mb-signup.html:9
+#: metabrainz/templates/supporters/mb-signup.html:9
 msgid ""
 "Please sign in with the MusicBrainz account that will be associated with\n"
 "    your MetaBrainz profile. If you don't have a MusicBrainz account or "
@@ -2317,130 +2753,95 @@ msgid ""
 "below."
 msgstr ""
 
-#: metabrainz/templates/users/mb-signup.html:17
+#: metabrainz/templates/supporters/mb-signup.html:17
 msgid "Sign up with MusicBrainz"
 msgstr ""
 
-#: metabrainz/templates/users/profile-edit.html:3
+#: metabrainz/templates/supporters/profile-edit.html:3
 msgid "Edit"
 msgstr ""
 
-#: metabrainz/templates/users/profile-edit.html:3
-#: metabrainz/templates/users/profile-edit.html:6
-#: metabrainz/templates/users/profile.html:3
-#: metabrainz/templates/users/profile.html:6
+#: metabrainz/templates/supporters/profile-edit.html:3
+#: metabrainz/templates/supporters/profile.html:3
+#: metabrainz/templates/supporters/profile.html:6
 msgid "Your Profile"
 msgstr ""
 
-#: metabrainz/templates/users/profile-edit.html:7
-#: metabrainz/templates/users/profile.html:51
-msgid "Edit contact information"
-msgstr ""
-
-#: metabrainz/templates/users/profile-edit.html:29
-msgid "Update"
-msgstr ""
-
-#: metabrainz/templates/users/profile.html:27
+#: metabrainz/templates/supporters/profile.html:34
 msgid "Organization information"
 msgstr ""
 
-#: metabrainz/templates/users/profile.html:29
-#: metabrainz/templates/users/profile.html:46
+#: metabrainz/templates/supporters/profile.html:36
+#: metabrainz/templates/supporters/profile.html:53
 msgid "Name:"
 msgstr ""
 
-#: metabrainz/templates/users/profile.html:31
+#: metabrainz/templates/supporters/profile.html:38
 msgid "Website URL:"
 msgstr ""
 
-#: metabrainz/templates/users/profile.html:33
+#: metabrainz/templates/supporters/profile.html:40
 msgid "API URL:"
 msgstr ""
 
-#: metabrainz/templates/users/profile.html:37
+#: metabrainz/templates/supporters/profile.html:44
 #, python-format
 msgid ""
 "Please <a href=\"%(contact_url)s\">contact us</a>\n"
 "          if you wish for us to update this information."
 msgstr ""
 
-#: metabrainz/templates/users/profile.html:44
+#: metabrainz/templates/supporters/profile.html:51
 msgid "Contact information"
 msgstr ""
 
-#: metabrainz/templates/users/profile.html:47
+#: metabrainz/templates/supporters/profile.html:54
 msgid "Email:"
 msgstr ""
 
-#: metabrainz/templates/users/profile.html:59
+#: metabrainz/templates/supporters/profile.html:56
+msgid "Datasets used:"
+msgstr ""
+
+#: metabrainz/templates/supporters/profile.html:77
 msgid "Data use permission granted"
 msgstr ""
 
-#: metabrainz/templates/users/profile.html:61
+#: metabrainz/templates/supporters/profile.html:83
 msgid ""
 "You have permission to use any of the data published by the MetaBrainz\n"
-"        Foundation. This includes data dumps released under a Creative "
+"          Foundation. This includes data dumps released under a Creative "
 "Commons\n"
-"        non-commercial license. Thank you for your support!"
+"          non-commercial license. Thank you for your support!"
 msgstr ""
 
-#: metabrainz/templates/users/profile.html:66
+#: metabrainz/templates/supporters/profile.html:88
 msgid ""
-"Please note that if your support falls behind by more than 60 days, this\n"
-"        permission may be withdrawn. You can always check your current "
+"Note 1: If your support falls behind by more than 60 days, this\n"
+"          permission may be withdrawn. You can always check your current "
 "permission\n"
-"        status on this page."
+"          status on this page."
 msgstr ""
 
-#: metabrainz/templates/users/profile.html:71
-msgid "No data use permission granted"
-msgstr ""
-
-#: metabrainz/templates/users/profile.html:73
+#: metabrainz/templates/supporters/profile.html:93
 msgid ""
-"You <strong>DO NOT</strong> currently have permission to use data\n"
-"        released under a Creative Commons non-commercial license."
+"Note 2: The IP addresses from which replication packets for the Live Data"
+" Feed are downloaded are logged."
 msgstr ""
 
-#: metabrainz/templates/users/profile.html:77
-msgid "Reason:"
-msgstr ""
-
-#: metabrainz/templates/users/profile.html:79
-#, python-format
-msgid ""
-"Your account is in bad standing, which means that you are more than\n"
-"          60 days behind in support payments. If you think this is a "
-"mistake,\n"
-"          please <a href=\"%(contact_url)s\">contact us</a>."
-msgstr ""
-
-#: metabrainz/templates/users/profile.html:83
-msgid "Your application for using the Live Data Feed has been rejected."
-msgstr ""
-
-#: metabrainz/templates/users/profile.html:85
-msgid "Your application for using the Live Data Feed is still pending."
-msgstr ""
-
-#: metabrainz/templates/users/profile.html:87
-msgid "Your application for using the Live Data Feed is in the waiting list."
-msgstr ""
-
-#: metabrainz/templates/users/profile.html:89
+#: metabrainz/templates/supporters/profile.html:132
 msgid "Unknown. :("
 msgstr ""
 
-#: metabrainz/templates/users/profile.html:96
-msgid "Access token"
+#: metabrainz/templates/supporters/profile.html:139
+msgid "Data Download"
 msgstr ""
 
-#: metabrainz/templates/users/profile.html:99
-msgid "Generate new token"
+#: metabrainz/templates/supporters/profile.html:159
+msgid "Live Data Feed Access token"
 msgstr ""
 
-#: metabrainz/templates/users/profile.html:102
+#: metabrainz/templates/supporters/profile.html:161
 msgid ""
 "This access token should be considered private. Don't check this token\n"
 "      into any publicly visible version control systems and similar "
@@ -2450,151 +2851,28 @@ msgid ""
 "      When you generate a new token, your current token is revoked."
 msgstr ""
 
-#: metabrainz/templates/users/profile.html:107
+#: metabrainz/templates/supporters/profile.html:175
+msgid "Generate new token"
+msgstr ""
+
+#: metabrainz/templates/supporters/profile.html:178
 #, python-format
 msgid ""
 "See the <a href=\"%(api_docs_url)s\">API documentation</a> for more "
 "information."
 msgstr ""
 
-#: metabrainz/templates/users/profile.html:121
+#: metabrainz/templates/supporters/profile.html:193
 msgid ""
 "Are you sure you want to generate new access token? Current token will be"
 " revoked!"
 msgstr ""
 
-#: metabrainz/templates/users/profile.html:131
+#: metabrainz/templates/supporters/profile.html:203
 msgid "Failed to generate new access token!"
 msgstr ""
 
-#: metabrainz/templates/users/signup-commercial.html:6
-msgid "Sign up <small>Commercial</small>"
-msgstr ""
-
-#: metabrainz/templates/users/signup-commercial.html:9
-msgid ""
-"<strong>Note:</strong> Signing up for any tier other than the <i>Stealth "
-"startup</i> tier\n"
-"    will publicly list your company on this web site. However, we will "
-"not publish any of\n"
-"    your private details."
-msgstr ""
-
-#: metabrainz/templates/users/signup-commercial.html:24
-#: metabrainz/templates/users/signup-non-commercial.html:24
-msgid "Account type"
-msgstr ""
-
-#: metabrainz/templates/users/signup-commercial.html:26
-msgid "Selected tier"
-msgstr ""
-
-#: metabrainz/templates/users/signup-commercial.html:32
-msgid "Change account type or tier"
-msgstr ""
-
-#: metabrainz/templates/users/signup-commercial.html:46
-#, python-format
-msgid ""
-"If you don't have an organization name, you probably want to sign up as a"
-"\n"
-"          <a href=\"%(signup_url)s\">non-commercial / personal</a> user."
-msgstr ""
-
-#: metabrainz/templates/users/signup-commercial.html:55
-#: metabrainz/templates/users/signup-non-commercial.html:33
-msgid "MusicBrainz Account"
-msgstr ""
-
-#: metabrainz/templates/users/signup-commercial.html:78
-msgid "(preferably in SVG format)"
-msgstr ""
-
-#: metabrainz/templates/users/signup-commercial.html:81
-msgid ""
-"Image should be about 250 pixels wide on a white or transparent\n"
-"          background. We will host it on our site."
-msgstr ""
-
-#: metabrainz/templates/users/signup-commercial.html:92
-msgid ""
-"URL to where developers can use your APIs using MusicBrainz IDs, if "
-"available.."
-msgstr ""
-
-#: metabrainz/templates/users/signup-commercial.html:103
-#: metabrainz/templates/users/signup-non-commercial.html:62
-msgid "(max 150 characters)"
-msgstr ""
-
-#: metabrainz/templates/users/signup-commercial.html:109
-#, python-format
-msgid ""
-"If you would like to support us with more than $%(tier_price)d,\n"
-"        please enter the actual amount here:"
-msgstr ""
-
-#: metabrainz/templates/users/signup-commercial.html:120
-msgid "Billing address"
-msgstr ""
-
-#: metabrainz/templates/users/signup-commercial.html:183
-msgid ""
-"I agree to treat my access token as a secret and will not share\n"
-"            this token publicly or commit it to a publicly visible source"
-" code repository."
-msgstr ""
-
-#: metabrainz/templates/users/signup-commercial.html:192
-msgid ""
-"The following information will be shown publicly: organization name,\n"
-"        logo, website and API URLs, data usage description."
-msgstr ""
-
-#: metabrainz/templates/users/signup-commercial.html:199
-msgid ""
-"We'll send you more details about payment process once your application\n"
-"        is approved."
-msgstr ""
-
-#: metabrainz/templates/users/signup-non-commercial.html:6
-msgid "Sign up <small>non-commercial</small>"
-msgstr ""
-
-#: metabrainz/templates/users/signup-non-commercial.html:9
-msgid ""
-"Please be aware that misuse of the non-commercial service for commercial "
-"purposes will\n"
-"    result in us revoking your access token and then billing you for your"
-" commercial use of our\n"
-"    Live Data Feed."
-msgstr ""
-
-#: metabrainz/templates/users/signup-non-commercial.html:27
-msgid "Change account type"
-msgstr ""
-
-#: metabrainz/templates/users/signup-non-commercial.html:42
-#: metabrainz/users/forms.py:69
-msgid "Name"
-msgstr ""
-
-#: metabrainz/templates/users/signup-non-commercial.html:49
-#: metabrainz/users/forms.py:72
-msgid "Email"
-msgstr ""
-
-#: metabrainz/templates/users/signup-non-commercial.html:72
-msgid ""
-"I agree to use the Live Data Feed for non-commercial (less than $500\n"
-"            income per year) or personal uses only. I also agree to treat"
-" my access\n"
-"            token as a secret and will not share this token publicly or "
-"commit it\n"
-"            to a source code repository."
-msgstr ""
-
-#: metabrainz/templates/users/supporters-list.html:9
+#: metabrainz/templates/supporters/supporters-list.html:9
 #, python-format
 msgid ""
 "The following organizations make use of the data-sets published by "
@@ -2606,188 +2884,28 @@ msgid ""
 "    may also be other organizations making use of our data that we don't "
 "know about yet. If you\n"
 "    know of a company using our data, please <a "
-"href=\"%(contact_url)s\">contact us</a>."
+"href=\"%(contact_url)s\">contact us</a>. If you want\n"
+"    to sign your company up as a supporter, go to our <a "
+"href=\"%(signup_form)s\">sign up page</a>."
 msgstr ""
 
-#: metabrainz/templates/users/supporters-list.html:21
-#: metabrainz/templates/users/tier.html:3
-#: metabrainz/templates/users/tier.html:6
+#: metabrainz/templates/supporters/supporters-list.html:23
+#: metabrainz/templates/supporters/tier.html:3
+#: metabrainz/templates/supporters/tier.html:6
 #, python-format
 msgid "%(tier_name)s tier"
 msgstr ""
 
-#: metabrainz/templates/users/supporters-list.html:30
-#: metabrainz/templates/users/tier.html:25
-msgid "This user has bad standing"
+#: metabrainz/templates/supporters/supporters-list.html:32
+#: metabrainz/templates/supporters/tier.html:25
+msgid "This supporter is behind on their payments."
 msgstr ""
 
-#: metabrainz/templates/users/tier.html:13
+#: metabrainz/templates/supporters/tier.html:13
 msgid "Sign up for this tier"
 msgstr ""
 
-#: metabrainz/templates/users/tier.html:19
+#: metabrainz/templates/supporters/tier.html:19
 msgid "Supporters on this tier"
-msgstr ""
-
-#: metabrainz/users/forms.py:14
-msgid "Contact name is required!"
-msgstr ""
-
-#: metabrainz/users/forms.py:15
-msgid "Email address is required!"
-msgstr ""
-
-#: metabrainz/users/forms.py:16
-msgid "How are you using our data?"
-msgstr ""
-
-#: metabrainz/users/forms.py:17
-msgid "Please, tell us how you (will) use our data."
-msgstr ""
-
-#: metabrainz/users/forms.py:18
-msgid "Please, limit usage description to 150 characters."
-msgstr ""
-
-#: metabrainz/users/forms.py:20
-msgid "You need to accept the agreement!"
-msgstr ""
-
-#: metabrainz/users/forms.py:35
-msgid "Organization name"
-msgstr ""
-
-#: metabrainz/users/forms.py:36
-msgid "You need to specify the name of your organization."
-msgstr ""
-
-#: metabrainz/users/forms.py:38
-msgid "Organization description"
-msgstr ""
-
-#: metabrainz/users/forms.py:39
-msgid "You need to provide description of your organization."
-msgstr ""
-
-#: metabrainz/users/forms.py:42
-msgid "Website URL"
-msgstr ""
-
-#: metabrainz/users/forms.py:43
-msgid "You need to specify website of the organization."
-msgstr ""
-
-#: metabrainz/users/forms.py:45
-msgid "Logo image URL"
-msgstr ""
-
-#: metabrainz/users/forms.py:46
-msgid "API URL"
-msgstr ""
-
-#: metabrainz/users/forms.py:48
-msgid "Street"
-msgstr ""
-
-#: metabrainz/users/forms.py:49
-msgid "You need to specify street."
-msgstr ""
-
-#: metabrainz/users/forms.py:51
-msgid "City"
-msgstr ""
-
-#: metabrainz/users/forms.py:52
-msgid "You need to specify city."
-msgstr ""
-
-#: metabrainz/users/forms.py:54
-msgid "State / Province"
-msgstr ""
-
-#: metabrainz/users/forms.py:55
-msgid "You need to specify state/province."
-msgstr ""
-
-#: metabrainz/users/forms.py:57
-msgid "Postcode"
-msgstr ""
-
-#: metabrainz/users/forms.py:58
-msgid "You need to specify postcode."
-msgstr ""
-
-#: metabrainz/users/forms.py:60
-msgid "Country"
-msgstr ""
-
-#: metabrainz/users/forms.py:61
-msgid "You need to specify country."
-msgstr ""
-
-#: metabrainz/users/forms.py:70
-msgid "Contact name field is empty."
-msgstr ""
-
-#: metabrainz/users/forms.py:74
-msgid "Email field is not a valid email address."
-msgstr ""
-
-#: metabrainz/users/forms.py:75
-msgid "Contact email field is empty."
-msgstr ""
-
-#: metabrainz/users/views.py:48
-msgid "Can't find tier with a specified ID."
-msgstr ""
-
-#: metabrainz/users/views.py:62 metabrainz/users/views.py:68
-msgid "Please select account type to sign up."
-msgstr ""
-
-#: metabrainz/users/views.py:85
-msgid "You need to choose support tier before signing up!"
-msgstr ""
-
-#: metabrainz/users/views.py:89
-msgid "You need to choose existing tier before signing up!"
-msgstr ""
-
-#: metabrainz/users/views.py:105
-msgid ""
-"Custom amount must be more than threshold amountfor selected tier or "
-"equal to it!"
-msgstr ""
-
-#: metabrainz/users/views.py:138
-msgid ""
-"Thanks for signing up! Your application will be reviewed soon. We will "
-"send you updates via email."
-msgstr ""
-
-#: metabrainz/users/views.py:152 metabrainz/users/views.py:199
-msgid ""
-"Failed to send welcome email to you. We are looking into it. Sorry for "
-"inconvenience!"
-msgstr ""
-
-#: metabrainz/users/views.py:157 metabrainz/users/views.py:204
-msgid "You already have a MetaBrainz account!"
-msgstr ""
-
-#: metabrainz/users/views.py:188
-msgid "Thanks for signing up!"
-msgstr ""
-
-#: metabrainz/users/views.py:223
-msgid "Login failed!"
-msgstr ""
-
-#: metabrainz/users/views.py:226
-msgid "Authorization code is missing!"
-msgstr ""
-
-#: metabrainz/users/views.py:270
-msgid "Can't generate new token unless account is active."
 msgstr ""
 

--- a/metabrainz/templates/base.html
+++ b/metabrainz/templates/base.html
@@ -83,6 +83,7 @@
               <div class="title"><a href="{{ url_for('index.contact') }}">{{ _('Contact us') }}</a></div>
               <ul>
                 <li><a href="https://blog.metabrainz.org/category/metabrainz/">{{ _('Blog') }}</a></li>
+                <li><a href="https://musicbrainz.org/doc/Communication/ChatBrainz">{{ _('Chat') }}</a></li>
                 <li><a href="https://twitter.com/MetaBrainz">{{ _('Twitter/X') }}</a></li>
                 <li><a href="https://mastodon.social/@metabrainz">{{ _('Mastodon') }}</a></li>
                 <li><a href="https://bsky.app/profile/metabrainz.org">{{ _('Bluesky') }}</a></li>

--- a/metabrainz/templates/index/contact.html
+++ b/metabrainz/templates/index/contact.html
@@ -8,7 +8,7 @@
   <h3>{{ _('Found a bug in one of our projects?') }}</h3>
   <p>
     {{ _('Found a broken link or something that doesn\'t work as you expect it to? You can report issues in our
-    <a href="%(bug_tracker_url)s">bug tracker</a>, or let us know on IRC or
+    <a href="%(bug_tracker_url)s">bug tracker</a>, or let us know on our chat or
     by email. Contact details are provided below. Please include details such as what happened, what you expected
     to happen, and the URLs of any pages involved.', bug_tracker_url='http://tickets.musicbrainz.org/secure/BrowseProjects.jspa') }}
   </p>
@@ -87,20 +87,27 @@
     answer any questions you may have.', forums_url='https://community.metabrainz.org/') }}
   </p>
 
-  <h3>{{ _('IRC') }}</h3>
+  <h3>{{ _('Chat') }}</h3>
   <p>
-    {{ _('The MetaBrainz/MusicBrainz team, as well as MusicBrainz supporters, hang out in the
-    <strong><a href="%(irc_url_mb)s">#musicbrainz</a></strong> and
-    <strong><a href="%(irc_url_meb)s">#metabrainz</a></strong>
-    channels on IRC chat at irc.libera.chat. If you don\'t have an IRC client
-    installed, consider using this
-    <a href="%(irc_webchat_url)s">webchat client</a>
-    instead. Please feel free to browse the
-    <a href="%(chatlogs_url)s">IRC log archives</a>.',
-    irc_url_mb='ircs://irc.libera.chat:6697/musicbrainz',
-    irc_url_meb='ircs://irc.libera.chat:6697/metabrainz',
-    irc_webchat_url='https://kiwiirc.com/nextclient/irc.libera.chat/#musicbrainz,#metabrainz',
+    {{ _('The MetaBrainz/MusicBrainz/ListenBrainz team and community hang out
+    on our Matrix, IRC and Discord channels. Visit the
+    <a href="%(chatbrainz_url)s">ChatBrainz</a>
+    page and join the chat. You can also browse the
+    <a href="%(chatlogs_url)s">chat log archives</a>.',
+    chatbrainz_url='https://musicbrainz.org/doc/Communication/ChatBrainz',
     chatlogs_url='http://chatlogs.metabrainz.org/') }}
+  </p>
+
+  <h3>{{ _('Social media') }}</h3>
+  <p>
+    {{ _('You can follow us on these social channels:') }}
+     <ul>
+      <li><a href="https://blog.metabrainz.org/">{{ _('Blog') }}</a></li>
+      <li><a href="https://x.com/MetaBrainz">{{ _('Twitter/X') }}</a></li>
+      <li><a href="https://mastodon.social/@metabrainz">{{ _('Mastodon') }}</a></li>
+      <li><a href="https://bsky.app/profile/metabrainz.org">{{ _('Bluesky') }}</a></li>
+      <li><a href="https://www.instagram.com/MetaBrainz/">{{ _('Instagram') }}</a></li>
+    </ul>
   </p>
 
   <h3>{{ _('Mailing address') }}</h3>

--- a/metabrainz/templates/index/social-contract.html
+++ b/metabrainz/templates/index/social-contract.html
@@ -14,7 +14,7 @@
   <ol>
     <li>
       <b>MetaBrainz's projects will remain 100% free</b>: The development process will be open to the public by using our community forum, 
-      meetings open to interested parties, and open IRC channels. The client and server software will remain free and accessible under generally 
+      meetings open to interested parties, and open chat channels. The client and server software will remain free and accessible under generally 
       accepted open licenses. The factual database content will be in the public domain and the non-factual database content will be released 
       under Creative Commons licenses. 
     </li>

--- a/metabrainz/templates/index/team.html
+++ b/metabrainz/templates/index/team.html
@@ -26,7 +26,7 @@
           {{ _('Originally from Germany, he now lives in Barcelona, Spain.') }}
         </p>
         <ul class="links">
-          <li><strong>IRC:</strong> mayhem</li>
+          <li><strong>Chat:</strong> mayhem</li>
           <li><strong>GitHub:</strong> <a href="https://github.com/mayhem">mayhem</a></li>
           <li><strong>Twitter/X:</strong> <a href="https://twitter.com/mayhembcn">mayhemBCN</a></li>
         </ul>
@@ -44,7 +44,7 @@
           ever hear, binge-watching old TV shows, and being the best drummer in the world on Rock Band 4.') }}
         </p>
         <ul class="links">
-          <li><strong>IRC:</strong> bitmap</li>
+          <li><strong>Chat:</strong> bitmap</li>
           <li><strong>GitHub:</strong> <a href="https://github.com/mwiencek">mwiencek</a></li>
           <li><strong>Last.fm:</strong> <a href="http://www.last.fm/user/fancy_lb_proxy">fancy_lb_proxy</a></li>
         </ul>
@@ -67,7 +67,7 @@
         </p>
         <p>{{ _('Originally from Spain, he now lives in Tartu, Estonia.') }}</p>
         <ul class="links">
-          <li><strong>IRC:</strong> reosarevok</li>
+          <li><strong>Chat:</strong> reosarevok</li>
           <li><strong>MusicBrainz:</strong> <a href="https://musicbrainz.org/user/reosarevok">reosarevok</a></li>
           <li><strong>GitHub:</strong> <a href="https://github.com/reosarevok">reosarevok</a></li>
           <li><strong>iNaturalist:</strong> <a href="https://www.inaturalist.org/people/reosarevok">reosarevok</a></li>
@@ -94,7 +94,7 @@
           geeqie_url='https://en.wikipedia.org/wiki/Geeqie') }}
         </p>
         <ul class="links">
-          <li><strong>IRC:</strong> zas</li>
+          <li><strong>Chat:</strong> zas</li>
         </ul>
       </div>
     </div>
@@ -109,7 +109,7 @@
           in the end. Besides that, he casually plays music, listens to music, eats music, … music, for an healthy way of life.') }}
         </p>
         <ul class="links">
-          <li><strong>IRC:</strong> yvanzo</li>
+          <li><strong>Chat:</strong> yvanzo</li>
         </ul>
       </div>
     </div>
@@ -130,7 +130,7 @@
           {{ _('Born in Canada and raised in France, Nicolas now lives in Barcelona, Spain.') }}
         </p>
         <ul class="links">
-          <li><strong>IRC:</strong> monkey</li>
+          <li><strong>Chat:</strong> monkey</li>
           <li><strong>GitHub:</strong> <a href="https://github.com/monkeydo">MonkeyDo</a></li>
         </ul>
       </div>
@@ -150,7 +150,7 @@
           CritiqueBrainz projects. He also spends a lot of time on the AcousticBrainz and ListenBrainz projects.') }}
         </p>
         <ul class="links">
-          <li><strong>IRC:</strong> lucifer</li>
+          <li><strong>Chat:</strong> lucifer</li>
           <li><strong>GitHub:</strong> <a href="https://github.com/amCap1712">amCap1712</a></li>
         </ul>
       </div>
@@ -172,7 +172,7 @@
 	  where he is a consultant and technical director.') }}
         </p>
         <ul class="links">
-          <li><strong>IRC:</strong> atj</li>
+          <li><strong>Chat:</strong> atj</li>
           <li><strong>MusicBrainz:</strong> <a href="https://musicbrainz.org/user/atj">atj</a></li>
           <li><strong>GitHub:</strong> <a href="https://github.com/atj">atj</a></li>
         </ul>
@@ -193,7 +193,7 @@
           and has 15 years experience across various graphic design/comms/marketing roles.') }}
         </p>
         <ul class="links">
-          <li><strong>IRC:</strong> aerozol</li>
+          <li><strong>Chat:</strong> aerozol</li>
           <li><strong>MusicBrainz:</strong> <a href="https://musicbrainz.org/user/aerozol">aerozol</a></li>
           <li><strong>ListenBrainz:</strong> <a href="https://listenbrainz.org/user/aerozol">aerozol</a></li>
         </ul>
@@ -214,7 +214,7 @@
           In his leisure moments, Ansh enjoys binge-watching movies and listening to music.') }}
         </p>
         <ul class="links">
-          <li><strong>IRC:</strong> ansh</li>
+          <li><strong>Chat:</strong> ansh</li>
           <li><strong>GitHub:</strong> <a href="https://github.com/anshg1214">anshg1214</a></li>
           <li><strong>ListenBrainz:</strong> <a href="https://listenbrainz.org/user/anshgoyal31">anshgoyal31</a></li>
         </ul>
@@ -240,7 +240,7 @@
           Akshat has always been fascinated by the creativity of people. He resides in New Delhi, India.') }}
         </p>
         <ul class="links">
-          <li><strong>IRC:</strong> akshaaatt</li>
+          <li><strong>Chat:</strong> akshaaatt</li>
           <li><strong>GitHub:</strong> <a href="https://github.com/akshaaatt">akshaaatt</a></li>
           <li><strong>Medium:</strong> <a href="https://medium.com/@akshaaatt">akshaaatt</a></li>
         </ul>
@@ -257,7 +257,7 @@
           When not staring at a screen, Param plays some chess and tries to listen to new music.') }}
         </p>
         <ul class="links">
-          <li><strong>IRC:</strong> param</li>
+          <li><strong>Chat:</strong> param</li>
           <li><strong>GitHub:</strong> <a href="https://github.com/paramsingh">paramsingh</a></li>
           <li><strong>Last.fm:</strong> <a href="http://www.last.fm/user/singhparam">singhparam</a></li>
           <li><strong>ListenBrainz:</strong> <a href="https://listenbrainz.org/user/iliekcomputers">iliekcomputers</a></li>
@@ -286,7 +286,7 @@
           gnt_url='https://en.wikipedia.org/wiki/Gin_and_tonic') }}
         </p>
         <ul class="links">
-          <li><strong>IRC:</strong> drsaunders</li>
+          <li><strong>Chat:</strong> drsaunders</li>
           <li><strong>MusicBrainz:</strong> <a href="https://musicbrainz.org/user/drsaunde">drsaunde</a></li>
         </ul>
       </div>
@@ -308,7 +308,7 @@
           III, colouring, and collecting all sorts of things, from stickers and stamps to bottlecaps.') }}
         </p>
         <ul class="links">
-          <li><strong>IRC:</strong> ApeKattQuest, MonkeyPython (plus a whole lot of other Lupin III references)</li>
+          <li><strong>Chat:</strong> ApeKattQuest, MonkeyPython (plus a whole lot of other Lupin III references)</li>
           <li><strong>MusicBrainz:</strong> <a href="https://musicbrainz.org/user/ApeKattQuest, MonkeyPython">ApeKattQuest, MonkeyPython</a></li>
           <li><strong>ListenBrainz:</strong> <a href="https://listenbrainz.org/user/ApeKattQuest, MonkeyPython">ApeKattQuest, MonkeyPython</a></li>
         </ul>


### PR DESCRIPTION
As mentioned by mayhem at the summit, updated "IRC" references to "Chat" or "ChatBrainz" references and changed the relevant links.

Will need testing, sorry, but hopefully this is most of the work done.