### PR TITLE
MEB-165: Make fonts as dark as allowed as per our guidelines.

### DIFF
--- a/frontend/css/main.less
+++ b/frontend/css/main.less
@@ -343,7 +343,6 @@ h1.page-title, h2.page-title {
 
   small {
     font-style: italic;
-    .text-muted;
   }
 
   .form-group:last-child { margin-bottom: 0px; }

--- a/frontend/css/theme/variables.less
+++ b/frontend/css/theme/variables.less
@@ -16,7 +16,7 @@
 @yellow: #ea9d11;
 @red: #c64040;
 @white: @pearl;
-@asphalt: #46433a;
+@asphalt: #1e1e1e;
 @cream: #fffedb;
 @pearl: #fffbfe;
 @cafe-con-leche: #ede5e2;


### PR DESCRIPTION
All text should now be #1e1e1e:

![image](https://github.com/user-attachments/assets/c195ab5f-8317-4eaf-ae8a-de95a9b4a428)

This meets MetaBrainz design guidelines.
