### PR TITLE
MEB-167: Clarify name in donations means real name 

### DIFF
--- a/metabrainz/messages.pot
+++ b/metabrainz/messages.pot
@@ -1,14 +1,14 @@
 # Translations template for PROJECT.
-# Copyright (C) 2024 ORGANIZATION
+# Copyright (C) 2025 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
 #
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-10-29 09:23+0000\n"
+"POT-Creation-Date: 2025-01-24 10:16+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,38 +17,38 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.16.0\n"
 
-#: metabrainz/payments/views.py:155
+#: metabrainz/payments/views.py:158
 msgid ""
 "Thank you for making a donation to the MetaBrainz Foundation. Your "
 "support is greatly appreciated! It may take some time before your "
 "donation appears in the list due to processing delays."
 msgstr ""
 
-#: metabrainz/payments/views.py:162
+#: metabrainz/payments/views.py:165
 msgid ""
 "Thank you for making a payment to the MetaBrainz Foundation. Your support"
 " is greatly appreciated!"
 msgstr ""
 
-#: metabrainz/payments/views.py:173
+#: metabrainz/payments/views.py:176
 msgid ""
 "We're sorry to see that you won't be donating today. We hope that you'll "
 "change your mind!"
 msgstr ""
 
-#: metabrainz/payments/views.py:179
+#: metabrainz/payments/views.py:182
 msgid ""
 "We're sorry to see that you won't be paying today. We hope that you'll "
 "change your mind!"
 msgstr ""
 
-#: metabrainz/payments/views.py:193
+#: metabrainz/payments/views.py:196
 msgid ""
 "We're sorry, but it appears we've run into an error and can't process "
 "your donation."
 msgstr ""
 
-#: metabrainz/payments/views.py:199
+#: metabrainz/payments/views.py:202
 msgid ""
 "We're sorry, but it appears we've run into an error and can't process "
 "your payment."
@@ -317,7 +317,7 @@ msgstr ""
 msgid "Sign in"
 msgstr ""
 
-#: metabrainz/templates/base.html:75 metabrainz/templates/navbar.html:68
+#: metabrainz/templates/base.html:75 metabrainz/templates/navbar.html:69
 msgid "Sign out"
 msgstr ""
 
@@ -413,6 +413,10 @@ msgstr ""
 
 #: metabrainz/templates/navbar.html:67
 msgid "Your profile"
+msgstr ""
+
+#: metabrainz/templates/navbar.html:68
+msgid "OAuth applications"
 msgstr ""
 
 #: metabrainz/templates/api/info.html:8
@@ -1334,13 +1338,13 @@ msgstr ""
 msgid "Originally from Germany, he now lives in Barcelona, Spain."
 msgstr ""
 
-#: metabrainz/templates/index/team.html:39
+#: metabrainz/templates/index/team.html:40
 msgid ""
 "<span class=\"name\">Michael Wiencek</span> &mdash; Senior Software "
 "Engineer"
 msgstr ""
 
-#: metabrainz/templates/index/team.html:41
+#: metabrainz/templates/index/team.html:42
 msgid ""
 "Michael is the senior developer for MusicBrainz, residing in his hometown"
 " of Chicago. He heard about MusicBrainz when\n"
@@ -1352,13 +1356,13 @@ msgid ""
 "drummer in the world on Rock Band 4."
 msgstr ""
 
-#: metabrainz/templates/index/team.html:57
+#: metabrainz/templates/index/team.html:58
 msgid ""
 "<span class=\"name\">Nicolás Tamargo</span> &mdash; Style Leader/Customer"
 " Support/Community Manager/Software Engineer"
 msgstr ""
 
-#: metabrainz/templates/index/team.html:59
+#: metabrainz/templates/index/team.html:60
 #, python-format
 msgid ""
 "Nicolás started (and still moonlights as) a hardcore editor, because he "
@@ -1376,15 +1380,15 @@ msgid ""
 "          or traveling around trying to watch some wildlife."
 msgstr ""
 
-#: metabrainz/templates/index/team.html:68
+#: metabrainz/templates/index/team.html:69
 msgid "Originally from Spain, he now lives in Tartu, Estonia."
 msgstr ""
 
-#: metabrainz/templates/index/team.html:81
+#: metabrainz/templates/index/team.html:82
 msgid "<span class=\"name\">Laurent Monin</span> &mdash; System Administrator"
 msgstr ""
 
-#: metabrainz/templates/index/team.html:83
+#: metabrainz/templates/index/team.html:84
 msgid ""
 "A zealous music devotee, Laurent Monin first stumbled upon MusicBrainz "
 "and Picard in attempts to codify his vast\n"
@@ -1394,7 +1398,7 @@ msgid ""
 "system administrator since 1998."
 msgstr ""
 
-#: metabrainz/templates/index/team.html:88
+#: metabrainz/templates/index/team.html:89
 #, python-format
 msgid ""
 "With his extensive repertoire of skills and passions, Laurent has "
@@ -1408,11 +1412,11 @@ msgid ""
 "France."
 msgstr ""
 
-#: metabrainz/templates/index/team.html:105
+#: metabrainz/templates/index/team.html:106
 msgid "<span class=\"name\">Yvan Rivierre</span> &mdash; Software Engineer"
 msgstr ""
 
-#: metabrainz/templates/index/team.html:107
+#: metabrainz/templates/index/team.html:108
 msgid ""
 "Yvan is a software engineer for MusicBrainz and comes from Nancy, France."
 " Initially he discovered MusicBrainz\n"
@@ -1422,13 +1426,13 @@ msgid ""
 "music, eats music, … music, for an healthy way of life."
 msgstr ""
 
-#: metabrainz/templates/index/team.html:120
+#: metabrainz/templates/index/team.html:121
 msgid ""
 "<span class=\"name\">Nicolas Pelletier</span> &mdash; BookBrainz Lead,  "
 "Software Engineer & Graphic Designer"
 msgstr ""
 
-#: metabrainz/templates/index/team.html:122
+#: metabrainz/templates/index/team.html:123
 msgid ""
 "Nicolas comes from a graphic design background, but was always a computer"
 " and electronics tinkerer at heart.\n"
@@ -1438,26 +1442,26 @@ msgid ""
 "he eventually joined the team."
 msgstr ""
 
-#: metabrainz/templates/index/team.html:127
+#: metabrainz/templates/index/team.html:128
 msgid ""
 "In his free time, Nicolas likes to go rock climbing, hence the nickname, "
 "and designing and building structures."
 msgstr ""
 
-#: metabrainz/templates/index/team.html:130
+#: metabrainz/templates/index/team.html:131
 msgid ""
 "Born in Canada and raised in France, Nicolas now lives in Barcelona, "
 "Spain."
 msgstr ""
 
-#: metabrainz/templates/index/team.html:146
+#: metabrainz/templates/index/team.html:147
 msgid ""
 "<span class=\"name\">Kartik Ohri</span> &mdash; "
 "ListenBrainz/CritiqueBrainz/Android App Lead &amp; Junior Software "
 "Engineer"
 msgstr ""
 
-#: metabrainz/templates/index/team.html:148
+#: metabrainz/templates/index/team.html:149
 msgid ""
 "Kartik joined the MetaBrainz community during Google Code-In 2018 and "
 "since then there has been\n"
@@ -1467,11 +1471,11 @@ msgid ""
 "AcousticBrainz and ListenBrainz projects."
 msgstr ""
 
-#: metabrainz/templates/index/team.html:166
+#: metabrainz/templates/index/team.html:167
 msgid "<span class=\"name\">Adam James</span> &mdash; System Administrator"
 msgstr ""
 
-#: metabrainz/templates/index/team.html:168
+#: metabrainz/templates/index/team.html:169
 msgid ""
 "Adam is a system administrator and occasional developer with over 15 "
 "years experience in Linux and Open Source\n"
@@ -1483,13 +1487,35 @@ msgid ""
 "\t  where he is a consultant and technical director."
 msgstr ""
 
-#: metabrainz/templates/index/team.html:189
+#: metabrainz/templates/index/team.html:190
+msgid "<span class=\"name\">Julian Anderson</span> &mdash; System Administrator"
+msgstr ""
+
+#: metabrainz/templates/index/team.html:192
+msgid ""
+"Julian took a liking to terminals as soon as he could get his hands on "
+"one, and in high school, he began building,\n"
+"\t  breaking, and rebuilding virtual machines in an effort to learn how "
+"they worked. Over the course of the following decade,\n"
+"\t  he refined his skills and eventually began a career in IT, with a "
+"focus on helping organizations make the most of their\n"
+"\t  digital infrastructure. Along the way, he developed a sizable music "
+"library, as well as a growing need to manage this\n"
+"\t  library; this need led him towards the MetaBrainz community.\n"
+"\n"
+"\t  In addition to assisting the MetaBrainz team with their system "
+"administration efforts, Julian enjoys listening to a wide\n"
+"\t  variety of music (& contributing to MusicBrainz accordingly), taking "
+"in natural scenery, reading, and traveling."
+msgstr ""
+
+#: metabrainz/templates/index/team.html:216
 msgid ""
 "<span class=\"name\">Simon Hartman</span> &mdash; Design, UX Consultant &"
 " Social Media Jockey"
 msgstr ""
 
-#: metabrainz/templates/index/team.html:191
+#: metabrainz/templates/index/team.html:218
 msgid ""
 "Simon has been contributing data and complaints about UX and design to "
 "MusicBrainz since 2009.\n"
@@ -1499,11 +1525,11 @@ msgid ""
 "design/comms/marketing roles."
 msgstr ""
 
-#: metabrainz/templates/index/team.html:210
+#: metabrainz/templates/index/team.html:237
 msgid "<span class=\"name\">Ansh Goyal</span> &mdash; Junior Software Engineer"
 msgstr ""
 
-#: metabrainz/templates/index/team.html:212
+#: metabrainz/templates/index/team.html:239
 msgid ""
 "Ansh is a Software Engineer and is based in New Delhi, India. He joined "
 "MetaBrainz as a Google Summer of Code student in 2022 and has been a part"
@@ -1514,15 +1540,15 @@ msgid ""
 "listening to music."
 msgstr ""
 
-#: metabrainz/templates/index/team.html:224
+#: metabrainz/templates/index/team.html:251
 msgid "Voluntary Project Leaders"
 msgstr ""
 
-#: metabrainz/templates/index/team.html:233
+#: metabrainz/templates/index/team.html:260
 msgid "<span class=\"name\">Akshat Tiwari</span> &mdash; Junior Software Engineer"
 msgstr ""
 
-#: metabrainz/templates/index/team.html:235
+#: metabrainz/templates/index/team.html:262
 msgid ""
 "Akshat started contributing to the MusicBrainz Android App out of love "
 "for the project and after dwelling\n"
@@ -1537,13 +1563,13 @@ msgid ""
 "He resides in New Delhi, India."
 msgstr ""
 
-#: metabrainz/templates/index/team.html:252
+#: metabrainz/templates/index/team.html:279
 msgid ""
 "<span class=\"name\">Param Singh</span> &mdash; Former ListenBrainz team "
 "leader"
 msgstr ""
 
-#: metabrainz/templates/index/team.html:254
+#: metabrainz/templates/index/team.html:281
 msgid ""
 "Param is a software engineer and the former leader of the ListenBrainz "
 "project. Param\n"
@@ -1555,13 +1581,13 @@ msgid ""
 "to listen to new music."
 msgstr ""
 
-#: metabrainz/templates/index/team.html:275
+#: metabrainz/templates/index/team.html:302
 msgid ""
 "<span class=\"name\">David \"drsaunde\" Saunders</span> &mdash; "
 "MusicBrainz Areas"
 msgstr ""
 
-#: metabrainz/templates/index/team.html:277
+#: metabrainz/templates/index/team.html:304
 #, python-format
 msgid ""
 "David is in charge of adding new areas to MusicBrainz when they're "
@@ -1577,11 +1603,11 @@ msgid ""
 "          as well as cheering for the Toronto Raptors."
 msgstr ""
 
-#: metabrainz/templates/index/team.html:302
+#: metabrainz/templates/index/team.html:329
 msgid "<span class=\"name\">Akira Holm</span> &mdash; MusicBrainz Instruments"
 msgstr ""
 
-#: metabrainz/templates/index/team.html:304
+#: metabrainz/templates/index/team.html:331
 msgid ""
 "ApeKattQuest or MonkeyPython has been a MusicBrainz editor since 2004, "
 "and\n"
@@ -1601,26 +1627,6 @@ msgstr ""
 
 #: metabrainz/templates/index/datasets/signup.html:3
 msgid "Please sign up"
-msgstr ""
-
-#: metabrainz/templates/oauth/prompt.html:4
-msgid "OAuth Authorization"
-msgstr ""
-
-#: metabrainz/templates/oauth/prompt.html:10
-msgid "This app requested permission to access:"
-msgstr ""
-
-#: metabrainz/templates/oauth/prompt.html:19
-msgid "Your identity on MetaBrainz"
-msgstr ""
-
-#: metabrainz/templates/oauth/prompt.html:32
-msgid "Allow access"
-msgstr ""
-
-#: metabrainz/templates/oauth/prompt.html:33
-msgid "Cancel"
 msgstr ""
 
 #: metabrainz/templates/payments/cancel_recurring.html:3
@@ -1733,7 +1739,7 @@ msgid "I would like this donation to be anonymous"
 msgstr ""
 
 #: metabrainz/templates/payments/donate.html:92
-msgid "Your name won't appear in the donors list"
+msgid "Your name and username won't appear in the donors list"
 msgstr ""
 
 #: metabrainz/templates/payments/donate.html:100
@@ -1741,6 +1747,12 @@ msgid "Donate with Credit Card"
 msgstr ""
 
 #: metabrainz/templates/payments/donate.html:113
+msgid ""
+"Your billing name and (if provided) your username will be listed\n"
+"        in our donors list unless you make your donation anonymous."
+msgstr ""
+
+#: metabrainz/templates/payments/donate.html:120
 #, python-format
 msgid ""
 "The personal information provided to the MetaBrainz Foundation during the"
@@ -1751,70 +1763,70 @@ msgid ""
 "        privacy policy</a>."
 msgstr ""
 
-#: metabrainz/templates/payments/donate.html:122
+#: metabrainz/templates/payments/donate.html:129
 #, python-format
 msgid ""
 "To find out how to cancel recurring donations take a look at\n"
 "        <a href=\"%(cancel_recurring_url)s\">this page</a>."
 msgstr ""
 
-#: metabrainz/templates/payments/donate.html:127
+#: metabrainz/templates/payments/donate.html:134
 msgid "Other ways to donate"
 msgstr ""
 
-#: metabrainz/templates/payments/donate.html:130
+#: metabrainz/templates/payments/donate.html:137
 msgid ""
 "If you use GitHub to sponsor your favourite projects, you can click below"
 " to Sponsor @metabrainz on GitHub Sponsors:"
 msgstr ""
 
-#: metabrainz/templates/payments/donate.html:133
+#: metabrainz/templates/payments/donate.html:140
 #: metabrainz/templates/payments/payment_base.html:29
 msgid "Non-US Bank transfer"
 msgstr ""
 
-#: metabrainz/templates/payments/donate.html:134
+#: metabrainz/templates/payments/donate.html:141
 msgid ""
 "You can make a donation, or recurring donations, via bank transfer to the"
 " following IBAN:"
 msgstr ""
 
-#: metabrainz/templates/payments/donate.html:136
+#: metabrainz/templates/payments/donate.html:143
 #, python-format
 msgid ""
 "Please indicate your name and use the word "
 "<em>%(donation_fixed_string)s</em> in the description field."
 msgstr ""
 
-#: metabrainz/templates/payments/donate.html:138
+#: metabrainz/templates/payments/donate.html:145
 msgid "US Check"
 msgstr ""
 
-#: metabrainz/templates/payments/donate.html:139
+#: metabrainz/templates/payments/donate.html:146
 msgid ""
 "Due to the increased unreliability of the US Postal Service we have "
 "stopped accepting paper checks. Sorry!"
 msgstr ""
 
-#: metabrainz/templates/payments/donate.html:234
+#: metabrainz/templates/payments/donate.html:241
 msgid ""
 "Enter your MusicBrainz username to have Picard/MusicBrainz stop nagging "
 "you"
 msgstr ""
 
-#: metabrainz/templates/payments/donate.html:249
+#: metabrainz/templates/payments/donate.html:256
 msgid "MusicBrainz is currently unavailable."
 msgstr ""
 
-#: metabrainz/templates/payments/donate.html:250
+#: metabrainz/templates/payments/donate.html:257
 msgid "Please, make sure that your username is correct."
 msgstr ""
 
-#: metabrainz/templates/payments/donate.html:252
+#: metabrainz/templates/payments/donate.html:259
 msgid "Your donation will be associated with this account."
 msgstr ""
 
-#: metabrainz/templates/payments/donate.html:254
+#: metabrainz/templates/payments/donate.html:261
 msgid "We can't find this account. Please, make sure it's correct"
 msgstr ""
 
@@ -2028,536 +2040,437 @@ msgid ""
 msgstr ""
 
 #: metabrainz/templates/reports/financial_reports/index.html:36
-#: metabrainz/templates/reports/financial_reports/index.html:55
-#: metabrainz/templates/reports/financial_reports/index.html:76
-#: metabrainz/templates/reports/financial_reports/index.html:96
-#: metabrainz/templates/reports/financial_reports/index.html:116
-#: metabrainz/templates/reports/financial_reports/index.html:136
-#: metabrainz/templates/reports/financial_reports/index.html:157
-#: metabrainz/templates/reports/financial_reports/index.html:181
-#: metabrainz/templates/reports/financial_reports/index.html:199
-#: metabrainz/templates/reports/financial_reports/index.html:228
-#: metabrainz/templates/reports/financial_reports/index.html:257
-#: metabrainz/templates/reports/financial_reports/index.html:286
-#: metabrainz/templates/reports/financial_reports/index.html:315
-#: metabrainz/templates/reports/financial_reports/index.html:344
-#: metabrainz/templates/reports/financial_reports/index.html:373
-#: metabrainz/templates/reports/financial_reports/index.html:402
-#: metabrainz/templates/reports/financial_reports/index.html:431
-#: metabrainz/templates/reports/financial_reports/index.html:460
-msgid "Quarterly reports"
-msgstr ""
-
-#: metabrainz/templates/reports/financial_reports/index.html:38
-#: metabrainz/templates/reports/financial_reports/index.html:40
-#: metabrainz/templates/reports/financial_reports/index.html:42
-#: metabrainz/templates/reports/financial_reports/index.html:52
 #: metabrainz/templates/reports/financial_reports/index.html:57
-#: metabrainz/templates/reports/financial_reports/index.html:59
-#: metabrainz/templates/reports/financial_reports/index.html:61
-#: metabrainz/templates/reports/financial_reports/index.html:63
-#: metabrainz/templates/reports/financial_reports/index.html:73
 #: metabrainz/templates/reports/financial_reports/index.html:78
-#: metabrainz/templates/reports/financial_reports/index.html:80
-#: metabrainz/templates/reports/financial_reports/index.html:82
-#: metabrainz/templates/reports/financial_reports/index.html:84
-#: metabrainz/templates/reports/financial_reports/index.html:93
 #: metabrainz/templates/reports/financial_reports/index.html:98
-#: metabrainz/templates/reports/financial_reports/index.html:100
-#: metabrainz/templates/reports/financial_reports/index.html:102
-#: metabrainz/templates/reports/financial_reports/index.html:104
-#: metabrainz/templates/reports/financial_reports/index.html:113
 #: metabrainz/templates/reports/financial_reports/index.html:118
-#: metabrainz/templates/reports/financial_reports/index.html:120
-#: metabrainz/templates/reports/financial_reports/index.html:122
-#: metabrainz/templates/reports/financial_reports/index.html:124
-#: metabrainz/templates/reports/financial_reports/index.html:133
 #: metabrainz/templates/reports/financial_reports/index.html:138
-#: metabrainz/templates/reports/financial_reports/index.html:140
-#: metabrainz/templates/reports/financial_reports/index.html:142
-#: metabrainz/templates/reports/financial_reports/index.html:144
-#: metabrainz/templates/reports/financial_reports/index.html:154
 #: metabrainz/templates/reports/financial_reports/index.html:159
-#: metabrainz/templates/reports/financial_reports/index.html:161
-#: metabrainz/templates/reports/financial_reports/index.html:163
-#: metabrainz/templates/reports/financial_reports/index.html:165
-#: metabrainz/templates/reports/financial_reports/index.html:178
 #: metabrainz/templates/reports/financial_reports/index.html:183
-#: metabrainz/templates/reports/financial_reports/index.html:185
-#: metabrainz/templates/reports/financial_reports/index.html:187
-#: metabrainz/templates/reports/financial_reports/index.html:189
-#: metabrainz/templates/reports/financial_reports/index.html:197
-#: metabrainz/templates/reports/financial_reports/index.html:201
 #: metabrainz/templates/reports/financial_reports/index.html:202
-#: metabrainz/templates/reports/financial_reports/index.html:203
-#: metabrainz/templates/reports/financial_reports/index.html:204
-#: metabrainz/templates/reports/financial_reports/index.html:208
-#: metabrainz/templates/reports/financial_reports/index.html:209
-#: metabrainz/templates/reports/financial_reports/index.html:210
-#: metabrainz/templates/reports/financial_reports/index.html:211
-#: metabrainz/templates/reports/financial_reports/index.html:212
-#: metabrainz/templates/reports/financial_reports/index.html:213
-#: metabrainz/templates/reports/financial_reports/index.html:214
-#: metabrainz/templates/reports/financial_reports/index.html:215
-#: metabrainz/templates/reports/financial_reports/index.html:216
-#: metabrainz/templates/reports/financial_reports/index.html:217
-#: metabrainz/templates/reports/financial_reports/index.html:218
-#: metabrainz/templates/reports/financial_reports/index.html:219
-#: metabrainz/templates/reports/financial_reports/index.html:226
-#: metabrainz/templates/reports/financial_reports/index.html:230
 #: metabrainz/templates/reports/financial_reports/index.html:231
-#: metabrainz/templates/reports/financial_reports/index.html:232
-#: metabrainz/templates/reports/financial_reports/index.html:233
-#: metabrainz/templates/reports/financial_reports/index.html:237
-#: metabrainz/templates/reports/financial_reports/index.html:238
-#: metabrainz/templates/reports/financial_reports/index.html:239
-#: metabrainz/templates/reports/financial_reports/index.html:240
-#: metabrainz/templates/reports/financial_reports/index.html:241
-#: metabrainz/templates/reports/financial_reports/index.html:242
-#: metabrainz/templates/reports/financial_reports/index.html:243
-#: metabrainz/templates/reports/financial_reports/index.html:244
-#: metabrainz/templates/reports/financial_reports/index.html:245
-#: metabrainz/templates/reports/financial_reports/index.html:246
-#: metabrainz/templates/reports/financial_reports/index.html:247
-#: metabrainz/templates/reports/financial_reports/index.html:248
-#: metabrainz/templates/reports/financial_reports/index.html:255
-#: metabrainz/templates/reports/financial_reports/index.html:259
 #: metabrainz/templates/reports/financial_reports/index.html:260
-#: metabrainz/templates/reports/financial_reports/index.html:261
-#: metabrainz/templates/reports/financial_reports/index.html:262
-#: metabrainz/templates/reports/financial_reports/index.html:266
-#: metabrainz/templates/reports/financial_reports/index.html:267
-#: metabrainz/templates/reports/financial_reports/index.html:268
-#: metabrainz/templates/reports/financial_reports/index.html:269
-#: metabrainz/templates/reports/financial_reports/index.html:270
-#: metabrainz/templates/reports/financial_reports/index.html:271
-#: metabrainz/templates/reports/financial_reports/index.html:272
-#: metabrainz/templates/reports/financial_reports/index.html:273
-#: metabrainz/templates/reports/financial_reports/index.html:274
-#: metabrainz/templates/reports/financial_reports/index.html:275
-#: metabrainz/templates/reports/financial_reports/index.html:276
-#: metabrainz/templates/reports/financial_reports/index.html:277
-#: metabrainz/templates/reports/financial_reports/index.html:284
-#: metabrainz/templates/reports/financial_reports/index.html:288
 #: metabrainz/templates/reports/financial_reports/index.html:289
-#: metabrainz/templates/reports/financial_reports/index.html:290
-#: metabrainz/templates/reports/financial_reports/index.html:291
-#: metabrainz/templates/reports/financial_reports/index.html:295
-#: metabrainz/templates/reports/financial_reports/index.html:296
-#: metabrainz/templates/reports/financial_reports/index.html:297
-#: metabrainz/templates/reports/financial_reports/index.html:298
-#: metabrainz/templates/reports/financial_reports/index.html:299
-#: metabrainz/templates/reports/financial_reports/index.html:300
-#: metabrainz/templates/reports/financial_reports/index.html:301
-#: metabrainz/templates/reports/financial_reports/index.html:302
-#: metabrainz/templates/reports/financial_reports/index.html:303
-#: metabrainz/templates/reports/financial_reports/index.html:304
-#: metabrainz/templates/reports/financial_reports/index.html:305
-#: metabrainz/templates/reports/financial_reports/index.html:306
-#: metabrainz/templates/reports/financial_reports/index.html:313
-#: metabrainz/templates/reports/financial_reports/index.html:317
 #: metabrainz/templates/reports/financial_reports/index.html:318
-#: metabrainz/templates/reports/financial_reports/index.html:319
-#: metabrainz/templates/reports/financial_reports/index.html:320
-#: metabrainz/templates/reports/financial_reports/index.html:324
-#: metabrainz/templates/reports/financial_reports/index.html:325
-#: metabrainz/templates/reports/financial_reports/index.html:326
-#: metabrainz/templates/reports/financial_reports/index.html:327
-#: metabrainz/templates/reports/financial_reports/index.html:328
-#: metabrainz/templates/reports/financial_reports/index.html:329
-#: metabrainz/templates/reports/financial_reports/index.html:330
-#: metabrainz/templates/reports/financial_reports/index.html:331
-#: metabrainz/templates/reports/financial_reports/index.html:332
-#: metabrainz/templates/reports/financial_reports/index.html:333
-#: metabrainz/templates/reports/financial_reports/index.html:334
-#: metabrainz/templates/reports/financial_reports/index.html:335
-#: metabrainz/templates/reports/financial_reports/index.html:342
-#: metabrainz/templates/reports/financial_reports/index.html:346
 #: metabrainz/templates/reports/financial_reports/index.html:347
-#: metabrainz/templates/reports/financial_reports/index.html:348
-#: metabrainz/templates/reports/financial_reports/index.html:349
-#: metabrainz/templates/reports/financial_reports/index.html:353
-#: metabrainz/templates/reports/financial_reports/index.html:354
-#: metabrainz/templates/reports/financial_reports/index.html:355
-#: metabrainz/templates/reports/financial_reports/index.html:356
-#: metabrainz/templates/reports/financial_reports/index.html:357
-#: metabrainz/templates/reports/financial_reports/index.html:358
-#: metabrainz/templates/reports/financial_reports/index.html:359
-#: metabrainz/templates/reports/financial_reports/index.html:360
-#: metabrainz/templates/reports/financial_reports/index.html:361
-#: metabrainz/templates/reports/financial_reports/index.html:362
-#: metabrainz/templates/reports/financial_reports/index.html:363
-#: metabrainz/templates/reports/financial_reports/index.html:364
-#: metabrainz/templates/reports/financial_reports/index.html:371
-#: metabrainz/templates/reports/financial_reports/index.html:375
 #: metabrainz/templates/reports/financial_reports/index.html:376
-#: metabrainz/templates/reports/financial_reports/index.html:377
-#: metabrainz/templates/reports/financial_reports/index.html:378
-#: metabrainz/templates/reports/financial_reports/index.html:382
-#: metabrainz/templates/reports/financial_reports/index.html:383
-#: metabrainz/templates/reports/financial_reports/index.html:384
-#: metabrainz/templates/reports/financial_reports/index.html:385
-#: metabrainz/templates/reports/financial_reports/index.html:386
-#: metabrainz/templates/reports/financial_reports/index.html:387
-#: metabrainz/templates/reports/financial_reports/index.html:388
-#: metabrainz/templates/reports/financial_reports/index.html:389
-#: metabrainz/templates/reports/financial_reports/index.html:390
-#: metabrainz/templates/reports/financial_reports/index.html:391
-#: metabrainz/templates/reports/financial_reports/index.html:392
-#: metabrainz/templates/reports/financial_reports/index.html:393
-#: metabrainz/templates/reports/financial_reports/index.html:400
-#: metabrainz/templates/reports/financial_reports/index.html:404
 #: metabrainz/templates/reports/financial_reports/index.html:405
-#: metabrainz/templates/reports/financial_reports/index.html:406
-#: metabrainz/templates/reports/financial_reports/index.html:407
-#: metabrainz/templates/reports/financial_reports/index.html:411
-#: metabrainz/templates/reports/financial_reports/index.html:412
-#: metabrainz/templates/reports/financial_reports/index.html:413
-#: metabrainz/templates/reports/financial_reports/index.html:414
-#: metabrainz/templates/reports/financial_reports/index.html:415
-#: metabrainz/templates/reports/financial_reports/index.html:416
-#: metabrainz/templates/reports/financial_reports/index.html:417
-#: metabrainz/templates/reports/financial_reports/index.html:418
-#: metabrainz/templates/reports/financial_reports/index.html:419
-#: metabrainz/templates/reports/financial_reports/index.html:420
-#: metabrainz/templates/reports/financial_reports/index.html:421
-#: metabrainz/templates/reports/financial_reports/index.html:422
-#: metabrainz/templates/reports/financial_reports/index.html:429
-#: metabrainz/templates/reports/financial_reports/index.html:433
 #: metabrainz/templates/reports/financial_reports/index.html:434
-#: metabrainz/templates/reports/financial_reports/index.html:435
-#: metabrainz/templates/reports/financial_reports/index.html:436
-#: metabrainz/templates/reports/financial_reports/index.html:440
-#: metabrainz/templates/reports/financial_reports/index.html:441
-#: metabrainz/templates/reports/financial_reports/index.html:442
-#: metabrainz/templates/reports/financial_reports/index.html:443
-#: metabrainz/templates/reports/financial_reports/index.html:444
-#: metabrainz/templates/reports/financial_reports/index.html:445
-#: metabrainz/templates/reports/financial_reports/index.html:446
-#: metabrainz/templates/reports/financial_reports/index.html:447
-#: metabrainz/templates/reports/financial_reports/index.html:448
-#: metabrainz/templates/reports/financial_reports/index.html:449
-#: metabrainz/templates/reports/financial_reports/index.html:450
-#: metabrainz/templates/reports/financial_reports/index.html:451
-#: metabrainz/templates/reports/financial_reports/index.html:458
-#: metabrainz/templates/reports/financial_reports/index.html:462
 #: metabrainz/templates/reports/financial_reports/index.html:463
-#: metabrainz/templates/reports/financial_reports/index.html:464
-#: metabrainz/templates/reports/financial_reports/index.html:465
-#: metabrainz/templates/reports/financial_reports/index.html:469
-#: metabrainz/templates/reports/financial_reports/index.html:470
-#: metabrainz/templates/reports/financial_reports/index.html:471
-#: metabrainz/templates/reports/financial_reports/index.html:472
-#: metabrainz/templates/reports/financial_reports/index.html:473
-#: metabrainz/templates/reports/financial_reports/index.html:474
-#: metabrainz/templates/reports/financial_reports/index.html:475
-#: metabrainz/templates/reports/financial_reports/index.html:476
-#: metabrainz/templates/reports/financial_reports/index.html:477
-#: metabrainz/templates/reports/financial_reports/index.html:478
-#: metabrainz/templates/reports/financial_reports/index.html:479
-#: metabrainz/templates/reports/financial_reports/index.html:480
-#: metabrainz/templates/reports/financial_reports/index.html:487
-#: metabrainz/templates/reports/financial_reports/index.html:509
-msgid "profit &amp; loss"
-msgstr ""
-
-#: metabrainz/templates/reports/financial_reports/index.html:39
-#: metabrainz/templates/reports/financial_reports/index.html:41
-#: metabrainz/templates/reports/financial_reports/index.html:43
-#: metabrainz/templates/reports/financial_reports/index.html:51
-#: metabrainz/templates/reports/financial_reports/index.html:58
-#: metabrainz/templates/reports/financial_reports/index.html:60
-#: metabrainz/templates/reports/financial_reports/index.html:62
-#: metabrainz/templates/reports/financial_reports/index.html:64
-#: metabrainz/templates/reports/financial_reports/index.html:72
-#: metabrainz/templates/reports/financial_reports/index.html:79
-#: metabrainz/templates/reports/financial_reports/index.html:81
-#: metabrainz/templates/reports/financial_reports/index.html:83
-#: metabrainz/templates/reports/financial_reports/index.html:85
-#: metabrainz/templates/reports/financial_reports/index.html:92
-#: metabrainz/templates/reports/financial_reports/index.html:99
-#: metabrainz/templates/reports/financial_reports/index.html:101
-#: metabrainz/templates/reports/financial_reports/index.html:103
-#: metabrainz/templates/reports/financial_reports/index.html:105
-#: metabrainz/templates/reports/financial_reports/index.html:112
-#: metabrainz/templates/reports/financial_reports/index.html:119
-#: metabrainz/templates/reports/financial_reports/index.html:121
-#: metabrainz/templates/reports/financial_reports/index.html:123
-#: metabrainz/templates/reports/financial_reports/index.html:125
-#: metabrainz/templates/reports/financial_reports/index.html:132
-#: metabrainz/templates/reports/financial_reports/index.html:139
-#: metabrainz/templates/reports/financial_reports/index.html:141
-#: metabrainz/templates/reports/financial_reports/index.html:143
-#: metabrainz/templates/reports/financial_reports/index.html:145
-#: metabrainz/templates/reports/financial_reports/index.html:153
-#: metabrainz/templates/reports/financial_reports/index.html:160
-#: metabrainz/templates/reports/financial_reports/index.html:162
-#: metabrainz/templates/reports/financial_reports/index.html:164
-#: metabrainz/templates/reports/financial_reports/index.html:166
-#: metabrainz/templates/reports/financial_reports/index.html:177
-#: metabrainz/templates/reports/financial_reports/index.html:184
-#: metabrainz/templates/reports/financial_reports/index.html:186
-#: metabrainz/templates/reports/financial_reports/index.html:188
-#: metabrainz/templates/reports/financial_reports/index.html:190
-#: metabrainz/templates/reports/financial_reports/index.html:196
-#: metabrainz/templates/reports/financial_reports/index.html:208
-#: metabrainz/templates/reports/financial_reports/index.html:209
-#: metabrainz/templates/reports/financial_reports/index.html:210
-#: metabrainz/templates/reports/financial_reports/index.html:211
-#: metabrainz/templates/reports/financial_reports/index.html:212
-#: metabrainz/templates/reports/financial_reports/index.html:213
-#: metabrainz/templates/reports/financial_reports/index.html:214
-#: metabrainz/templates/reports/financial_reports/index.html:215
-#: metabrainz/templates/reports/financial_reports/index.html:216
-#: metabrainz/templates/reports/financial_reports/index.html:217
-#: metabrainz/templates/reports/financial_reports/index.html:218
-#: metabrainz/templates/reports/financial_reports/index.html:219
-#: metabrainz/templates/reports/financial_reports/index.html:225
-#: metabrainz/templates/reports/financial_reports/index.html:237
-#: metabrainz/templates/reports/financial_reports/index.html:238
-#: metabrainz/templates/reports/financial_reports/index.html:239
-#: metabrainz/templates/reports/financial_reports/index.html:240
-#: metabrainz/templates/reports/financial_reports/index.html:241
-#: metabrainz/templates/reports/financial_reports/index.html:242
-#: metabrainz/templates/reports/financial_reports/index.html:243
-#: metabrainz/templates/reports/financial_reports/index.html:244
-#: metabrainz/templates/reports/financial_reports/index.html:245
-#: metabrainz/templates/reports/financial_reports/index.html:246
-#: metabrainz/templates/reports/financial_reports/index.html:247
-#: metabrainz/templates/reports/financial_reports/index.html:248
-#: metabrainz/templates/reports/financial_reports/index.html:254
-#: metabrainz/templates/reports/financial_reports/index.html:266
-#: metabrainz/templates/reports/financial_reports/index.html:267
-#: metabrainz/templates/reports/financial_reports/index.html:268
-#: metabrainz/templates/reports/financial_reports/index.html:269
-#: metabrainz/templates/reports/financial_reports/index.html:270
-#: metabrainz/templates/reports/financial_reports/index.html:271
-#: metabrainz/templates/reports/financial_reports/index.html:272
-#: metabrainz/templates/reports/financial_reports/index.html:273
-#: metabrainz/templates/reports/financial_reports/index.html:274
-#: metabrainz/templates/reports/financial_reports/index.html:275
-#: metabrainz/templates/reports/financial_reports/index.html:276
-#: metabrainz/templates/reports/financial_reports/index.html:277
-#: metabrainz/templates/reports/financial_reports/index.html:283
-#: metabrainz/templates/reports/financial_reports/index.html:295
-#: metabrainz/templates/reports/financial_reports/index.html:296
-#: metabrainz/templates/reports/financial_reports/index.html:297
-#: metabrainz/templates/reports/financial_reports/index.html:298
-#: metabrainz/templates/reports/financial_reports/index.html:299
-#: metabrainz/templates/reports/financial_reports/index.html:300
-#: metabrainz/templates/reports/financial_reports/index.html:301
-#: metabrainz/templates/reports/financial_reports/index.html:302
-#: metabrainz/templates/reports/financial_reports/index.html:303
-#: metabrainz/templates/reports/financial_reports/index.html:304
-#: metabrainz/templates/reports/financial_reports/index.html:305
-#: metabrainz/templates/reports/financial_reports/index.html:306
-#: metabrainz/templates/reports/financial_reports/index.html:312
-#: metabrainz/templates/reports/financial_reports/index.html:324
-#: metabrainz/templates/reports/financial_reports/index.html:325
-#: metabrainz/templates/reports/financial_reports/index.html:326
-#: metabrainz/templates/reports/financial_reports/index.html:327
-#: metabrainz/templates/reports/financial_reports/index.html:328
-#: metabrainz/templates/reports/financial_reports/index.html:329
-#: metabrainz/templates/reports/financial_reports/index.html:330
-#: metabrainz/templates/reports/financial_reports/index.html:331
-#: metabrainz/templates/reports/financial_reports/index.html:332
-#: metabrainz/templates/reports/financial_reports/index.html:333
-#: metabrainz/templates/reports/financial_reports/index.html:334
-#: metabrainz/templates/reports/financial_reports/index.html:335
-#: metabrainz/templates/reports/financial_reports/index.html:341
-#: metabrainz/templates/reports/financial_reports/index.html:353
-#: metabrainz/templates/reports/financial_reports/index.html:354
-#: metabrainz/templates/reports/financial_reports/index.html:355
-#: metabrainz/templates/reports/financial_reports/index.html:356
-#: metabrainz/templates/reports/financial_reports/index.html:357
-#: metabrainz/templates/reports/financial_reports/index.html:358
-#: metabrainz/templates/reports/financial_reports/index.html:359
-#: metabrainz/templates/reports/financial_reports/index.html:360
-#: metabrainz/templates/reports/financial_reports/index.html:361
-#: metabrainz/templates/reports/financial_reports/index.html:362
-#: metabrainz/templates/reports/financial_reports/index.html:363
-#: metabrainz/templates/reports/financial_reports/index.html:364
-#: metabrainz/templates/reports/financial_reports/index.html:370
-#: metabrainz/templates/reports/financial_reports/index.html:382
-#: metabrainz/templates/reports/financial_reports/index.html:383
-#: metabrainz/templates/reports/financial_reports/index.html:384
-#: metabrainz/templates/reports/financial_reports/index.html:385
-#: metabrainz/templates/reports/financial_reports/index.html:386
-#: metabrainz/templates/reports/financial_reports/index.html:387
-#: metabrainz/templates/reports/financial_reports/index.html:388
-#: metabrainz/templates/reports/financial_reports/index.html:389
-#: metabrainz/templates/reports/financial_reports/index.html:390
-#: metabrainz/templates/reports/financial_reports/index.html:391
-#: metabrainz/templates/reports/financial_reports/index.html:392
-#: metabrainz/templates/reports/financial_reports/index.html:393
-#: metabrainz/templates/reports/financial_reports/index.html:399
-#: metabrainz/templates/reports/financial_reports/index.html:411
-#: metabrainz/templates/reports/financial_reports/index.html:412
-#: metabrainz/templates/reports/financial_reports/index.html:413
-#: metabrainz/templates/reports/financial_reports/index.html:414
-#: metabrainz/templates/reports/financial_reports/index.html:415
-#: metabrainz/templates/reports/financial_reports/index.html:416
-#: metabrainz/templates/reports/financial_reports/index.html:417
-#: metabrainz/templates/reports/financial_reports/index.html:418
-#: metabrainz/templates/reports/financial_reports/index.html:419
-#: metabrainz/templates/reports/financial_reports/index.html:420
-#: metabrainz/templates/reports/financial_reports/index.html:421
-#: metabrainz/templates/reports/financial_reports/index.html:422
-#: metabrainz/templates/reports/financial_reports/index.html:428
-#: metabrainz/templates/reports/financial_reports/index.html:440
-#: metabrainz/templates/reports/financial_reports/index.html:441
-#: metabrainz/templates/reports/financial_reports/index.html:442
-#: metabrainz/templates/reports/financial_reports/index.html:443
-#: metabrainz/templates/reports/financial_reports/index.html:444
-#: metabrainz/templates/reports/financial_reports/index.html:445
-#: metabrainz/templates/reports/financial_reports/index.html:446
-#: metabrainz/templates/reports/financial_reports/index.html:447
-#: metabrainz/templates/reports/financial_reports/index.html:448
-#: metabrainz/templates/reports/financial_reports/index.html:449
-#: metabrainz/templates/reports/financial_reports/index.html:450
-#: metabrainz/templates/reports/financial_reports/index.html:451
-#: metabrainz/templates/reports/financial_reports/index.html:457
-#: metabrainz/templates/reports/financial_reports/index.html:469
-#: metabrainz/templates/reports/financial_reports/index.html:470
-#: metabrainz/templates/reports/financial_reports/index.html:471
-#: metabrainz/templates/reports/financial_reports/index.html:472
-#: metabrainz/templates/reports/financial_reports/index.html:473
-#: metabrainz/templates/reports/financial_reports/index.html:474
-#: metabrainz/templates/reports/financial_reports/index.html:475
-#: metabrainz/templates/reports/financial_reports/index.html:476
-#: metabrainz/templates/reports/financial_reports/index.html:477
-#: metabrainz/templates/reports/financial_reports/index.html:478
-#: metabrainz/templates/reports/financial_reports/index.html:479
-#: metabrainz/templates/reports/financial_reports/index.html:480
-#: metabrainz/templates/reports/financial_reports/index.html:486
-#: metabrainz/templates/reports/financial_reports/index.html:508
-msgid "balance sheet"
-msgstr ""
-
-#: metabrainz/templates/reports/financial_reports/index.html:49
-#: metabrainz/templates/reports/financial_reports/index.html:70
-#: metabrainz/templates/reports/financial_reports/index.html:90
-#: metabrainz/templates/reports/financial_reports/index.html:110
-#: metabrainz/templates/reports/financial_reports/index.html:130
-#: metabrainz/templates/reports/financial_reports/index.html:151
-#: metabrainz/templates/reports/financial_reports/index.html:175
-#: metabrainz/templates/reports/financial_reports/index.html:194
-#: metabrainz/templates/reports/financial_reports/index.html:223
-#: metabrainz/templates/reports/financial_reports/index.html:252
-#: metabrainz/templates/reports/financial_reports/index.html:281
-#: metabrainz/templates/reports/financial_reports/index.html:310
-#: metabrainz/templates/reports/financial_reports/index.html:339
-#: metabrainz/templates/reports/financial_reports/index.html:368
-#: metabrainz/templates/reports/financial_reports/index.html:397
-#: metabrainz/templates/reports/financial_reports/index.html:426
-#: metabrainz/templates/reports/financial_reports/index.html:455
-#: metabrainz/templates/reports/financial_reports/index.html:484
-#: metabrainz/templates/reports/financial_reports/index.html:506
+#: metabrainz/templates/reports/financial_reports/index.html:492
+#: metabrainz/templates/reports/financial_reports/index.html:514
 msgid "Year end reports"
 msgstr ""
 
-#: metabrainz/templates/reports/financial_reports/index.html:206
-#: metabrainz/templates/reports/financial_reports/index.html:235
-#: metabrainz/templates/reports/financial_reports/index.html:264
-#: metabrainz/templates/reports/financial_reports/index.html:293
-#: metabrainz/templates/reports/financial_reports/index.html:322
-#: metabrainz/templates/reports/financial_reports/index.html:351
-#: metabrainz/templates/reports/financial_reports/index.html:380
-#: metabrainz/templates/reports/financial_reports/index.html:409
-#: metabrainz/templates/reports/financial_reports/index.html:438
-#: metabrainz/templates/reports/financial_reports/index.html:467
-msgid "Monthly reports"
-msgstr ""
-
-#: metabrainz/templates/reports/financial_reports/index.html:208
-#: metabrainz/templates/reports/financial_reports/index.html:237
-#: metabrainz/templates/reports/financial_reports/index.html:266
-#: metabrainz/templates/reports/financial_reports/index.html:295
-#: metabrainz/templates/reports/financial_reports/index.html:324
-#: metabrainz/templates/reports/financial_reports/index.html:353
-#: metabrainz/templates/reports/financial_reports/index.html:382
-#: metabrainz/templates/reports/financial_reports/index.html:411
-#: metabrainz/templates/reports/financial_reports/index.html:440
-#: metabrainz/templates/reports/financial_reports/index.html:469
-#: metabrainz/templates/reports/financial_reports/index.html:491
-#: metabrainz/templates/reports/financial_reports/index.html:513
-#: metabrainz/templates/reports/financial_reports/index.html:529
-msgid "December"
-msgstr ""
-
-#: metabrainz/templates/reports/financial_reports/index.html:209
-#: metabrainz/templates/reports/financial_reports/index.html:238
-#: metabrainz/templates/reports/financial_reports/index.html:267
-#: metabrainz/templates/reports/financial_reports/index.html:296
-#: metabrainz/templates/reports/financial_reports/index.html:325
-#: metabrainz/templates/reports/financial_reports/index.html:354
-#: metabrainz/templates/reports/financial_reports/index.html:383
-#: metabrainz/templates/reports/financial_reports/index.html:412
-#: metabrainz/templates/reports/financial_reports/index.html:441
-#: metabrainz/templates/reports/financial_reports/index.html:470
-#: metabrainz/templates/reports/financial_reports/index.html:492
-#: metabrainz/templates/reports/financial_reports/index.html:514
-msgid "November"
-msgstr ""
-
-#: metabrainz/templates/reports/financial_reports/index.html:210
-#: metabrainz/templates/reports/financial_reports/index.html:239
-#: metabrainz/templates/reports/financial_reports/index.html:268
-#: metabrainz/templates/reports/financial_reports/index.html:297
-#: metabrainz/templates/reports/financial_reports/index.html:326
-#: metabrainz/templates/reports/financial_reports/index.html:355
-#: metabrainz/templates/reports/financial_reports/index.html:384
-#: metabrainz/templates/reports/financial_reports/index.html:413
-#: metabrainz/templates/reports/financial_reports/index.html:442
-#: metabrainz/templates/reports/financial_reports/index.html:471
-#: metabrainz/templates/reports/financial_reports/index.html:493
-#: metabrainz/templates/reports/financial_reports/index.html:515
-msgid "October"
-msgstr ""
-
-#: metabrainz/templates/reports/financial_reports/index.html:211
-#: metabrainz/templates/reports/financial_reports/index.html:240
-#: metabrainz/templates/reports/financial_reports/index.html:269
-#: metabrainz/templates/reports/financial_reports/index.html:298
-#: metabrainz/templates/reports/financial_reports/index.html:327
-#: metabrainz/templates/reports/financial_reports/index.html:356
-#: metabrainz/templates/reports/financial_reports/index.html:385
-#: metabrainz/templates/reports/financial_reports/index.html:414
-#: metabrainz/templates/reports/financial_reports/index.html:443
-#: metabrainz/templates/reports/financial_reports/index.html:472
+#: metabrainz/templates/reports/financial_reports/index.html:38
+#: metabrainz/templates/reports/financial_reports/index.html:45
+#: metabrainz/templates/reports/financial_reports/index.html:47
+#: metabrainz/templates/reports/financial_reports/index.html:49
+#: metabrainz/templates/reports/financial_reports/index.html:51
+#: metabrainz/templates/reports/financial_reports/index.html:59
+#: metabrainz/templates/reports/financial_reports/index.html:66
+#: metabrainz/templates/reports/financial_reports/index.html:68
+#: metabrainz/templates/reports/financial_reports/index.html:70
+#: metabrainz/templates/reports/financial_reports/index.html:72
+#: metabrainz/templates/reports/financial_reports/index.html:80
+#: metabrainz/templates/reports/financial_reports/index.html:87
+#: metabrainz/templates/reports/financial_reports/index.html:89
+#: metabrainz/templates/reports/financial_reports/index.html:91
+#: metabrainz/templates/reports/financial_reports/index.html:93
+#: metabrainz/templates/reports/financial_reports/index.html:100
+#: metabrainz/templates/reports/financial_reports/index.html:107
+#: metabrainz/templates/reports/financial_reports/index.html:109
+#: metabrainz/templates/reports/financial_reports/index.html:111
+#: metabrainz/templates/reports/financial_reports/index.html:113
+#: metabrainz/templates/reports/financial_reports/index.html:120
+#: metabrainz/templates/reports/financial_reports/index.html:127
+#: metabrainz/templates/reports/financial_reports/index.html:129
+#: metabrainz/templates/reports/financial_reports/index.html:131
+#: metabrainz/templates/reports/financial_reports/index.html:133
+#: metabrainz/templates/reports/financial_reports/index.html:140
+#: metabrainz/templates/reports/financial_reports/index.html:147
+#: metabrainz/templates/reports/financial_reports/index.html:149
+#: metabrainz/templates/reports/financial_reports/index.html:151
+#: metabrainz/templates/reports/financial_reports/index.html:153
+#: metabrainz/templates/reports/financial_reports/index.html:161
+#: metabrainz/templates/reports/financial_reports/index.html:168
+#: metabrainz/templates/reports/financial_reports/index.html:170
+#: metabrainz/templates/reports/financial_reports/index.html:172
+#: metabrainz/templates/reports/financial_reports/index.html:174
+#: metabrainz/templates/reports/financial_reports/index.html:185
+#: metabrainz/templates/reports/financial_reports/index.html:192
+#: metabrainz/templates/reports/financial_reports/index.html:194
+#: metabrainz/templates/reports/financial_reports/index.html:196
+#: metabrainz/templates/reports/financial_reports/index.html:198
+#: metabrainz/templates/reports/financial_reports/index.html:204
+#: metabrainz/templates/reports/financial_reports/index.html:216
+#: metabrainz/templates/reports/financial_reports/index.html:217
+#: metabrainz/templates/reports/financial_reports/index.html:218
+#: metabrainz/templates/reports/financial_reports/index.html:219
+#: metabrainz/templates/reports/financial_reports/index.html:220
+#: metabrainz/templates/reports/financial_reports/index.html:221
+#: metabrainz/templates/reports/financial_reports/index.html:222
+#: metabrainz/templates/reports/financial_reports/index.html:223
+#: metabrainz/templates/reports/financial_reports/index.html:224
+#: metabrainz/templates/reports/financial_reports/index.html:225
+#: metabrainz/templates/reports/financial_reports/index.html:226
+#: metabrainz/templates/reports/financial_reports/index.html:227
+#: metabrainz/templates/reports/financial_reports/index.html:233
+#: metabrainz/templates/reports/financial_reports/index.html:245
+#: metabrainz/templates/reports/financial_reports/index.html:246
+#: metabrainz/templates/reports/financial_reports/index.html:247
+#: metabrainz/templates/reports/financial_reports/index.html:248
+#: metabrainz/templates/reports/financial_reports/index.html:249
+#: metabrainz/templates/reports/financial_reports/index.html:250
+#: metabrainz/templates/reports/financial_reports/index.html:251
+#: metabrainz/templates/reports/financial_reports/index.html:252
+#: metabrainz/templates/reports/financial_reports/index.html:253
+#: metabrainz/templates/reports/financial_reports/index.html:254
+#: metabrainz/templates/reports/financial_reports/index.html:255
+#: metabrainz/templates/reports/financial_reports/index.html:256
+#: metabrainz/templates/reports/financial_reports/index.html:262
+#: metabrainz/templates/reports/financial_reports/index.html:274
+#: metabrainz/templates/reports/financial_reports/index.html:275
+#: metabrainz/templates/reports/financial_reports/index.html:276
+#: metabrainz/templates/reports/financial_reports/index.html:277
+#: metabrainz/templates/reports/financial_reports/index.html:278
+#: metabrainz/templates/reports/financial_reports/index.html:279
+#: metabrainz/templates/reports/financial_reports/index.html:280
+#: metabrainz/templates/reports/financial_reports/index.html:281
+#: metabrainz/templates/reports/financial_reports/index.html:282
+#: metabrainz/templates/reports/financial_reports/index.html:283
+#: metabrainz/templates/reports/financial_reports/index.html:284
+#: metabrainz/templates/reports/financial_reports/index.html:285
+#: metabrainz/templates/reports/financial_reports/index.html:291
+#: metabrainz/templates/reports/financial_reports/index.html:303
+#: metabrainz/templates/reports/financial_reports/index.html:304
+#: metabrainz/templates/reports/financial_reports/index.html:305
+#: metabrainz/templates/reports/financial_reports/index.html:306
+#: metabrainz/templates/reports/financial_reports/index.html:307
+#: metabrainz/templates/reports/financial_reports/index.html:308
+#: metabrainz/templates/reports/financial_reports/index.html:309
+#: metabrainz/templates/reports/financial_reports/index.html:310
+#: metabrainz/templates/reports/financial_reports/index.html:311
+#: metabrainz/templates/reports/financial_reports/index.html:312
+#: metabrainz/templates/reports/financial_reports/index.html:313
+#: metabrainz/templates/reports/financial_reports/index.html:314
+#: metabrainz/templates/reports/financial_reports/index.html:320
+#: metabrainz/templates/reports/financial_reports/index.html:332
+#: metabrainz/templates/reports/financial_reports/index.html:333
+#: metabrainz/templates/reports/financial_reports/index.html:334
+#: metabrainz/templates/reports/financial_reports/index.html:335
+#: metabrainz/templates/reports/financial_reports/index.html:336
+#: metabrainz/templates/reports/financial_reports/index.html:337
+#: metabrainz/templates/reports/financial_reports/index.html:338
+#: metabrainz/templates/reports/financial_reports/index.html:339
+#: metabrainz/templates/reports/financial_reports/index.html:340
+#: metabrainz/templates/reports/financial_reports/index.html:341
+#: metabrainz/templates/reports/financial_reports/index.html:342
+#: metabrainz/templates/reports/financial_reports/index.html:343
+#: metabrainz/templates/reports/financial_reports/index.html:349
+#: metabrainz/templates/reports/financial_reports/index.html:361
+#: metabrainz/templates/reports/financial_reports/index.html:362
+#: metabrainz/templates/reports/financial_reports/index.html:363
+#: metabrainz/templates/reports/financial_reports/index.html:364
+#: metabrainz/templates/reports/financial_reports/index.html:365
+#: metabrainz/templates/reports/financial_reports/index.html:366
+#: metabrainz/templates/reports/financial_reports/index.html:367
+#: metabrainz/templates/reports/financial_reports/index.html:368
+#: metabrainz/templates/reports/financial_reports/index.html:369
+#: metabrainz/templates/reports/financial_reports/index.html:370
+#: metabrainz/templates/reports/financial_reports/index.html:371
+#: metabrainz/templates/reports/financial_reports/index.html:372
+#: metabrainz/templates/reports/financial_reports/index.html:378
+#: metabrainz/templates/reports/financial_reports/index.html:390
+#: metabrainz/templates/reports/financial_reports/index.html:391
+#: metabrainz/templates/reports/financial_reports/index.html:392
+#: metabrainz/templates/reports/financial_reports/index.html:393
+#: metabrainz/templates/reports/financial_reports/index.html:394
+#: metabrainz/templates/reports/financial_reports/index.html:395
+#: metabrainz/templates/reports/financial_reports/index.html:396
+#: metabrainz/templates/reports/financial_reports/index.html:397
+#: metabrainz/templates/reports/financial_reports/index.html:398
+#: metabrainz/templates/reports/financial_reports/index.html:399
+#: metabrainz/templates/reports/financial_reports/index.html:400
+#: metabrainz/templates/reports/financial_reports/index.html:401
+#: metabrainz/templates/reports/financial_reports/index.html:407
+#: metabrainz/templates/reports/financial_reports/index.html:419
+#: metabrainz/templates/reports/financial_reports/index.html:420
+#: metabrainz/templates/reports/financial_reports/index.html:421
+#: metabrainz/templates/reports/financial_reports/index.html:422
+#: metabrainz/templates/reports/financial_reports/index.html:423
+#: metabrainz/templates/reports/financial_reports/index.html:424
+#: metabrainz/templates/reports/financial_reports/index.html:425
+#: metabrainz/templates/reports/financial_reports/index.html:426
+#: metabrainz/templates/reports/financial_reports/index.html:427
+#: metabrainz/templates/reports/financial_reports/index.html:428
+#: metabrainz/templates/reports/financial_reports/index.html:429
+#: metabrainz/templates/reports/financial_reports/index.html:430
+#: metabrainz/templates/reports/financial_reports/index.html:436
+#: metabrainz/templates/reports/financial_reports/index.html:448
+#: metabrainz/templates/reports/financial_reports/index.html:449
+#: metabrainz/templates/reports/financial_reports/index.html:450
+#: metabrainz/templates/reports/financial_reports/index.html:451
+#: metabrainz/templates/reports/financial_reports/index.html:452
+#: metabrainz/templates/reports/financial_reports/index.html:453
+#: metabrainz/templates/reports/financial_reports/index.html:454
+#: metabrainz/templates/reports/financial_reports/index.html:455
+#: metabrainz/templates/reports/financial_reports/index.html:456
+#: metabrainz/templates/reports/financial_reports/index.html:457
+#: metabrainz/templates/reports/financial_reports/index.html:458
+#: metabrainz/templates/reports/financial_reports/index.html:459
+#: metabrainz/templates/reports/financial_reports/index.html:465
+#: metabrainz/templates/reports/financial_reports/index.html:477
+#: metabrainz/templates/reports/financial_reports/index.html:478
+#: metabrainz/templates/reports/financial_reports/index.html:479
+#: metabrainz/templates/reports/financial_reports/index.html:480
+#: metabrainz/templates/reports/financial_reports/index.html:481
+#: metabrainz/templates/reports/financial_reports/index.html:482
+#: metabrainz/templates/reports/financial_reports/index.html:483
+#: metabrainz/templates/reports/financial_reports/index.html:484
+#: metabrainz/templates/reports/financial_reports/index.html:485
+#: metabrainz/templates/reports/financial_reports/index.html:486
+#: metabrainz/templates/reports/financial_reports/index.html:487
+#: metabrainz/templates/reports/financial_reports/index.html:488
 #: metabrainz/templates/reports/financial_reports/index.html:494
 #: metabrainz/templates/reports/financial_reports/index.html:516
-msgid "September"
+msgid "balance sheet"
 msgstr ""
 
+#: metabrainz/templates/reports/financial_reports/index.html:39
+#: metabrainz/templates/reports/financial_reports/index.html:44
+#: metabrainz/templates/reports/financial_reports/index.html:46
+#: metabrainz/templates/reports/financial_reports/index.html:48
+#: metabrainz/templates/reports/financial_reports/index.html:50
+#: metabrainz/templates/reports/financial_reports/index.html:60
+#: metabrainz/templates/reports/financial_reports/index.html:65
+#: metabrainz/templates/reports/financial_reports/index.html:67
+#: metabrainz/templates/reports/financial_reports/index.html:69
+#: metabrainz/templates/reports/financial_reports/index.html:71
+#: metabrainz/templates/reports/financial_reports/index.html:81
+#: metabrainz/templates/reports/financial_reports/index.html:86
+#: metabrainz/templates/reports/financial_reports/index.html:88
+#: metabrainz/templates/reports/financial_reports/index.html:90
+#: metabrainz/templates/reports/financial_reports/index.html:92
+#: metabrainz/templates/reports/financial_reports/index.html:101
+#: metabrainz/templates/reports/financial_reports/index.html:106
+#: metabrainz/templates/reports/financial_reports/index.html:108
+#: metabrainz/templates/reports/financial_reports/index.html:110
+#: metabrainz/templates/reports/financial_reports/index.html:112
+#: metabrainz/templates/reports/financial_reports/index.html:121
+#: metabrainz/templates/reports/financial_reports/index.html:126
+#: metabrainz/templates/reports/financial_reports/index.html:128
+#: metabrainz/templates/reports/financial_reports/index.html:130
+#: metabrainz/templates/reports/financial_reports/index.html:132
+#: metabrainz/templates/reports/financial_reports/index.html:141
+#: metabrainz/templates/reports/financial_reports/index.html:146
+#: metabrainz/templates/reports/financial_reports/index.html:148
+#: metabrainz/templates/reports/financial_reports/index.html:150
+#: metabrainz/templates/reports/financial_reports/index.html:152
+#: metabrainz/templates/reports/financial_reports/index.html:162
+#: metabrainz/templates/reports/financial_reports/index.html:167
+#: metabrainz/templates/reports/financial_reports/index.html:169
+#: metabrainz/templates/reports/financial_reports/index.html:171
+#: metabrainz/templates/reports/financial_reports/index.html:173
+#: metabrainz/templates/reports/financial_reports/index.html:186
+#: metabrainz/templates/reports/financial_reports/index.html:191
+#: metabrainz/templates/reports/financial_reports/index.html:193
+#: metabrainz/templates/reports/financial_reports/index.html:195
+#: metabrainz/templates/reports/financial_reports/index.html:197
+#: metabrainz/templates/reports/financial_reports/index.html:205
+#: metabrainz/templates/reports/financial_reports/index.html:209
+#: metabrainz/templates/reports/financial_reports/index.html:210
+#: metabrainz/templates/reports/financial_reports/index.html:211
 #: metabrainz/templates/reports/financial_reports/index.html:212
+#: metabrainz/templates/reports/financial_reports/index.html:216
+#: metabrainz/templates/reports/financial_reports/index.html:217
+#: metabrainz/templates/reports/financial_reports/index.html:218
+#: metabrainz/templates/reports/financial_reports/index.html:219
+#: metabrainz/templates/reports/financial_reports/index.html:220
+#: metabrainz/templates/reports/financial_reports/index.html:221
+#: metabrainz/templates/reports/financial_reports/index.html:222
+#: metabrainz/templates/reports/financial_reports/index.html:223
+#: metabrainz/templates/reports/financial_reports/index.html:224
+#: metabrainz/templates/reports/financial_reports/index.html:225
+#: metabrainz/templates/reports/financial_reports/index.html:226
+#: metabrainz/templates/reports/financial_reports/index.html:227
+#: metabrainz/templates/reports/financial_reports/index.html:234
+#: metabrainz/templates/reports/financial_reports/index.html:238
+#: metabrainz/templates/reports/financial_reports/index.html:239
+#: metabrainz/templates/reports/financial_reports/index.html:240
 #: metabrainz/templates/reports/financial_reports/index.html:241
+#: metabrainz/templates/reports/financial_reports/index.html:245
+#: metabrainz/templates/reports/financial_reports/index.html:246
+#: metabrainz/templates/reports/financial_reports/index.html:247
+#: metabrainz/templates/reports/financial_reports/index.html:248
+#: metabrainz/templates/reports/financial_reports/index.html:249
+#: metabrainz/templates/reports/financial_reports/index.html:250
+#: metabrainz/templates/reports/financial_reports/index.html:251
+#: metabrainz/templates/reports/financial_reports/index.html:252
+#: metabrainz/templates/reports/financial_reports/index.html:253
+#: metabrainz/templates/reports/financial_reports/index.html:254
+#: metabrainz/templates/reports/financial_reports/index.html:255
+#: metabrainz/templates/reports/financial_reports/index.html:256
+#: metabrainz/templates/reports/financial_reports/index.html:263
+#: metabrainz/templates/reports/financial_reports/index.html:267
+#: metabrainz/templates/reports/financial_reports/index.html:268
+#: metabrainz/templates/reports/financial_reports/index.html:269
 #: metabrainz/templates/reports/financial_reports/index.html:270
+#: metabrainz/templates/reports/financial_reports/index.html:274
+#: metabrainz/templates/reports/financial_reports/index.html:275
+#: metabrainz/templates/reports/financial_reports/index.html:276
+#: metabrainz/templates/reports/financial_reports/index.html:277
+#: metabrainz/templates/reports/financial_reports/index.html:278
+#: metabrainz/templates/reports/financial_reports/index.html:279
+#: metabrainz/templates/reports/financial_reports/index.html:280
+#: metabrainz/templates/reports/financial_reports/index.html:281
+#: metabrainz/templates/reports/financial_reports/index.html:282
+#: metabrainz/templates/reports/financial_reports/index.html:283
+#: metabrainz/templates/reports/financial_reports/index.html:284
+#: metabrainz/templates/reports/financial_reports/index.html:285
+#: metabrainz/templates/reports/financial_reports/index.html:292
+#: metabrainz/templates/reports/financial_reports/index.html:296
+#: metabrainz/templates/reports/financial_reports/index.html:297
+#: metabrainz/templates/reports/financial_reports/index.html:298
 #: metabrainz/templates/reports/financial_reports/index.html:299
+#: metabrainz/templates/reports/financial_reports/index.html:303
+#: metabrainz/templates/reports/financial_reports/index.html:304
+#: metabrainz/templates/reports/financial_reports/index.html:305
+#: metabrainz/templates/reports/financial_reports/index.html:306
+#: metabrainz/templates/reports/financial_reports/index.html:307
+#: metabrainz/templates/reports/financial_reports/index.html:308
+#: metabrainz/templates/reports/financial_reports/index.html:309
+#: metabrainz/templates/reports/financial_reports/index.html:310
+#: metabrainz/templates/reports/financial_reports/index.html:311
+#: metabrainz/templates/reports/financial_reports/index.html:312
+#: metabrainz/templates/reports/financial_reports/index.html:313
+#: metabrainz/templates/reports/financial_reports/index.html:314
+#: metabrainz/templates/reports/financial_reports/index.html:321
+#: metabrainz/templates/reports/financial_reports/index.html:325
+#: metabrainz/templates/reports/financial_reports/index.html:326
+#: metabrainz/templates/reports/financial_reports/index.html:327
 #: metabrainz/templates/reports/financial_reports/index.html:328
+#: metabrainz/templates/reports/financial_reports/index.html:332
+#: metabrainz/templates/reports/financial_reports/index.html:333
+#: metabrainz/templates/reports/financial_reports/index.html:334
+#: metabrainz/templates/reports/financial_reports/index.html:335
+#: metabrainz/templates/reports/financial_reports/index.html:336
+#: metabrainz/templates/reports/financial_reports/index.html:337
+#: metabrainz/templates/reports/financial_reports/index.html:338
+#: metabrainz/templates/reports/financial_reports/index.html:339
+#: metabrainz/templates/reports/financial_reports/index.html:340
+#: metabrainz/templates/reports/financial_reports/index.html:341
+#: metabrainz/templates/reports/financial_reports/index.html:342
+#: metabrainz/templates/reports/financial_reports/index.html:343
+#: metabrainz/templates/reports/financial_reports/index.html:350
+#: metabrainz/templates/reports/financial_reports/index.html:354
+#: metabrainz/templates/reports/financial_reports/index.html:355
+#: metabrainz/templates/reports/financial_reports/index.html:356
 #: metabrainz/templates/reports/financial_reports/index.html:357
+#: metabrainz/templates/reports/financial_reports/index.html:361
+#: metabrainz/templates/reports/financial_reports/index.html:362
+#: metabrainz/templates/reports/financial_reports/index.html:363
+#: metabrainz/templates/reports/financial_reports/index.html:364
+#: metabrainz/templates/reports/financial_reports/index.html:365
+#: metabrainz/templates/reports/financial_reports/index.html:366
+#: metabrainz/templates/reports/financial_reports/index.html:367
+#: metabrainz/templates/reports/financial_reports/index.html:368
+#: metabrainz/templates/reports/financial_reports/index.html:369
+#: metabrainz/templates/reports/financial_reports/index.html:370
+#: metabrainz/templates/reports/financial_reports/index.html:371
+#: metabrainz/templates/reports/financial_reports/index.html:372
+#: metabrainz/templates/reports/financial_reports/index.html:379
+#: metabrainz/templates/reports/financial_reports/index.html:383
+#: metabrainz/templates/reports/financial_reports/index.html:384
+#: metabrainz/templates/reports/financial_reports/index.html:385
 #: metabrainz/templates/reports/financial_reports/index.html:386
+#: metabrainz/templates/reports/financial_reports/index.html:390
+#: metabrainz/templates/reports/financial_reports/index.html:391
+#: metabrainz/templates/reports/financial_reports/index.html:392
+#: metabrainz/templates/reports/financial_reports/index.html:393
+#: metabrainz/templates/reports/financial_reports/index.html:394
+#: metabrainz/templates/reports/financial_reports/index.html:395
+#: metabrainz/templates/reports/financial_reports/index.html:396
+#: metabrainz/templates/reports/financial_reports/index.html:397
+#: metabrainz/templates/reports/financial_reports/index.html:398
+#: metabrainz/templates/reports/financial_reports/index.html:399
+#: metabrainz/templates/reports/financial_reports/index.html:400
+#: metabrainz/templates/reports/financial_reports/index.html:401
+#: metabrainz/templates/reports/financial_reports/index.html:408
+#: metabrainz/templates/reports/financial_reports/index.html:412
+#: metabrainz/templates/reports/financial_reports/index.html:413
+#: metabrainz/templates/reports/financial_reports/index.html:414
 #: metabrainz/templates/reports/financial_reports/index.html:415
+#: metabrainz/templates/reports/financial_reports/index.html:419
+#: metabrainz/templates/reports/financial_reports/index.html:420
+#: metabrainz/templates/reports/financial_reports/index.html:421
+#: metabrainz/templates/reports/financial_reports/index.html:422
+#: metabrainz/templates/reports/financial_reports/index.html:423
+#: metabrainz/templates/reports/financial_reports/index.html:424
+#: metabrainz/templates/reports/financial_reports/index.html:425
+#: metabrainz/templates/reports/financial_reports/index.html:426
+#: metabrainz/templates/reports/financial_reports/index.html:427
+#: metabrainz/templates/reports/financial_reports/index.html:428
+#: metabrainz/templates/reports/financial_reports/index.html:429
+#: metabrainz/templates/reports/financial_reports/index.html:430
+#: metabrainz/templates/reports/financial_reports/index.html:437
+#: metabrainz/templates/reports/financial_reports/index.html:441
+#: metabrainz/templates/reports/financial_reports/index.html:442
+#: metabrainz/templates/reports/financial_reports/index.html:443
 #: metabrainz/templates/reports/financial_reports/index.html:444
+#: metabrainz/templates/reports/financial_reports/index.html:448
+#: metabrainz/templates/reports/financial_reports/index.html:449
+#: metabrainz/templates/reports/financial_reports/index.html:450
+#: metabrainz/templates/reports/financial_reports/index.html:451
+#: metabrainz/templates/reports/financial_reports/index.html:452
+#: metabrainz/templates/reports/financial_reports/index.html:453
+#: metabrainz/templates/reports/financial_reports/index.html:454
+#: metabrainz/templates/reports/financial_reports/index.html:455
+#: metabrainz/templates/reports/financial_reports/index.html:456
+#: metabrainz/templates/reports/financial_reports/index.html:457
+#: metabrainz/templates/reports/financial_reports/index.html:458
+#: metabrainz/templates/reports/financial_reports/index.html:459
+#: metabrainz/templates/reports/financial_reports/index.html:466
+#: metabrainz/templates/reports/financial_reports/index.html:470
+#: metabrainz/templates/reports/financial_reports/index.html:471
+#: metabrainz/templates/reports/financial_reports/index.html:472
 #: metabrainz/templates/reports/financial_reports/index.html:473
+#: metabrainz/templates/reports/financial_reports/index.html:477
+#: metabrainz/templates/reports/financial_reports/index.html:478
+#: metabrainz/templates/reports/financial_reports/index.html:479
+#: metabrainz/templates/reports/financial_reports/index.html:480
+#: metabrainz/templates/reports/financial_reports/index.html:481
+#: metabrainz/templates/reports/financial_reports/index.html:482
+#: metabrainz/templates/reports/financial_reports/index.html:483
+#: metabrainz/templates/reports/financial_reports/index.html:484
+#: metabrainz/templates/reports/financial_reports/index.html:485
+#: metabrainz/templates/reports/financial_reports/index.html:486
+#: metabrainz/templates/reports/financial_reports/index.html:487
+#: metabrainz/templates/reports/financial_reports/index.html:488
 #: metabrainz/templates/reports/financial_reports/index.html:495
 #: metabrainz/templates/reports/financial_reports/index.html:517
-msgid "August"
+msgid "profit &amp; loss"
 msgstr ""
 
-#: metabrainz/templates/reports/financial_reports/index.html:213
-#: metabrainz/templates/reports/financial_reports/index.html:242
-#: metabrainz/templates/reports/financial_reports/index.html:271
-#: metabrainz/templates/reports/financial_reports/index.html:300
-#: metabrainz/templates/reports/financial_reports/index.html:329
-#: metabrainz/templates/reports/financial_reports/index.html:358
-#: metabrainz/templates/reports/financial_reports/index.html:387
-#: metabrainz/templates/reports/financial_reports/index.html:416
-#: metabrainz/templates/reports/financial_reports/index.html:445
-#: metabrainz/templates/reports/financial_reports/index.html:474
-#: metabrainz/templates/reports/financial_reports/index.html:496
-#: metabrainz/templates/reports/financial_reports/index.html:518
-msgid "July"
+#: metabrainz/templates/reports/financial_reports/index.html:42
+#: metabrainz/templates/reports/financial_reports/index.html:63
+#: metabrainz/templates/reports/financial_reports/index.html:84
+#: metabrainz/templates/reports/financial_reports/index.html:104
+#: metabrainz/templates/reports/financial_reports/index.html:124
+#: metabrainz/templates/reports/financial_reports/index.html:144
+#: metabrainz/templates/reports/financial_reports/index.html:165
+#: metabrainz/templates/reports/financial_reports/index.html:189
+#: metabrainz/templates/reports/financial_reports/index.html:207
+#: metabrainz/templates/reports/financial_reports/index.html:236
+#: metabrainz/templates/reports/financial_reports/index.html:265
+#: metabrainz/templates/reports/financial_reports/index.html:294
+#: metabrainz/templates/reports/financial_reports/index.html:323
+#: metabrainz/templates/reports/financial_reports/index.html:352
+#: metabrainz/templates/reports/financial_reports/index.html:381
+#: metabrainz/templates/reports/financial_reports/index.html:410
+#: metabrainz/templates/reports/financial_reports/index.html:439
+#: metabrainz/templates/reports/financial_reports/index.html:468
+msgid "Quarterly reports"
 msgstr ""
 
 #: metabrainz/templates/reports/financial_reports/index.html:214
@@ -2570,24 +2483,7 @@ msgstr ""
 #: metabrainz/templates/reports/financial_reports/index.html:417
 #: metabrainz/templates/reports/financial_reports/index.html:446
 #: metabrainz/templates/reports/financial_reports/index.html:475
-#: metabrainz/templates/reports/financial_reports/index.html:497
-#: metabrainz/templates/reports/financial_reports/index.html:519
-msgid "June"
-msgstr ""
-
-#: metabrainz/templates/reports/financial_reports/index.html:215
-#: metabrainz/templates/reports/financial_reports/index.html:244
-#: metabrainz/templates/reports/financial_reports/index.html:273
-#: metabrainz/templates/reports/financial_reports/index.html:302
-#: metabrainz/templates/reports/financial_reports/index.html:331
-#: metabrainz/templates/reports/financial_reports/index.html:360
-#: metabrainz/templates/reports/financial_reports/index.html:389
-#: metabrainz/templates/reports/financial_reports/index.html:418
-#: metabrainz/templates/reports/financial_reports/index.html:447
-#: metabrainz/templates/reports/financial_reports/index.html:476
-#: metabrainz/templates/reports/financial_reports/index.html:498
-#: metabrainz/templates/reports/financial_reports/index.html:520
-msgid "May"
+msgid "Monthly reports"
 msgstr ""
 
 #: metabrainz/templates/reports/financial_reports/index.html:216
@@ -2602,7 +2498,8 @@ msgstr ""
 #: metabrainz/templates/reports/financial_reports/index.html:477
 #: metabrainz/templates/reports/financial_reports/index.html:499
 #: metabrainz/templates/reports/financial_reports/index.html:521
-msgid "April"
+#: metabrainz/templates/reports/financial_reports/index.html:537
+msgid "December"
 msgstr ""
 
 #: metabrainz/templates/reports/financial_reports/index.html:217
@@ -2617,7 +2514,7 @@ msgstr ""
 #: metabrainz/templates/reports/financial_reports/index.html:478
 #: metabrainz/templates/reports/financial_reports/index.html:500
 #: metabrainz/templates/reports/financial_reports/index.html:522
-msgid "March"
+msgid "November"
 msgstr ""
 
 #: metabrainz/templates/reports/financial_reports/index.html:218
@@ -2632,7 +2529,7 @@ msgstr ""
 #: metabrainz/templates/reports/financial_reports/index.html:479
 #: metabrainz/templates/reports/financial_reports/index.html:501
 #: metabrainz/templates/reports/financial_reports/index.html:523
-msgid "February"
+msgid "October"
 msgstr ""
 
 #: metabrainz/templates/reports/financial_reports/index.html:219
@@ -2647,11 +2544,131 @@ msgstr ""
 #: metabrainz/templates/reports/financial_reports/index.html:480
 #: metabrainz/templates/reports/financial_reports/index.html:502
 #: metabrainz/templates/reports/financial_reports/index.html:524
+msgid "September"
+msgstr ""
+
+#: metabrainz/templates/reports/financial_reports/index.html:220
+#: metabrainz/templates/reports/financial_reports/index.html:249
+#: metabrainz/templates/reports/financial_reports/index.html:278
+#: metabrainz/templates/reports/financial_reports/index.html:307
+#: metabrainz/templates/reports/financial_reports/index.html:336
+#: metabrainz/templates/reports/financial_reports/index.html:365
+#: metabrainz/templates/reports/financial_reports/index.html:394
+#: metabrainz/templates/reports/financial_reports/index.html:423
+#: metabrainz/templates/reports/financial_reports/index.html:452
+#: metabrainz/templates/reports/financial_reports/index.html:481
+#: metabrainz/templates/reports/financial_reports/index.html:503
+#: metabrainz/templates/reports/financial_reports/index.html:525
+msgid "August"
+msgstr ""
+
+#: metabrainz/templates/reports/financial_reports/index.html:221
+#: metabrainz/templates/reports/financial_reports/index.html:250
+#: metabrainz/templates/reports/financial_reports/index.html:279
+#: metabrainz/templates/reports/financial_reports/index.html:308
+#: metabrainz/templates/reports/financial_reports/index.html:337
+#: metabrainz/templates/reports/financial_reports/index.html:366
+#: metabrainz/templates/reports/financial_reports/index.html:395
+#: metabrainz/templates/reports/financial_reports/index.html:424
+#: metabrainz/templates/reports/financial_reports/index.html:453
+#: metabrainz/templates/reports/financial_reports/index.html:482
+#: metabrainz/templates/reports/financial_reports/index.html:504
+#: metabrainz/templates/reports/financial_reports/index.html:526
+msgid "July"
+msgstr ""
+
+#: metabrainz/templates/reports/financial_reports/index.html:222
+#: metabrainz/templates/reports/financial_reports/index.html:251
+#: metabrainz/templates/reports/financial_reports/index.html:280
+#: metabrainz/templates/reports/financial_reports/index.html:309
+#: metabrainz/templates/reports/financial_reports/index.html:338
+#: metabrainz/templates/reports/financial_reports/index.html:367
+#: metabrainz/templates/reports/financial_reports/index.html:396
+#: metabrainz/templates/reports/financial_reports/index.html:425
+#: metabrainz/templates/reports/financial_reports/index.html:454
+#: metabrainz/templates/reports/financial_reports/index.html:483
+#: metabrainz/templates/reports/financial_reports/index.html:505
+#: metabrainz/templates/reports/financial_reports/index.html:527
+msgid "June"
+msgstr ""
+
+#: metabrainz/templates/reports/financial_reports/index.html:223
+#: metabrainz/templates/reports/financial_reports/index.html:252
+#: metabrainz/templates/reports/financial_reports/index.html:281
+#: metabrainz/templates/reports/financial_reports/index.html:310
+#: metabrainz/templates/reports/financial_reports/index.html:339
+#: metabrainz/templates/reports/financial_reports/index.html:368
+#: metabrainz/templates/reports/financial_reports/index.html:397
+#: metabrainz/templates/reports/financial_reports/index.html:426
+#: metabrainz/templates/reports/financial_reports/index.html:455
+#: metabrainz/templates/reports/financial_reports/index.html:484
+#: metabrainz/templates/reports/financial_reports/index.html:506
+#: metabrainz/templates/reports/financial_reports/index.html:528
+msgid "May"
+msgstr ""
+
+#: metabrainz/templates/reports/financial_reports/index.html:224
+#: metabrainz/templates/reports/financial_reports/index.html:253
+#: metabrainz/templates/reports/financial_reports/index.html:282
+#: metabrainz/templates/reports/financial_reports/index.html:311
+#: metabrainz/templates/reports/financial_reports/index.html:340
+#: metabrainz/templates/reports/financial_reports/index.html:369
+#: metabrainz/templates/reports/financial_reports/index.html:398
+#: metabrainz/templates/reports/financial_reports/index.html:427
+#: metabrainz/templates/reports/financial_reports/index.html:456
+#: metabrainz/templates/reports/financial_reports/index.html:485
+#: metabrainz/templates/reports/financial_reports/index.html:507
+#: metabrainz/templates/reports/financial_reports/index.html:529
+msgid "April"
+msgstr ""
+
+#: metabrainz/templates/reports/financial_reports/index.html:225
+#: metabrainz/templates/reports/financial_reports/index.html:254
+#: metabrainz/templates/reports/financial_reports/index.html:283
+#: metabrainz/templates/reports/financial_reports/index.html:312
+#: metabrainz/templates/reports/financial_reports/index.html:341
+#: metabrainz/templates/reports/financial_reports/index.html:370
+#: metabrainz/templates/reports/financial_reports/index.html:399
+#: metabrainz/templates/reports/financial_reports/index.html:428
+#: metabrainz/templates/reports/financial_reports/index.html:457
+#: metabrainz/templates/reports/financial_reports/index.html:486
+#: metabrainz/templates/reports/financial_reports/index.html:508
+#: metabrainz/templates/reports/financial_reports/index.html:530
+msgid "March"
+msgstr ""
+
+#: metabrainz/templates/reports/financial_reports/index.html:226
+#: metabrainz/templates/reports/financial_reports/index.html:255
+#: metabrainz/templates/reports/financial_reports/index.html:284
+#: metabrainz/templates/reports/financial_reports/index.html:313
+#: metabrainz/templates/reports/financial_reports/index.html:342
+#: metabrainz/templates/reports/financial_reports/index.html:371
+#: metabrainz/templates/reports/financial_reports/index.html:400
+#: metabrainz/templates/reports/financial_reports/index.html:429
+#: metabrainz/templates/reports/financial_reports/index.html:458
+#: metabrainz/templates/reports/financial_reports/index.html:487
+#: metabrainz/templates/reports/financial_reports/index.html:509
+#: metabrainz/templates/reports/financial_reports/index.html:531
+msgid "February"
+msgstr ""
+
+#: metabrainz/templates/reports/financial_reports/index.html:227
+#: metabrainz/templates/reports/financial_reports/index.html:256
+#: metabrainz/templates/reports/financial_reports/index.html:285
+#: metabrainz/templates/reports/financial_reports/index.html:314
+#: metabrainz/templates/reports/financial_reports/index.html:343
+#: metabrainz/templates/reports/financial_reports/index.html:372
+#: metabrainz/templates/reports/financial_reports/index.html:401
+#: metabrainz/templates/reports/financial_reports/index.html:430
+#: metabrainz/templates/reports/financial_reports/index.html:459
+#: metabrainz/templates/reports/financial_reports/index.html:488
+#: metabrainz/templates/reports/financial_reports/index.html:510
+#: metabrainz/templates/reports/financial_reports/index.html:532
 msgid "January"
 msgstr ""
 
-#: metabrainz/templates/reports/financial_reports/index.html:489
-#: metabrainz/templates/reports/financial_reports/index.html:511
+#: metabrainz/templates/reports/financial_reports/index.html:497
+#: metabrainz/templates/reports/financial_reports/index.html:519
 msgid "Monthly balance sheets"
 msgstr ""
 
@@ -2667,27 +2684,21 @@ msgstr ""
 msgid "Non-commercial / Personal"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:30
+#: metabrainz/templates/supporters/account-type.html:34
 msgid "Non-commercial"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:33
-msgid "Commercial"
+#: metabrainz/templates/supporters/account-type.html:35
+msgid "$0.00/month and up"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:55
-#: metabrainz/templates/supporters/account-type.html:102
-#, python-format
-msgid "$%(tier_price)s/month and up"
+#: metabrainz/templates/supporters/account-type.html:36
+msgid "Personal or university assignment user."
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:59
-#: metabrainz/templates/supporters/account-type.html:105
-msgid "More info"
-msgstr ""
-
-#: metabrainz/templates/supporters/account-type.html:61
-#: metabrainz/templates/supporters/account-type.html:107
+#: metabrainz/templates/supporters/account-type.html:39
+#: metabrainz/templates/supporters/account-type.html:76
+#: metabrainz/templates/supporters/account-type.html:122
 #: metabrainz/templates/supporters/mb-signup.html:3
 #: metabrainz/templates/supporters/mb-signup.html:6
 #: metabrainz/templates/supporters/signup-commercial.html:3
@@ -2695,23 +2706,38 @@ msgstr ""
 msgid "Sign up"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:71
+#: metabrainz/templates/supporters/account-type.html:48
+msgid "Commercial"
+msgstr ""
+
+#: metabrainz/templates/supporters/account-type.html:70
+#: metabrainz/templates/supporters/account-type.html:117
+#, python-format
+msgid "$%(tier_price)s/month and up"
+msgstr ""
+
+#: metabrainz/templates/supporters/account-type.html:74
+#: metabrainz/templates/supporters/account-type.html:120
+msgid "More info"
+msgstr ""
+
+#: metabrainz/templates/supporters/account-type.html:86
 msgid "View all tiers"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:79
+#: metabrainz/templates/supporters/account-type.html:94
 msgid "Some of our Unicorn members"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:90
+#: metabrainz/templates/supporters/account-type.html:105
 msgid "See all our supporters"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:113
+#: metabrainz/templates/supporters/account-type.html:128
 msgid "View featured tiers"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:120
+#: metabrainz/templates/supporters/account-type.html:135
 #, python-format
 msgid ""
 "If you are not sure which tier to pick, please\n"

--- a/metabrainz/templates/payments/donate.html
+++ b/metabrainz/templates/payments/donate.html
@@ -89,7 +89,7 @@
               <label>
                 {{ form.anonymous(id="anonymous-flag") | safe }}
                 {{ _('I would like this donation to be anonymous') }}
-                <br /><small>{{ _('Your name won\'t appear in the donors list') }}</small>
+                <br /><small>{{ _('Your name and username won\'t appear in the donors list') }}</small>
               </label>
             </div>
           </div>
@@ -107,6 +107,13 @@
       </form>
 
     </div>
+
+    <p>
+      <small>
+        {{ _('Your billing name and (if provided) your username will be listed
+        in our donors list unless you make your donation anonymous.') }}
+      </small>
+    </p>
 
     <p>
       <small>


### PR DESCRIPTION
### Implement MEB-167

# Description
Apparently, even though a donor only enters their username from the donate page, their real name is also published as per their billing info unless the donation is anonymous. While "your name" is indicated under the anonymous checkbox, given there's nothing indicating your real name will be used at all, this is only easily understandable as "your username" which you are providing. Just to make sure, I asked my wife what she thought would get published by checking the form and she just said "well, that username there, right?".

It's even more confusing given just under the form we say "The personal information provided to the MetaBrainz Foundation during the donation process will not be shared with anyone" - most people, without more information being provided, would I think assume that includes their real name - I know I would have.

We had a person in support asking (very nicely) for us to remove their real name. I feel they could have been a lot less nice given the surprise of seeing their name effectively doxxed with little warning.

If we are going to publish real names (I assume this is some US requirement to prove real humans are donating or something) then we need to be *very clear* that this will happen. I'm not sure this change is enough, but at least it's not entirely unspecified anymore.

# Testing
Loaded the page locally to make sure it shows up fine.