### PR TITLE
Remove fixed height properties in tier styles

### DIFF
--- a/frontend/css/main.less
+++ b/frontend/css/main.less
@@ -104,7 +104,6 @@ h1.page-title, h2.page-title {
   #primary-tiers {
     .tier {
       .thumbnail {
-        height: 259px;
         h3 {
           margin-top: 8px;
           font-size: 20px;
@@ -119,7 +118,6 @@ h1.page-title, h2.page-title {
           overflow: hidden;
           text-overflow: ellipsis;
           display: -webkit-box;
-          height: 57px; // fallback
           -webkit-line-clamp: 3; // number of lines to show
           -webkit-box-orient: vertical;
         }


### PR DESCRIPTION
I think this broke because MeB.org's default font size was increased some months back.

Before:
![image](https://github.com/user-attachments/assets/d8137eca-3b7e-4097-83c4-2a9fd7846271)

After:
![image](https://github.com/user-attachments/assets/c061c781-9aec-4d7f-acd9-54fd26aee06c)
