### PR TITLE
Add notification_sent flag

### DIFF
--- a/admin/schema_updates/2025-07-22-add-notification_sent-to-notification.sql
+++ b/admin/schema_updates/2025-07-22-add-notification_sent-to-notification.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE notification ADD COLUMN notification_sent BOOL DEFAULT FALSE;
+
+END;

--- a/admin/sql/create_tables.sql
+++ b/admin/sql/create_tables.sql
@@ -109,6 +109,7 @@ CREATE TABLE notification (
     body                      TEXT,
     template_id               TEXT, --MB Mail template id.
     template_params           JSONB, --params for given MB Mail template.
+    notification_sent         BOOL DEFAULT FALSE,
 
     CONSTRAINT mail_type      CHECK(
       -- caller needs to provide either (subject and body) or (template_id and template_params).

--- a/metabrainz/db/notification.py
+++ b/metabrainz/db/notification.py
@@ -228,7 +228,8 @@ def get_digest_notifications() -> List[dict]:
         query = sqlalchemy.text(
             """
                 SELECT 
-                        notification.musicbrainz_row_id
+                         notification.id
+                        ,notification.musicbrainz_row_id
                         ,notification.subject
                         ,notification.body
                         ,notification.template_id
@@ -238,12 +239,13 @@ def get_digest_notifications() -> List[dict]:
                 FROM
                         notification
                 JOIN
-                        user_preference ON notification.musicbrainz_row_id = user_preference.musicbrainz_row_id
-
+                        user_preference
+                ON
+                        notification.musicbrainz_row_id = user_preference.musicbrainz_row_id
                 WHERE
                         user_preference.digest = true
                         AND (notification.created + (INTERVAL '1 day' * user_preference.digest_age)) <= NOW()
-                        AND notification.read = false      
+                        AND notification.notification_sent = false      
             """
         )
         result = connection.execute(query)

--- a/metabrainz/model/notification.py
+++ b/metabrainz/model/notification.py
@@ -33,6 +33,7 @@ class Notification(db.Model):
     body = db.Column(db.Text)
     template_id = db.Column(db.Text)
     template_params = db.Column(JSONB)
+    notification_sent = db.Column(db.Boolean, default=False)
 
     __table_args__=(
         db.CheckConstraint(


### PR DESCRIPTION
Instead of using `read` column to mark notifications as sent, added a column `notification_sent` which can be marked as true after sending a notification.