### PR TITLE
Fix server error bug when all notifications are marked as important.

### DIFF
--- a/metabrainz/db/notification.py
+++ b/metabrainz/db/notification.py
@@ -195,6 +195,9 @@ def filter_non_digest_notifications(notifications: List[dict]) -> List[dict]:
 
     """
     user_ids_to_check = tuple(i["user_id"] for i in notifications)
+    if not user_ids_to_check:
+        return []
+    
     with db.engine.connect() as connection:
         query = sqlalchemy.text("""
                         SELECT musicbrainz_row_id

--- a/metabrainz/notifications/views_test.py
+++ b/metabrainz/notifications/views_test.py
@@ -211,7 +211,7 @@ class NotificationViewsTest(FlaskTestCase):
                 "send_email": True
             }
         ]
-        url = f'notification/send?token=good_token'
+        url = 'notification/send?token=good_token'
         res = self.client.post(
             url,
             json=test_data


### PR DESCRIPTION
`filter_non_digest_notifications ` returns an empty list when all the notifications in the list are marked as important and not give a 503.
Fixed f-string linting issue.