### PR TITLE
Fix ISE during commercial user signup

### DIFF
--- a/metabrainz/supporter/views.py
+++ b/metabrainz/supporter/views.py
@@ -181,7 +181,7 @@ def signup_commercial():
 
     form_errors = {k: ". ".join(v) for k, v in form.errors.items()}
     form_data = dict(**form.data)
-    if form_data["amount_pledged"]:
+    if form_data["amount_pledged"] is not None:
         form_data["amount_pledged"] = float(form_data["amount_pledged"])
     form_data.pop("csrf_token", None)
 


### PR DESCRIPTION
Decimal objects cannot be directly serialized by default json encoder and need to be converted to float first, hence the if condition for `amount_pledged` field. `Decimal(0)` is falsy so instead do the `is not None` check.