### PR TITLE
consul_config: fall back to pgbouncer-master when pgbouncer-slave is …

### DIFF
--- a/consul_config.py.ctmpl
+++ b/consul_config.py.ctmpl
@@ -92,6 +92,10 @@ SERVER_BASE_URL = f"{PREFERRED_URL_SCHEME}://{MAIL_FROM_DOMAIN}"
 {{with index (service "pgbouncer-slave") 0}}
 MB_DATABASE_URI = "postgresql://musicbrainz_ro@{{.Address}}:{{.Port}}/musicbrainz_db"
 {{end}}
+{{else if service "pgbouncer-master"}}
+{{with index (service "pgbouncer-master") 0}}
+MB_DATABASE_URI = "postgresql://musicbrainz_ro@{{.Address}}:{{.Port}}/musicbrainz_db"
+{{end}}
 {{else}}
 MB_DATABASE_URI = ""
 {{end}}


### PR DESCRIPTION
…unavailable

When pgbouncer-slave is down, MB_DATABASE_URI was set to an empty string, causing the OAuth app to crash on startup. Fall back to pgbouncer-master instead.