### PR TITLE
Add http-socket to oauth config

### DIFF
--- a/docker/oauth/oauth.ini
+++ b/docker/oauth/oauth.ini
@@ -3,6 +3,7 @@ uid = www-data
 gid = www-data
 master = true
 socket = 0.0.0.0:13050
+http-socket = 0.0.0.0:13052
 module = metabrainz:create_oauth_app()
 enable-threads = true
 chdir = /code/metabrainz


### PR DESCRIPTION
This socket can be used to allow MusicBrainz and other projects to directly communicate with MetaBrainz over the internal VLAN network, rather than through the gateway servers, which avoids a whole host of issues. It depends on further changes in docker-server-configs.

(I skipped over port 13051 to avoid confusion with pgbouncer-listenbrainz, even though it can be used internally without conflicts.)