### PR TITLE
Drop Twitter from footer/contact page

### DIFF
--- a/metabrainz/templates/base.html
+++ b/metabrainz/templates/base.html
@@ -84,7 +84,6 @@
               <ul>
                 <li><a href="https://blog.metabrainz.org/category/metabrainz/">{{ _('Blog') }}</a></li>
                 <li><a href="https://musicbrainz.org/doc/Communication/ChatBrainz">{{ _('Chat') }}</a></li>
-                <li><a href="https://twitter.com/MetaBrainz">{{ _('Twitter/X') }}</a></li>
                 <li><a href="https://mastodon.social/@metabrainz">{{ _('Mastodon') }}</a></li>
                 <li><a href="https://bsky.app/profile/metabrainz.org">{{ _('Bluesky') }}</a></li>
                 <li><a href="https://www.instagram.com/MetaBrainz/">{{ _('Instagram') }}</a></li>

--- a/metabrainz/templates/index/contact.html
+++ b/metabrainz/templates/index/contact.html
@@ -103,7 +103,6 @@
     {{ _('You can follow us on these social channels:') }}
      <ul>
       <li><a href="https://blog.metabrainz.org/">{{ _('Blog') }}</a></li>
-      <li><a href="https://x.com/MetaBrainz">{{ _('Twitter/X') }}</a></li>
       <li><a href="https://mastodon.social/@metabrainz">{{ _('Mastodon') }}</a></li>
       <li><a href="https://bsky.app/profile/metabrainz.org">{{ _('Bluesky') }}</a></li>
       <li><a href="https://www.instagram.com/MetaBrainz/">{{ _('Instagram') }}</a></li>


### PR DESCRIPTION
We haven't used Twitter since 2024.

This does not update `messages.pot` since I saw that there are a lot of extra changes there when I tried, so it might not be intended to be done on every PR.