### PR TITLE
Make more stuff translatable

### DIFF
--- a/frontend/js/src/Profile.tsx
+++ b/frontend/js/src/Profile.tsx
@@ -571,10 +571,15 @@ function SupporterAccountDeletionNotice() {
               <strong>{t("Need to delete your account?")}</strong>
             </p>
             <p className="text-muted" style={{ marginBottom: 0 }}>
-              {t(
-                "Deletion of supporter accounts requires manual review. Please contact us at"
-              )}{" "}
-              <a href="mailto:support@metabrainz.org">support@metabrainz.org</a>.
+              <Trans
+                defaults={t(
+                  "Deletion of supporter accounts requires manual review. Please contact us at <email />."
+                )}
+                // eslint-disable-next-line jsx-a11y/anchor-has-content
+                components={{
+                  email: <a href="mailto:support@metabrainz.org">support@metabrainz.org</a>
+                }}
+              />
             </p>
           </div>
         </div>

--- a/frontend/js/src/Profile.tsx
+++ b/frontend/js/src/Profile.tsx
@@ -107,7 +107,7 @@ function SupporterProfile({ user, csrf_token }: ProfileProps) {
       !currentToken ||
       window.confirm(
         t(
-          "Are you sure you want to generate new access token? Current token will be revoked!"
+          "Are you sure you want to generate a new access token? The current token will be revoked!"
         )
       )
     ) {

--- a/frontend/js/src/ProfileDelete.tsx
+++ b/frontend/js/src/ProfileDelete.tsx
@@ -67,7 +67,9 @@ function ProfileDelete({ csrf_token, username }: ProfileDeleteProps) {
             </ul>
             <p>
               <strong>
-                {t("Your username will be reserved and cannot be reused.")}
+                {t(
+                  "Your username will be reserved and cannot be reused without the intervention of an administrator."
+                )}
               </strong>
             </p>
 

--- a/frontend/js/src/ProfileDelete.tsx
+++ b/frontend/js/src/ProfileDelete.tsx
@@ -61,7 +61,7 @@ function ProfileDelete({ csrf_token, username }: ProfileDeleteProps) {
             <p>{t("Deleting your account will:")}</p>
             <ul>
               <li>{t("Permanently remove all your account information")}</li>
-              <li>{t("Revoke all your API tokens and access")}</li>
+              <li>{t("Revoke all your tokens and access to the replication API")}</li>
               <li>{t("Remove your supporter status (if applicable)")}</li>
               <li>{t("Log you out of all MetaBrainz services")}</li>
             </ul>

--- a/frontend/js/src/forms/LoginUser.tsx
+++ b/frontend/js/src/forms/LoginUser.tsx
@@ -1,6 +1,6 @@
 import { Formik } from "formik";
 import React, { JSX } from "react";
-import { useTranslation } from "react-i18next";
+import { Trans, useTranslation } from "react-i18next";
 import * as Yup from "yup";
 import { getPageProps, renderRoot } from "../utils";
 import {
@@ -106,8 +106,13 @@ function LoginUser({
             )}
           </Formik>
           <div className="auth-card-footer text-center">
-            {t("Don't have an account?")}{" "}
-            <a href={getAuthPageUrl("/signup")}>{t("Sign up")}</a>
+            <Trans
+              defaults={t(
+                "Don't have an account? <signupLink>Sign up</signupLink>"
+              )}
+              // eslint-disable-next-line jsx-a11y/anchor-has-content
+              components={{signupLink: <a href={getAuthPageUrl("/signup")} />}}
+            />
           </div>
         </div>
       </div>

--- a/frontend/js/src/forms/SignupCommercial.tsx
+++ b/frontend/js/src/forms/SignupCommercial.tsx
@@ -505,7 +505,7 @@ function SignupCommercial({
                   </p>
                   <p>
                     {t(
-                      "I also agree that if I generate a Live Data Feed access token, that I treat my access token as a secret and will not share this token publicly or commit it to a source code repository."
+                      "I also agree that if I generate a Live Data Feed access token, then I will treat my access token as a secret and will not share this token publicly or commit it to a source code repository."
                     )}
                   </p>
                 </CheckboxInput>

--- a/frontend/js/src/forms/SignupCommercial.tsx
+++ b/frontend/js/src/forms/SignupCommercial.tsx
@@ -35,8 +35,10 @@ function AmountPledgedField({ tier, ...props }: AmountPledgedFieldProps) {
   return (
     <div className="form-group">
       <label htmlFor="amount_pledged">
-        {t("If you would like to support us with more than $")} {tier.price}
-        {t(", please enter the actual amount here:")}
+        {t(
+          "If you would like to support us with more than ${{minPledge}}, please enter the actual amount here:",
+          {minPledge: tier.price.toString()},
+        )}
       </label>
       <div>
         <input
@@ -239,7 +241,7 @@ function SignupCommercial({
                     >
                       <b>{tier.name}</b>
                       <p className="text-muted">
-                        ${tier.price}/{t("month and up")}
+                        {t("${{tierPrice}}/month and up", {tierPrice: tier.price.toString()})}
                       </p>
                     </div>
                     <div

--- a/frontend/js/src/forms/SignupCommercial.tsx
+++ b/frontend/js/src/forms/SignupCommercial.tsx
@@ -419,7 +419,7 @@ function SignupCommercial({
                 >
                   <p className="text-muted">
                     {t(
-                      "URL to where developers can use your APIs using MusicBrainz IDs, if available.."
+                      "URL to where developers can use your APIs using MusicBrainz IDs, if available."
                     )}
                   </p>
                 </AuthCardTextInput>

--- a/frontend/js/src/forms/SignupCommercial.tsx
+++ b/frontend/js/src/forms/SignupCommercial.tsx
@@ -566,12 +566,22 @@ function SignupCommercial({
             ) : (
               <>
                 <div className="small">
-                  {t("Not a supporter?")}{" "}
-                  <a href="/signup">{t("Create a user account")}</a>
+                  <Trans
+                    defaults={t(
+                      "Not a supporter? <signupLink>Create a user account</signupLink>"
+                    )}
+                    // eslint-disable-next-line jsx-a11y/anchor-has-content
+                    components={{signupLink: <a href="/signup" />}}
+                  />
                 </div>
                 <div className="small">
-                  {t("Already have an account?")}{" "}
-                  <a href="/login">{t("Sign in")}</a>
+                  <Trans
+                    defaults={t(
+                      "Already have an account? <loginLink>Sign in</loginLink>"
+                    )}
+                    // eslint-disable-next-line jsx-a11y/anchor-has-content
+                    components={{loginLink: <a href="/login" />}}
+                  />
                 </div>
               </>
             )}

--- a/frontend/js/src/forms/SignupNonCommercial.tsx
+++ b/frontend/js/src/forms/SignupNonCommercial.tsx
@@ -1,6 +1,6 @@
 import { Formik } from "formik";
 import React, { JSX } from "react";
-import { useTranslation } from "react-i18next";
+import { Trans, useTranslation } from "react-i18next";
 import * as Yup from "yup";
 import MTCaptcha from "./MTCaptcha";
 import { getPageProps, renderRoot } from "../utils";
@@ -331,12 +331,22 @@ function SignupNonCommercial({
             ) : (
               <>
                 <div className="small">
-                  {t("Not a supporter?")}{" "}
-                  <a href="/signup">{t("Create a user account")}</a>
+                  <Trans
+                    defaults={t(
+                      "Not a supporter? <signupLink>Create a user account</signupLink>"
+                    )}
+                    // eslint-disable-next-line jsx-a11y/anchor-has-content
+                    components={{signupLink: <a href="/signup" />}}
+                  />
                 </div>
                 <div className="small">
-                  {t("Already have an account?")}{" "}
-                  <a href="/login">{t("Sign in")}</a>
+                  <Trans
+                    defaults={t(
+                      "Already have an account? <loginLink>Sign in</loginLink>"
+                    )}
+                    // eslint-disable-next-line jsx-a11y/anchor-has-content
+                    components={{loginLink: <a href="/login" />}}
+                  />
                 </div>
               </>
             )}

--- a/frontend/js/src/forms/SignupNonCommercial.tsx
+++ b/frontend/js/src/forms/SignupNonCommercial.tsx
@@ -104,7 +104,7 @@ function SignupNonCommercial({
         <div className="auth-card">
           <h1 className="page-title text-center">
             {existing_user ? t("Become a Supporter") : t("Sign up")}{" "}
-            <small>{t("non-commercial")}</small>
+            <small>{t("Non-commercial")}</small>
           </h1>
           <div className="h4 text-center">
             {t("Access all MetaBrainz projects")}

--- a/frontend/js/src/forms/SignupUser.tsx
+++ b/frontend/js/src/forms/SignupUser.tsx
@@ -1,6 +1,6 @@
 import { Formik } from "formik";
 import React, { JSX } from "react";
-import { useTranslation } from "react-i18next";
+import { Trans, useTranslation } from "react-i18next";
 import * as Yup from "yup";
 import MTCaptcha from "./MTCaptcha";
 import { getPageProps, renderRoot } from "../utils";
@@ -47,8 +47,14 @@ function SignupUser({
           </div>
           {is_registration_request_signup && registration_request_client_name && (
             <p className="text-center text-muted">
-              {t("Registration started by")}{" "}
-              <strong>{registration_request_client_name}</strong>
+              <Trans
+                defaults={t(
+                  "Registration started by <client />"
+                )}
+                components={{
+                  client: <strong>{registration_request_client_name}</strong>
+                }}
+              />
             </p>
           )}
           <Formik

--- a/frontend/js/src/forms/SignupUser.tsx
+++ b/frontend/js/src/forms/SignupUser.tsx
@@ -234,8 +234,13 @@ function SignupUser({
           </Formik>
           <ConditionsModal />
           <div className="auth-card-footer text-center">
-            {t("Already have an account?")}{" "}
-            <a href={getAuthPageUrl("/login")}>{t("Sign in")}</a>
+            <Trans
+              defaults={t(
+                "Already have an account? <loginLink>Sign in</loginLink>"
+              )}
+              // eslint-disable-next-line jsx-a11y/anchor-has-content
+              components={{loginLink: <a href={getAuthPageUrl("/login")} />}}
+            />
           </div>
         </div>
       </div>

--- a/frontend/js/src/hooks/useEmailValidation.ts
+++ b/frontend/js/src/hooks/useEmailValidation.ts
@@ -79,7 +79,7 @@ function useEmailValidation() {
       }
       const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
       if (!emailRegex.test(email)) {
-        return t("Invalid email address");
+        return t("Invalid email address.");
       }
 
       if (emailValidationCache[email] !== undefined) {

--- a/metabrainz/templates/index/conflict-policy.html
+++ b/metabrainz/templates/index/conflict-policy.html
@@ -14,221 +14,226 @@
   <h2>{{ _('Introduction') }}</h2>
 
   <p>
-    Conflicts between people arise in open source projects constantly and the projects by the 
+    {{ _('Conflicts between people arise in open source projects constantly and the projects by the 
     MetaBrainz Foundation are no different. This policy aims to establish a clear and unambiguous 
     policy for reporting and addressing conflicts in our community. In this policy we aim to 
     establish a fair practice that balances the need for confidentiality and our desire for 
-    transparency in our operations.
+    transparency in our operations.') }}
   </p>
 
   <p>
-    Before you continue to read this policy, we encourage you to review our existing community policies 
-    including our <a href="/social-contract">Social Contract</a>, 
-    <a href="/code-of-conduct">the Code of Conduct</a>, 
-    and our <a href="/privacy">Privacy Policy</a>. These policies establish the norms and rules for 
+    {{ _('Before you continue to read this policy, we encourage you to review our existing community policies 
+    including our <a href="%(social_contract_url)s">Social Contract</a>, 
+    <a href="%(code_of_conduct_url)s">the Code of Conduct</a>, 
+    and our <a href="%(privacy_policy_url)s">Privacy Policy</a>. These policies establish the norms and rules for 
     participation in our projects; these policies apply equally to the contractors of the MetaBrainz 
-    Foundation and any participants in our projects.
+    Foundation and any participants in our projects.',
+    social_contract_url='/social-contract',
+    code_of_conduct_url='/code-of-conduct',
+    privacy_policy_url='/privacy') }}
   </p>
 
   <p>
-    This policy divides conflicts into two categories: Private and public. Private conflicts are conflicts 
+    {{ _('This policy divides conflicts into two categories: Private and public. Private conflicts are conflicts 
     that involve *confidential* information regarding contributors, contractors or supporters. Otherwise, any conflicts 
     that do not involve confidential information are considered to be public conflicts. For instance, a 
     conflict between a contractor and the Executive Director (aka BDFL) that involves contractor pay is 
     considered a private conflict because pay rates are confidential information. A public conflict in edit 
     notes between two editors in our community does not involve confidential information and therefore should 
-    be considered a public conflict.
+    be considered a public conflict.') }}
   </p>
 
   <p>
-    When conflicts arise we aim to disclose as much information as possible about the conflict in a timely 
+    {{ _('When conflicts arise we aim to disclose as much information as possible about the conflict in a timely 
     fashion. When conflicts contain confidential matters we will aim to disclose as much information as 
     possible, while fully respecting the confidentiality of the people involved in the conflict. With any 
     private conflict we will aim to extract the relevant lessons for the team and community in an effort to 
     evolve our policies to prevent future conflicts. Should the involved parties disagree whether a conflict 
     is private or public, the question about the nature of the conflict will be presented for the next higher 
     level in the chain of command to decide. (e.g. if a community member and the community manager disagree on 
-    a conflict being public or private, the Executive Director shall decide if the conflict is public or private).
+    a conflict being public or private, the Executive Director shall decide if the conflict is public or private).') }}
   </p>
 
 
   <h2 class="page-title">{{ _('Reporting and Response') }}</h2>
 
   <p>
-    We aim to not have conflict in our community, but we recognize that in reality conflicts will arise and we 
+    {{ _('We aim to not have conflict in our community, but we recognize that in reality conflicts will arise and we 
     must be prepared to address them in a fair manner. When conflicts arise, we prefer to have community or team 
     members resolve the conflicts among themselves, using our existing policies as guidelines for resolving the 
-    conflict.
+    conflict.') }}
   </p>
 
 
   <p>
-    If you do not feel comfortable resolving a conflict on your own, you should feel free to report the conflict to 
+    {{ _('If you do not feel comfortable resolving a conflict on your own, you should feel free to report the conflict to 
     us. How you address the conflict depends on who is involved in the conflict and your comfort level. Please see 
     the detailed sections below on how and with whom to address your conflict. We aim to address conflicts as soon 
-    as possible in an effort to prevent them from escalating unnecessarily.
+    as possible in an effort to prevent them from escalating unnecessarily.') }}
   </p>
 
-  <h3>Direct conflict resolution</h3>
+  <h3>{{ _('Direct conflict resolution') }}</h3>
 
   <p>
-   In direct conflict resolution, the involved parties will attempt to resolve the conflict themselves without 
+   {{ _('In direct conflict resolution, the involved parties will attempt to resolve the conflict themselves without 
    involving any MetaBrainz Foundation team member. You should aim to use direct resolution when the conflict does 
-   not involve the violation of one of our policies or if the conflict is minor. 
+   not involve the violation of one of our policies or if the conflict is minor.') }}
    </p>
 
   <p>
-    For instance, if a user uses a rude tone, is disruptive or flagrantly ignores our project guidelines, we suggest 
+    {{ _('For instance, if a user uses a rude tone, is disruptive or flagrantly ignores our project guidelines, we suggest 
     that you use direct conflict resolution to resolve the conflict. Some resources that might give you some suggestions 
-    on how to go about resolving the conflict might be this <a href="https://opensource.com/life/16/5/conflict-resolution-primer">
-    conflict resolution primer</a> and <a href="https://hbr.org/2015/01/how-to-handle-difficult-conversations-at-work">how to
-    have difficult conversations at work</a>.
+    on how to go about resolving the conflict might be this <a href="%(conflict_resolution_primer_url)s">
+    conflict resolution primer</a> and <a href="%(difficult_conversations_url)s">how to
+    have difficult conversations at work</a>.',
+    conflict_resolution_primer_url='https://opensource.com/life/16/5/conflict-resolution-primer',
+    difficult_conversations_url='https://hbr.org/2015/01/how-to-handle-difficult-conversations-at-work') }}
   </p>
 
-  <h3>Informal reporting</h3>
+  <h3>{{ _('Informal reporting') }}</h3>
 
   <p>
-    You may use informal reporting of a conflict if you aim to communicate a concern or incident without 
+    {{ _('You may use informal reporting of a conflict if you aim to communicate a concern or incident without 
     seeking a corrective outcome. Informal reporting may also be an option if you have not been personally 
     victimized, but you’ve witnessed a violation of our policies or where you wish to maintain confidentiality 
-    throughout the entire reporting process.
+    throughout the entire reporting process.') }}
   </p>
 
   <p>
-    For editing in MusicBrainz you may informally report a user using the “Report this user for bad behavior” 
+    {{ _('For editing in MusicBrainz you may informally report a user using the “Report this user for bad behavior” 
     link from the user’s profile. For reporting bad user behavior in other of our projects, please report them to our 
     community manager by mailing <span class="backemail">gro.zniarbatem@reganam-ytinummoc</span> . For conflicts 
-    that involve the community manager, report them by mailing <span class="backemail">gro.zniarbatem@de</span> .
+    that involve the community manager, report them by mailing <span class="backemail">gro.zniarbatem@de</span> .') }}
   </p>
 
   <p>
-    Depending the the severity of the issue, repeated informal complaints may eventually require a formal response 
+    {{ _('Depending the the severity of the issue, repeated informal complaints may eventually require a formal response 
     from the MetaBrainz team. If an involved party requires anonymity, the conflict becomes a private conflict. If at 
     all possible minor issues should be resolved in a public forum in order for all people to witness and learn from 
-    the issue at hand.
+    the issue at hand.') }}
   </p>
 
-  <h3>Formal complaint process</h3>
+  <h3>{{ _('Formal complaint process') }}</h3>
 
   <p>
-    All complaints about conflicts should be submitted via email. To whom a complaint should be mailed and who will 
-    carry out the investigation will be described in the next section.
+    {{ _('All complaints about conflicts should be submitted via email. To whom a complaint should be mailed and who will 
+    carry out the investigation will be described in the next section.') }}
   </p>
 
   <p>
-    All complaint submissions to the Foundation should include the following:
+    {{ _('All complaint submissions to the Foundation should include the following:') }}
   </p>
 
   <ul>
-     <li>Contact info, if it is different than the email used to submit the conflict</li>
-     <li>Who was involved in the conflict</li>
-     <li>Where and when the incident happened </li>
-     <li>A description of what happened -- ideally with links (e.g. chatlogs, edit notes) that outlines what 
-         happened so that the persons evaluating the conflict may understand the issue at hand.</li>
-     <li>Any related pieces of information that provide more context on the conflict. (e.g. links, screenshots)</li>
-     <li>An indication if this conflict is ongoing or not</li>
+     <li>{{ _('Contact info, if it is different than the email used to submit the conflict') }}</li>
+     <li>{{ _('Who was involved in the conflict') }}</li>
+     <li>{{ _('Where and when the incident happened') }}</li>
+     <li>{{ _('A description of what happened -- ideally with links (e.g. chatlogs, edit notes) that outlines what 
+         happened so that the persons evaluating the conflict may understand the issue at hand') }}</li>
+     <li>{{ _('Any related pieces of information that provide more context on the conflict (e.g. links, screenshots)') }}</li>
+     <li>{{ _('An indication if this conflict is ongoing or not') }}</li>
   </ul>
 
 
   <p>
-    The investigation that follows aims to determine:
+    {{ _('The investigation that follows aims to determine:') }}
   </p>
 
   <ul>
-     <li>The nature and severity of the incident</li>
-     <li>Whether or not the incident is considered a violation of MetaBrainz’ conduct policies or core values</li>
-     <li>The amount of harm experienced by the person who submitted the complaint and the broader MetaBrainz community 
-         as a result of the incident</li>
-     <li>Whether there have been prior complaints against the individual or individuals reported</li>
-     <li>Whether the incident is ongoing</li>
+     <li>{{ _('The nature and severity of the incident') }}</li>
+     <li>{{ _('Whether or not the incident is considered a violation of MetaBrainz’ conduct policies or core values') }}</li>
+     <li>{{ _('The amount of harm experienced by the person who submitted the complaint and the broader MetaBrainz community 
+         as a result of the incident') }}</li>
+     <li>{{ _('Whether there have been prior complaints against the individual or individuals reported') }}</li>
+     <li>{{ _('Whether the incident is ongoing') }}</li>
   </ul>
 
   <p>
-    The following potential forms of resolution may apply to any team members involved in the conflict:
+    {{ _('The following potential forms of resolution may apply to any team members involved in the conflict:') }}
   </p>
   <ul>
-     <li>Nothing (if it has been found no violation occurred) </li>
-     <li>Creating a plan to improve the performance</li>
-     <li>Creating a negative performance evaluation</li>
-     <li>Mediation, an intervention by a third party to resolve the conflict.</li>
-     <li>Suspension or forced leave</li>
-     <li>Termination of contract</li>
+     <li>{{ _('Nothing (if it has been found no violation occurred)') }}</li>
+     <li>{{ _('Creating a plan to improve the performance') }}</li>
+     <li>{{ _('Creating a negative performance evaluation') }}</li>
+     <li>{{ _('Mediation, an intervention by a third party to resolve the conflict') }}</li>
+     <li>{{ _('Suspension or forced leave') }}</li>
+     <li>{{ _('Termination of contract') }}</li>
   </ul>
 
   <p>
-    The following potential forms of resolution may apply to non team members involved in the conflict:
+    {{ _('The following potential forms of resolution may apply to non team members involved in the conflict:') }}
   </p>
 
   <ul>
-     <li>Nothing (if it has been found no violation occurred)</li>
-     <li>A reprimand, either public or private.</li>
-     <li>Suspension of the users’ account.</li>
-     <li>Deletion of the users’ account.</li>
-     <li>Removal of user privileges (e.g. if an auto editor commits a serious offence, they may lose their auto editor status) </li>
+     <li>{{ _('Nothing (if it has been found no violation occurred)') }}</li>
+     <li>{{ _('A reprimand, either public or private') }}</li>
+     <li>{{ _('Suspension of the users’ account') }}</li>
+     <li>{{ _('Deletion of the users’ account') }}</li>
+     <li>{{ _('Removal of user privileges (e.g. if an auto editor commits a serious offence, they may lose their auto editor status)') }}</li>
   </ul>
 
-  <h3>Filing a complaint</h3>
+  <h3>{{ _('Filing a complaint') }}</h3>
 
   <p>
-    NOTE: For complaints not about MetaBrainz staff, please see the <em>Informal reporting</em> section above.
+    {{ _('NOTE: For complaints not about MetaBrainz staff, please see the <em>Informal reporting</em> section above.') }}
   <p>
 
   <p>
-    If the complaint does not involve the Executive Director (ED), do the following:
+    {{ _('If the complaint does not involve the Executive Director (ED), do the following:') }}
   </p>
 
   <ul>
-    <li>If team member has directly violated conduct policies or engaged in otherwise harmful behavior, a formal complaint should be filed.</li>
-    <li>Mail <span class="backemail">gro.zniarbatem@de</span> and include the complaint information outlined above.</li>
-    <li>You should expect a response within a working day acknowledging the complaint.</li>
-    <li>The complaint will be investigated by the ED, member(s) of the board of directors or a neutral third party.</li>
-    <li>Once the investigation has been completed, the ED, with the support of others involved in the investigation will respond. The 
+    <li>{{ _('If team member has directly violated conduct policies or engaged in otherwise harmful behavior, a formal complaint should be filed.') }}</li>
+    <li>{{ _('Mail <span class="backemail">gro.zniarbatem@de</span> and include the complaint information outlined above.') }}</li>
+    <li>{{ _('You should expect a response within a working day acknowledging the complaint.') }}</li>
+    <li>{{ _('The complaint will be investigated by the ED, member(s) of the board of directors or a neutral third party.') }}</li>
+    <li>{{ _('Once the investigation has been completed, the ED, with the support of others involved in the investigation will respond. The 
         ED will respond to incidents no later than 7 working days after a complaint has been filed with either a resolution or an 
-        explanation of why the process must be extended.</li>
+        explanation of why the process must be extended.') }}</li>
   </ul>
 
   <p>
-    If a complaint involves the Executive Director, do the following:
+    {{ _('If a complaint involves the Executive Director, do the following:') }}
   </p>
 
   <ul>
-    <li>If the Executive Director has directly violated conduct policies or engaged in otherwise harmful behavior, 
-        a formal complaint should be filed with the board of directors.</li>
-    <li>Mail <span class="backemail">gro.zniarbatem@noituloser-tcilfnoc</span> and include the complaint information outlined above.</li>
-    <li>You should get a response within 5 working days acknowledging the complaint.</li>
-    <li>The complaint will be investigated by the member(s) of the board of directors, the community manager, a neutral 
-        third party or a combination thereof.</li>
-    <li>Once the investigation has been completed, the board, with the support of others involved in the investigation 
+    <li>{{ _('If the Executive Director has directly violated conduct policies or engaged in otherwise harmful behavior, 
+        a formal complaint should be filed with the board of directors.') }}</li>
+    <li>{{ _('Mail <span class="backemail">gro.zniarbatem@noituloser-tcilfnoc</span> and include the complaint information outlined above.') }}</li>
+    <li>{{ _('You should get a response within 5 working days acknowledging the complaint.') }}</li>
+    <li>{{ _('The complaint will be investigated by the member(s) of the board of directors, the community manager, a neutral 
+        third party or a combination thereof.') }}</li>
+    <li>{{ _('Once the investigation has been completed, the board, with the support of others involved in the investigation 
         will respond. The board will aim to respond to incidents no later than 15 working days after a complaint has been filed 
-        with either a resolution or an explanation of why the process must be extended.</li>
+        with either a resolution or an explanation of why the process must be extended.') }}</li>
   </ul>
 
-  <h2>Confidentiality</h2>
+  <h2>{{ _('Confidentiality') }}</h2>
 
   <p>
-    Confidentiality is an important aspect of conflict resolution and all of the conflicts brought to the attention of the foundation 
-    will be evaluated with confidentiality in mind and acted upon accordingly.
+    {{ _('Confidentiality is an important aspect of conflict resolution and all of the conflicts brought to the attention of the foundation 
+    will be evaluated with confidentiality in mind and acted upon accordingly.') }}
   </p>
 
   <p>
-    We work hard to make all of the actions of the foundation as transparent and open as possible. In cases where we cannot 
+    {{ _('We work hard to make all of the actions of the foundation as transparent and open as possible. In cases where we cannot 
     disclose all aspects of a conflict we will disclose that a conflict is or has occurred and we will attempt to disclose the 
     appropriate amount of information about the conflict while balancing the need for confidentiality and our desire to learn 
     from conflicts so that we as a foundation and community can learn from these conflicts and improve our policies to avoid the 
-    conflicts in the future.
+    conflicts in the future.') }}
   </p>
 
   <p>
-    Any breaches of confidentiality will be treated as severe breaches of our conduct policies.
+    {{ _('Any breaches of confidentiality will be treated as severe breaches of our conduct policies.') }}
   </p>
 
-  <h2>Retaliation</h2>
+  <h2>{{ _('Retaliation') }}</h2>
 
   <p>
-    We will not allow retaliation for any contractor or volunteer that files a complaint or is involved in an investigation. If you 
+    {{ _('We will not allow retaliation for any contractor or volunteer that files a complaint or is involved in an investigation. If you 
     believe that you are being treated negatively because of your involvement in a complaint please report this complaint directly 
     to the ED at <span class="backemail">gro.zniarbatem@de</span> or the board at 
-    <span class="backemail">gro.zniarbatem@noituloser-tcilfnoc</span> .
+    <span class="backemail">gro.zniarbatem@noituloser-tcilfnoc</span>.') }}
   </p>
 
 {% endblock %}

--- a/metabrainz/templates/index/contact.html
+++ b/metabrainz/templates/index/contact.html
@@ -83,8 +83,9 @@
   
   <h3>{{ _('Forums') }}</h3>
   <p>
-    {{ _('Please come ask your questions at our <a href="%(forums_url)s">forums</a>! We would love to
-    answer any questions you may have.', forums_url='https://community.metabrainz.org/') }}
+    {{ _('Please come ask your questions at our <a href="%(forums_url)s">forums</a>!
+    The community and the team will be more than happy to help you.',
+    forums_url='https://community.metabrainz.org/') }}
   </p>
 
   <h3>{{ _('Chat') }}</h3>

--- a/metabrainz/templates/index/contact.html
+++ b/metabrainz/templates/index/contact.html
@@ -40,7 +40,7 @@
   <h3>{{ _('Advertising requests') }}</h3>
   <p>
     {{ _('We are currently evaluating our overall online advertising strategy. We are evaluating advertising, traffic optimization,
-    search engine optimization and software monitization technologies. If you provide these professional services, please provide a detailed
+    search engine optimization and software monetization technologies. If you provide these professional services, please provide a detailed
     deck of your comprehensive services to the following email address. <em>Please respect our other non-media teams and do not contact us 
     regarding these services on any other of our email addresses. We will disregard the entirety of your submissions if you contact us any other way!</em>') }}
   </p>

--- a/metabrainz/templates/index/gdpr.html
+++ b/metabrainz/templates/index/gdpr.html
@@ -7,200 +7,209 @@
 
   <h2>{{ _('Introduction') }}</h2>
   <p>
-    The General Data Protection Regulation is a complex EU regulation that stipulates many points for protecting private data of
+    {{ _('The General Data Protection Regulation is a complex EU regulation that stipulates many points for protecting private data of
     users on the Internet. Even though this is an EU regulation, it has a worldwide impact due to the nature of the Internet.
     The MetaBrainz Foundation with its collection of projects is also affected by this regulation. We’ve been learning and adapting
     our sites to be compliant with the GDPR – sadly this regulation isn’t entirely black and white and there is an incredible
-    amount of room left for interpretation of these rules.
+    amount of room left for interpretation of these rules.') }}
   </p>
   <p>
-    The good news is that this regulation is roughly in line with our established practices: We’ve always held private information
+    {{ _('The good news is that this regulation is roughly in line with our established practices: We’ve always held private information
     in a high regard and applied the sort of rules to ourselves as we wish to have our own private data treated. Luckily, this
     makes our compliance effort considerably easier. We’ve made two significant changes to how we treat your data and also adopted
     terminology as used in the GDPR in order to use the same languages that many other sites are now adopting. Please keep reading
-    to find out the exact details of what we are doing to comply.
+    to find out the exact details of what we are doing to comply.') }}
   </p>
   <p>
-    However, we do ask for your compassion and help in our process of complying with the GDPR. As we already mentioned, the GDPR is
+    {{ _('However, we do ask for your compassion and help in our process of complying with the GDPR. As we already mentioned, the GDPR is
     a complex set of rules that are not fully clarified yet. We’ve taken action on the steps that are clear to us and we’re following
     ongoing conversations on points that are in gray zones or unclear to us. We’ve made our best initial effort on compliance and
     promise to keep working on it as the picture becomes more clear. If you believe that we could improve our compliance, please
-    <a href="{{ url_for('index.contact') }}">contact us</a> and let us know what we can do to improve. It would also help us if you
-    could provide concrete discussion or examples to help us understand and take action on your suggestion.
+    <a href="%(contact_url)s">contact us</a> and let us know what we can do to improve. It would also help us if you
+    could provide concrete discussion or examples to help us understand and take action on your suggestion.',
+    contact_url=url_for('index.contact')) }}
   </p>
   <p>
-    Finally, below are the key sections of the GDPR as we understand them and how they affect your data in our ecosystem. Where
+    {{ _('Finally, below are the key sections of the GDPR as we understand them and how they affect your data in our ecosystem. Where
     possible, we provide links for deeper understanding, links for you to examine our relevant code and links to tickets to follow
-    the process of improving our compliance.
+    the process of improving our compliance.') }}
   </p>
 
   <h2>{{ _('Right to be forgotten') }}</h2>
 
   <p>
-    Summary: <i>Provide the user with the ability to remove their private data from our services</i>.
+    {{ _('Summary: <i>Provide the user with the ability to remove their private data from our services</i>.') }}
   </p>
   <p>
-    The most important aspect of the right to be forgotten is the ability to delete your account. Once you request for us to delete
+    {{ _('The most important aspect of the right to be forgotten is the ability to delete your account. Once you request for us to delete
     your account, we will remove any personally identifying information you may have provided us from your account (name, email
     address, gender, biography, URL, etc.). The visible name on your account will be changed to “Deleted User #####” and effectively
-    the account will no longer be identifiable as your account.
+    the account will no longer be identifiable as your account.') }}
   </p>
   <p>
-    However, given the nature of our projects where we work on collaborative databases, your contributions that are not personally
+    {{ _('However, given the nature of our projects where we work on collaborative databases, your contributions that are not personally
     identifying are valuable assets to our database and these contributions will not be removed from our databases. But we will
-    ensure that these contributions no longer contain personally identifying data.
+    ensure that these contributions no longer contain personally identifying data.') }}
   </p>
   <p>
-    Our process of automatically deleting your accounts across the MetaBrainz ecosystem is not complete yet (see below for a set of
+    {{ _('Our process of automatically deleting your accounts across the MetaBrainz ecosystem is not complete yet (see below for a set of
     tickets where you can track our progress). If you would like to delete your accounts in the MetaBrainz ecosystem or mark a
-    donation that is currently public as a private donation, please <a href="{{ url_for('index.contact') }}">contact us</a>
-    and we will address your request as soon as possible.
+    donation that is currently public as a private donation, please <a href="%(contact_url)s">contact us</a>
+    and we will address your request as soon as possible.',
+    contact_url=url_for('index.contact')) }}
   </p>
   <p>
-    Links:
+    {{ _('Links:') }}
   </p>
   <ul>
      <li>
-       <a href="https://github.com/metabrainz/musicbrainz-server/blob/master/lib/MusicBrainz/Server/Data/Editor.pm">How we delete
-       accounts in MusicBrainz</a> (warning, geek content ahead!)
+       {{ _('<a href="%(editor_deletion_doc_url)s">How we delete accounts
+       in MusicBrainz</a> (warning, geek content ahead!)',
+       editor_deletion_doc_url='https://github.com/metabrainz/musicbrainz-server/blob/master/lib/MusicBrainz/Server/Data/Editor.pm') }}
      </li>
-     <li>Implement sitewide user account deletion in
+     <li>{{ _('Implement sitewide user account deletion in
          <a href="https://tickets.metabrainz.org/browse/MBS-9680">MusicBrainz</a>,
          <a href="https://tickets.metabrainz.org/browse/AB-337">AcousticBrainz</a>,
          <a href="https://tickets.metabrainz.org/browse/BB-260">BookBrainz</a>,
          <a href="https://tickets.metabrainz.org/browse/MEB-103">the MetaBrainz Site</a>,
          <a href="https://tickets.metabrainz.org/browse/LB-354">ListenBrainz</a>, and
-         <a href="https://tickets.metabrainz.org/browse/CB-307">CritiqueBrainz</a>.
+         <a href="https://tickets.metabrainz.org/browse/CB-307">CritiqueBrainz</a>.') }}
      </li>
   </ul>
 
   <h2>{{ _('Restriction of processing') }}</h2>
 
   <p>
-    Summary: <i>To allow the user to control how their personally identifying data is being used.</i>
+    {{ _('Summary: <i>To allow the user to control how their personally identifying data is being used.</i>') }}
   </p>
   <p>
-    Except for the ListenBrainz and AcousticBrainz projects, we do not process personally identifying data. Any personally
+    {{ _('Except for the ListenBrainz and AcousticBrainz projects, we do not process personally identifying data. Any personally
     identifying data that our projects store is for the purpose of being able to contact you about your contributions to our database
-    (email address) or for voluntarily showing information about you to other users (biography, homepage, location, etc).
+    (email address) or for voluntarily showing information about you to other users (biography, homepage, location, etc).') }}
   </p>
   <p>
-    The ListenBrainz project differs in that the Listens (metadata about what music you have listened to) are stored on our servers
-    and <a href="https://listenbrainz.org/data">made available to the public</a>. We believe Listens to be personally identifying
+    {{ _('The ListenBrainz project differs in that the Listens (metadata about what music you have listened to) are stored on our servers
+    and <a href="%(listenbrainz_data_url)s">made available to the public</a>. We believe Listens to be personally identifying
     data and furthermore, we have goals of creating open source recommendation engines with this data, which involves processing the
     user’s data. These two points are fundamental goals of the ListenBrainz project and we do not see a reasonable way to reach another
-    compromise position.
+    compromise position.',
+    listenbrainz_data_url='https://listenbrainz.org/data') }}
   </p>
   <p>
-    Because of this, we are going to require users to either acknowledge that we may process their Listen data or alternatively to
+    {{ _('Because of this, we are going to require users to either acknowledge that we may process their Listen data or alternatively to
     delete their account, including all of their Listens. Please note that if you decide to delete your ListenBrainz account, it may
-    take up to two weeks for all of your listens to no longer be included in our efforts to build a recommendation engine. 
+    take up to two weeks for all of your listens to no longer be included in our efforts to build a recommendation engine.') }}
   </p>
   <p>
-    We have always made it clear that the data in ListenBrainz was to be public and that we plan to build new tools with your data, so
-    this should not come as a surprise to our users.
+    {{ _('We have always made it clear that the data in ListenBrainz was to be public and that we plan to build new tools with your data, so
+    this should not come as a surprise to our users.') }}
   </p>
   <p>
-    The AcousticBrainz project does not track who submits data to the database. If you create an account and use our data creation
+    {{ _('The AcousticBrainz project does not track who submits data to the database. If you create an account and use our data creation
     tools (e.g. create a dataset or participate in a challenge) then we link your participation and the things that you create to
     your account. If you choose to delete your account then we keep the non personally identifying data that you create, but anonymize
-    it so that it cannot be linked back to you.
+    it so that it cannot be linked back to you.') }}
   </p>
 
   <h2>{{ _('Right to data portability / exporting your data') }}</h2>
 
   <p>
-    Summary: <i>You have the right to access/download the data we store about you</i>.
+    {{ _('Summary: <i>You have the right to access/download the data we store about you</i>.') }}
   </p>
   <p>
-    Except for the ListenBrainz and AcousticBrainz projects, we do not store personally identifying data beyond the
+    {{ _('Except for the ListenBrainz and AcousticBrainz projects, we do not store personally identifying data beyond the
     information that is available in your public profile on each of our projects. Since this data is plainly available in your
-    profile we do not provide a means for you to export this data.
+    profile we do not provide a means for you to export this data.') }}
   </p>
   <p>
-    There are the following exceptions to this:
+    {{ _('There are the following exceptions to this:') }}
   </p>
   <ul>
      <li>
-        <b>IP addresses</b>: If you visit one of our sites the IP address of your computer is stored in our web logs for 7 days
+        {{ _('<b>IP addresses</b>: If you visit one of our sites the IP address of your computer is stored in our web logs for 7 days
         before our servers automatically delete them. This data is almost never used by anyone: the only time we look at the
         IP addresses is if our sites are adversely impacted by the actions of some unknown users. In that case, we may investigate
         the logs to identify the IP address that needs to be blocked in order to restore the stability of our service.
         This data is not available to anyone but the contractors of the MetaBrainz Foundation and is not available to download
-        to anyone at all.
+        to anyone at all.') }}
      </li>
      <li>
-        <b>ListenBrainz Listen data</b>: Users may <a href="https://listenbrainz.org/profile/export">export their ListenBrainz Listen
-        data</a> directly from the site. The user Listen data is also included in the <a href="https://listenbrainz.org/data">ListenBrainz
-        data dumps</a> that are available for public download.
+        {{ _('<b>ListenBrainz Listen data</b>: Users may <a href="%(listenbrainz_export_url)s">export their ListenBrainz Listen
+        data</a> directly from the site. The user Listen data is also included in the <a href="%(listenbrainz_data_url)s">ListenBrainz
+        data dumps</a> that are available for public download.',
+        listenbrainz_export_url='https://listenbrainz.org/profile/export',
+        listenbrainz_data_url='https://listenbrainz.org/data') }}
      </li>
   </ul>
 
   <p>
-    All of the non personally identifying data, such as your metadata contributions, are publicly visible, available for download
+    {{ _('All of the non personally identifying data, such as your metadata contributions, are publicly visible, available for download
     and available via the project APIs. For details about this data, downloads and APIs please check the documentation for the
-    respective projects you are interested in.
+    respective projects you are interested in.') }}
   </p>
   <p>
-    Anyone wishing to get a list of financial donations they have made to the MetaBrainz Foundation, please
-    <a href="{{ url_for('index.contact') }}">contact us</a> and provide your MusicBrainz editor name so that we can look up
-    your donations.
+    {{ _('Anyone wishing to get a list of financial donations they have made to the MetaBrainz Foundation, please
+    <a href="%(contact_url)s">contact us</a> and provide your MusicBrainz editor name so that we can look up
+    your donations.',
+    contact_url=url_for('index.contact')) }}
   </p>
 
   <h2>{{ _('Right to rectification') }}</h2>
 
   <p>
-    Summary: <i>You have the right to correct your data</i>.
+    {{ _('Summary: <i>You have the right to correct your data</i>.') }}
   </p>
   <p>
-    All of our projects allow their users to update their personally identifying information in their profiles. Furthermore, most
+    {{ _('All of our projects allow their users to update their personally identifying information in their profiles. Furthermore, most
     of our projects allow the editing of their own metadata contributions. If you find that some of your data is incorrect, please
-    feel free to edit the data since we provide the tools to do so.
+    feel free to edit the data since we provide the tools to do so.') }}
   </p>
   <p>
-    If anyone who has made a financial donation to the MetaBrainz Foundation would like to make their donation private, please
-    <a href="{{ url_for('index.contact') }}">contact us</a>.
+    {{ _('If anyone who has made a financial donation to the MetaBrainz Foundation would like to make their donation private, please
+    <a href="%(contact_url)s">contact us</a>.',
+    contact_url=url_for('index.contact')) }}
   </p>
 
   <h2>{{ _('Right to be informed') }}</h2>
   <p>
-    Summary: <i>You have the right to be informed about how we use your data in plain English</i>.
+    {{ _('Summary: <i>You have the right to be informed about how we use your data in plain English</i>.') }}
   </p>
   <p>
-    Our privacy policy, as well as other policies, have always been written by humans for human consumption. We abhor legalese and
-    not speaking in direct terms.
+    {{ _('Our privacy policy, as well as other policies, have always been written by humans for human consumption. We abhor legalese and
+    not speaking in direct terms.') }}
   </p>
   <p>
-    Links:
+    {{ _('Links:') }}
   </p>
   <ul>
     <li>
-      <a href="https://metabrainz.org/social-contract">{{_('Social Contract')}}</a>
+      <a href="https://metabrainz.org/social-contract">{{ _('Social contract') }}</a>
     </li>
     <li>
-      <a href="https://metabrainz.org/code-of-conduct">{{_('Code of Conduct')}}</a>
+      <a href="https://metabrainz.org/code-of-conduct">{{ _('Code of conduct') }}</a>
     </li>
     <li>
-      <a href="https://metabrainz.org/privacy">{{ _('Privacy Policy') }}</a>
+      <a href="https://metabrainz.org/privacy">{{ _('Privacy policy') }}</a>
     </li>
   </ul>
 
   <h2>{{ _('Right to access') }}</h2>
 
   <p>
-    Summary: <i>You have the right to access the data that we collect about you</i>.
+    {{ _('Summary: <i>You have the right to access the data that we collect about you</i>.') }}
   </p>
   <p>
-    All of our projects make all of the data we collect on your behalf, privately identifying or not, available to you. The
-    only exception to this are the IP addresses we store for 7 days – see above for details.
+    {{ _('All of our projects make all of the data we collect on your behalf, privately identifying or not, available to you. The
+    only exception to this are the IP addresses we store for 7 days – see above for details.') }}
   </p>
 
   <h2>{{ _('Privacy/GDPR Representative') }}</h2>
 
   <p>
-   If you have any questions about our privacy policy, please <a href="{{ url_for('index.contact') }}">contact us</a>. To report
+   {{ _('If you have any questions about our privacy policy, please <a href="%(contact_url)s">contact us</a>. To report
    any privacy problems, violations or leaks, our GDPR representative is our Interim Executive Director Nicolás Tamargo and for
-   privacy issues contact him at <strong><a href="mailto:gdpr@metabrainz.org">gdpr@metabrainz.org</a></strong>.
+   privacy issues contact him at <strong><a href="mailto:gdpr@metabrainz.org">gdpr@metabrainz.org</a></strong>.',
+   contact_url=url_for('index.contact')) }}
   </p>
 
 {% endblock %}

--- a/metabrainz/templates/index/privacy.html
+++ b/metabrainz/templates/index/privacy.html
@@ -9,137 +9,139 @@
   <p>
   <ol>
     <li>
-      You do not have to provide any personal data to be able to browse the contents of the databases published by MetaBrainz.
+      {{ _('You do not have to provide any personal data to be able to browse the contents of the databases published by MetaBrainz.') }}
     </li>
     <li>
-      You do not have to provide any personally-identifying information if you choose not to.
+      {{ _('You do not have to provide any personally-identifying information if you choose not to.') }}
     </li>
     <li>
-      We will never reveal your email address on MetaBrainz controlled web sites.
+      {{ _('We will never reveal your email address on MetaBrainz controlled web sites.') }}
     </li>
   </ol>
   <p>
-    In order to get maximum value out of the MetaBrainz projects, you may want to create an account and log in. 
+    {{ _('In order to get maximum value out of the MetaBrainz projects, you may want to create an account and log in. 
     Doing so grants you the ability to: edit the databases, contribute your own data, communicate with other users, and keep track 
     of recently released music from artists in your MusicBrainz collection. If you choose to create an account then the minimum we 
     ask is that you: choose a unique username and password, use a web browser that accepts "session" cookies, and provide a verified 
-    email address.
+    email address.') }}
   </p>
   <p>
-    If you do not create an account (or are not logged in) you will not have access to the above listed features, however, you will 
-    still have full access to browse and examine the databases.
+    {{ _('If you do not create an account (or are not logged in) you will not have access to the above listed features, however, you will 
+    still have full access to browse and examine the databases.') }}
   </p>
 
   <h2>{{ _('Applicable to all users') }}</h2>
 
   <h3>{{ _('Cookies') }}</h3>
   <p>
-    We use two cookies that contain sensitive information:
+    {{ _('We use two cookies that contain sensitive information:') }}
   </p>
 
   <ol>
     <li>
-      <b>remember_login</b>: If you choose the "Log in permanently" option when logging in to one of our sites; the cookie will be used to 
-      remember your login details.
+      {{ _('<b>remember_login</b>: If you choose the "Log in permanently" option when logging in to one of our sites; the cookie will be used to 
+      remember your login details.') }}
     </li>
     <li>
-      <b>musicbrainz_server_session, session, or connect.sid</b>: If you are logged into one of our sites, your current session ID is stored in this cookie.
+      {{ _('<b>musicbrainz_server_session, session, or connect.sid</b>: If you are logged into one of our sites, your current session ID is stored in this cookie.') }}
     </li>
   </ol>
 
   <p>
-    We may store dynamic preference information in other cookies, but these do not contain any sensitive information.
+    {{ _('We may store dynamic preference information in other cookies, but these do not contain any sensitive information.') }}
   </p>
 
   <h3>{{ _('Web and FTP access logs') }}</h3>
 
   <p>
-    In a practice similar to other web sites (and APIs) we keep logs of all web requests made against our servers. These logs include: your IP
-    address, your browser's (or API client's) "User-Agent" string, and which page (or API endpoint) you requested with which parameters. Aggregate information about web and FTP traffic is
-    made available to the public via our site usage pages.
+    {{ _('In a practice similar to other web sites (and APIs) we keep logs of all web requests made against our servers. These logs include: your IP
+    address, your browser\'s (or API client\'s) "User-Agent" string, and which page (or API endpoint) you requested with which parameters. Aggregate information about web and FTP traffic is
+    made available to the public via our site usage pages.') }}
   </p>
 
   <h3>{{ _('Third-Party content') }}</h3>
   <p>
-    Our projects' web pages may load some third-party content. Some, but possibly not all sites are listed below:
+    {{ _('Our projects\' web pages may load some third-party content. Some, but possibly not all sites are listed below:') }}
   </p>
 
   <ol>
     <li>
-      Cover art and other images: These are provided by the various cover art sites that have given MusicBrainz permission to do so and our own 
-      <a href="https://coverartarchive.org">Cover Art Archive</a>. This means that the relevant site will know (if they want to) your IP 
-      address, User-Agent string, etc., and which MusicBrainz web page you were visiting (the one which included the cover art image).
+      {{ _('Cover art and other images: These are provided by the various cover art sites that have given MusicBrainz permission to do so and our own 
+      <a href="%(caa_url)s">Cover Art Archive</a>. This means that the relevant site will know (if they want to) your IP 
+      address, User-Agent string, etc., and which MusicBrainz web page you were visiting (the one which included the cover art image).',
+      caa_url='https://coverartarchive.org/') }}
     </li>
     <li>
-      AcoustID: Our fingerprints tab loads fingerprint information from acoustid.org.
+      {{ _('AcoustID: Our fingerprints tab loads fingerprint information from acoustid.org.') }}
     </li>
     <li>
-      MTCaptcha: Our account creation page loads third party content in order to prevent spammers from creating accounts.
+      {{ _('MTCaptcha: Our account creation page loads third party content in order to prevent spammers from creating accounts.') }}
     </li>
   </ol>
 
   <p>
-    <i>The above information assumes that you are using "normal" web browser settings, whereby images are always loaded and HTTP referrer 
-    information is always sent.</i>
+    {{ _('<i>The above information assumes that you are using "normal" web browser settings, whereby images are always loaded and HTTP referrer 
+    information is always sent.</i>') }}
   </p>
 
   <p>
-    It is impractical to constantly modify this privacy policy when MusicBrainz changes which third party content it utilizes. We will 
+    {{ _('It is impractical to constantly modify this privacy policy when MusicBrainz changes which third party content it utilizes. We will 
     aim to use common sense, respect to our community and community review when adding more content from third party sites. We will also 
-    periodically review our policy to ensure that it remains current.
+    periodically review our policy to ensure that it remains current.') }}
   </p>
 
   <h2>{{ _('Applicable to account holders') }}</h2>
 
   <h3>{{ _('Account creation') }}</h3>
   <p>
-    When creating an account with a MetaBrainz project you need to pick a unique username and choose a password, the username you pick is the 
+    {{ _('When creating an account with a MetaBrainz project you need to pick a unique username and choose a password, the username you pick is the 
     only name associated with your account and will be what other MetaBrainz users know you as. You may optionally also tell us other 
-    information about yourself that will be displayed to other MetaBrainz users and the public.
+    information about yourself that will be displayed to other MetaBrainz users and the public.') }}
   </p>
 
   <p>
-    Additionally, in order to edit the databases you will need to provide a confirmed email address. This email address will be held in 
+    {{ _('Additionally, in order to edit the databases you will need to provide a confirmed email address. This email address will be held in 
     confidence, the only method of revealing your email address to another user is if you choose to send a message to another 
     user and enable the option to "reveal my email address". Changing the email address stored with your account will require you to 
-    verify the new address.
+    verify the new address.') }}
   </p>
 
   <h3>{{ _('Edits and Notes') }}</h3>
   <p>
-    If you make any changes to a MetaBrainz project database, such as adding any data, the details of those changes will be visible to 
-    other logged-in users and the change will be associated with your username.
+    {{ _('If you make any changes to a MetaBrainz project database, such as adding any data, the details of those changes will be visible to 
+    other logged-in users and the change will be associated with your username.') }}
   </p>
 
   <h3>{{ _('Subscriptions on MusicBrainz') }}</h3>
   <p>
-    As a logged-in user you can subscribe to one or more artists, labels, collections or other editors. The act of subscribing causes 
+    {{ _('As a logged-in user you can subscribe to one or more artists, labels, collections or other editors. The act of subscribing causes 
     any edits made to (or by in the case of another editor) those entities to be emailed to you. By default, other users can see your 
-    list of subscriptions, however, you can opt out of this by editing the appropriate preference.
+    list of subscriptions, however, you can opt out of this by editing the appropriate preference.') }}
   </p>
 
   <p>
-    This does not provide "perfect" privacy though, in some cases it will be possible to infer information about the contents of your 
+    {{ _('This does not provide "perfect" privacy though, in some cases it will be possible to infer information about the contents of your 
     subscription list even though you have disallowed others from viewing that list directly. This imperfection arises because various 
     parts of the system behave differently depending on whether or not an entity has any subscribers; also, the number of users 
     subscribed to each artist is available via the artist pages. In the most extreme (possibly contrived) example, imagine that all 
     users have their subscriptions set to "public", except for exactly one user whose list is "private". In that case, any discrepancy 
     for a given artist between the shown list of subscribers and the total number of subscribers must be down to that one user. Thus, 
-    you can infer what artists are on that user's list.
+    you can infer what artists are on that user\'s list.') }}
   </p>
 
   <h2>{{ _('Third-party sites') }}</h2>
   <p>
-    Our code reviews are done on GitHub, which is not under the control of MetaBrainz. Participating in code reviews or other
-    tasks carried out on GitHub are subject to <a href="https://help.github.com/articles/github-privacy-statement/">GitHub's privacy 
-    policy</a>.
+    {{ _('Our code reviews are done on GitHub, which is not under the control of MetaBrainz. Participating in code reviews or other
+    tasks carried out on GitHub are subject to <a href="%(github_url)s">GitHub\'s privacy policy</a>.',
+    github_url='https://help.github.com/articles/github-privacy-statement/') }}
   </p>
 
   <p>
-    Our translations platform is provided and hosted by Weblate, which has a data processing agreement with MetaBrainz.
-    Participating in translations is subject to <a href="https://translations.metabrainz.org/legal/">dedicated legal terms</a>.
+    {{ _('Our translations platform is provided and hosted by Weblate, which has a data processing agreement with MetaBrainz.
+    Participating in translations is subject to <a href="%(weblate_url)s">dedicated legal terms</a>.
     Any translations you make will be submitted to our Git repositories and publicly associated with your username;
-    if you so choose, you can also publicly associate them with your own verified email address.
+    if you so choose, you can also publicly associate them with your own verified email address.',
+    weblate_url='https://translations.metabrainz.org/legal/') }}
   </p>
 
   <h2>{{ _('MetaBrainz donors') }}</h2>
@@ -157,18 +159,19 @@
 
   <h2>{{ _('Exceptions') }}</h2>
   <p>
-    <i><b>Please note</b>: Reasonable exceptions may apply to the above policy, for example to comply with applicable laws.
+    {{ _('<i><b>Please note</b>: Reasonable exceptions may apply to the above policy, for example to comply with applicable laws.
     Also, members of the MetaBrainz team and other personnel contracted to provide services to MetaBrainz may have access to
     our infrastructure and could therefore view any information contained therein. However all personnel are contractually bound
-    by non-disclosure clauses which prevent them from making any such information available to others.
+    by non-disclosure clauses which prevent them from making any such information available to others.') }}
   </p>
 
   <h2>{{ _('Privacy/GDPR Representative') }}</h2>
 
   <p>
-   If you have any questions about our GDPR statement, please <a href="{{ url_for('index.contact') }}">contact us</a>. To report
+   {{ _('If you have any questions about our GDPR statement, please <a href="%(contact_url)s">contact us</a>. To report
    any privacy problems, violations or leaks, our GDPR representative is our Interim Executive Director Nicolás Tamargo and for
-   privacy issues contact him at <strong><a href="mailto:gdpr@metabrainz.org">gdpr@metabrainz.org</a></strong>.
+   privacy issues contact him at <strong><a href="mailto:gdpr@metabrainz.org">gdpr@metabrainz.org</a></strong>.',
+   contact_url=url_for('index.contact'))}}
   </p>
 
 {% endblock %}

--- a/metabrainz/templates/index/privacy.html
+++ b/metabrainz/templates/index/privacy.html
@@ -85,7 +85,7 @@
   </p>
 
   <p>
-    {{ _('It is impractical to constantly modify this privacy policy when MusicBrainz changes which third party content it utilizes. We will 
+    {{ _('It is impractical to constantly modify this privacy policy when MetaBrainz projects change which third party content they utilize. We will 
     aim to use common sense, respect to our community and community review when adding more content from third party sites. We will also 
     periodically review our policy to ensure that it remains current.') }}
   </p>

--- a/metabrainz/templates/index/team.html
+++ b/metabrainz/templates/index/team.html
@@ -26,7 +26,7 @@
           {{ _('He lives on in our hearts and in open source.') }}
         </p>
         <ul class="links">
-          <li><strong>Chat:</strong> you're welcome to try</li>
+          <li><strong>Chat:</strong> {{ _('you’re welcome to try') }}</li>
           <li><strong>GitHub:</strong> <a href="https://github.com/mayhem">mayhem</a></li>
           <li><strong>ListenBrainz:</strong> <a href="https://listenbrainz.org/user/rob">rob</a></li>
         </ul>
@@ -312,7 +312,7 @@
           gnt_url='https://en.wikipedia.org/wiki/Gin_and_tonic') }}
         </p>
         <ul class="links">
-          <li><strong>Chat:</strong> you're welcome to try</li>
+          <li><strong>Chat:</strong> {{ _('you’re welcome to try') }}</li>
           <li><strong>MusicBrainz:</strong> <a href="https://musicbrainz.org/user/drsaunde">drsaunde</a></li>
         </ul>
       </div>

--- a/metabrainz/templates/payments/donate.html
+++ b/metabrainz/templates/payments/donate.html
@@ -143,7 +143,7 @@
     <p>{{ _('Please indicate your name and use the word <em>%(donation_fixed_string)s</em> in the description field.', donation_fixed_string='DONATION') }}</p>
 
     <h3>{{ _('US Check') }}</h3>
-    <p>{{ _('Due to the increased unreliability of the US Postal Service we have stopped accepting paper checks. Sorry!') }}</p>
+    <p>{{ _('Due to the increased unreliability of the US Postal Service and the relatively large fees involved, we ask you to only send a paper check if it is the only possible option. Due to the fees, we will not cash checks for less than $25.') }}</p>
 
   </div>
 {% endblock %}

--- a/metabrainz/templates/supporters/account-type.html
+++ b/metabrainz/templates/supporters/account-type.html
@@ -43,13 +43,8 @@
               <div class="price">{{ _('$0.00/month and up') }}</div>
               <div class="description">{{ _('Personal or university assignment user.') }}</div>
               <div class="buttons">
-                {% if is_upgrade %}
-                <p><a href="{{ url_for('supporters.upgrade_noncommercial') }}"
-                      class="btn btn-primary btn-block" role="button">{{ _('Upgrade') }}</a></p>
-                {% else %}
                 <p><a href="{{ url_for('supporters.signup_noncommercial') }}"
-                      class="btn btn-primary btn-block" role="button">{{ _('Sign up') }}</a></p>
-                {% endif %}
+                    class="btn btn-primary btn-block" role="button">{{ _('Sign up') }}</a></p>
               </div>
             </div>
           </div>
@@ -85,13 +80,8 @@
                     <div class="buttons">
                       <p><a href="{{ url_for('supporters.tier', tier_id=tier.id) }}"
                             class="btn btn-default btn-block" role="button">{{ _('More info') }}</a></p>
-                      {% if is_upgrade %}
-                      <p><a href="{{ url_for('supporters.upgrade_commercial', tier_id=tier.id) }}"
-                            class="btn btn-primary btn-block" role="button">{{ _('Upgrade') }}</a></p>
-                      {% else %}
                       <p><a href="{{ url_for('supporters.signup_commercial', tier_id=tier.id) }}"
                             class="btn btn-primary btn-block" role="button">{{ _('Sign up') }}</a></p>
-                      {% endif %}
                     </div>
                   </div>
                 </div>
@@ -136,13 +126,8 @@
               <td>
                 <a href="{{ url_for('supporters.tier', tier_id=tier.id) }}"
                    class="btn btn-default btn-xs" role="button">{{ _('More info') }}</a>
-                {% if is_upgrade %}
-                <a href="{{ url_for('supporters.upgrade_commercial', tier_id=tier.id) }}"
-                   class="btn btn-primary btn-xs" role="button">{{ _('Upgrade') }}</a>
-                {% else %}
                 <a href="{{ url_for('supporters.signup_commercial', tier_id=tier.id) }}"
                    class="btn btn-primary btn-xs" role="button">{{ _('Sign up') }}</a>
-                {% endif %}
               </td>
             </tr>
           {% endfor %}
@@ -159,12 +144,6 @@
       <a href="%(contact_url)s">contact us</a>.', contact_url=url_for('index.contact')) }}
     </div>
 
-  {% endif %}
-
-  {% if is_upgrade %}
-  <div style="margin-top: 20px">
-    <a href="{{ url_for('index.profile') }}" class="btn btn-default">{{ _('Back to Profile') }}</a>
-  </div>
   {% endif %}
 
 {% endblock %}


### PR DESCRIPTION
Please double check if this is the right way to do these things - I've aped what I saw @MonkeyDo do for the combined strings. I checked locally and they seem to work, anyway. I also made some big policy docs translatable, moved the URLs into variables but not quite sure what to do if anything with the email addresses.