### PR TITLE
Add http-socket and health endpoint for haproxy-internal

### DIFF
--- a/docker/oauth/oauth.ini
+++ b/docker/oauth/oauth.ini
@@ -3,6 +3,7 @@ uid = www-data
 gid = www-data
 master = true
 socket = 0.0.0.0:13050
+; HTTP socket for HAProxy internal gateway (haproxy-internal)
 http-socket = 0.0.0.0:13052
 module = metabrainz:create_oauth_app()
 enable-threads = true

--- a/metabrainz/oauth/views.py
+++ b/metabrainz/oauth/views.py
@@ -336,6 +336,12 @@ def introspect_token():
     return authorization_server.create_endpoint_response("introspection")
 
 
+@oauth2_bp.route("/health")
+def health():
+    """Health check endpoint for HAProxy internal gateway."""
+    return "OK", 200
+
+
 def split_by_crlf(s):
     return [v for v in s.splitlines() if v]
 


### PR DESCRIPTION
Enables the internal HAProxy gateway to connect to the oauth service over HTTP.

## Changes
- `docker/oauth/oauth.ini` — add `http-socket = 0.0.0.0:13052` (port already published in docker-server-configs)
- `oauth/views.py` — add `/health` endpoint on the oauth2 blueprint

## Notes
- Port 13052 and the `metabrainz-oauth-http` Consul service are already wired in docker-server-configs
- The `oauth-phase-2` branch already has the `http-socket` change (from Michael) — this PR can be superseded by that if it merges first
- The health endpoint is a bonus; HAProxy currently uses `/.well-known/openid-configuration` which already works

## Tested
Test oauth on isaac (port 13052) is already responding to HTTP — confirmed HAProxy can health-check and proxy through it.

Part of: https://github.com/metabrainz/haproxy-internal