### PR TITLE
Make usernames case-insensitive

### DIFF
--- a/admin/schema_updates/2026-07-27-case-insensitive-usernames.sql
+++ b/admin/schema_updates/2026-07-27-case-insensitive-usernames.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+DROP INDEX user_name_unq_idx;
+CREATE UNIQUE INDEX user_name_unq_idx ON "user" (LOWER(name));
+
+DROP INDEX old_username_username_idx;
+CREATE INDEX old_username_username_idx ON old_username (LOWER(username));
+
+COMMIT;

--- a/admin/sql/create_indexes.sql
+++ b/admin/sql/create_indexes.sql
@@ -3,8 +3,8 @@ BEGIN;
 CREATE INDEX payment_supporter_id_idx ON payment (supporter_id);
 
 CREATE UNIQUE INDEX user_login_id_idx ON "user" (login_id);
-CREATE UNIQUE INDEX user_name_unq_idx ON "user" (name);
-CREATE INDEX old_username_username_idx ON old_username (username);
+CREATE UNIQUE INDEX user_name_unq_idx ON "user" (LOWER(name));
+CREATE INDEX old_username_username_idx ON old_username (LOWER(username));
 CREATE INDEX moderation_log_user_id_idx ON moderation_log (user_id);
 
 CREATE INDEX idx_webhook_delivery_status ON webhook_delivery(status);

--- a/metabrainz/admin/views.py
+++ b/metabrainz/admin/views.py
@@ -4,6 +4,7 @@ from flask import Response, request, redirect, url_for, current_app
 from flask_admin import expose
 from flask_login import current_user
 from markupsafe import Markup
+from sqlalchemy.exc import IntegrityError
 
 from metabrainz.admin import AdminIndexView, AdminBaseView, forms, AdminModelView
 from metabrainz.admin.forms import VerifyEmailForm, EditUsernameForm, ModerateUserForm, DeleteUserForm, \
@@ -80,6 +81,22 @@ def _get_boolean_param(name):
     if value.lower() == "true":
         return True
     return False
+
+
+def _username_change_error(user, new_username, *, allow_unchanged=False):
+    if allow_unchanged and new_username == user.name:
+        return None
+
+    existing_user = User.get(name=new_username)
+    if existing_user is not None:
+        if existing_user.id == user.id:
+            return "Username is already set to this value."
+        return "Username is already in use."
+
+    if OldUsername.get(new_username) is not None:
+        return "Username cannot be used."
+
+    return None
 
 
 class SupportersView(AdminBaseView):
@@ -159,6 +176,20 @@ class SupportersView(AdminBaseView):
         })
 
         if form.validate_on_submit():
+            new_name = form.username.data.strip()
+            username_error = _username_change_error(
+                supporter.user,
+                new_name,
+                allow_unchanged=True,
+            )
+            if username_error is not None:
+                form.username.errors.append(username_error)
+                return self.render(
+                    'admin/supporters/edit.html',
+                    supporter=supporter,
+                    form=form,
+                )
+
             update_data = {
                 'contact_name': form.contact_name.data,
                 'state': form.state.data,
@@ -197,7 +228,6 @@ class SupportersView(AdminBaseView):
 
             old_name = supporter.user.name
             old_email = supporter.user.email
-            new_name = form.username.data
             new_email = form.email.data
 
             supporter.user.name = new_name
@@ -211,7 +241,19 @@ class SupportersView(AdminBaseView):
                 supporter.user.last_updated = updated_at
             if email_changed and new_email:
                 supporter.user.email_confirmed_at = updated_at
-            supporter.update(**update_data)
+            if username_changed:
+                db.session.add(OldUsername(username=old_name))
+
+            try:
+                supporter.update(**update_data)
+            except IntegrityError:
+                db.session.rollback()
+                form.username.errors.append("Username is already in use.")
+                return self.render(
+                    'admin/supporters/edit.html',
+                    supporter=supporter,
+                    form=form,
+                )
 
             # Emit user.updated event if username or email changed
             if email_changed or username_changed:
@@ -640,16 +682,9 @@ class UserModelView(AdminModelView):
 
         new_username = form.username.data.strip()
 
-        if new_username == user.name:
-            flash.error("Username is already set to this value.")
-            return redirect(url_for('.details_view', id=user_id))
-
-        if User.query.filter_by(name=new_username).first() is not None:
-            flash.error("Username is already in use.")
-            return redirect(url_for('.details_view', id=user_id))
-
-        if OldUsername.query.filter_by(username=new_username).first() is not None:
-            flash.error("Username cannot be used.")
+        username_error = _username_change_error(user, new_username)
+        if username_error is not None:
+            flash.error(username_error)
             return redirect(url_for('.details_view', id=user_id))
 
         try:

--- a/metabrainz/admin/views_test.py
+++ b/metabrainz/admin/views_test.py
@@ -1,9 +1,10 @@
+from unittest.mock import patch
+
 from brainzutils import cache
-from metabrainz.testing import FlaskTestCase
-from metabrainz.model.supporter import Supporter
 from flask import url_for
 from flask_login import logout_user
 from sqlalchemy import delete
+from sqlalchemy.exc import IntegrityError
 
 from metabrainz.model import db
 from metabrainz.model.moderation_log import ModerationLog
@@ -130,6 +131,131 @@ class AdminViewsTestCase(FlaskTestCase):
         )
         db.session.commit()
         return supporter
+
+    def _edit_username(self, user, new_username):
+        response = self.client.get(url_for("users-admin.details_view", id=user.id))
+        self.assertEqual(response.status_code, 200)
+        form = self.get_context_variable("edit_username_form")
+        return self.client.post(
+            url_for("users-admin.edit_username", user_id=user.id),
+            data={
+                "username": new_username,
+                "csrf_token": form.csrf_token.current_token,
+            },
+            follow_redirects=False,
+        )
+
+    def _edit_supporter_username(self, supporter, new_username):
+        supporter.user.email = supporter.user.unconfirmed_email
+        supporter.user.unconfirmed_email = None
+        db.session.commit()
+
+        response = self.client.get(url_for("supportersview.edit", supporter_id=supporter.id))
+        self.assertEqual(response.status_code, 200)
+        form = self.get_context_variable("form")
+        return self.client.post(
+            url_for("supportersview.edit", supporter_id=supporter.id),
+            data={
+                "username": new_username,
+                "email": supporter.user.email,
+                "contact_name": supporter.contact_name,
+                "state": supporter.state,
+                "tier": "None",
+                "amount_pledged": "0",
+                "csrf_token": form.csrf_token.current_token,
+            },
+            follow_redirects=False,
+        )
+
+    def test_admin_edit_username_rejects_different_case_of_existing_username(self):
+        user = self.create_user()
+
+        response = self._edit_username(user, "ADMIN_USER")
+
+        self.assertEqual(response.status_code, 302)
+        db.session.refresh(user)
+        self.assertEqual(user.name, "regular_user")
+        self.assertMessageFlashed("Username is already in use.", "error")
+
+    def test_admin_edit_username_rejects_different_case_of_old_username(self):
+        user = self.create_user()
+        db.session.add(OldUsername(username="FormerUser"))
+        db.session.commit()
+
+        response = self._edit_username(user, "formeruser")
+
+        self.assertEqual(response.status_code, 302)
+        db.session.refresh(user)
+        self.assertEqual(user.name, "regular_user")
+        self.assertMessageFlashed("Username cannot be used.", "error")
+
+    def test_admin_edit_username_treats_case_only_change_as_same_username(self):
+        user = self.create_user()
+
+        response = self._edit_username(user, "REGULAR_USER")
+
+        self.assertEqual(response.status_code, 302)
+        db.session.refresh(user)
+        self.assertEqual(user.name, "regular_user")
+        self.assertMessageFlashed("Username is already set to this value.", "error")
+
+    def test_admin_edit_username_treats_exact_change_as_same_username(self):
+        user = self.create_user()
+
+        response = self._edit_username(user, "regular_user")
+
+        self.assertEqual(response.status_code, 302)
+        db.session.refresh(user)
+        self.assertEqual(user.name, "regular_user")
+        self.assertMessageFlashed("Username is already set to this value.", "error")
+        self.assertIsNone(OldUsername.get("regular_user"))
+
+    def test_admin_supporter_edit_rejects_different_case_of_existing_username(self):
+        supporter = self.create_supporter()
+
+        response = self._edit_supporter_username(supporter, "ADMIN_USER")
+
+        self.assertEqual(response.status_code, 200)
+        form = self.get_context_variable("form")
+        self.assertIn("Username is already in use.", form.username.errors)
+        db.session.refresh(supporter.user)
+        self.assertEqual(supporter.user.name, "regular_user")
+
+    def test_admin_supporter_edit_rejects_different_case_of_old_username(self):
+        supporter = self.create_supporter()
+        db.session.add(OldUsername(username="FormerUser"))
+        db.session.commit()
+
+        response = self._edit_supporter_username(supporter, "formeruser")
+
+        self.assertEqual(response.status_code, 200)
+        form = self.get_context_variable("form")
+        self.assertIn("Username cannot be used.", form.username.errors)
+        db.session.refresh(supporter.user)
+        self.assertEqual(supporter.user.name, "regular_user")
+
+    def test_admin_supporter_edit_reserves_previous_username(self):
+        supporter = self.create_supporter()
+
+        response = self._edit_supporter_username(supporter, "RenamedUser")
+
+        self.assertEqual(response.status_code, 302)
+        db.session.refresh(supporter.user)
+        self.assertEqual(supporter.user.name, "RenamedUser")
+        self.assertIsNotNone(OldUsername.get("REGULAR_USER"))
+
+    def test_admin_supporter_edit_handles_concurrent_username_conflict(self):
+        supporter = self.create_supporter()
+
+        with patch.object(Supporter, "update", side_effect=IntegrityError(None, None, None)):
+            response = self._edit_supporter_username(supporter, "AvailableUser")
+
+        self.assertEqual(response.status_code, 200)
+        form = self.get_context_variable("form")
+        self.assertIn("Username is already in use.", form.username.errors)
+        db.session.refresh(supporter.user)
+        self.assertEqual(supporter.user.name, "regular_user")
+        self.assertIsNone(OldUsername.get("regular_user"))
 
     def test_admin_delete_user(self):
         """Test that admin can delete a regular (non-supporter) user."""

--- a/metabrainz/model/old_username.py
+++ b/metabrainz/model/old_username.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, Identity, Text, DateTime, func
+from sqlalchemy import Column, Integer, Identity, Text, DateTime, Index, func
 
 from metabrainz.model import db
 
@@ -9,3 +9,11 @@ class OldUsername(db.Model):
     id = Column(Integer, Identity(), primary_key=True)
     username = Column(Text, nullable=False)
     deleted_at = Column(DateTime(timezone=True), nullable=False, default=func.now())
+
+    __table_args__ = (
+        Index("old_username_username_idx", func.lower(username)),
+    )
+
+    @classmethod
+    def get(cls, username):
+        return cls.query.filter(func.lower(cls.username) == func.lower(username)).first()

--- a/metabrainz/model/user.py
+++ b/metabrainz/model/user.py
@@ -3,7 +3,7 @@ from datetime import datetime, timezone
 from uuid import uuid4
 from flask import current_app
 from flask_login import UserMixin
-from sqlalchemy import Column, Integer, Identity, Text, DateTime, func, Boolean
+from sqlalchemy import Column, Integer, Identity, Text, DateTime, Index, func, Boolean
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
 from sqlalchemy.orm import Mapped
@@ -23,7 +23,7 @@ class User(db.Model, UserMixin):
 
     id = Column(Integer, Identity(), primary_key=True)
     login_id = Column(UUID, nullable=False, unique=True, default=uuid4)
-    name = Column(Text, unique=True, nullable=False)
+    name = Column(Text, nullable=False)
     password = Column(Text, nullable=False)  # TODO: add a constraint to ensure password is cleared when deleted field is set
 
     email = Column(Text)
@@ -36,6 +36,10 @@ class User(db.Model, UserMixin):
 
     deleted = Column(Boolean, nullable=False, default=False)
     is_blocked = Column(Boolean, nullable=False, default=False)
+
+    __table_args__ = (
+        Index("user_name_unq_idx", func.lower(name), unique=True),
+    )
 
     # Tracks until when the user's "remember me" login is expected to stay valid. This mirrors the
     # lifetime of the flask-login remember cookie set at login time and is None when the user did not
@@ -91,7 +95,7 @@ class User(db.Model, UserMixin):
         from metabrainz import bcrypt
 
         name = kwargs.pop("name")
-        if OldUsername.query.filter_by(username=name).first() is not None:
+        if OldUsername.get(name) is not None:
             raise UsernameNotAllowedException()
 
         password = kwargs.pop("password")
@@ -108,14 +112,26 @@ class User(db.Model, UserMixin):
         return new_user
 
     @classmethod
+    def _get(cls, filters: dict):
+        filters = filters.copy()
+        query = cls.query
+        if "name" in filters:
+            name = filters.pop("name")
+            query = query.filter(func.lower(cls.name) == func.lower(name))
+        return query.filter_by(**filters).first()
+
+    @classmethod
     def get(cls, **kwargs):
-        row = cls.query.filter_by(**kwargs).first()
+        row = cls._get(kwargs)
         if row:
             return row
 
         if "email" in kwargs:
-            kwargs["unconfirmed_email"] = kwargs.pop("email")
-            return cls.query.filter_by(**kwargs).first()
+            unconfirmed_email_kwargs = kwargs.copy()
+            # check for email column was already performed and a matching user not found,
+            # so now check with unconfirmed email.
+            unconfirmed_email_kwargs["unconfirmed_email"] = unconfirmed_email_kwargs.pop("email")
+            return cls._get(unconfirmed_email_kwargs)
 
         return None
 

--- a/metabrainz/model/user_test.py
+++ b/metabrainz/model/user_test.py
@@ -1,9 +1,31 @@
+from sqlalchemy.exc import IntegrityError
+
 from metabrainz.model import db
 from metabrainz.model.user import User
 from metabrainz.testing import FlaskTestCase
 
 
 class UserModelTestCase(FlaskTestCase):
+
+    def test_username_lookup_and_uniqueness_are_case_insensitive(self):
+        user = User.add(
+            name="MixedCaseUser",
+            unconfirmed_email="mixed@example.com",
+            password="<PASSWORD>",
+        )
+        db.session.commit()
+
+        self.assertEqual(User.get(name="mixedcaseuser"), user)
+        self.assertEqual(User.get(name="MIXEDCASEUSER"), user)
+        self.assertEqual(user.name, "MixedCaseUser")
+
+        User.add(
+            name="mixedcaseuser",
+            unconfirmed_email="duplicate@example.com",
+            password="<PASSWORD>",
+        )
+        with self.assertRaises(IntegrityError):
+            db.session.commit()
 
     def test_add_requires_unconfirmed_email(self):
         with self.assertRaisesRegex(ValueError, "Email address is required."):

--- a/metabrainz/oauth/tests/test_oauth_registration_request.py
+++ b/metabrainz/oauth/tests/test_oauth_registration_request.py
@@ -262,7 +262,7 @@ class OAuthRegistrationRequestTestCase(OAuthTestCase):
         application = self.create_oauth_app()
         self._allow_registration_request_client(application)
 
-        response = self._create_registration_request(application, username="test-user-2")
+        response = self._create_registration_request(application, username="TEST-USER-2")
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json["error"], "invalid_request")
         self.assertEqual(response.json["error_description"], "The requested username is already in use.")

--- a/metabrainz/supporter/views_test.py
+++ b/metabrainz/supporter/views_test.py
@@ -388,7 +388,7 @@ class SupportersViewsTestCase(FlaskTestCase):
         response = self.client.post(
             url_for('supporters.signup_commercial', tier_id=self.tier.id),
             data={
-                "username": "existing-test-user",
+                "username": "EXISTING-TEST-USER",
                 "email": "newemail@example.com",
                 "password": "securepassword123",
                 "confirm_password": "securepassword123",
@@ -489,7 +489,7 @@ class SupportersViewsTestCase(FlaskTestCase):
         response = self.client.post(
             url_for('supporters.signup_noncommercial'),
             data={
-                "username": "existing-test-user",  # Already exists
+                "username": "EXISTING-TEST-USER",  # Already exists
                 "email": "newemail@example.com",
                 "password": "securepassword123",
                 "confirm_password": "securepassword123",

--- a/metabrainz/user/migrate_mb_users.py
+++ b/metabrainz/user/migrate_mb_users.py
@@ -39,7 +39,7 @@ to the watermark.
 
 ``old_editor_name`` has no id or update timestamp, so its comparatively small set of names
 is read in full on every run. Inserts into ``old_username`` skip names already present,
-making the repeated scan idempotent.
+using case-insensitive comparisons, making the repeated scan idempotent.
 """
 from datetime import datetime, timedelta, timezone
 from uuid import uuid4
@@ -158,7 +158,7 @@ INSERT_OLD_USERNAMES_QUERY = """
           WHERE NOT EXISTS (
                     SELECT 1
                       FROM old_username AS existing
-                     WHERE existing.username = candidate.username
+                     WHERE lower(existing.username) = lower(candidate.username)
                 )
 """
 

--- a/metabrainz/user/registration.py
+++ b/metabrainz/user/registration.py
@@ -16,7 +16,7 @@ def validate_registration_username(username: str | None) -> tuple[str, str | Non
         return username, "invalid_username"
     if User.get(name=username) is not None:
         return username, "username_taken"
-    if OldUsername.query.filter_by(username=username).first() is not None:
+    if OldUsername.get(username) is not None:
         return username, "username_not_allowed"
     return username, None
 

--- a/metabrainz/user/views_test.py
+++ b/metabrainz/user/views_test.py
@@ -175,13 +175,13 @@ class UsersViewsTestCase(FlaskTestCase):
         self.create_user()
 
         self._test_user_signup_helper({
-            "username": "test_user_1",
+            "username": "TEST_USER_1",
             "email": "test2@gmail.com",
             "password": "<PASSWORD>",
             "confirm_password": "<PASSWORD>",
         }, 200)
         props = json.loads(self.get_context_variable("props"))
-        self.assertEqual(props["initial_errors"], {"username": "Another user with username 'test_user_1' exists."})
+        self.assertEqual(props["initial_errors"], {"username": "Another user with username 'TEST_USER_1' exists."})
 
     def test_user_signup_logged_in(self):
         data = {
@@ -221,7 +221,7 @@ class UsersViewsTestCase(FlaskTestCase):
 
         current_dt = datetime.now(timezone.utc)
         self._test_user_login_helper({
-            "username": "test_user_1",
+            "username": "TEST_USER_1",
             "password": "<PASSWORD>",
         }, 302)
         self.assertEqual(current_user.name, "test_user_1")
@@ -1091,7 +1091,7 @@ class UsersViewsTestCase(FlaskTestCase):
 
         # Try to create a new user with the same username
         self._test_user_signup_helper({
-            "username": "test_user_1",
+            "username": "TEST_USER_1",
             "email": "newemail@example.com",
             "password": "<PASSWORD>",
             "confirm_password": "<PASSWORD>",


### PR DESCRIPTION
Compare active and retired usernames with LOWER() while preserving the spelling originally chosen for display. Enforce the same rule with functional indexes in SQLAlchemy metadata and bootstrap DDL so duplicate case variants cannot be created under concurrency.

Add an upgrade migration that locks the user table, reports any existing case-variant collisions with account IDs, and aborts before replacing the current indexes. This keeps deployed databases safe and leaves ambiguous identities for explicit moderation.

Apply shared case-insensitive validation to user and supporter administration, reserve a supporter's previous username after a rename, and turn concurrent uniqueness failures into form errors instead of server errors.

Expand model, login, registration, OAuth, supporter, and admin tests to cover mixed-case lookup, uniqueness, retired names, and edit conflicts.