### PR TITLE
Fix webhook delivery queue state boundaries

### DIFF
--- a/config.py.example
+++ b/config.py.example
@@ -168,6 +168,8 @@ WEBHOOK_TASK_SOFT_TIME_LIMIT = 90  # Soft timeout for Celery tasks (seconds)
 WEBHOOK_DEFAULT_RATE_LIMIT = '100/m'  # Default rate limit for webhook deliveries
 WEBHOOK_CIRCUIT_BREAKER_THRESHOLD = 5  # Number of failures before opening circuit breaker
 WEBHOOK_CIRCUIT_BREAKER_TIMEOUT = 300  # Seconds to wait before attempting recovery (5 minutes)
+WEBHOOK_PENDING_DELIVERY_TIMEOUT = 600  # Requeue pending deliveries not claimed within 10 minutes
+WEBHOOK_PROCESSING_DELIVERY_TIMEOUT = 300  # Recover deliveries abandoned by dead workers
 
 SIGNUP_RATE_LIMIT_PER_IP = 5
 REMEMBER_COOKIE_DURATION = timedelta(days=365)

--- a/consul_config.py.ctmpl
+++ b/consul_config.py.ctmpl
@@ -164,6 +164,8 @@ WEBHOOK_TASK_SOFT_TIME_LIMIT = {{template "KEY" "webhook/soft_time_limit"}}
 WEBHOOK_DEFAULT_RATE_LIMIT = '''{{template "KEY" "webhook/rate_limit"}}'''
 WEBHOOK_CIRCUIT_BREAKER_THRESHOLD = {{template "KEY" "webhook/circuit_breaker_threshold"}}
 WEBHOOK_CIRCUIT_BREAKER_TIMEOUT = {{template "KEY" "webhook/circuit_breaker_timeout"}}
+WEBHOOK_PENDING_DELIVERY_TIMEOUT = 600  # Requeue pending deliveries not claimed within 10 minutes
+WEBHOOK_PROCESSING_DELIVERY_TIMEOUT = 300  # Recover deliveries abandoned by dead workers
 
 STATIC_RESOURCES_DIR = '/static'
 

--- a/metabrainz/admin/webhooks.py
+++ b/metabrainz/admin/webhooks.py
@@ -14,6 +14,7 @@ from metabrainz.admin.forms import RetryDeliveryForm
 from metabrainz.model import db
 from metabrainz.model.webhook import Webhook, WebhookDelivery, EVENT_USER_CREATED, EVENT_USER_DELETED, \
     EVENT_USER_UPDATED
+from metabrainz.webhooks.tasks import enqueue_webhook_delivery
 
 
 def validate_webhook_url(form, field):
@@ -201,20 +202,31 @@ class WebhookDeliveryModelView(AdminModelView):
             
             count = 0
             skipped = 0
+            failed = 0
             for delivery in query.all():
                 if delivery.status in ["failed", "pending"]:
-                    delivery.status = "pending"
-                    delivery.error_message = None
-                    count += 1
+                    try:
+                        if enqueue_webhook_delivery(delivery):
+                            count += 1
+                        else:
+                            skipped += 1
+                    except Exception as error:
+                        failed += 1
+                        current_app.logger.error(
+                            "Failed to enqueue webhook delivery %s: %s",
+                            delivery.id,
+                            error,
+                            exc_info=True,
+                        )
                 else:
                     skipped += 1
-            
-            db.session.commit()
-            
+
             if count > 0:
                 flash(f"Queued {count} delivery(ies) for retry.", "success")
             if skipped > 0:
                 flash(f"Skipped {skipped} delivery(ies) (only failed/pending can be retried).", "info")
+            if failed > 0:
+                flash(f"Failed to queue {failed} delivery(ies). They will be retried automatically.", "error")
         except Exception as e:
             db.session.rollback()
             current_app.logger.error(f"Error retrying deliveries: {str(e)}", exc_info=True)
@@ -240,11 +252,14 @@ class WebhookDeliveryModelView(AdminModelView):
                 )
                 return redirect(url_for(".details_view", id=delivery_id))
 
-            delivery.status = "pending"
-            delivery.error_message = None
-            db.session.commit()
-
-            flash("Delivery has been queued for retry.", "success")
+            if enqueue_webhook_delivery(delivery):
+                flash("Delivery has been queued for retry.", "success")
+            else:
+                flash(
+                    "Delivery state changed before it could be queued. "
+                    "No retry task was created.",
+                    "warning",
+                )
         except Exception as e:
             db.session.rollback()
             current_app.logger.error(f"Error retrying delivery {delivery_id}: {str(e)}", exc_info=True)

--- a/metabrainz/model/webhook.py
+++ b/metabrainz/model/webhook.py
@@ -79,11 +79,8 @@ class Webhook(db.Model):
         db.session.add(delivery)
         db.session.commit()
 
-        from metabrainz.webhooks.tasks import deliver_webhook
-        deliver_webhook.apply_async(
-            args=[str(delivery.id)],
-            queue="webhooks"
-        )
+        from metabrainz.webhooks.tasks import publish_new_webhook_delivery
+        publish_new_webhook_delivery(delivery)
 
         return delivery
 

--- a/metabrainz/model/webhook_delivery.py
+++ b/metabrainz/model/webhook_delivery.py
@@ -42,12 +42,8 @@ class WebhookDelivery(db.Model):
 
     def process(self, session: requests.Session):
         """Process the webhook delivery by making an HTTP request to the webhook URL."""
-        if self.status not in ["pending", "failed"]:
+        if self.status != "processing":
             raise ValueError(f"Cannot process delivery in status {self.status}")
-
-        self.status = "processing"
-        self.updated_at = datetime.now(timezone.utc)
-        db.session.commit()
 
         try:
             headers = {

--- a/metabrainz/webhooks/delivery.py
+++ b/metabrainz/webhooks/delivery.py
@@ -105,6 +105,36 @@ class WebhookDeliveryEngine:
         if not webhook:
             raise WebhookDeliveryError(f"Webhook not found for delivery {delivery_id}")
 
+        # Atomically claim the row before checking the circuit or making an HTTP
+        # request. This makes stale-pending recovery safe when an older queued
+        # copy of the same Celery task eventually arrives.
+        claimed = WebhookDelivery.query.filter(
+            WebhookDelivery.id == delivery.id,
+            WebhookDelivery.status == "pending",
+        ).update(
+            {
+                WebhookDelivery.status: "processing",
+                WebhookDelivery.updated_at: datetime.now(timezone.utc),
+            },
+            synchronize_session=False,
+        )
+        db.session.commit()
+
+        if not claimed:
+            current_app.logger.info(
+                "Skipping webhook delivery %s because its status is %s",
+                delivery_id,
+                delivery.status,
+            )
+            return {
+                "success": False,
+                "delivery_id": str(delivery_id),
+                "skipped": True,
+                "error": f"Delivery is already {delivery.status}",
+            }
+
+        db.session.refresh(delivery)
+
         if not webhook.is_active:
             delivery.status = "failed"
             delivery.error_message = "Webhook is not active"

--- a/metabrainz/webhooks/tasks.py
+++ b/metabrainz/webhooks/tasks.py
@@ -3,11 +3,33 @@ from typing import Any
 
 from celery import shared_task
 from flask import current_app
+from sqlalchemy import and_, or_
 from sqlalchemy.exc import SQLAlchemyError
 
 from metabrainz.model import db
-from metabrainz.model.webhook_delivery import WebhookDelivery
+from metabrainz.model.webhook_delivery import (
+    WebhookDelivery,
+    WebhookDeliveryError,
+)
 from metabrainz.webhooks.delivery import WebhookDeliveryEngine
+
+
+def release_processing_delivery(delivery_id: str, error_message: str) -> None:
+    """Release a claimed delivery before Celery retries the task."""
+    db.session.rollback()
+    WebhookDelivery.query.filter(
+        WebhookDelivery.id == delivery_id,
+        WebhookDelivery.status == "processing",
+    ).update(
+        {
+            WebhookDelivery.status: "pending",
+            WebhookDelivery.error_message: error_message[:1000],
+            WebhookDelivery.next_retry_at: None,
+            WebhookDelivery.updated_at: datetime.now(timezone.utc),
+        },
+        synchronize_session=False,
+    )
+    db.session.commit()
 
 
 @shared_task(
@@ -34,13 +56,36 @@ def deliver_webhook(self, delivery_id: str):
             f"Starting webhook delivery {delivery_id} "
             f"(attempt {self.request.retries + 1})"
         )
-        WebhookDeliveryEngine.deliver(delivery_id)
+        return WebhookDeliveryEngine.deliver(delivery_id)
     except SQLAlchemyError as e:
         current_app.logger.error(
             f"Database error during webhook delivery {delivery_id}: {e}",
             exc_info=True
         )
+        try:
+            release_processing_delivery(
+                delivery_id,
+                f"Database error during webhook delivery: {e}",
+            )
+        except SQLAlchemyError:
+            db.session.rollback()
+            current_app.logger.error(
+                "Could not return webhook delivery %s to a retryable state",
+                delivery_id,
+                exc_info=True,
+            )
         raise self.retry(exc=e, countdown=2 ** self.request.retries * 60)
+    except WebhookDeliveryError as e:
+        current_app.logger.warning(
+            "Webhook delivery task %s was not run: %s",
+            delivery_id,
+            e,
+        )
+        return {
+            "success": False,
+            "delivery_id": delivery_id,
+            "error": str(e),
+        }
     except Exception as e:
         current_app.logger.error(
             f"Unexpected error during webhook delivery {delivery_id}: {e}",
@@ -48,17 +93,95 @@ def deliver_webhook(self, delivery_id: str):
         )
 
         try:
-            delivery = WebhookDelivery.query.get(delivery_id)
-            if delivery and delivery.status in ["pending", "processing"]:
-                delivery.status = "failed"
-                delivery.error_message = f"Unexpected error: {str(e)}"
-                delivery.schedule_retry()
-                delivery.updated_at = datetime.now(timezone.utc)
-                db.session.commit()
+            release_processing_delivery(
+                delivery_id,
+                f"Unexpected error: {e}",
+            )
         except Exception as update_error:
             current_app.logger.error(
                 f"Failed to update delivery {delivery_id} after error: {update_error}"
             )
+        raise self.retry(exc=e, countdown=2 ** self.request.retries * 60)
+
+
+def _publish_webhook_delivery(delivery_id, enqueued_at: datetime) -> None:
+    """Publish a delivery task and recover safely if broker publication fails."""
+    try:
+        deliver_webhook.apply_async(
+            args=[str(delivery_id)],
+            queue="webhooks",
+        )
+    except Exception as error:
+        db.session.rollback()
+        retry_at = datetime.now(timezone.utc) + timedelta(seconds=30)
+        WebhookDelivery.query.filter(
+            WebhookDelivery.id == delivery_id,
+            WebhookDelivery.status == "pending",
+            WebhookDelivery.updated_at == enqueued_at,
+        ).update(
+            {
+                WebhookDelivery.status: "failed",
+                WebhookDelivery.error_message: (
+                    f"Failed to enqueue webhook delivery: {error}"
+                )[:1000],
+                WebhookDelivery.next_retry_at: retry_at,
+                WebhookDelivery.updated_at: datetime.now(timezone.utc),
+            },
+            synchronize_session=False,
+        )
+        db.session.commit()
+        raise
+
+
+def publish_new_webhook_delivery(delivery: WebhookDelivery) -> None:
+    """Publish a newly committed pending delivery without another DB update."""
+    if delivery.status != "pending":
+        raise ValueError(
+            f"Cannot publish new delivery in status {delivery.status}"
+        )
+    _publish_webhook_delivery(delivery.id, delivery.updated_at)
+
+
+def _enqueue_webhook_delivery_if(
+    delivery_id,
+    *eligibility_conditions,
+) -> bool:
+    """
+    Atomically make an eligible delivery pending, then publish its task.
+
+    Duplicate queued tasks are safe because delivery workers atomically claim
+    pending rows. The eligibility conditions only need to prevent a retry from
+    resetting a completed or freshly claimed delivery.
+    """
+    enqueued_at = datetime.now(timezone.utc)
+    transitioned = WebhookDelivery.query.filter(
+        WebhookDelivery.id == delivery_id,
+        *eligibility_conditions,
+    ).update(
+        {
+            WebhookDelivery.status: "pending",
+            WebhookDelivery.error_message: None,
+            WebhookDelivery.next_retry_at: None,
+            WebhookDelivery.updated_at: enqueued_at,
+        },
+        synchronize_session=False,
+    )
+    db.session.commit()
+
+    if not transitioned:
+        return False
+
+    _publish_webhook_delivery(delivery_id, enqueued_at)
+    return True
+
+
+def enqueue_webhook_delivery(delivery: WebhookDelivery) -> bool:
+    """Queue an administrator-requested retry if it has not been claimed."""
+    return _enqueue_webhook_delivery_if(
+        delivery.id,
+        WebhookDelivery.status.in_(["failed", "pending"]),
+    )
+
 
 @shared_task(name="metabrainz.webhooks.tasks.retry_failed_webhooks")
 def retry_failed_webhooks() -> dict[str, Any]:
@@ -75,37 +198,62 @@ def retry_failed_webhooks() -> dict[str, Any]:
         current_app.logger.info("Starting webhook retry scheduler")
 
         now = datetime.now(timezone.utc)
-        deliveries_to_retry = WebhookDelivery.query.filter(
+        pending_timeout = current_app.config.get(
+            "WEBHOOK_PENDING_DELIVERY_TIMEOUT",
+            600,
+        )
+        processing_timeout = current_app.config.get(
+            "WEBHOOK_PROCESSING_DELIVERY_TIMEOUT",
+            300,
+        )
+        stale_pending_before = now - timedelta(
+            seconds=pending_timeout,
+        )
+        stale_processing_before = now - timedelta(
+            seconds=processing_timeout,
+        )
+        retry_eligibility = or_(
+            and_(
+                WebhookDelivery.status == "failed",
+                WebhookDelivery.next_retry_at.isnot(None),
+                WebhookDelivery.next_retry_at <= now,
+            ),
+            and_(
+                WebhookDelivery.status == "pending",
+                WebhookDelivery.updated_at <= stale_pending_before,
+            ),
+            and_(
+                WebhookDelivery.status == "processing",
+                WebhookDelivery.updated_at <= stale_processing_before,
+            ),
+        )
+        delivery_ids_to_retry = WebhookDelivery.query.filter(
             WebhookDelivery.webhook.has(is_active=True),
-            WebhookDelivery.status == "failed",
-            WebhookDelivery.next_retry_at.isnot(None),
-            WebhookDelivery.next_retry_at <= now
+            retry_eligibility,
+        ).with_entities(
+            WebhookDelivery.id,
         ).limit(1000).all()
 
         queued_count = 0
         error_count = 0
 
-        for delivery in deliveries_to_retry:
+        for delivery_id, in delivery_ids_to_retry:
             try:
-                delivery.status = "pending"
-                delivery.updated_at = datetime.now(timezone.utc)
-                db.session.commit()
-
-                deliver_webhook.apply_async(
-                    args=[str(delivery.id)],
-                    queue="webhooks"
-                )
-
-                queued_count += 1
+                if _enqueue_webhook_delivery_if(
+                    delivery_id,
+                    WebhookDelivery.webhook.has(is_active=True),
+                    retry_eligibility,
+                ):
+                    queued_count += 1
             except Exception as e:
                 error_count += 1
                 current_app.logger.error(
-                    f"Failed to re-queue delivery {delivery.id}: {e}",
-                    exc_info=True
+                    f"Failed to re-queue delivery {delivery_id}: {e}",
+                    exc_info=True,
                 )
 
         result = {
-            "found": len(deliveries_to_retry),
+            "found": len(delivery_ids_to_retry),
             "queued": queued_count,
             "errors": error_count,
         }

--- a/metabrainz/webhooks/tests/test_admin_webhooks.py
+++ b/metabrainz/webhooks/tests/test_admin_webhooks.py
@@ -1,8 +1,11 @@
+from unittest.mock import patch
+
 from flask import url_for
 
 from metabrainz.model import db
 from metabrainz.model.user import User
 from metabrainz.model.webhook import Webhook, EVENT_USER_CREATED, EVENT_USER_UPDATED
+from metabrainz.model.webhook_delivery import WebhookDelivery
 from metabrainz.testing import FlaskTestCase
 
 
@@ -19,6 +22,27 @@ class WebhookAdminTestCase(FlaskTestCase):
         )
         db.session.commit()
         self.temporary_login(self.admin_user)
+
+    def create_failed_delivery(self):
+        webhook = Webhook(
+            name="Retry Webhook",
+            url="https://example.com/retry",
+            secret="secret",
+            events=[EVENT_USER_CREATED],
+            is_active=True,
+        )
+        db.session.add(webhook)
+        db.session.flush()
+        delivery = WebhookDelivery(
+            webhook_id=webhook.id,
+            event_type=EVENT_USER_CREATED,
+            payload={"user_id": 1},
+            status="failed",
+            retry_count=1,
+        )
+        db.session.add(delivery)
+        db.session.commit()
+        return delivery
 
     def test_webhook_admin_index_requires_auth(self):
         """Test that webhook admin index requires authentication."""
@@ -323,3 +347,61 @@ class WebhookAdminTestCase(FlaskTestCase):
         self.assertEqual(len(webhook.events), 2)
         self.assertIn(EVENT_USER_CREATED, webhook.events)
         self.assertIn(EVENT_USER_UPDATED, webhook.events)
+
+    def test_retry_delivery_enqueues_task(self):
+        """The admin retry action must publish a delivery task."""
+        delivery = self.create_failed_delivery()
+        self.client.get(url_for(
+            "webhook-deliveries-admin.details_view",
+            id=delivery.id,
+        ))
+        csrf_token = self.get_context_variable(
+            "retry_form"
+        ).csrf_token.current_token
+
+        with patch(
+            "metabrainz.webhooks.tasks.deliver_webhook.apply_async"
+        ) as apply_async:
+            response = self.client.post(
+                url_for(
+                    "webhook-deliveries-admin.retry_delivery",
+                    delivery_id=delivery.id,
+                ),
+                data={"csrf_token": csrf_token},
+            )
+
+        self.assertEqual(response.status_code, 302)
+        apply_async.assert_called_once_with(
+            args=[str(delivery.id)],
+            queue="webhooks",
+        )
+        db.session.refresh(delivery)
+        self.assertEqual(delivery.status, "pending")
+
+    def test_retry_delivery_broker_failure_is_recoverable(self):
+        """A failed admin enqueue must leave the row retryable."""
+        delivery = self.create_failed_delivery()
+        self.client.get(url_for(
+            "webhook-deliveries-admin.details_view",
+            id=delivery.id,
+        ))
+        csrf_token = self.get_context_variable(
+            "retry_form"
+        ).csrf_token.current_token
+
+        with patch(
+            "metabrainz.webhooks.tasks.deliver_webhook.apply_async",
+            side_effect=RuntimeError("broker unavailable"),
+        ):
+            response = self.client.post(
+                url_for(
+                    "webhook-deliveries-admin.retry_delivery",
+                    delivery_id=delivery.id,
+                ),
+                data={"csrf_token": csrf_token},
+            )
+
+        self.assertEqual(response.status_code, 302)
+        db.session.refresh(delivery)
+        self.assertEqual(delivery.status, "failed")
+        self.assertIsNotNone(delivery.next_retry_at)

--- a/metabrainz/webhooks/tests/test_webhook_delivery_engine.py
+++ b/metabrainz/webhooks/tests/test_webhook_delivery_engine.py
@@ -218,6 +218,30 @@ class WebhookDeliveryEngineTestCase(FlaskTestCase):
         self.assertEqual(len(mock_requests.request_history), 0)
 
     @requests_mock.Mocker()
+    def test_duplicate_task_does_not_deliver_twice(self, mock_requests):
+        """Only one queued copy may claim and send a delivery."""
+        mock_requests.post(
+            "https://example.com/webhook",
+            status_code=200,
+            text="OK",
+        )
+        delivery = WebhookDelivery(
+            webhook_id=self.webhook.id,
+            event_type=EVENT_USER_CREATED,
+            payload=self.payload,
+            status="pending",
+        )
+        db.session.add(delivery)
+        db.session.commit()
+
+        first = WebhookDeliveryEngine.deliver(str(delivery.id))
+        second = WebhookDeliveryEngine.deliver(str(delivery.id))
+
+        self.assertTrue(first["success"])
+        self.assertTrue(second["skipped"])
+        self.assertEqual(len(mock_requests.request_history), 1)
+
+    @requests_mock.Mocker()
     def test_circuit_breaker_records_success(self, mock_requests):
         """Test that successful delivery records success in circuit breaker."""
         mock_requests.post(

--- a/metabrainz/webhooks/tests/test_webhook_tasks.py
+++ b/metabrainz/webhooks/tests/test_webhook_tasks.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timezone, timedelta
+from unittest.mock import patch
 
 import requests_mock
 
@@ -6,10 +7,13 @@ from metabrainz.model import db
 from metabrainz.model.webhook import Webhook, EVENT_USER_CREATED, EVENT_USER_UPDATED
 from metabrainz.model.webhook_delivery import WebhookDelivery
 from metabrainz.testing import FlaskTestCase
+from metabrainz.webhooks import tasks as webhook_tasks
 from metabrainz.webhooks.tasks import (
     deliver_webhook,
     retry_failed_webhooks,
-    cleanup_old_deliveries
+    cleanup_old_deliveries,
+    enqueue_webhook_delivery,
+    publish_new_webhook_delivery,
 )
 
 
@@ -146,20 +150,38 @@ class WebhookTasksTestCase(FlaskTestCase):
         db.session.add(inactive_webhook)
         db.session.commit()
 
-        delivery = WebhookDelivery(
-            webhook_id=inactive_webhook.id,
-            event_type=EVENT_USER_CREATED,
-            payload=self.payload,
-            status="failed",
-            retry_count=1,
-            next_retry_at=datetime.now(timezone.utc) - timedelta(minutes=5)
-        )
-        db.session.add(delivery)
+        now = datetime.now(timezone.utc)
+        deliveries = [
+            WebhookDelivery(
+                webhook_id=inactive_webhook.id,
+                event_type=EVENT_USER_CREATED,
+                payload=self.payload,
+                status="failed",
+                retry_count=1,
+                next_retry_at=now - timedelta(minutes=5),
+            ),
+            WebhookDelivery(
+                webhook_id=inactive_webhook.id,
+                event_type=EVENT_USER_CREATED,
+                payload=self.payload,
+                status="pending",
+                updated_at=now - timedelta(minutes=20),
+            ),
+            WebhookDelivery(
+                webhook_id=inactive_webhook.id,
+                event_type=EVENT_USER_CREATED,
+                payload=self.payload,
+                status="processing",
+                updated_at=now - timedelta(minutes=10),
+            ),
+        ]
+        db.session.add_all(deliveries)
         db.session.commit()
 
         result = retry_failed_webhooks()
         self.assertEqual(result["found"], 0)
         self.assertEqual(result["queued"], 0)
+        self.assertEqual(result["errors"], 0)
 
     def test_cleanup_old_deliveries_task(self):
         """Test cleanup_old_deliveries periodic task."""
@@ -215,3 +237,181 @@ class WebhookTasksTestCase(FlaskTestCase):
         self.assertEqual(result["found"], 0)
         self.assertEqual(result["queued"], 0)
         self.assertEqual(result["errors"], 0)
+
+    def test_enqueue_failure_restores_retryable_failed_state(self):
+        """A broker failure must not orphan a pending delivery."""
+        delivery = WebhookDelivery(
+            webhook_id=self.webhook.id,
+            event_type=EVENT_USER_CREATED,
+            payload=self.payload,
+            status="pending",
+        )
+        db.session.add(delivery)
+        db.session.commit()
+
+        with patch.object(
+            deliver_webhook,
+            "apply_async",
+            side_effect=RuntimeError("broker unavailable"),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "broker unavailable"):
+                enqueue_webhook_delivery(delivery)
+
+        db.session.refresh(delivery)
+        self.assertEqual(delivery.status, "failed")
+        self.assertEqual(delivery.retry_count, 0)
+        self.assertIsNotNone(delivery.next_retry_at)
+        self.assertIn("Failed to enqueue", delivery.error_message)
+
+    def test_new_delivery_publish_does_not_update_database_state(self):
+        """Publishing a newly created delivery does not need a DB transition."""
+        delivery = WebhookDelivery(
+            webhook_id=self.webhook.id,
+            event_type=EVENT_USER_CREATED,
+            payload=self.payload,
+            status="pending",
+        )
+        db.session.add(delivery)
+        db.session.commit()
+        original_updated_at = delivery.updated_at
+
+        with patch.object(deliver_webhook, "apply_async") as apply_async:
+            publish_new_webhook_delivery(delivery)
+
+        apply_async.assert_called_once_with(
+            args=[str(delivery.id)],
+            queue="webhooks",
+        )
+        db.session.refresh(delivery)
+        self.assertEqual(delivery.status, "pending")
+        self.assertEqual(delivery.updated_at, original_updated_at)
+
+    def test_stale_retry_cannot_resurrect_completed_delivery(self):
+        """A stale retry caller must not overwrite a newer delivery state."""
+        delivery = WebhookDelivery(
+            webhook_id=self.webhook.id,
+            event_type=EVENT_USER_CREATED,
+            payload=self.payload,
+            status="failed",
+            next_retry_at=datetime.now(timezone.utc) - timedelta(minutes=1),
+        )
+        db.session.add(delivery)
+        db.session.commit()
+
+        delivery_id = delivery.id
+        expected_updated_at = delivery.updated_at
+        db.session.expunge(delivery)
+
+        WebhookDelivery.query.filter(
+            WebhookDelivery.id == delivery_id,
+        ).update(
+            {
+                WebhookDelivery.status: "delivered",
+                WebhookDelivery.updated_at: datetime.now(timezone.utc),
+            },
+            synchronize_session=False,
+        )
+        db.session.commit()
+
+        stale_delivery = WebhookDelivery(
+            id=delivery_id,
+            status="failed",
+            updated_at=expected_updated_at,
+        )
+        with patch.object(deliver_webhook, "apply_async") as apply_async:
+            queued = enqueue_webhook_delivery(stale_delivery)
+
+        self.assertFalse(queued)
+        apply_async.assert_not_called()
+        current_delivery = db.session.get(
+            WebhookDelivery,
+            {"id": delivery_id},
+        )
+        self.assertEqual(current_delivery.status, "delivered")
+
+    def test_retry_task_recovers_stale_pending_delivery(self):
+        """Pending rows that were never claimed are eventually requeued."""
+        delivery = WebhookDelivery(
+            webhook_id=self.webhook.id,
+            event_type=EVENT_USER_CREATED,
+            payload=self.payload,
+            status="pending",
+            updated_at=datetime.now(timezone.utc) - timedelta(minutes=20),
+        )
+        db.session.add(delivery)
+        db.session.commit()
+
+        with patch.object(deliver_webhook, "apply_async") as apply_async:
+            result = retry_failed_webhooks()
+
+        self.assertEqual(result["found"], 1)
+        self.assertEqual(result["queued"], 1)
+        apply_async.assert_called_once_with(
+            args=[str(delivery.id)],
+            queue="webhooks",
+        )
+
+    def test_retry_task_recovers_stale_processing_delivery(self):
+        """Rows abandoned by a dead worker are eventually requeued."""
+        delivery = WebhookDelivery(
+            webhook_id=self.webhook.id,
+            event_type=EVENT_USER_CREATED,
+            payload=self.payload,
+            status="processing",
+            updated_at=datetime.now(timezone.utc) - timedelta(minutes=10),
+        )
+        db.session.add(delivery)
+        db.session.commit()
+
+        with patch.object(deliver_webhook, "apply_async") as apply_async:
+            result = retry_failed_webhooks()
+
+        self.assertEqual(result["found"], 1)
+        self.assertEqual(result["queued"], 1)
+        apply_async.assert_called_once_with(
+            args=[str(delivery.id)],
+            queue="webhooks",
+        )
+
+    def test_retry_task_does_not_reset_freshly_claimed_delivery(self):
+        """Retry eligibility is checked again during the pending transition."""
+        delivery = WebhookDelivery(
+            webhook_id=self.webhook.id,
+            event_type=EVENT_USER_CREATED,
+            payload=self.payload,
+            status="pending",
+            updated_at=datetime.now(timezone.utc) - timedelta(minutes=20),
+        )
+        db.session.add(delivery)
+        db.session.commit()
+
+        enqueue_if_eligible = webhook_tasks._enqueue_webhook_delivery_if
+
+        def claim_before_retry(delivery_id, *eligibility_conditions):
+            WebhookDelivery.query.filter(
+                WebhookDelivery.id == delivery_id,
+            ).update(
+                {
+                    WebhookDelivery.status: "processing",
+                    WebhookDelivery.updated_at: datetime.now(timezone.utc),
+                },
+                synchronize_session=False,
+            )
+            db.session.commit()
+            return enqueue_if_eligible(delivery_id, *eligibility_conditions)
+
+        with (
+            patch.object(
+                webhook_tasks,
+                "_enqueue_webhook_delivery_if",
+                side_effect=claim_before_retry,
+            ),
+            patch.object(deliver_webhook, "apply_async") as apply_async,
+        ):
+            result = retry_failed_webhooks()
+
+        self.assertEqual(result["found"], 1)
+        self.assertEqual(result["queued"], 0)
+        apply_async.assert_not_called()
+        db.session.refresh(delivery)
+        self.assertEqual(delivery.status, "processing")


### PR DESCRIPTION
Persist webhook delivery state consistently across the database and Celery publication boundary so broker or worker failures cannot leave deliveries permanently pending.

- centralize task publication for new, scheduled, and administrator-triggered deliveries
- return broker publication failures to a retryable failed state without consuming an HTTP retry
- recover stale pending rows and processing rows abandoned by dead workers
- require the related webhook to remain administrator-enabled for every scheduled retry state
- atomically claim pending deliveries before sending to suppress duplicate HTTP requests
- compare status and update timestamp when requeueing so stale callers cannot resurrect claimed or completed deliveries
- release processing claims before retrying task-level failures
- report concurrent retry transitions accurately in the administration interface