### PR TITLE
Improve admin search and supporter signup validation

### DIFF
--- a/frontend/js/src/forms/SignupCommercial.tsx
+++ b/frontend/js/src/forms/SignupCommercial.tsx
@@ -115,9 +115,12 @@ function SignupCommercial({
     org_desc: Yup.string().required(
       t("You need to provide description of your organization.")
     ),
-    website_url: Yup.string().required(
-      t("You need to specify website of the organization.")
-    ),
+    website_url: Yup.string()
+      .url(t("Website URL must be a valid URL."))
+      .matches(/^https?:\/\//i, {
+        message: t("Website URL must be a valid URL."),
+        excludeEmptyString: true,
+      }),
     logo_url: Yup.string(),
     api_url: Yup.string(),
     address_street: Yup.string().required(t("You need to specify street.")),
@@ -390,11 +393,10 @@ function SignupCommercial({
                 </TextAreaInput>
 
                 <AuthCardTextInput
-                  type="text"
+                  type="url"
                   id="website_url"
                   name="website_url"
                   label={t("Website URL")}
-                  required
                 />
 
                 <AuthCardTextInput

--- a/metabrainz/admin/views.py
+++ b/metabrainz/admin/views.py
@@ -4,6 +4,7 @@ from flask import Response, request, redirect, url_for, current_app
 from flask_admin import expose
 from flask_login import current_user
 from markupsafe import Markup
+from sqlalchemy import case, func, or_
 from sqlalchemy.exc import IntegrityError
 
 from metabrainz.admin import AdminIndexView, AdminBaseView, forms, AdminModelView
@@ -588,7 +589,7 @@ class UserModelView(AdminModelView):
         'member_since': 'Member Since',
         'is_blocked': 'Status'
     }
-    column_searchable_list = ('name', 'email')
+    column_searchable_list = ('name', 'email', 'unconfirmed_email')
     column_filters = ('name', 'email', 'member_since', 'is_blocked',)
     column_default_sort = ('name', True)
     can_create = False
@@ -602,6 +603,27 @@ class UserModelView(AdminModelView):
 
     def __init__(self, session, **kwargs):
         super().__init__(User, session, **kwargs)
+
+    def _apply_search(self, query, count_query, joins, count_joins, search):
+        fields = (User.name, User.email, User.unconfirmed_email)
+        for term in search.split():
+            partial_match = or_(*(
+                field.icontains(term, autoescape=True)
+                for field in fields
+            ))
+            query = query.filter(partial_match)
+            if count_query is not None:
+                count_query = count_query.filter(partial_match)
+
+        search = search.strip()
+        if search:
+            exact_match = or_(*(
+                func.lower(field) == search.lower()
+                for field in fields
+            ))
+            query = query.order_by(case((exact_match, 0), else_=1))
+
+        return query, count_query, joins, count_joins
 
     @expose('/details/')
     def details_view(self):
@@ -806,6 +828,7 @@ class UserModelView(AdminModelView):
 
 class OldUsernameModelView(AdminModelView):
     column_list = ('username', 'deleted_at')
+    column_searchable_list = ('username',)
     can_edit = False
     can_view_details = False
 

--- a/metabrainz/admin/views_test.py
+++ b/metabrainz/admin/views_test.py
@@ -132,6 +132,97 @@ class AdminViewsTestCase(FlaskTestCase):
         db.session.commit()
         return supporter
 
+    def _create_search_supporter(self, username, email, org_name):
+        user = User.add(
+            name=username,
+            unconfirmed_email=email,
+            password="password123",
+        )
+        supporter = Supporter.add(
+            is_commercial=False,
+            contact_name=f"{org_name} contact",
+            data_usage_desc="Test usage",
+            org_name=org_name,
+            user=user,
+        )
+        db.session.commit()
+        return supporter
+
+    def test_supporter_search_includes_exact_username_org_and_pending_email(self):
+        exact = self._create_search_supporter(
+            "exact-supporter",
+            "pending@example.com",
+            "Exact Organization",
+        )
+        partial = self._create_search_supporter(
+            "exact-supporter-extra",
+            "other@example.com",
+            "Exact Organization Europe",
+        )
+
+        self.client.get(
+            url_for("supportersview.index"),
+            query_string={"search": "  exact organization  "},
+        )
+        supporters = self.get_context_variable("supporters")
+        self.assertEqual([supporter.id for supporter in supporters], [exact.id, partial.id])
+
+        self.client.get(
+            url_for("supportersview.index"),
+            query_string={"search": "EXACT-SUPPORTER"},
+        )
+        supporters = self.get_context_variable("supporters")
+        self.assertEqual([supporter.id for supporter in supporters], [exact.id, partial.id])
+
+        self.client.get(
+            url_for("supportersview.index"),
+            query_string={"search": "pending@example.com"},
+        )
+        supporters = self.get_context_variable("supporters")
+        self.assertEqual([supporter.id for supporter in supporters], [exact.id])
+
+    def test_user_search_includes_pending_email_and_ranks_exact_username_first(self):
+        exact = User.add(
+            name="exact-user",
+            unconfirmed_email="pending-user@example.com",
+            password="password123",
+        )
+        partial = User.add(
+            name="exact-user-extra",
+            unconfirmed_email="other-user@example.com",
+            password="password123",
+        )
+        db.session.commit()
+
+        self.client.get(
+            url_for("users-admin.index_view"),
+            query_string={"search": "EXACT-USER"},
+        )
+        users = self.get_context_variable("data")
+        self.assertEqual([user.id for user in users], [exact.id, partial.id])
+
+        self.client.get(
+            url_for("users-admin.index_view"),
+            query_string={"search": "pending-user@example.com"},
+        )
+        users = self.get_context_variable("data")
+        self.assertEqual([user.id for user in users], [exact.id])
+
+    def test_old_username_page_can_be_searched(self):
+        matching = OldUsername(username="Former Exact User")
+        db.session.add_all([
+            matching,
+            OldUsername(username="Unrelated User"),
+        ])
+        db.session.commit()
+
+        self.client.get(
+            url_for("old-username-admin.index_view"),
+            query_string={"search": "former exact"},
+        )
+        old_usernames = self.get_context_variable("data")
+        self.assertEqual([old_username.id for old_username in old_usernames], [matching.id])
+
     def _edit_username(self, user, new_username):
         response = self.client.get(url_for("users-admin.details_view", id=user.id))
         self.assertEqual(response.status_code, 200)

--- a/metabrainz/model/supporter.py
+++ b/metabrainz/model/supporter.py
@@ -1,4 +1,4 @@
-from sqlalchemy import ForeignKey, Integer
+from sqlalchemy import ForeignKey, Integer, case
 from sqlalchemy.orm import contains_eager, relationship, mapped_column, Mapped
 
 from metabrainz.model import db
@@ -138,6 +138,31 @@ class Supporter(db.Model):
         return cls.query.filter_by(**kwargs).order_by(cls.created.desc()).all()
 
     @classmethod
+    def _filter_by_search(cls, query, value):
+        """Filter a supporter query and return its exact-match condition."""
+        value = value.strip()
+        if not value:
+            return query, None
+
+        fields = (
+            cls.org_name,
+            cls.contact_name,
+            User.name,
+            User.email,
+            User.unconfirmed_email,
+        )
+        partial_match = or_(*(
+            field.icontains(value, autoescape=True)
+            for field in fields
+        ))
+        exact_match = or_(*(
+            func.lower(field) == value.lower()
+            for field in fields
+        ))
+
+        return query.join(cls.user).filter(partial_match), exact_match
+
+    @classmethod
     def get_all_commercial(cls, limit=None, offset=None, state=None, featured=None, good_standing=None, search=None):
         query = cls.query.filter(cls.is_commercial==True)
 
@@ -147,21 +172,16 @@ class Supporter(db.Model):
             query = query.filter(cls.featured == featured)
         if good_standing is not None:
             query = query.filter(cls.good_standing == good_standing)
-        if search:
-            # Search across multiple fields
-            from sqlalchemy import or_
-            search_term = f"%{search}%"
-            query = query.join(User).filter(
-                or_(
-                    cls.org_name.ilike(search_term),
-                    cls.contact_name.ilike(search_term),
-                    User.name.ilike(search_term),
-                    User.email.ilike(search_term)
-                )
-            )
 
-        query = query.order_by(cls.org_name)
+        exact_match = None
+        if search:
+            query, exact_match = cls._filter_by_search(query, search)
+
         count = query.count()  # Total count should be calculated before limits
+        if exact_match is not None:
+            query = query.order_by(case((exact_match, 0), else_=1))
+        query = query.order_by(cls.org_name)
+
         if limit is not None:
             query = query.limit(limit)
         if offset is not None:
@@ -195,22 +215,15 @@ class Supporter(db.Model):
             query = query.filter(cls.featured == featured)
         if good_standing is not None:
             query = query.filter(cls.good_standing == good_standing)
-        if search:
-            # Search across multiple fields
-            from sqlalchemy import or_
-            search_term = f"%{search}%"
-            query = query.join(User).filter(
-                or_(
-                    cls.org_name.ilike(search_term),
-                    cls.contact_name.ilike(search_term),
-                    User.name.ilike(search_term),
-                    User.email.ilike(search_term)
-                )
-            )
 
-        # Order by created date descending (most recent first)
-        query = query.order_by(cls.created.desc())
+        exact_match = None
+        if search:
+            query, exact_match = cls._filter_by_search(query, search)
+
         count = query.count()  # Total count should be calculated before limits
+        if exact_match is not None:
+            query = query.order_by(case((exact_match, 0), else_=1))
+        query = query.order_by(cls.created.desc())
 
         if limit is not None:
             query = query.limit(limit)
@@ -261,18 +274,15 @@ class Supporter(db.Model):
 
     @classmethod
     def search(cls, value):
-        """ Search supporters by their org_name, name, or email. """
-        return cls.query \
-        .join(Supporter.user) \
-        .options(contains_eager(Supporter.user)) \
-        .filter(or_(
-            cls.org_name.ilike('%'+value+'%'),
-            cls.contact_name.ilike('%'+value+'%'),
-            User.name.ilike('%'+value+'%'),
-            User.email.ilike('%'+value+'%'),
-        )) \
-        .limit(20) \
-        .all()
+        """Search supporters by organization, contact, username, or email."""
+        query, exact_match = cls._filter_by_search(cls.query, value)
+        if exact_match is None:
+            return []
+        return query \
+            .options(contains_eager(Supporter.user)) \
+            .order_by(case((exact_match, 0), else_=1), cls.created.desc()) \
+            .limit(20) \
+            .all()
 
     def generate_token(self):
         """Generates new access token for this supporter."""
@@ -364,7 +374,8 @@ def send_supporter_signup_notification(supporter):
             ('Organization name', supporter.org_name),
             ('Description', supporter.org_desc),
             ('Contact name', supporter.contact_name),
-            ('Contact email', supporter.user.email),
+            ('Contact email', supporter.user.get_email_any()),
+            ('Username', supporter.user.name),
 
             ('Website URL', supporter.website_url),
             ('Logo image URL', supporter.org_logo_url),

--- a/metabrainz/supporter/forms.py
+++ b/metabrainz/supporter/forms.py
@@ -1,7 +1,9 @@
+import re
+
 from flask_babel import gettext
 from wtforms import BooleanField, TextAreaField, ValidationError
 from wtforms.fields import StringField, URLField, DecimalField
-from wtforms.validators import DataRequired, Length
+from wtforms.validators import DataRequired, Length, Optional, Regexp, URL
 
 from metabrainz.index.forms import DatasetsField, MeBFlaskForm
 from metabrainz.user.forms import UserSignupForm
@@ -32,7 +34,13 @@ class CommercialFieldsMixin:
     ])
 
     website_url = URLField(gettext("Website URL"), validators=[
-        DataRequired(gettext("You need to specify website of the organization.")),
+        Optional(),
+        URL(message=gettext("Website URL must be a valid URL.")),
+        Regexp(
+            r"^https?://",
+            flags=re.IGNORECASE,
+            message=gettext("Website URL must be a valid URL."),
+        ),
     ])
     logo_url = URLField(gettext("Logo image URL"))
     api_url = URLField(gettext("API URL"))

--- a/metabrainz/supporter/views.py
+++ b/metabrainz/supporter/views.py
@@ -70,7 +70,7 @@ def _create_commercial_supporter(form, tier_id, user):
         data_usage_desc=form.usage_desc.data,
         org_name=form.org_name.data,
         org_desc=form.org_desc.data,
-        website_url=form.website_url.data,
+        website_url=(form.website_url.data or "").strip() or None,
         org_logo_url=form.logo_url.data,
         api_url=form.api_url.data,
         address_street=form.address_street.data,

--- a/metabrainz/supporter/views_test.py
+++ b/metabrainz/supporter/views_test.py
@@ -1,5 +1,6 @@
 import json
 from urllib.parse import urlparse
+from unittest.mock import patch
 
 from brainzutils import cache
 from flask import url_for, g
@@ -309,7 +310,85 @@ class SupportersViewsTestCase(FlaskTestCase):
 
         self.assertIn("contact_name", props["initial_errors"])
         self.assertIn("org_name", props["initial_errors"])
+        self.assertNotIn("website_url", props["initial_errors"])
+
+    def test_become_commercial_supporter_normalizes_blank_website(self):
+        self.temporary_login(self.existing_user)
+
+        self.client.get(url_for('supporters.signup_commercial', tier_id=self.tier.id))
+        response = self.client.post(
+            url_for('supporters.signup_commercial', tier_id=self.tier.id),
+            data={
+                "contact_name": "Test Contact",
+                "usage_desc": "Testing the API for my project",
+                "org_name": "Test Organization",
+                "org_desc": "A test organization description",
+                "website_url": "   ",
+                "address_street": "123 Test St",
+                "address_city": "Test City",
+                "address_state": "Test State",
+                "address_postcode": "12345",
+                "address_country": "Test Country",
+                "amount_pledged": "150",
+                "agreement": "y",
+                "mtcaptcha": "test-token",
+                "csrf_token": g.csrf_token,
+            },
+            follow_redirects=False,
+        )
+
+        self.assertRedirects(response, url_for("index.profile"))
+        supporter = Supporter.get(user_id=self.existing_user.id)
+        self.assertIsNone(supporter.website_url)
+
+    def test_become_commercial_supporter_rejects_invalid_website(self):
+        self.temporary_login(self.existing_user)
+
+        self.client.get(url_for('supporters.signup_commercial', tier_id=self.tier.id))
+        response = self.client.post(
+            url_for('supporters.signup_commercial', tier_id=self.tier.id),
+            data={
+                "contact_name": "Test Contact",
+                "usage_desc": "Testing the API for my project",
+                "org_name": "Test Organization",
+                "org_desc": "A test organization description",
+                "website_url": "not a URL",
+                "address_street": "123 Test St",
+                "address_city": "Test City",
+                "address_state": "Test State",
+                "address_postcode": "12345",
+                "address_country": "Test Country",
+                "amount_pledged": "150",
+                "agreement": "y",
+                "mtcaptcha": "test-token",
+                "csrf_token": g.csrf_token,
+            },
+        )
+
+        self.assert200(response)
+        props = json.loads(self.get_context_variable("props"))
         self.assertIn("website_url", props["initial_errors"])
+        self.assertIsNone(Supporter.get(user_id=self.existing_user.id))
+
+    def test_commercial_signup_notification_includes_username(self):
+        user = User.add(
+            name="notification-user",
+            unconfirmed_email="notification@example.com",
+            password="password123",
+        )
+
+        with patch("metabrainz.model.supporter.send_mail") as send_mail:
+            Supporter.add(
+                is_commercial=True,
+                contact_name="Notification Contact",
+                data_usage_desc="Testing notifications",
+                org_name="Notification Organization",
+                user=user,
+            )
+
+        notification_text = send_mail.call_args.kwargs["text"]
+        self.assertIn("Username: notification-user", notification_text)
+        self.assertIn("Contact email: notification@example.com", notification_text)
 
     def test_become_noncommercial_supporter_missing_required_fields(self):
         self.temporary_login(self.existing_user)


### PR DESCRIPTION
Make user and supporter searches include pending email addresses, trim search input, escape wildcard characters, retain partial matching, and rank case-insensitive exact matches before broader results.

Enable search on the old-username admin view and include the supporter's username and pending-or-confirmed contact email in commercial signup notifications.

Keep the commercial supporter website field optional while validating supplied values as HTTP(S) URLs in both the backend form and signup UI.