### PR TITLE
Fix OAuth token cleanup performance

### DIFF
--- a/admin/schema_updates/2026-07-28-add-oauth-token-cleanup-indexes.sql
+++ b/admin/schema_updates/2026-07-28-add-oauth-token-cleanup-indexes.sql
@@ -1,0 +1,9 @@
+-- Run without a surrounding transaction so writes can continue while these
+-- indexes are built.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS access_token_cleanup_idx
+    ON oauth.access_token (issued_at, id)
+    WHERE issued_at IS NOT NULL;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS refresh_token_cleanup_idx
+    ON oauth.refresh_token (issued_at, id)
+    WHERE issued_at IS NOT NULL;

--- a/admin/sql/oauth/create_indexes.sql
+++ b/admin/sql/oauth/create_indexes.sql
@@ -16,10 +16,14 @@ CREATE INDEX code_client_id_idx ON oauth.code (client_id);
 CREATE INDEX access_token_user_id_idx ON oauth.access_token (user_id);
 CREATE INDEX access_token_client_id_idx ON oauth.access_token (client_id);
 CREATE INDEX access_token_authorization_code_id_idx ON oauth.access_token (authorization_code_id);
+CREATE INDEX access_token_cleanup_idx ON oauth.access_token (issued_at, id)
+    WHERE issued_at IS NOT NULL;
 
 CREATE INDEX refresh_token_user_id_idx ON oauth.refresh_token (user_id);
 CREATE INDEX refresh_token_client_id_idx ON oauth.refresh_token (client_id);
 CREATE INDEX refresh_token_authorization_code_id_idx ON oauth.refresh_token (authorization_code_id);
+CREATE INDEX refresh_token_cleanup_idx ON oauth.refresh_token (issued_at, id)
+    WHERE issued_at IS NOT NULL;
 
 CREATE INDEX l_access_token_scope_access_token_id_idx ON oauth.l_access_token_scope (access_token_id);
 CREATE INDEX l_access_token_scope_scope_id_idx ON oauth.l_access_token_scope (scope_id);

--- a/metabrainz/oauth/tasks.py
+++ b/metabrainz/oauth/tasks.py
@@ -3,51 +3,91 @@ from typing import Any
 
 from celery import shared_task
 from flask import current_app
-from sqlalchemy import text
+from sqlalchemy import Table, and_, delete, or_, select
 
-from metabrainz.model import db
+from metabrainz.model import OAuth2AccessToken, OAuth2RefreshToken, db
 
 
-DELETE_OLD_TOKENS_SQL = """
-DELETE FROM oauth.{table_name}
-WHERE
-    (
-        COALESCE(revoked, FALSE) = TRUE
-        AND issued_at IS NOT NULL
-        AND issued_at < :cutoff_date
+TOKEN_CLEANUP_BATCH_SIZE = 5_000
+
+
+def _cleanup_token_table(
+    token_table: Table,
+    cutoff_date: datetime,
+    batch_size: int,
+) -> int:
+    deleted_total = 0
+    expires_at = (
+        token_table.c.issued_at
+        + token_table.c.expires_in * timedelta(seconds=1)
     )
-    OR (
-        issued_at IS NOT NULL
-        AND expires_in IS NOT NULL
-        AND issued_at + (expires_in * INTERVAL '1 second') < :cutoff_date
+    candidates = (
+        select(token_table.c.id)
+        .where(
+            token_table.c.issued_at.is_not(None),
+            token_table.c.issued_at < cutoff_date,
+            or_(
+                token_table.c.revoked.is_(True),
+                and_(
+                    token_table.c.expires_in.is_not(None),
+                    expires_at < cutoff_date,
+                ),
+            ),
+        )
+        .order_by(token_table.c.issued_at, token_table.c.id)
+        .limit(batch_size)
+        .with_for_update(skip_locked=True)
+        .cte("candidates")
     )
-"""
+    statement = delete(token_table).where(
+        token_table.c.id.in_(select(candidates.c.id))
+    )
+
+    while True:
+        result = db.session.execute(statement)
+        deleted = result.rowcount or 0
+        db.session.commit()
+        deleted_total += deleted
+
+        if deleted < batch_size:
+            return deleted_total
 
 
 @shared_task(name="metabrainz.oauth.tasks.cleanup_old_tokens")
-def cleanup_old_tokens(days: int = 7) -> dict[str, Any]:
+def cleanup_old_tokens(
+    days: int = 7,
+    batch_size: int = TOKEN_CLEANUP_BATCH_SIZE,
+) -> dict[str, Any]:
     """
     Delete expired or revoked OAuth tokens older than the retention window.
+
+    Tokens are deleted and committed in bounded batches. Locked rows are
+    skipped and can be picked up by a later run.
 
     Revoked tokens do not currently store a revocation timestamp, so their
     age is based on issued_at. Expired tokens are deleted only when the
     computed expiry timestamp is older than the retention window.
     """
+    deleted_access_tokens = 0
+    deleted_refresh_tokens = 0
+
     try:
+        if batch_size <= 0:
+            raise ValueError("batch_size must be greater than zero")
+
         cutoff_date = datetime.now(timezone.utc) - timedelta(days=days)
 
-        access_token_result = db.session.execute(
-            text(DELETE_OLD_TOKENS_SQL.format(table_name="access_token")),
-            {"cutoff_date": cutoff_date},
+        deleted_access_tokens = _cleanup_token_table(
+            OAuth2AccessToken.__table__,
+            cutoff_date,
+            batch_size,
         )
-        refresh_token_result = db.session.execute(
-            text(DELETE_OLD_TOKENS_SQL.format(table_name="refresh_token")),
-            {"cutoff_date": cutoff_date},
+        deleted_refresh_tokens = _cleanup_token_table(
+            OAuth2RefreshToken.__table__,
+            cutoff_date,
+            batch_size,
         )
-        db.session.commit()
 
-        deleted_access_tokens = access_token_result.rowcount or 0
-        deleted_refresh_tokens = refresh_token_result.rowcount or 0
         result = {
             "access_tokens": deleted_access_tokens,
             "refresh_tokens": deleted_refresh_tokens,
@@ -66,8 +106,8 @@ def cleanup_old_tokens(days: int = 7) -> dict[str, Any]:
             exc_info=True,
         )
         return {
-            "access_tokens": 0,
-            "refresh_tokens": 0,
-            "total": 0,
+            "access_tokens": deleted_access_tokens,
+            "refresh_tokens": deleted_refresh_tokens,
+            "total": deleted_access_tokens + deleted_refresh_tokens,
             "error": str(e),
         }

--- a/metabrainz/oauth/tests/test_oauth_tasks.py
+++ b/metabrainz/oauth/tests/test_oauth_tasks.py
@@ -104,7 +104,8 @@ class OAuthTasksTestCase(OAuthTestCase):
         removed_refresh_ids = {old_expired_refresh.id, old_revoked_refresh.id}
         kept_refresh_ids = {recent_revoked_refresh.id, active_refresh.id}
 
-        result = cleanup_old_tokens(days=7)
+        # A batch size of one exercises multiple commits for each token table.
+        result = cleanup_old_tokens(days=7, batch_size=1)
 
         self.assertEqual(result["access_tokens"], 2)
         self.assertEqual(result["refresh_tokens"], 2)
@@ -128,3 +129,11 @@ class OAuthTasksTestCase(OAuthTestCase):
         self.assertEqual(schedule["task"], "metabrainz.oauth.tasks.cleanup_old_tokens")
         self.assertEqual(schedule["args"], (7,))
         self.assertEqual(schedule["options"], {"queue": "webhooks_maintenance"})
+
+    def test_cleanup_old_tokens_rejects_invalid_batch_size(self):
+        result = cleanup_old_tokens(days=7, batch_size=0)
+
+        self.assertEqual(result["access_tokens"], 0)
+        self.assertEqual(result["refresh_tokens"], 0)
+        self.assertEqual(result["total"], 0)
+        self.assertEqual(result["error"], "batch_size must be greater than zero")


### PR DESCRIPTION
Replace the monolithic OAuth token DELETE statements with bounded, lock-aware batches. Select up to 5,000 eligible token IDs at a time, ordered by issued_at and id, lock them with FOR UPDATE SKIP LOCKED, delete them, and commit each batch independently.

Add partial indexes on (issued_at, id) for both OAuth token tables so the database can efficiently locate and order cleanup candidates. Build the indexes concurrently when upgrading existing installations and add them to the bootstrap DDL for newly initialized databases.