### PR TITLE
Misc fixes after accounts migration

### DIFF
--- a/config.py.example
+++ b/config.py.example
@@ -132,10 +132,11 @@ OAUTH2_TOKEN_EXPIRES_IN = {
     "authorization_code": 3600,
     "implicit": 3600,
     "client_credentials": 3600,
-    # This entry configures the refresh token itself, not access tokens
-    # issued by the refresh token grant.
-    "refresh_token": 180 * 24 * 60 * 60,  # 6 months
 }
+# This entry configures the refresh token itself, not access tokens
+# issued by the refresh token grant and is therefore a separate variable
+# not a part of the OAUTH2_TOKEN_EXPIRES_IN dict.
+OAUTH2_REFRESH_TOKEN_EXPIRES_IN = 180 * 24 * 60 * 60  # 6 months
 OAUTH2_AUTHORIZATION_CODE_EXPIRES_IN = 600
 OAUTH2_REGISTRATION_REQUEST_EXPIRES_IN = 300
 

--- a/config.py.example
+++ b/config.py.example
@@ -132,6 +132,9 @@ OAUTH2_TOKEN_EXPIRES_IN = {
     "authorization_code": 3600,
     "implicit": 3600,
     "client_credentials": 3600,
+    # This entry configures the refresh token itself, not access tokens
+    # issued by the refresh token grant.
+    "refresh_token": 180 * 24 * 60 * 60,  # 6 months
 }
 OAUTH2_AUTHORIZATION_CODE_EXPIRES_IN = 600
 OAUTH2_REGISTRATION_REQUEST_EXPIRES_IN = 300

--- a/consul_config.py.ctmpl
+++ b/consul_config.py.ctmpl
@@ -36,8 +36,9 @@ SQLALCHEMY_MUSICBRAINZ_URI = 'postgresql://{{template "KEY" "postgresql/mb_usern
 {{end}}
 {{end}}
 
-{{if service "metabrainz-redis"}}
-{{with index (service "metabrainz-redis") 0}}
+{{- $redisService := key (printf "docker-server-configs/MeB/config.%s.json/%s" (env "DEPLOY_ENV") "redis/service") | trimSpace -}}
+{{if service $redisService}}
+{{with index (service $redisService) 0}}
 REDIS = {
     "host": '''{{.Address}}''',
     "port": {{.Port}},

--- a/consul_config.py.ctmpl
+++ b/consul_config.py.ctmpl
@@ -148,6 +148,9 @@ OAUTH2_TOKEN_EXPIRES_IN = {
     "authorization_code": 3600,
     "implicit": 3600,
     "client_credentials": 3600,
+    # This entry configures the refresh token itself, not access tokens
+    # issued by the refresh token grant.
+    "refresh_token": 180 * 24 * 60 * 60,  # 6 months
 }
 OAUTH2_AUTHORIZATION_CODE_EXPIRES_IN = 600
 

--- a/consul_config.py.ctmpl
+++ b/consul_config.py.ctmpl
@@ -149,10 +149,11 @@ OAUTH2_TOKEN_EXPIRES_IN = {
     "authorization_code": 3600,
     "implicit": 3600,
     "client_credentials": 3600,
-    # This entry configures the refresh token itself, not access tokens
-    # issued by the refresh token grant.
-    "refresh_token": 180 * 24 * 60 * 60,  # 6 months
 }
+# This entry configures the refresh token itself, not access tokens
+# issued by the refresh token grant and is therefore a separate variable
+# not a part of the OAUTH2_TOKEN_EXPIRES_IN dict.
+OAUTH2_REFRESH_TOKEN_EXPIRES_IN = 180 * 24 * 60 * 60  # 6 months
 OAUTH2_AUTHORIZATION_CODE_EXPIRES_IN = 600
 
 OIDC_ID_TOKEN_EXPIRATION = 3600

--- a/frontend/js/src/forms/ProfileChangePassword.tsx
+++ b/frontend/js/src/forms/ProfileChangePassword.tsx
@@ -3,7 +3,7 @@ import React, { JSX } from "react";
 import { useTranslation } from "react-i18next";
 import * as Yup from "yup";
 import { getPageProps, renderRoot } from "../utils";
-import { TextInput } from "./utils";
+import { PasswordInput } from "./utils";
 
 type ProfileChangePasswordProps = {
   csrf_token: string;
@@ -64,8 +64,7 @@ function ProfileChangePassword({
               )}
             </div>
 
-            <TextInput
-              type="password"
+            <PasswordInput
               id="current_password"
               name="current_password"
               label={t("Current Password")}
@@ -73,8 +72,7 @@ function ProfileChangePassword({
               required
             />
 
-            <TextInput
-              type="password"
+            <PasswordInput
               id="password"
               name="password"
               label={t("New Password")}
@@ -82,8 +80,7 @@ function ProfileChangePassword({
               required
             />
 
-            <TextInput
-              type="password"
+            <PasswordInput
               id="confirm_password"
               name="confirm_password"
               label={t("Confirm New Password")}

--- a/frontend/js/src/forms/ProfileChangePassword.tsx
+++ b/frontend/js/src/forms/ProfileChangePassword.tsx
@@ -3,7 +3,7 @@ import React, { JSX } from "react";
 import { useTranslation } from "react-i18next";
 import * as Yup from "yup";
 import { getPageProps, renderRoot } from "../utils";
-import { PasswordInput } from "./utils";
+import { AuthCardPasswordInput } from "./utils";
 
 type ProfileChangePasswordProps = {
   csrf_token: string;
@@ -31,7 +31,7 @@ function ProfileChangePassword({
         initialTouched={initial_errors}
         validationSchema={Yup.object({
           current_password: Yup.string().required(
-            t("Current password is required!")
+            t("Current password is required!"),
           ),
           password: Yup.string()
             .required(t("Password is required!"))
@@ -43,7 +43,7 @@ function ProfileChangePassword({
             .max(64)
             .oneOf(
               [Yup.ref("password")],
-              t("Confirm Password should match password!")
+              t("Confirm Password should match password!"),
             ),
         })}
         onSubmit={() => {}}
@@ -64,27 +64,30 @@ function ProfileChangePassword({
               )}
             </div>
 
-            <PasswordInput
+            <AuthCardPasswordInput
               id="current_password"
               name="current_password"
               label={t("Current Password")}
               autoComplete="current-password"
+              horizontal
               required
             />
 
-            <PasswordInput
+            <AuthCardPasswordInput
               id="password"
               name="password"
               label={t("New Password")}
               autoComplete="new-password"
+              horizontal
               required
             />
 
-            <PasswordInput
+            <AuthCardPasswordInput
               id="confirm_password"
               name="confirm_password"
               label={t("Confirm New Password")}
               autoComplete="new-password"
+              horizontal
               required
             />
 
@@ -125,6 +128,6 @@ document.addEventListener("DOMContentLoaded", () => {
     <ProfileChangePassword
       csrf_token={csrf_token}
       initial_errors={initial_errors}
-    />
+    />,
   );
 });

--- a/frontend/js/src/forms/password.ts
+++ b/frontend/js/src/forms/password.ts
@@ -1,0 +1,19 @@
+export const BCRYPT_MAX_PASSWORD_BYTES = 72;
+
+export function passwordExceedsBcryptByteLimit(
+  value: string | undefined
+): boolean {
+  return (
+    typeof value === "string" &&
+    new TextEncoder().encode(value).byteLength > BCRYPT_MAX_PASSWORD_BYTES
+  );
+}
+
+export function setPasswordByteLimitValidity(
+  input: HTMLInputElement,
+  errorMessage: string
+): void {
+  input.setCustomValidity(
+    passwordExceedsBcryptByteLimit(input.value) ? errorMessage : ""
+  );
+}

--- a/frontend/js/src/forms/utils.tsx
+++ b/frontend/js/src/forms/utils.tsx
@@ -1,6 +1,10 @@
 import React, { JSX } from "react";
 import { Field, FieldConfig, useField } from "formik";
 import { useTranslation } from "react-i18next";
+import {
+  passwordExceedsBcryptByteLimit,
+  setPasswordByteLimitValidity,
+} from "./password";
 
 export type FormLevelAlertProps = {
   errors: Record<string, string> | null | undefined;
@@ -20,18 +24,31 @@ export function getAuthPageUrl(path: "/login" | "/signup"): string {
 export type TextInputProps = JSX.IntrinsicElements["input"] &
   FieldConfig & {
     label: string;
+    inputRef?: React.RefObject<HTMLInputElement | null>;
   };
 
-export function TextInput({ label, children, ...props }: TextInputProps) {
+export function TextInput({
+  label,
+  children,
+  inputRef,
+  ...props
+}: TextInputProps) {
   const [field, meta] = useField(props);
   const hasError = meta.touched && meta.error;
+  const inputProps = { ...props };
+  delete inputProps.validate;
   return (
     <div className={`form-group ${hasError ? "has-error" : ""}`}>
       <label className="col-sm-4 control-label" htmlFor={props.id}>
         {label} {props.required && <span style={{ color: "red" }}>*</span>}
       </label>
       <div className="col-sm-5">
-        <input className="form-control" {...field} {...props} />
+        <input
+          className="form-control"
+          {...field}
+          {...inputProps}
+          ref={inputRef}
+        />
       </div>
       {children}
       {hasError ? (
@@ -129,17 +146,20 @@ export type AuthCardTextInputProps = JSX.IntrinsicElements["input"] &
     label: string | JSX.Element;
     labelLink?: string | JSX.Element;
     optionalInputButton?: JSX.Element;
+    inputRef?: React.RefObject<HTMLInputElement | null>;
   };
 
 export function AuthCardTextInput({
   label,
   labelLink,
   children,
+  inputRef,
   ...props
 }: AuthCardTextInputProps) {
   const [field, meta] = useField(props);
   const hasError = meta.touched && meta.error;
   const { optionalInputButton, ...otherProps } = props;
+  delete otherProps.validate;
   const labelElement = (
     <label className="control-label" htmlFor={props.id}>
       {label} {props.required && <span style={{ color: "red" }}>*</span>}
@@ -162,6 +182,7 @@ export function AuthCardTextInput({
           {...field}
           {...otherProps}
           required={props.required}
+          ref={inputRef}
         />
         {optionalInputButton}
       </div>
@@ -175,6 +196,22 @@ export function AuthCardTextInput({
 export function AuthCardPasswordInput({ ...props }: AuthCardTextInputProps) {
   const { t } = useTranslation();
   const [passwordVisible, setPasswordVisible] = React.useState(false);
+  const inputRef = React.useRef<HTMLInputElement>(null);
+  const byteLimitError = t("Password must not exceed 72 bytes.");
+  const { onInput, validate, ...inputProps } = props;
+  const updateByteLimitValidity = React.useCallback(
+    (input: HTMLInputElement) => {
+      setPasswordByteLimitValidity(input, byteLimitError);
+    },
+    [byteLimitError]
+  );
+
+  React.useEffect(() => {
+    if (inputRef.current) {
+      updateByteLimitValidity(inputRef.current);
+    }
+  }, [updateByteLimitValidity]);
+
   const glyphIcon = passwordVisible
     ? "glyphicon-eye-close"
     : "glyphicon-eye-open";
@@ -195,9 +232,57 @@ export function AuthCardPasswordInput({ ...props }: AuthCardTextInputProps) {
   );
   return (
     <AuthCardTextInput
-      {...props}
+      {...inputProps}
       type={passwordVisible ? "text" : "password"}
       optionalInputButton={passwordShowButton}
+      inputRef={inputRef}
+      validate={(value) => {
+        if (passwordExceedsBcryptByteLimit(value)) {
+          return byteLimitError;
+        }
+        return validate?.(value);
+      }}
+      onInput={(event) => {
+        updateByteLimitValidity(event.currentTarget);
+        onInput?.(event);
+      }}
+    />
+  );
+}
+
+export function PasswordInput({ ...props }: TextInputProps) {
+  const { t } = useTranslation();
+  const inputRef = React.useRef<HTMLInputElement>(null);
+  const byteLimitError = t("Password must not exceed 72 bytes.");
+  const { onInput, validate, ...inputProps } = props;
+  const updateByteLimitValidity = React.useCallback(
+    (input: HTMLInputElement) => {
+      setPasswordByteLimitValidity(input, byteLimitError);
+    },
+    [byteLimitError]
+  );
+
+  React.useEffect(() => {
+    if (inputRef.current) {
+      updateByteLimitValidity(inputRef.current);
+    }
+  }, [updateByteLimitValidity]);
+
+  return (
+    <TextInput
+      {...inputProps}
+      type="password"
+      inputRef={inputRef}
+      validate={(value) => {
+        if (passwordExceedsBcryptByteLimit(value)) {
+          return byteLimitError;
+        }
+        return validate?.(value);
+      }}
+      onInput={(event) => {
+        updateByteLimitValidity(event.currentTarget);
+        onInput?.(event);
+      }}
     />
   );
 }

--- a/frontend/js/src/forms/utils.tsx
+++ b/frontend/js/src/forms/utils.tsx
@@ -24,31 +24,18 @@ export function getAuthPageUrl(path: "/login" | "/signup"): string {
 export type TextInputProps = JSX.IntrinsicElements["input"] &
   FieldConfig & {
     label: string;
-    inputRef?: React.RefObject<HTMLInputElement | null>;
   };
 
-export function TextInput({
-  label,
-  children,
-  inputRef,
-  ...props
-}: TextInputProps) {
+export function TextInput({ label, children, ...props }: TextInputProps) {
   const [field, meta] = useField(props);
   const hasError = meta.touched && meta.error;
-  const inputProps = { ...props };
-  delete inputProps.validate;
   return (
     <div className={`form-group ${hasError ? "has-error" : ""}`}>
       <label className="col-sm-4 control-label" htmlFor={props.id}>
         {label} {props.required && <span style={{ color: "red" }}>*</span>}
       </label>
       <div className="col-sm-5">
-        <input
-          className="form-control"
-          {...field}
-          {...inputProps}
-          ref={inputRef}
-        />
+        <input className="form-control" {...field} {...props} />
       </div>
       {children}
       {hasError ? (
@@ -120,10 +107,7 @@ export type OAuthTextInputProps = JSX.IntrinsicElements["input"] &
     label: string;
   };
 
-export function OAuthTextInput({
-  label,
-  ...props
-}: OAuthTextInputProps) {
+export function OAuthTextInput({ label, ...props }: OAuthTextInputProps) {
   const [field, meta] = useField(props);
   const hasError = meta.touched && meta.error;
   return (
@@ -147,6 +131,7 @@ export type AuthCardTextInputProps = JSX.IntrinsicElements["input"] &
     labelLink?: string | JSX.Element;
     optionalInputButton?: JSX.Element;
     inputRef?: React.RefObject<HTMLInputElement | null>;
+    horizontal?: boolean;
   };
 
 export function AuthCardTextInput({
@@ -154,6 +139,7 @@ export function AuthCardTextInput({
   labelLink,
   children,
   inputRef,
+  horizontal = false,
   ...props
 }: AuthCardTextInputProps) {
   const [field, meta] = useField(props);
@@ -161,9 +147,24 @@ export function AuthCardTextInput({
   const { optionalInputButton, ...otherProps } = props;
   delete otherProps.validate;
   const labelElement = (
-    <label className="control-label" htmlFor={props.id}>
+    <label
+      className={`${horizontal ? "col-sm-4 " : ""}control-label`}
+      htmlFor={props.id}
+    >
       {label} {props.required && <span style={{ color: "red" }}>*</span>}
     </label>
+  );
+  const inputElement = (
+    <div className={optionalInputButton ? "input-group" : ""}>
+      <input
+        className="form-control"
+        {...field}
+        {...otherProps}
+        required={props.required}
+        ref={inputRef}
+      />
+      {optionalInputButton}
+    </div>
   );
   return (
     <div className={`form-group ${hasError ? "has-error" : ""}`}>
@@ -176,18 +177,19 @@ export function AuthCardTextInput({
         labelElement
       )}
       {children}
-      <div className={optionalInputButton ? "input-group" : ""}>
-        <input
-          className="form-control"
-          {...field}
-          {...otherProps}
-          required={props.required}
-          ref={inputRef}
-        />
-        {optionalInputButton}
-      </div>
+      {horizontal ? (
+        <div className="col-sm-5">{inputElement}</div>
+      ) : (
+        inputElement
+      )}
       {hasError ? (
-        <div className="small help-block text-danger">{meta.error}</div>
+        <div
+          className={`${
+            horizontal ? "col-sm-offset-4 col-sm-5 " : ""
+          }small help-block text-danger`}
+        >
+          {meta.error}
+        </div>
       ) : null}
     </div>
   );
@@ -203,7 +205,7 @@ export function AuthCardPasswordInput({ ...props }: AuthCardTextInputProps) {
     (input: HTMLInputElement) => {
       setPasswordByteLimitValidity(input, byteLimitError);
     },
-    [byteLimitError]
+    [byteLimitError],
   );
 
   React.useEffect(() => {
@@ -235,43 +237,6 @@ export function AuthCardPasswordInput({ ...props }: AuthCardTextInputProps) {
       {...inputProps}
       type={passwordVisible ? "text" : "password"}
       optionalInputButton={passwordShowButton}
-      inputRef={inputRef}
-      validate={(value) => {
-        if (passwordExceedsBcryptByteLimit(value)) {
-          return byteLimitError;
-        }
-        return validate?.(value);
-      }}
-      onInput={(event) => {
-        updateByteLimitValidity(event.currentTarget);
-        onInput?.(event);
-      }}
-    />
-  );
-}
-
-export function PasswordInput({ ...props }: TextInputProps) {
-  const { t } = useTranslation();
-  const inputRef = React.useRef<HTMLInputElement>(null);
-  const byteLimitError = t("Password must not exceed 72 bytes.");
-  const { onInput, validate, ...inputProps } = props;
-  const updateByteLimitValidity = React.useCallback(
-    (input: HTMLInputElement) => {
-      setPasswordByteLimitValidity(input, byteLimitError);
-    },
-    [byteLimitError]
-  );
-
-  React.useEffect(() => {
-    if (inputRef.current) {
-      updateByteLimitValidity(inputRef.current);
-    }
-  }, [updateByteLimitValidity]);
-
-  return (
-    <TextInput
-      {...inputProps}
-      type="password"
       inputRef={inputRef}
       validate={(value) => {
         if (passwordExceedsBcryptByteLimit(value)) {

--- a/metabrainz/__init__.py
+++ b/metabrainz/__init__.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import pprint
 import sys
@@ -20,6 +21,10 @@ from metabrainz.utils import get_global_props
 deploy_env = os.environ.get('DEPLOY_ENV', '')
 
 CONSUL_CONFIG_FILE_RETRY_COUNT = 10
+LOG_FORMAT = (
+    "[%(asctime)s] %(levelname)s %(name)s in "
+    "%(pathname)s:%(lineno)d: %(message)s"
+)
 
 # Service types control which set of blueprints (and admin views) a process serves.
 # This lets us run the website and the OAuth2 provider as separate, independently
@@ -32,6 +37,21 @@ SERVICE_WEB = "web"      # the website: everything except the OAuth2 endpoints
 SERVICE_OAUTH = "oauth"  # the OAuth2 provider: the full app, gated to OAuth2 traffic by the gateway
 
 bcrypt = Bcrypt()
+
+
+def configure_logging(app):
+    """Configure application and root handlers with a consistent log format."""
+    formatter = logging.Formatter(LOG_FORMAT)
+    root_logger = logging.getLogger()
+
+    if not root_logger.handlers:
+        root_logger.addHandler(logging.StreamHandler())
+
+    for handler in root_logger.handlers:
+        handler.setFormatter(formatter)
+
+    for handler in app.logger.handlers:
+        handler.setFormatter(formatter)
 
 
 def create_app(debug=None, config_path=None, service=SERVICE_ALL):
@@ -73,6 +93,8 @@ def create_app(debug=None, config_path=None, service=SERVICE_ALL):
 
     if debug is not None:
         app.debug = debug
+
+    configure_logging(app)
 
     if app.debug and app.config['SECRET_KEY']:
         app.init_debug_toolbar()

--- a/metabrainz/admin/views_test.py
+++ b/metabrainz/admin/views_test.py
@@ -567,3 +567,42 @@ class AdminViewsTestCase(FlaskTestCase):
         self.assertEqual(user.email, "new@example.com")
         self.assertIsNone(user.unconfirmed_email)
         self.assertMessageFlashed("User's email is already verified", "error")
+
+    def test_admin_reject_supporter_with_unconfirmed_email(self):
+        """ Rejecting a supporter who has not confirmed their email notifies the unconfirmed address. """
+        self._login_admin()
+        supporter = self.create_supporter()
+        supporter_id = supporter.id
+        self.assertIsNone(supporter.user.email)
+
+        with patch("metabrainz.model.supporter.send_mail") as send_mail:
+            response = self.client.get(
+                url_for("supportersview.reject"),
+                query_string={"supporter_id": supporter_id},
+            )
+
+        self.assertStatus(response, 302)
+        self.assertEqual(send_mail.call_args.kwargs["recipients"], ["regular@example.com"])
+
+        supporter = Supporter.get(id=supporter_id)
+        self.assertEqual(supporter.state, "rejected")
+
+    def test_admin_reject_supporter_without_any_email(self):
+        """ Rejecting a supporter who has no email address at all does not attempt to send mail. """
+        self._login_admin()
+        supporter = self.create_supporter()
+        supporter_id = supporter.id
+        supporter.user.unconfirmed_email = None
+        db.session.commit()
+
+        with patch("metabrainz.model.supporter.send_mail") as send_mail:
+            response = self.client.get(
+                url_for("supportersview.reject"),
+                query_string={"supporter_id": supporter_id},
+            )
+
+        self.assertStatus(response, 302)
+        send_mail.assert_not_called()
+
+        supporter = Supporter.get(id=supporter_id)
+        self.assertEqual(supporter.state, "rejected")

--- a/metabrainz/index/forms.py
+++ b/metabrainz/index/forms.py
@@ -7,6 +7,8 @@ from wtforms.validators import DataRequired
 from wtforms.validators import EqualTo, Length
 from wtforms.widgets.core import ListWidget, CheckboxInput
 
+from metabrainz.password import validate_bcrypt_password_length
+
 
 class MeBFlaskForm(FlaskForm):
 
@@ -61,10 +63,12 @@ class UserChangePasswordForm(MeBFlaskForm):
     """Password change form for logged in users."""
     current_password = PasswordField(validators=[
         DataRequired(gettext("Current password is required!")),
+        validate_bcrypt_password_length,
     ])
     password = PasswordField(validators=[
         DataRequired(gettext("Password is required!")),
-        Length(min=8, max=64)
+        Length(min=8, max=64),
+        validate_bcrypt_password_length,
     ])
     confirm_password = PasswordField(validators=[
         DataRequired(gettext("Confirm Password is required!")),

--- a/metabrainz/model/oauth/base_token.py
+++ b/metabrainz/model/oauth/base_token.py
@@ -2,6 +2,7 @@ from datetime import timedelta, datetime, timezone
 
 from authlib.integrations.flask_oauth2.requests import FlaskOAuth2Request
 from authlib.oauth2.rfc6749 import TokenMixin
+from flask import current_app
 from sqlalchemy import func, Column, Integer, DateTime, ForeignKey, Boolean, Identity
 from sqlalchemy.orm import relationship, declared_attr
 
@@ -108,11 +109,13 @@ def save_token(token_data, request: FlaskOAuth2Request):
     db.session.add(access_token)
 
     if refresh_token is not None:
+        # refresh tokens are long lived compared to access tokens, the expiry is renewed
+        # every time the refresh token is used to obtain a new access token.
         refresh_token = OAuth2RefreshToken(
             client_id=request.client.id,
             user_id=user_id,
             refresh_token=refresh_token,
-            expires_in=token_data["expires_in"],  # TODO: fix refresh token expiry, for existing retain or reset ?
+            expires_in=current_app.config["OAUTH2_TOKEN_EXPIRES_IN"]["refresh_token"],
             scopes=refresh_token_scopes,
             authorization_code_id=authorization_code_id
         )

--- a/metabrainz/model/oauth/base_token.py
+++ b/metabrainz/model/oauth/base_token.py
@@ -115,7 +115,7 @@ def save_token(token_data, request: FlaskOAuth2Request):
             client_id=request.client.id,
             user_id=user_id,
             refresh_token=refresh_token,
-            expires_in=current_app.config["OAUTH2_TOKEN_EXPIRES_IN"]["refresh_token"],
+            expires_in=current_app.config["OAUTH2_REFRESH_TOKEN_EXPIRES_IN"],
             scopes=refresh_token_scopes,
             authorization_code_id=authorization_code_id
         )

--- a/metabrainz/model/supporter.py
+++ b/metabrainz/model/supporter.py
@@ -353,11 +353,15 @@ class Supporter(db.Model):
                          "WAITING" if self.state == STATE_WAITING else \
                          "LIMITED" if self.state == STATE_LIMITED else \
                          self.state
-            send_mail(
-                subject="[MetaBrainz] Your account has been updated",
-                text='State of your MetaBrainz account has been changed to "%s".' % state_name,
-                recipients=[self.user.email],
-            )
+            # supporters whose email is not confirmed yet still need to be notified,
+            # but a supporter may have no email address at all (for instance, after
+            # the account is deleted) in which case there is nothing to notify.
+            if email := self.user.get_email_any():
+                send_mail(
+                    subject="[MetaBrainz] Your account has been updated",
+                    text='State of your MetaBrainz account has been changed to "%s".' % state_name,
+                    recipients=[email],
+                )
 
 
 def send_supporter_signup_notification(supporter):

--- a/metabrainz/model/supporter.py
+++ b/metabrainz/model/supporter.py
@@ -123,9 +123,6 @@ class Supporter(db.Model):
             raise TypeError('Unexpected **kwargs: %r' % kwargs)
         db.session.add(new_supporter)
 
-        if new_supporter.is_commercial:
-            send_supporter_signup_notification(new_supporter)
-
         return new_supporter
 
     @classmethod

--- a/metabrainz/oauth/authorization_server.py
+++ b/metabrainz/oauth/authorization_server.py
@@ -65,6 +65,9 @@ class CustomAuthorizationServer(AuthorizationServer):
         refresh_token_generator = create_token_generator(conf, 48)
 
         expires_conf = config.get("OAUTH2_TOKEN_EXPIRES_IN")
+        if isinstance(expires_conf, dict):
+            expires_conf = expires_conf.copy()
+            expires_conf.pop("refresh_token", None)
         expires_generator = create_token_expires_in_generator(expires_conf)
         return CustomBearerTokenGenerator(
             access_token_generator, refresh_token_generator, expires_generator

--- a/metabrainz/oauth/authorization_server.py
+++ b/metabrainz/oauth/authorization_server.py
@@ -65,9 +65,6 @@ class CustomAuthorizationServer(AuthorizationServer):
         refresh_token_generator = create_token_generator(conf, 48)
 
         expires_conf = config.get("OAUTH2_TOKEN_EXPIRES_IN")
-        if isinstance(expires_conf, dict):
-            expires_conf = expires_conf.copy()
-            expires_conf.pop("refresh_token", None)
         expires_generator = create_token_expires_in_generator(expires_conf)
         return CustomBearerTokenGenerator(
             access_token_generator, refresh_token_generator, expires_generator

--- a/metabrainz/oauth/tests/__init__.py
+++ b/metabrainz/oauth/tests/__init__.py
@@ -271,7 +271,7 @@ class OAuthTestCase(FlaskTestCase):
         db_refresh_token = next(token for token in refresh_tokens if token.refresh_token == data["refresh_token"])
         self.assertEqual(
             db_refresh_token.expires_in,
-            self.app.config["OAUTH2_TOKEN_EXPIRES_IN"]["refresh_token"],
+            self.app.config["OAUTH2_REFRESH_TOKEN_EXPIRES_IN"],
         )
         refresh_tokens = {token.refresh_token for token in refresh_tokens}
         self.assertIn(data["refresh_token"], refresh_tokens)
@@ -325,6 +325,14 @@ class OAuthTestCase(FlaskTestCase):
             OAuth2RefreshToken.user_id == self.user2.id,
             OAuth2RefreshToken.revoked.is_(False),
         ).all()
+        db_refresh_token = next(
+            token for token in refresh_tokens
+            if token.refresh_token == new_token["refresh_token"]
+        )
+        self.assertEqual(
+            db_refresh_token.expires_in,
+            self.app.config["OAUTH2_REFRESH_TOKEN_EXPIRES_IN"],
+        )
         refresh_tokens = {token.refresh_token for token in refresh_tokens}
         self.assertIn(new_token["refresh_token"], refresh_tokens)
         self.assertTrue(new_token["refresh_token"].startswith("mebr"))

--- a/metabrainz/oauth/tests/__init__.py
+++ b/metabrainz/oauth/tests/__init__.py
@@ -341,7 +341,12 @@ class OAuthTestCase(FlaskTestCase):
 
         return token
 
-    def introspection_success_helper(self, data):
+    def introspection_success_helper(self, data, expires_in=3600):
+        """ ``expires_in`` is the lifetime of the token being introspected.
+
+        Refresh tokens have their own lifetime, so callers introspecting one
+        pass OAUTH2_REFRESH_TOKEN_EXPIRES_IN rather than the access token
+        default. """
         self.temporary_login(self.user2)
 
         response = self.client.post("/oauth2/introspect", data=data)
@@ -355,6 +360,6 @@ class OAuthTestCase(FlaskTestCase):
         self.assertEqual(response.json["token_type"],  "Bearer")
         self.assertNotIn("metabrainz_user_id", response.json)
         self.assertIsNotNone(response.json["issued_at"])
-        self.assertEqual(response.json["expires_at"] - response.json["issued_at"], 3600)
+        self.assertEqual(response.json["expires_at"] - response.json["issued_at"], expires_in)
 
         self.assert_security_headers(response)

--- a/metabrainz/oauth/tests/__init__.py
+++ b/metabrainz/oauth/tests/__init__.py
@@ -268,6 +268,11 @@ class OAuthTestCase(FlaskTestCase):
             OAuth2RefreshToken.client_id == OAuth2Client.id,
             OAuth2RefreshToken.user_id == self.user2.id,
         ).all()
+        db_refresh_token = next(token for token in refresh_tokens if token.refresh_token == data["refresh_token"])
+        self.assertEqual(
+            db_refresh_token.expires_in,
+            self.app.config["OAUTH2_TOKEN_EXPIRES_IN"]["refresh_token"],
+        )
         refresh_tokens = {token.refresh_token for token in refresh_tokens}
         self.assertIn(data["refresh_token"], refresh_tokens)
         self.assertTrue(data["refresh_token"].startswith("mebr"))

--- a/metabrainz/oauth/tests/test_oauth_introspection.py
+++ b/metabrainz/oauth/tests/test_oauth_introspection.py
@@ -30,7 +30,7 @@ class IntrospectionTestCase(OAuthTestCase):
             "client_secret": application["client_secret"],
             "token": token["refresh_token"],
         }
-        self.introspection_success_helper(data)
+        self.introspection_success_helper(data, self.app.config["OAUTH2_REFRESH_TOKEN_EXPIRES_IN"])
 
         data = {
             "client_id": application["client_id"],
@@ -46,7 +46,7 @@ class IntrospectionTestCase(OAuthTestCase):
             "token": token["refresh_token"],
             "token_type_hint": "refresh_token",
         }
-        self.introspection_success_helper(data)
+        self.introspection_success_helper(data, self.app.config["OAUTH2_REFRESH_TOKEN_EXPIRES_IN"])
 
     def _test_oauth_introspection_error_helper(self, data):
         response = self.client.post("/oauth2/introspect", data=data)

--- a/metabrainz/oauth/tests/test_oauth_revocation.py
+++ b/metabrainz/oauth/tests/test_oauth_revocation.py
@@ -59,7 +59,7 @@ class RevocationTestCase(OAuthTestCase):
             "client_secret": application["client_secret"],
             "token": token["refresh_token"],
         }
-        self.introspection_success_helper(data)
+        self.introspection_success_helper(data, self.app.config["OAUTH2_REFRESH_TOKEN_EXPIRES_IN"])
         self.refresh_grant_success_helper(application, token)
 
     def test_oauth_revoke_refresh_token(self):
@@ -75,7 +75,7 @@ class RevocationTestCase(OAuthTestCase):
             "client_secret": application["client_secret"],
             "token": token["refresh_token"],
         }
-        self.introspection_success_helper(data)
+        self.introspection_success_helper(data, self.app.config["OAUTH2_REFRESH_TOKEN_EXPIRES_IN"])
 
         response = self.client.post("/oauth2/revoke", data=data)
         self.assert200(response)

--- a/metabrainz/password.py
+++ b/metabrainz/password.py
@@ -1,0 +1,13 @@
+from flask_babel import gettext
+from wtforms import ValidationError
+
+
+BCRYPT_MAX_PASSWORD_BYTES = 72
+
+
+def validate_bcrypt_password_length(form, field):
+    """Ensure bcrypt can hash or check the submitted password."""
+    if field.data and len(field.data.encode("utf-8")) > BCRYPT_MAX_PASSWORD_BYTES:
+        raise ValidationError(
+            gettext("Password must not exceed %(max_bytes)s bytes.", max_bytes=BCRYPT_MAX_PASSWORD_BYTES)
+        )

--- a/metabrainz/supporter/views.py
+++ b/metabrainz/supporter/views.py
@@ -8,7 +8,11 @@ from werkzeug.exceptions import NotFound, BadRequest
 
 from metabrainz import flash
 from metabrainz.model import Dataset, db
-from metabrainz.model.supporter import Supporter, InactiveSupporterException
+from metabrainz.model.supporter import (
+    InactiveSupporterException,
+    Supporter,
+    send_supporter_signup_notification,
+)
 from metabrainz.model.tier import Tier
 from metabrainz.model.token import TokenGenerationLimitException
 from metabrainz.model.user import User
@@ -64,7 +68,7 @@ def tier(tier_id):
 
 def _create_commercial_supporter(form, tier_id, user):
     """Create a commercial supporter record."""
-    Supporter.add(
+    return Supporter.add(
         is_commercial=True,
         contact_name=form.contact_name.data,
         data_usage_desc=form.usage_desc.data,
@@ -157,8 +161,9 @@ def signup_commercial():
     if form.validate_on_submit():
         if existing_user:
             # Existing user becoming a supporter
-            _create_commercial_supporter(form, tier_id, current_user)
+            supporter = _create_commercial_supporter(form, tier_id, current_user)
             db.session.commit()
+            send_supporter_signup_notification(supporter)
 
             flash.success(gettext(
                 "Thanks for becoming a supporter! Your application will be reviewed "
@@ -178,8 +183,9 @@ def signup_commercial():
                 }))
 
             user = User.add(name=form.username.data, unconfirmed_email=form.email.data, password=form.password.data)
-            _create_commercial_supporter(form, tier_id, user)
+            supporter = _create_commercial_supporter(form, tier_id, user)
             db.session.commit()
+            send_supporter_signup_notification(supporter)
             increment_signup_count()
 
             user.emit_event(EVENT_USER_CREATED)

--- a/metabrainz/supporter/views_test.py
+++ b/metabrainz/supporter/views_test.py
@@ -379,7 +379,7 @@ class SupportersViewsTestCase(FlaskTestCase):
         self.assertIn("website_url", props["initial_errors"])
         self.assertIsNone(Supporter.get(user_id=self.existing_user.id))
 
-    def test_commercial_signup_notification_includes_username(self):
+    def test_commercial_signup_notification_includes_signup_details(self):
         user = User.add(
             name="notification-user",
             unconfirmed_email="notification@example.com",

--- a/metabrainz/supporter/views_test.py
+++ b/metabrainz/supporter/views_test.py
@@ -9,7 +9,11 @@ from sqlalchemy import delete
 
 from metabrainz.model import db
 from metabrainz.model.dataset import Dataset
-from metabrainz.model.supporter import Supporter, STATE_ACTIVE
+from metabrainz.model.supporter import (
+    STATE_ACTIVE,
+    Supporter,
+    send_supporter_signup_notification,
+)
 from metabrainz.model.tier import Tier
 from metabrainz.model.user import User
 from metabrainz.testing import FlaskTestCase
@@ -173,28 +177,29 @@ class SupportersViewsTestCase(FlaskTestCase):
         self.assertEqual(props["tier"]["name"], "Test Tier")
         self.assertEqual(props["tier"]["price"], 100.0)
 
-        response = self.client.post(
-            url_for('supporters.signup_commercial', tier_id=self.tier.id),
-            data={
-                "contact_name": "Test Contact",
-                "usage_desc": "Testing the API for my project",
-                "org_name": "Test Organization",
-                "org_desc": "A test organization description",
-                "website_url": "https://example.com",
-                "logo_url": "https://example.com/logo.png",
-                "api_url": "https://api.example.com",
-                "address_street": "123 Test St",
-                "address_city": "Test City",
-                "address_state": "Test State",
-                "address_postcode": "12345",
-                "address_country": "Test Country",
-                "amount_pledged": "150",
-                "agreement": "y",
-                "mtcaptcha": "test-token",
-                "csrf_token": g.csrf_token,
-            },
-            follow_redirects=False
-        )
+        with patch("metabrainz.model.supporter.send_mail") as send_mail:
+            response = self.client.post(
+                url_for('supporters.signup_commercial', tier_id=self.tier.id),
+                data={
+                    "contact_name": "Test Contact",
+                    "usage_desc": "Testing the API for my project",
+                    "org_name": "Test Organization",
+                    "org_desc": "A test organization description",
+                    "website_url": "https://example.com",
+                    "logo_url": "https://example.com/logo.png",
+                    "api_url": "https://api.example.com",
+                    "address_street": "123 Test St",
+                    "address_city": "Test City",
+                    "address_state": "Test State",
+                    "address_postcode": "12345",
+                    "address_country": "Test Country",
+                    "amount_pledged": "150",
+                    "agreement": "y",
+                    "mtcaptcha": "test-token",
+                    "csrf_token": g.csrf_token,
+                },
+                follow_redirects=False
+            )
         self.assertRedirects(response, url_for('index.profile'))
 
         supporter = Supporter.query.filter_by(user_id=self.existing_user.id).first()
@@ -203,6 +208,10 @@ class SupportersViewsTestCase(FlaskTestCase):
         self.assertEqual(supporter.org_name, "Test Organization")
         self.assertEqual(supporter.contact_name, "Test Contact")
         self.assertEqual(float(supporter.amount_pledged), 150.0)
+        self.assertIn(
+            f"Tier: {self.tier.name} (#{self.tier.id})",
+            send_mail.call_args.kwargs["text"],
+        )
 
     def test_become_commercial_supporter_amount_pledged_validation(self):
         self.temporary_login(self.existing_user)
@@ -377,18 +386,26 @@ class SupportersViewsTestCase(FlaskTestCase):
             password="password123",
         )
 
+        supporter = Supporter.add(
+            is_commercial=True,
+            contact_name="Notification Contact",
+            data_usage_desc="Testing notifications",
+            org_name="Notification Organization",
+            tier_id=self.tier.id,
+            user=user,
+        )
+        db.session.commit()
+
         with patch("metabrainz.model.supporter.send_mail") as send_mail:
-            Supporter.add(
-                is_commercial=True,
-                contact_name="Notification Contact",
-                data_usage_desc="Testing notifications",
-                org_name="Notification Organization",
-                user=user,
-            )
+            send_supporter_signup_notification(supporter)
 
         notification_text = send_mail.call_args.kwargs["text"]
         self.assertIn("Username: notification-user", notification_text)
         self.assertIn("Contact email: notification@example.com", notification_text)
+        self.assertIn(
+            f"Tier: {self.tier.name} (#{self.tier.id})",
+            notification_text,
+        )
 
     def test_become_noncommercial_supporter_missing_required_fields(self):
         self.temporary_login(self.existing_user)

--- a/metabrainz/templates/users/reauthenticate.html
+++ b/metabrainz/templates/users/reauthenticate.html
@@ -14,7 +14,12 @@
     <div class="form-group">
       {{ form.password.label(class="col-sm-4 control-label") }}
       <div class="col-sm-5">
-        {{ form.password(class="form-control", autocomplete="current-password", required=True) }}
+        {{ form.password(
+          class="form-control",
+          autocomplete="current-password",
+          required=True,
+          data_max_utf8_bytes=72
+        ) }}
       </div>
     </div>
 
@@ -25,4 +30,22 @@
       </div>
     </div>
   </form>
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  <script>
+    document.addEventListener("DOMContentLoaded", function () {
+      var passwordInput = document.querySelector("[data-max-utf8-bytes]");
+      var byteLimitError = {{ _("Password must not exceed 72 bytes.")|tojson }};
+
+      function updatePasswordValidity() {
+        var byteLength = new TextEncoder().encode(passwordInput.value).byteLength;
+        passwordInput.setCustomValidity(byteLength > 72 ? byteLimitError : "");
+      }
+
+      passwordInput.addEventListener("input", updatePasswordValidity);
+      updatePasswordValidity();
+    });
+  </script>
 {% endblock %}

--- a/metabrainz/templates/users/reauthenticate.html
+++ b/metabrainz/templates/users/reauthenticate.html
@@ -44,7 +44,30 @@
         passwordInput.setCustomValidity(byteLength > 72 ? byteLimitError : "");
       }
 
-      passwordInput.addEventListener("input", updatePasswordValidity);
+      function throttle(callback, limit) {
+        var waiting = false;
+        var queued = false;
+
+        return function throttledCallback() {
+          if (waiting) {
+            queued = true;
+            return;
+          }
+
+          callback();
+          waiting = true;
+          window.setTimeout(function () {
+            waiting = false;
+            if (queued) {
+              queued = false;
+              throttledCallback();
+            }
+          }, limit);
+        };
+      }
+
+      var throttledUpdatePasswordValidity = throttle(updatePasswordValidity, 500);
+      passwordInput.addEventListener("input", throttledUpdatePasswordValidity);
       updatePasswordValidity();
     });
   </script>

--- a/metabrainz/user/forms.py
+++ b/metabrainz/user/forms.py
@@ -6,6 +6,7 @@ from wtforms.validators import DataRequired, EqualTo, Length
 from metabrainz.model.domain_blacklist import DomainBlacklist
 from metabrainz.index.forms import MeBFlaskForm
 from metabrainz.mtcaptcha import MTCaptchaField, validate_mtcaptcha
+from metabrainz.password import validate_bcrypt_password_length
 from metabrainz.user.username import validate_username
 
 
@@ -27,7 +28,8 @@ class UserSignupForm(MeBFlaskForm):
     ])
     password = PasswordField(validators=[
         DataRequired(gettext("Password is required!")),
-        Length(min=8, max=64)
+        Length(min=8, max=64),
+        validate_bcrypt_password_length,
     ])
     confirm_password = PasswordField(validators=[
         DataRequired(gettext("Confirm Password is required!")),
@@ -43,13 +45,19 @@ class UserSignupForm(MeBFlaskForm):
 class UserLoginForm(MeBFlaskForm):
     """ Login form for existing users. """
     username = StringField(gettext("Username"), validators=[DataRequired(gettext("Username is required!"))])
-    password = PasswordField(gettext("Password"), validators=[DataRequired(gettext("Password is required!"))])
+    password = PasswordField(gettext("Password"), validators=[
+        DataRequired(gettext("Password is required!")),
+        validate_bcrypt_password_length,
+    ])
     remember_me = BooleanField(gettext("Remember me"), default="checked")
 
 
 class UserReauthenticationForm(MeBFlaskForm):
     """Form for refreshing an existing login session."""
-    password = PasswordField(gettext("Password"), validators=[DataRequired(gettext("Password is required!"))])
+    password = PasswordField(gettext("Password"), validators=[
+        DataRequired(gettext("Password is required!")),
+        validate_bcrypt_password_length,
+    ])
 
 
 class ForgotUsernameForm(MeBFlaskForm):
@@ -67,7 +75,8 @@ class ResetPasswordForm(MeBFlaskForm):
     """ Form for a user to reset their password. """
     password = PasswordField(validators=[
         DataRequired(gettext("Password is required!")),
-        Length(min=8, max=64)
+        Length(min=8, max=64),
+        validate_bcrypt_password_length,
     ])
     confirm_password = PasswordField(validators=[
         DataRequired(gettext("Confirm Password is required!")),

--- a/metabrainz/user/views.py
+++ b/metabrainz/user/views.py
@@ -22,6 +22,15 @@ from metabrainz.user.registration import validate_registration_email
 users_bp = Blueprint("users", __name__)
 
 
+def _parse_link_timestamp(value):
+    try:
+        timestamp = int(value)
+        created_at = datetime.fromtimestamp(timestamp, tz=timezone.utc)
+    except (OSError, OverflowError, TypeError, ValueError):
+        return None
+    return timestamp, created_at
+
+
 @users_bp.route("/signup", methods=["GET", "POST"])
 @login_forbidden
 def signup():
@@ -154,8 +163,13 @@ def reauthenticate():
 def verify_email():
     """ User"s email verification endpoint. """
     user_id = request.args.get("user_id")
-    timestamp = int(request.args.get("timestamp"))
-    if datetime.fromtimestamp(timestamp) + current_app.config["EMAIL_VERIFICATION_EXPIRY"] <= datetime.now():
+    parsed_timestamp = _parse_link_timestamp(request.args.get("timestamp"))
+    if parsed_timestamp is None:
+        flash.error("Unable to verify email.")
+        return redirect(url_for("index.home"))
+
+    timestamp, created_at = parsed_timestamp
+    if created_at + current_app.config["EMAIL_VERIFICATION_EXPIRY"] <= datetime.now(timezone.utc):
         flash.error("Email verification link expired.")
         return redirect(url_for("index.home"))
 
@@ -312,8 +326,13 @@ def reset_password():
     """ User"s reset password endpoint. """
     user_id = request.args.get("user_id")
 
-    timestamp = int(request.args.get("timestamp"))
-    if datetime.fromtimestamp(timestamp) + current_app.config["EMAIL_RESET_PASSWORD_EXPIRY"] <= datetime.now():
+    parsed_timestamp = _parse_link_timestamp(request.args.get("timestamp"))
+    if parsed_timestamp is None:
+        flash.error("Unable to reset password.")
+        return redirect(url_for("index.home"))
+
+    timestamp, created_at = parsed_timestamp
+    if created_at + current_app.config["EMAIL_RESET_PASSWORD_EXPIRY"] <= datetime.now(timezone.utc):
         flash.error("Password reset link expired.")
         return redirect(url_for("index.home"))
 

--- a/metabrainz/user/views_test.py
+++ b/metabrainz/user/views_test.py
@@ -407,6 +407,21 @@ class UsersViewsTestCase(FlaskTestCase):
         self.assertEqual(response.status_code, 302)
         self.assertMessageFlashed("Unable to verify email.", "error")
 
+    def test_user_email_verify_invalid_timestamp(self):
+        for timestamp in (None, "not-a-timestamp"):
+            with self.subTest(timestamp=timestamp):
+                query_string = {"user_id": 1, "checksum": "invalid"}
+                if timestamp is not None:
+                    query_string["timestamp"] = timestamp
+
+                response = self.client.get(
+                    url_for("users.verify_email"),
+                    query_string=query_string,
+                )
+
+                self.assertRedirects(response, url_for("index.home"))
+                self.assertMessageFlashed("Unable to verify email.", "error")
+
     def test_user_email_verify_user_invalid(self):
         self.create_user()
 
@@ -705,6 +720,42 @@ class UsersViewsTestCase(FlaskTestCase):
         self.assertEqual(response.status_code, 302)
         self.assertFalse(current_user.is_anonymous)
         self.assertEqual(current_user.name, "test_user_1")
+
+    def test_reset_password_rejects_password_over_bcrypt_byte_limit(self):
+        self._test_forgot_password_helper({
+            "username": "test_user_1",
+            "email": "test@example.com",
+        }, 302)
+        reset_password_link = self.get_context_variable("reset_password_link")
+        password = "🔒" * 19
+
+        response = self.client.post(reset_password_link, data={
+            "password": password,
+            "confirm_password": password,
+            "csrf_token": g.csrf_token,
+        })
+
+        self.assertEqual(response.status_code, 200)
+        props = json.loads(self.get_context_variable("props"))
+        self.assertEqual(
+            props["initial_errors"],
+            {"password": "Password must not exceed 72 bytes."},
+        )
+
+    def test_reset_password_invalid_timestamp(self):
+        for timestamp in (None, "not-a-timestamp"):
+            with self.subTest(timestamp=timestamp):
+                query_string = {"user_id": 1, "checksum": "invalid"}
+                if timestamp is not None:
+                    query_string["timestamp"] = timestamp
+
+                response = self.client.post(
+                    url_for("users.reset_password"),
+                    query_string=query_string,
+                )
+
+                self.assertRedirects(response, url_for("index.home"))
+                self.assertMessageFlashed("Unable to reset password.", "error")
 
     def test_reset_password_missing_checksum(self):
         self.create_user()


### PR DESCRIPTION
- Fix OAuth refresh token expiration configuration
- Validate account links and bcrypt password length
- Include standard context in application logs
- Send supporter tier notification after commit
- Notify supporters at their available email address even if unconfirmed
- Use redis/service from consul to separate prod/test redis