### PR TITLE
Add a new privacy summary page

### DIFF
--- a/frontend/js/src/PrivacySummary.tsx
+++ b/frontend/js/src/PrivacySummary.tsx
@@ -1,0 +1,22 @@
+import React, { JSX } from "react";
+import { useTranslation } from "react-i18next";
+import PrivacySummaryContent from "./forms/PrivacySummaryContent";
+import { getPageProps, renderRoot } from "./utils";
+
+function PrivacySummary(): JSX.Element {
+  const { t } = useTranslation();
+
+  return (
+    <div className="well well-lg" style={{ maxWidth: "800px", margin: "0 auto" }}>
+      <h2 className="page-title">{t("Privacy Policy")}</h2>
+      <hr/>
+      <PrivacySummaryContent />
+    </div>
+  );
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  const { domContainer } = getPageProps();
+
+  renderRoot(domContainer, <PrivacySummary />);
+});

--- a/frontend/js/src/forms/ConditionsModal.tsx
+++ b/frontend/js/src/forms/ConditionsModal.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { Trans, useTranslation } from "react-i18next";
-import { ProjectIconPills } from "./utils";
+import { useTranslation } from "react-i18next";
+import PrivacySummaryContent from "./PrivacySummaryContent";
 
 export default function ConditionsModal() {
   const { t } = useTranslation();
@@ -20,69 +20,7 @@ export default function ConditionsModal() {
             </button>
             <h4 className="modal-title">{t("Privacy Policy")}</h4>
           </div>
-          <h5>{t("Licensing")}</h5>
-          <p>
-            {t(
-              "Any contributions you make to any MetaBrainz service will be released into the Public Domain and/or licensed under a Creative Commons by-nc-sa license. Furthermore, you give the MetaBrainz Foundation the right to license this data for commercial use."
-            )}
-            <br />
-            <Trans
-              defaults={t(
-                "Please read our <licenseLink>license page</licenseLink> for more details."
-              )}
-              components={{licenseLink: (
-                // eslint-disable-next-line jsx-a11y/anchor-has-content
-                <a
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  href="/social-contract"
-                />
-              )}}
-            />
-          </p>
-          <h5>{t("Privacy")}</h5>
-          <p>
-            {t(
-              "MetaBrainz strongly believes in the privacy of its users. Any personal information you choose to provide will not be sold or shared with anyone else."
-            )}
-            <br />
-            <Trans
-              defaults={t(
-                "Please read our <privacyLink>privacy policy</privacyLink> for more details."
-              )}
-              components={{privacyLink: (
-                // eslint-disable-next-line jsx-a11y/anchor-has-content
-                <a target="_blank" rel="noopener noreferrer" href="/privacy" />
-              )}}
-            />
-          </p>
-          <h5>{t("GDPR compliance")}</h5>
-          <p>
-            {t(
-              "You may remove your personal information from our services anytime by deleting your account."
-            )}
-            <br />
-            <Trans
-              defaults={t(
-                "Please read our <gdprLink>GDPR compliance statement</gdprLink> for more details."
-              )}
-              components={{gdprLink: (
-                // eslint-disable-next-line jsx-a11y/anchor-has-content
-                <a target="_blank" rel="noopener noreferrer" href="/gdpr" />
-              )}}
-            />
-          </p>
-          <hr />
-          <ProjectIconPills />
-          <p>
-            {t(
-              "Creating an account on MetaBrainz will give you access to all of our projects, such as MusicBrainz, ListenBrainz, BookBrainz, and more."
-            )}
-            <br />
-            {t(
-              "We create a placeholder account for all the MetaBrainz projects when you sign up, and you are one log-in away from activating them."
-            )}
-          </p>
+          <PrivacySummaryContent />
           <button
             className="btn btn-primary center-block"
             type="button"

--- a/frontend/js/src/forms/PrivacySummaryContent.tsx
+++ b/frontend/js/src/forms/PrivacySummaryContent.tsx
@@ -7,7 +7,7 @@ export default function PrivacySummaryContent(): JSX.Element {
 
   return (
     <>
-      <h5>{t("Licensing")}</h5>
+      <h5><b>{t("Licensing")}</b></h5>
       <p>
         {t(
           "Any contributions you make to any MetaBrainz service will be released into the Public Domain and/or licensed under a Creative Commons by-nc-sa license. Furthermore, you give the MetaBrainz Foundation the right to license this data for commercial use."
@@ -29,7 +29,7 @@ export default function PrivacySummaryContent(): JSX.Element {
           }}
         />
       </p>
-      <h5>{t("Privacy")}</h5>
+      <h5><b>{t("Privacy")}</b></h5>
       <p>
         {t(
           "MetaBrainz strongly believes in the privacy of its users. Any personal information you choose to provide will not be sold or shared with anyone else."
@@ -47,7 +47,7 @@ export default function PrivacySummaryContent(): JSX.Element {
           }}
         />
       </p>
-      <h5>{t("GDPR compliance")}</h5>
+      <h5><b>{t("GDPR compliance")}</b></h5>
       <p>
         {t(
           "You may remove your personal information from our services anytime by deleting your account."

--- a/frontend/js/src/forms/PrivacySummaryContent.tsx
+++ b/frontend/js/src/forms/PrivacySummaryContent.tsx
@@ -1,0 +1,81 @@
+import React, { JSX } from "react";
+import { Trans, useTranslation } from "react-i18next";
+import { ProjectIconPills } from "./utils";
+
+export default function PrivacySummaryContent(): JSX.Element {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <h5>{t("Licensing")}</h5>
+      <p>
+        {t(
+          "Any contributions you make to any MetaBrainz service will be released into the Public Domain and/or licensed under a Creative Commons by-nc-sa license. Furthermore, you give the MetaBrainz Foundation the right to license this data for commercial use."
+        )}
+        <br />
+        <Trans
+          defaults={t(
+            "Please read our <licenseLink>license page</licenseLink> for more details."
+          )}
+          components={{
+            licenseLink: (
+              // eslint-disable-next-line jsx-a11y/anchor-has-content
+              <a
+                target="_blank"
+                rel="noopener noreferrer"
+                href="/social-contract"
+              />
+            ),
+          }}
+        />
+      </p>
+      <h5>{t("Privacy")}</h5>
+      <p>
+        {t(
+          "MetaBrainz strongly believes in the privacy of its users. Any personal information you choose to provide will not be sold or shared with anyone else."
+        )}
+        <br />
+        <Trans
+          defaults={t(
+            "Please read our <privacyLink>privacy policy</privacyLink> for more details."
+          )}
+          components={{
+            privacyLink: (
+              // eslint-disable-next-line jsx-a11y/anchor-has-content
+              <a target="_blank" rel="noopener noreferrer" href="/privacy" />
+            ),
+          }}
+        />
+      </p>
+      <h5>{t("GDPR compliance")}</h5>
+      <p>
+        {t(
+          "You may remove your personal information from our services anytime by deleting your account."
+        )}
+        <br />
+        <Trans
+          defaults={t(
+            "Please read our <gdprLink>GDPR compliance statement</gdprLink> for more details."
+          )}
+          components={{
+            gdprLink: (
+              // eslint-disable-next-line jsx-a11y/anchor-has-content
+              <a target="_blank" rel="noopener noreferrer" href="/gdpr" />
+            ),
+          }}
+        />
+      </p>
+      <hr />
+      <ProjectIconPills />
+      <p>
+        {t(
+          "Creating an account on MetaBrainz will give you access to all of our projects, such as MusicBrainz, ListenBrainz, BookBrainz, and more."
+        )}
+        <br />
+        {t(
+          "We create a placeholder account for all the MetaBrainz projects when you sign up, and you are one log-in away from activating them."
+        )}
+      </p>
+    </>
+  );
+}

--- a/metabrainz/templates/users/privacy-summary.html
+++ b/metabrainz/templates/users/privacy-summary.html
@@ -1,0 +1,8 @@
+{% extends 'base-react.html' %}
+
+{% block title %}{{ _('Privacy Policy') }} - MetaBrainz Foundation{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  <script src="{{ get_static_path('privacySummary.js') }}" type="text/javascript"></script>
+{% endblock %}

--- a/metabrainz/user/views.py
+++ b/metabrainz/user/views.py
@@ -31,6 +31,11 @@ def _parse_link_timestamp(value):
     return timestamp, created_at
 
 
+@users_bp.route("/privacy-summary")
+def privacy_summary():
+    return render_template("users/privacy-summary.html", props=json.dumps({}))
+
+
 @users_bp.route("/signup", methods=["GET", "POST"])
 @login_forbidden
 def signup():

--- a/metabrainz/user/views_test.py
+++ b/metabrainz/user/views_test.py
@@ -101,6 +101,10 @@ class UsersViewsTestCase(FlaskTestCase):
         self.assertFalse(props["is_registration_request_signup"])
         self.assertIsNone(props["registration_request_client_name"])
 
+    def test_privacy_summary(self):
+        response = self.client.get(url_for("users.privacy_summary"))
+        self.assert200(response)
+
     def test_user_signup_missing_csrf_token(self):
         self._test_user_signup_missing_fields_helper({
             "username": "test_user_1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -58,6 +58,7 @@ export default function (env, argv) {
       oauthPrompt: path.resolve(jsDir, "src/forms/OAuthPrompt.tsx"),
       applications: path.resolve(jsDir, "src/Applications.tsx"),
       oauthError: path.resolve(jsDir, "src/OAuthError.tsx"),
+      privacySummary: path.resolve(jsDir, "src/PrivacySummary.tsx"),
       signupUser: path.resolve(jsDir, "src/forms/SignupUser.tsx"),
       loginUser: path.resolve(jsDir, "src/forms/LoginUser.tsx"),
       lostPassword: path.resolve(jsDir, "src/forms/LostPassword.tsx"),


### PR DESCRIPTION
This page is showing the content of the extra info modal we have on the signup page, and is destined to be used by third-parties that might want to create accounts programmatically.

This page should be linked to wherever a third-party creates a MeB account, along with a checkbox to agree to have users' contributions made public (like we have on the signup page):
> I accept that my contributions will be released into the public domain or licensed for use by the MetaBrainz Foundation, who will never share your personal information.

<img width="1197" height="969" alt="image" src="https://github.com/user-attachments/assets/92770c80-2031-4638-88cb-343947b8c299" />
