### PR TITLE
Trim whitespaces in usernames

### DIFF
--- a/metabrainz/model/user.py
+++ b/metabrainz/model/user.py
@@ -6,7 +6,7 @@ from flask_login import UserMixin
 from sqlalchemy import Column, Integer, Identity, Text, DateTime, Index, func, Boolean
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
-from sqlalchemy.orm import Mapped
+from sqlalchemy.orm import Mapped, validates
 
 from metabrainz.model import db
 from metabrainz.model.moderation_log import ModerationLog
@@ -90,11 +90,19 @@ class User(db.Model, UserMixin):
             return False
         return self.remember_me_until > datetime.now(timezone.utc)
 
+    @staticmethod
+    def normalize_name(name):
+        return name.strip() if isinstance(name, str) else name
+
+    @validates("name")
+    def _normalize_name(self, key, name):
+        return self.normalize_name(name)
+
     @classmethod
     def add(cls, **kwargs):
         from metabrainz import bcrypt
 
-        name = kwargs.pop("name")
+        name = cls.normalize_name(kwargs.pop("name"))
         if OldUsername.get(name) is not None:
             raise UsernameNotAllowedException()
 

--- a/metabrainz/model/user_test.py
+++ b/metabrainz/model/user_test.py
@@ -1,7 +1,8 @@
 from sqlalchemy.exc import IntegrityError
 
 from metabrainz.model import db
-from metabrainz.model.user import User
+from metabrainz.model.old_username import OldUsername
+from metabrainz.model.user import User, UsernameNotAllowedException
 from metabrainz.testing import FlaskTestCase
 
 
@@ -26,6 +27,39 @@ class UserModelTestCase(FlaskTestCase):
         )
         with self.assertRaises(IntegrityError):
             db.session.commit()
+
+    def test_add_trims_username_whitespace(self):
+        user = User.add(
+            name="  test-user \t",
+            unconfirmed_email="trimmed@example.com",
+            password="<PASSWORD>",
+        )
+        db.session.commit()
+
+        self.assertEqual(user.name, "test-user")
+        self.assertEqual(User.get(name="test-user"), user)
+
+    def test_name_assignment_trims_username_whitespace(self):
+        user = User.add(
+            name="test-user",
+            unconfirmed_email="trimmed@example.com",
+            password="<PASSWORD>",
+        )
+
+        user.name = "  renamed-user \t"
+
+        self.assertEqual(user.name, "renamed-user")
+
+    def test_add_checks_trimmed_username_against_old_usernames(self):
+        db.session.add(OldUsername(username="reserved-user"))
+        db.session.commit()
+
+        with self.assertRaises(UsernameNotAllowedException):
+            User.add(
+                name="  reserved-user \t",
+                unconfirmed_email="reserved@example.com",
+                password="<PASSWORD>",
+            )
 
     def test_add_requires_unconfirmed_email(self):
         with self.assertRaisesRegex(ValueError, "Email address is required."):

--- a/metabrainz/user/forms.py
+++ b/metabrainz/user/forms.py
@@ -18,10 +18,15 @@ def validate_email_domain(form, field):
 
 class UserSignupForm(MeBFlaskForm):
     """ Sign up form for new users. """
-    username = StringField(gettext("Username"), validators=[
-        DataRequired(gettext("Username is required!")),
-        validate_username,
-    ])
+    username = StringField(
+        gettext("Username"),
+        default="",
+        filters=[str.strip],
+        validators=[
+            DataRequired(gettext("Username is required!")),
+            validate_username,
+        ],
+    )
     email = EmailField(validators=[
         DataRequired(gettext("Email address is required!")),
         validate_email_domain

--- a/metabrainz/user/views_test.py
+++ b/metabrainz/user/views_test.py
@@ -95,6 +95,18 @@ class UsersViewsTestCase(FlaskTestCase):
         self.assertIsNotNone(user.last_updated)
         self.assertEqual(current_user, user)
 
+    def test_user_signup_trims_username_whitespace(self):
+        self._test_user_signup_helper({
+            "username": "  test_user_1 \t",
+            "email": "test@example.com",
+            "password": "<PASSWORD>",
+            "confirm_password": "<PASSWORD>",
+        }, 302)
+
+        user = User.get(name="test_user_1")
+        self.assertIsNotNone(user)
+        self.assertEqual(user.name, "test_user_1")
+
     def test_user_signup_regular_flow_is_not_registration_request_signup(self):
         self.client.get("/signup")
         props = json.loads(self.get_context_variable("props"))


### PR DESCRIPTION
Like it says on the tin, this PR adds usernames normalization to remove leading and trailign whitespaces using the python `str.strip()` method.
Applied both at form validation time (WTForms), but also at database insertion time (SQLALchemy) and when comparing against old (reserved) usernames.
Adds regression tests for each case.

Used Codex (AI) to generate the tests, and to suggest an approach for the sqlalchemy class validation method