### PR TITLE
Return email claims for OAuth email scope

### DIFF
--- a/metabrainz/oauth/oidc_grant.py
+++ b/metabrainz/oauth/oidc_grant.py
@@ -1,7 +1,27 @@
 from authlib.oidc.core import grants, UserInfo
+from authlib.oauth2.rfc6749.util import scope_to_list
 from flask import current_app
 
 from metabrainz.model import db, OAuth2AuthorizationCode, OAuth2Client
+
+
+def build_user_info(user, scope, include_member_since=False):
+    user_info = UserInfo(
+        sub=str(user.id),
+        username=user.name,
+    )
+
+    if include_member_since:
+        user_info["member_since"] = user.member_since.isoformat() if user.member_since else None
+
+    granted_scopes = set(scope_to_list(scope) or [])
+    if "email" in granted_scopes:
+        email = user.get_email_any()
+        if email:
+            user_info["email"] = email
+            user_info["email_verified"] = user.is_email_confirmed()
+
+    return user_info
 
 
 class OpenIDCodeMixin:
@@ -25,11 +45,7 @@ class OpenIDCodeMixin:
         }
 
     def generate_user_info(self, user, scope):
-        user_info = UserInfo(
-            sub=str(user.id),
-            username=user.name,
-        )
-        return user_info
+        return build_user_info(user, scope)
 
 
 class OpenIDCode(OpenIDCodeMixin, grants.OpenIDCode):

--- a/metabrainz/oauth/tests/__init__.py
+++ b/metabrainz/oauth/tests/__init__.py
@@ -98,6 +98,11 @@ class OAuthTestCase(FlaskTestCase):
         expected_scopes = [
             {"name": "profile", "description": "View your public account information"}
         ]
+        if "email" in query_string["scope"].split():
+            expected_scopes.append({
+                "name": "email",
+                "description": "View your email address"
+            })
         if openid:
             expected_scopes.append({
                 "name": "openid",
@@ -169,11 +174,12 @@ class OAuthTestCase(FlaskTestCase):
         self.authorize_oauth_prompt_confirm_helper(query_string, only_one_code=only_one_code)
 
     def authorize_success_for_token_grant_helper(self, application, redirect_uri,
-                                                 only_one_code=False, approval_prompt=None):
+                                                 only_one_code=False, approval_prompt=None,
+                                                 scope="profile"):
         query_string = {
             "client_id": application["client_id"],
             "response_type": "code",
-            "scope": "profile",
+            "scope": scope,
             "state": "random-state",
             "redirect_uri": redirect_uri,
         }

--- a/metabrainz/oauth/tests/test_openid.py
+++ b/metabrainz/oauth/tests/test_openid.py
@@ -58,6 +58,9 @@ class OpenIdIntegrationTestCase(OAuthTestCase):
     def test_openid_userinfo_endpoint_success(self):
         application = self.create_oauth_app()
         redirect_uri = "https://example.com/callback"
+        self.user2.email = "confirmed@example.com"
+        self.user2.email_confirmed_at = self.user2.member_since
+        db.session.commit()
 
         self.temporary_login(self.user2)
         code = self.authorize_success_for_token_grant_helper(application, redirect_uri, True)
@@ -74,6 +77,59 @@ class OpenIdIntegrationTestCase(OAuthTestCase):
         self.assertEqual(data["username"], self.user2.name)
         self.assertNotIn("metabrainz_user_id", data)
         self.assertEqual(data["member_since"], self.user2.member_since.isoformat())
+        self.assertNotIn("email", data)
+        self.assertNotIn("email_verified", data)
+        self.assert_security_headers(response)
+
+    def test_openid_userinfo_endpoint_returns_confirmed_email_with_email_scope(self):
+        application = self.create_oauth_app()
+        redirect_uri = "https://example.com/callback"
+        self.user2.email = "confirmed@example.com"
+        self.user2.email_confirmed_at = self.user2.member_since
+        db.session.commit()
+
+        self.temporary_login(self.user2)
+        code = self.authorize_success_for_token_grant_helper(
+            application,
+            redirect_uri,
+            True,
+            scope="profile email",
+        )
+        token = self.token_success_token_grant_helper(application, code, redirect_uri, True)
+
+        response = self.client.get(
+            "/oauth2/userinfo",
+            headers={"Authorization": f"Bearer {token['access_token']}"},
+        )
+
+        self.assert200(response)
+        self.assertEqual(response.json["email"], "confirmed@example.com")
+        self.assertIs(response.json["email_verified"], True)
+        self.assert_security_headers(response)
+
+    def test_openid_userinfo_endpoint_returns_unconfirmed_email_with_email_scope(self):
+        application = self.create_oauth_app()
+        redirect_uri = "https://example.com/callback"
+        self.user2.unconfirmed_email = "pending@example.com"
+        db.session.commit()
+
+        self.temporary_login(self.user2)
+        code = self.authorize_success_for_token_grant_helper(
+            application,
+            redirect_uri,
+            True,
+            scope="profile email",
+        )
+        token = self.token_success_token_grant_helper(application, code, redirect_uri, True)
+
+        response = self.client.get(
+            "/oauth2/userinfo",
+            headers={"Authorization": f"Bearer {token['access_token']}"},
+        )
+
+        self.assert200(response)
+        self.assertEqual(response.json["email"], "pending@example.com")
+        self.assertIs(response.json["email_verified"], False)
         self.assert_security_headers(response)
 
     def test_openid_userinfo_endpoint_missing_token(self):
@@ -134,6 +190,9 @@ class OpenIdIntegrationTestCase(OAuthTestCase):
     def test_openid_code_flow_success(self):
         application = self.create_oauth_app()
         redirect_uri = "https://example.com/callback"
+        self.user2.email = "confirmed@example.com"
+        self.user2.email_confirmed_at = self.user2.member_since
+        db.session.commit()
         query_string = {
             "client_id": application["client_id"],
             "response_type": "code",
@@ -175,6 +234,50 @@ class OpenIdIntegrationTestCase(OAuthTestCase):
         claims = _decode_id_token_claims(data["id_token"])
         self.assertEqual(claims["sub"], str(self.user2.id))
         self.assertEqual(claims["username"], self.user2.name)
+        self.assertNotIn("email", claims)
+        self.assertNotIn("email_verified", claims)
+        self.assert_security_headers(token_response)
+
+    def test_openid_code_flow_id_token_includes_email_claims_with_email_scope(self):
+        application = self.create_oauth_app()
+        redirect_uri = "https://example.com/callback"
+        self.user2.email = "confirmed@example.com"
+        self.user2.email_confirmed_at = self.user2.member_since
+        db.session.commit()
+        query_string = {
+            "client_id": application["client_id"],
+            "response_type": "code",
+            "scope": "openid profile email",
+            "state": "random-state",
+            "nonce": "test-nonce",
+            "redirect_uri": redirect_uri,
+        }
+
+        self.temporary_login(self.user2)
+        self.authorize_oauth_prompt_helper(query_string, openid=True)
+        response = self.client.post(
+            "/oauth2/authorize/confirm",
+            query_string=query_string,
+            data={"confirm": "yes", "csrf_token": g.csrf_token},
+        )
+        self.assertEqual(response.status_code, 302)
+        code = parse_qs(urlparse(response.location).query)["code"][0]
+
+        token_response = self.client.post(
+            "/oauth2/token",
+            data={
+                "client_id": application["client_id"],
+                "client_secret": application["client_secret"],
+                "grant_type": "authorization_code",
+                "redirect_uri": redirect_uri,
+                "code": code,
+            },
+        )
+
+        self.assert200(token_response)
+        claims = _decode_id_token_claims(token_response.json["id_token"])
+        self.assertEqual(claims["email"], "confirmed@example.com")
+        self.assertIs(claims["email_verified"], True)
         self.assert_security_headers(token_response)
 
     def test_openid_implicit_flow_id_token_token(self):

--- a/metabrainz/oauth/views.py
+++ b/metabrainz/oauth/views.py
@@ -12,6 +12,7 @@ from metabrainz.model.oauth.client import OAuth2ClientPrivilege
 from metabrainz.model.user import User
 from metabrainz.oauth.authorization_server import authorization_server
 from metabrainz.oauth.forms import AuthorizationForm
+from metabrainz.oauth.oidc_grant import build_user_info
 from metabrainz.oauth.registration_request import (
     create_registration_request,
     delete_registration_request,
@@ -324,11 +325,7 @@ def user_info():
 
     user = User.get(id=token.user_id)
 
-    return {
-        "sub": str(user.id),
-        "username": user.name,
-        "member_since": user.member_since.isoformat() if user.member_since else None,
-    }
+    return build_user_info(user, token.get_scope(), include_member_since=True)
 
 
 @oauth2_bp.route("/introspect", methods=["POST"])


### PR DESCRIPTION
Share claim construction between OIDC ID tokens and the UserInfo endpoint, and expose email and email_verified only when the access token has the email scope.

Cover confirmed and pending addresses and verify that email details are not leaked when the scope is absent.