### PR TITLE
Reject non-UUID session identifiers in load_user

### DIFF
--- a/metabrainz/user/__init__.py
+++ b/metabrainz/user/__init__.py
@@ -1,4 +1,5 @@
 from functools import wraps
+from uuid import UUID
 
 from flask import abort, flash, redirect, request, url_for
 from flask_login import LoginManager, current_user
@@ -15,10 +16,14 @@ login_manager.needs_refresh_message_category = "info"
 
 @login_manager.user_loader
 def load_user(login_id):
+    # Sessions created before get_id() switched from the integer primary key to login_id
+    # still carry an integer here. Reject anything that isn't a UUID before it reaches the
+    # database, otherwise postgres raises a DataError on the ::uuid cast.
     try:
-        return User.get(login_id=login_id)
-    except (ValueError, TypeError):
+        login_id = str(UUID(str(login_id)))
+    except (ValueError, TypeError, AttributeError):
         return None
+    return User.get(login_id=login_id)
 
 
 @login_manager.unauthorized_handler

--- a/metabrainz/user/load_user_test.py
+++ b/metabrainz/user/load_user_test.py
@@ -1,0 +1,43 @@
+from sqlalchemy import delete
+
+from metabrainz.model import db
+from metabrainz.model.user import User
+from metabrainz.testing import FlaskTestCase
+from metabrainz.user import load_user
+
+
+class LoadUserTestCase(FlaskTestCase):
+
+    def setUp(self):
+        super(LoadUserTestCase, self).setUp()
+        self.user = User.add(
+            name="test_user_1",
+            password="<PASSWORD>",
+            unconfirmed_email="test@example.com",
+        )
+        db.session.commit()
+
+    def tearDown(self):
+        db.session.rollback()
+        db.session.execute(delete(User))
+        db.session.commit()
+        super(LoadUserTestCase, self).tearDown()
+
+    def test_loads_user_by_login_id(self):
+        loaded = load_user(str(self.user.login_id))
+        self.assertIsNotNone(loaded)
+        self.assertEqual(loaded.id, self.user.id)
+
+    def test_legacy_integer_session_id_returns_none(self):
+        """ Sessions predating the switch from the integer primary key to login_id carry an
+        integer, which postgres cannot cast to uuid. """
+        self.assertIsNone(load_user(str(self.user.id)))
+        self.assertIsNone(load_user("560"))
+
+    def test_malformed_login_id_returns_none(self):
+        self.assertIsNone(load_user("garbage"))
+        self.assertIsNone(load_user(""))
+        self.assertIsNone(load_user(None))
+
+    def test_unknown_login_id_returns_none(self):
+        self.assertIsNone(load_user("00000000-0000-4000-8000-000000000000"))


### PR DESCRIPTION
User.get_id() returns login_id, a uuid column, but session and remember cookies issued before that change still carry the integer primary key. flask-login passes the stored value straight to the user loader, so those cookies reached the database as "user".login_id = '560'::uuid and raised sqlalchemy.exc.DataError, turning every request from an affected browser into a 500.

Parse the identifier as a UUID before querying and return None when it does not parse. flask-login then treats the request as anonymous, so a stale cookie logs the user out once instead of erroring. REMEMBER_COOKIE_DURATION is a year, so these cookies keep arriving for a long time and the check needs to stay.