### PR TITLE
Fix mail delivery and harden payment webhooks                                                                                                                                                                         

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ config.py
 .DS_Store
 *.csv
 .idea/
+
+# pytest --junitxml output
+/reports/

--- a/metabrainz/index/views.py
+++ b/metabrainz/index/views.py
@@ -1,7 +1,7 @@
 import datetime
 import json
 
-from flask import Blueprint, render_template, redirect, url_for, make_response, g, request
+from flask import Blueprint, current_app, render_template, redirect, url_for, make_response, g, request
 from flask_login import current_user, login_required, fresh_login_required, logout_user
 from flask_wtf.csrf import generate_csrf
 from werkzeug.exceptions import NotFound, Forbidden
@@ -207,32 +207,48 @@ def profile_edit():
         form = UserEditForm()
 
     if form.validate_on_submit():
+        email_conflict = False
         if current_user.email != form.email.data:
             user = User.get(email=form.email.data)
             if user is None:
                 current_user.unconfirmed_email = form.email.data
                 db.session.commit()
-                flash.success(f"Email verification link sent to {form.email.data}")
-                send_verification_email(
-                    current_user,
-                    "Please verify your email address",
-                    "email/user-email-address-verification.txt"
-                )
+                try:
+                    send_verification_email(
+                        current_user,
+                        "Please verify your email address",
+                        "email/user-email-address-verification.txt"
+                    )
+                except Exception:
+                    current_app.logger.exception(
+                        "Error sending verification email for user %s", current_user.id
+                    )
+                    flash.error(
+                        f"The verification email for {form.email.data} could not be sent. "
+                        f"Your email address is unchanged until it is verified. "
+                        f"Please request a new verification email from your profile."
+                    )
+                else:
+                    flash.success(f"Email verification link sent to {form.email.data}")
             else:
+                # The address belongs to someone else. Fall through to the form so
+                # the error is rendered instead of being discarded by the redirect.
+                email_conflict = True
                 form.email.errors.append(
                     f"The given email address ({form.email.data}) is associated with a different account."
                 )
 
-        if current_user.supporter:
-            kwargs = {
-                "contact_name": form.contact_name.data,
-            }
-            if not current_user.supporter.is_commercial:
-                kwargs["datasets"] = form.datasets.data
-            current_user.supporter.update(**kwargs)
+        if not email_conflict:
+            if current_user.supporter:
+                kwargs = {
+                    "contact_name": form.contact_name.data,
+                }
+                if not current_user.supporter.is_commercial:
+                    kwargs["datasets"] = form.datasets.data
+                current_user.supporter.update(**kwargs)
 
-        flash.success(gettext("Profile updated successfully."))
-        return redirect(url_for("index.profile"))
+            flash.success(gettext("Profile updated successfully."))
+            return redirect(url_for("index.profile"))
 
     form_data = {"email": current_user.email}
     if current_user.supporter:

--- a/metabrainz/invoices/send_invoices.py
+++ b/metabrainz/invoices/send_invoices.py
@@ -13,7 +13,7 @@ from quickbooks.objects.detailline import SalesItemLineDetail
 from quickbooks import exceptions
 
 from brainzutils import cache
-from brainzutils.mail import send_mail
+from metabrainz.mail import send_mail
 
 SEND_DELAY = 5
 MAIL_SUBJECT = "Invoice {invoice_number} from the MetaBrainz Foundation"

--- a/metabrainz/mail.py
+++ b/metabrainz/mail.py
@@ -1,0 +1,78 @@
+"""Application-owned email delivery helpers."""
+
+import smtplib
+import socket
+from email.mime.application import MIMEApplication
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from email.utils import formataddr
+
+from flask import current_app
+
+SMTP_TIMEOUT = 10
+
+
+def send_mail(
+    subject: str,
+    text: str,
+    recipients: list[str],
+    attachments=None,
+    from_name="MetaBrainz Notifications",
+    from_addr=None,
+    boundary=None,
+):
+    """Send an email to a list of bare email addresses.
+
+    Keeping display names out of ``recipients`` is intentional: the values are
+    also used as SMTP envelope addresses, where ``Name <address>`` is invalid.
+    """
+    if not isinstance(recipients, list):
+        raise ValueError("recipients must be a list of email addresses")
+
+    if "SMTP_SERVER" not in current_app.config or "SMTP_PORT" not in current_app.config:
+        raise ValueError("Flask current_app requires config items SMTP_SERVER and SMTP_PORT to be set")
+
+    if attachments is None:
+        attachments = []
+    if from_addr is None:
+        from_addr = "noreply@" + current_app.config["MAIL_FROM_DOMAIN"]
+
+    if current_app.config["TESTING"]:
+        return
+
+    if not recipients:
+        return
+
+    message = MIMEMultipart(boundary=boundary) if boundary is not None else MIMEMultipart()
+    message["To"] = ", ".join(recipients)
+    message["Subject"] = subject
+    message["From"] = formataddr((from_name, from_addr))
+    message.attach(MIMEText(text, _charset="utf-8"))
+
+    for file_obj, subtype, name in attachments:
+        attachment = MIMEApplication(file_obj.read(), _subtype=subtype)
+        file_obj.close()
+        attachment.add_header("content-disposition", "attachment", filename=name)
+        message.attach(attachment)
+
+    smtp_server = None
+    try:
+        smtp_server = smtplib.SMTP(
+            current_app.config["SMTP_SERVER"],
+            current_app.config["SMTP_PORT"],
+            timeout=SMTP_TIMEOUT,
+        )
+        smtp_server.sendmail(from_addr, recipients, message.as_string())
+    except (socket.error, smtplib.SMTPException) as exc:
+        current_app.logger.error("Error while sending email: %s", exc, exc_info=True)
+        raise MailException(exc) from exc
+    finally:
+        if smtp_server is not None:
+            try:
+                smtp_server.quit()
+            except (socket.error, smtplib.SMTPException) as exc:
+                current_app.logger.warning("Error while closing SMTP connection: %s", exc)
+
+
+class MailException(Exception):
+    """Email delivery failed."""

--- a/metabrainz/mail_test.py
+++ b/metabrainz/mail_test.py
@@ -1,0 +1,43 @@
+import smtplib
+import unittest
+from unittest.mock import patch
+
+from flask import Flask
+
+from metabrainz.mail import MailException, send_mail
+
+
+class SendMailTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.app = Flask(__name__)
+        self.app.config.update(
+            TESTING=False,
+            SMTP_SERVER="smtp.example.com",
+            SMTP_PORT=25,
+            MAIL_FROM_DOMAIN="metabrainz.org",
+        )
+
+    @patch("metabrainz.mail.smtplib.SMTP")
+    def test_uses_bare_recipient_for_header_and_envelope(self, smtp):
+        with self.app.app_context():
+            send_mail(
+                subject="Test subject",
+                text="Test body",
+                recipients=["recipient@example.com"],
+            )
+        from_addr, recipients, message = smtp.return_value.sendmail.call_args.args
+        self.assertEqual(from_addr, "noreply@metabrainz.org")
+        self.assertEqual(recipients, ["recipient@example.com"])
+        self.assertIn("To: recipient@example.com", message)
+
+    @patch("metabrainz.mail.smtplib.SMTP")
+    def test_wraps_smtp_delivery_errors(self, smtp):
+        smtp.return_value.sendmail.side_effect = smtplib.SMTPDataError(550, b"header syntax")
+
+        with self.app.app_context(), self.assertRaises(MailException):
+            send_mail(
+                subject="Test subject",
+                text="Test body",
+                recipients=["recipient@example.com"],
+            )

--- a/metabrainz/model/access_log.py
+++ b/metabrainz/model/access_log.py
@@ -1,7 +1,7 @@
 from metabrainz.model import db
 from metabrainz.model.token import Token
 from metabrainz.model.supporter import Supporter
-from brainzutils.mail import send_mail
+from metabrainz.mail import send_mail
 from brainzutils import cache
 from sqlalchemy import func, text
 from sqlalchemy.dialects import postgresql

--- a/metabrainz/model/payment.py
+++ b/metabrainz/model/payment.py
@@ -20,6 +20,19 @@ PAYMENT_METHOD_WEPAY = 'wepay'  # no longer supported
 PAYMENT_METHOD_CHECK = 'check'
 
 
+def _stripe_metadata_bool(metadata, key):
+    value = metadata.get(key)
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized == "true":
+            return True
+        if normalized == "false":
+            return False
+    raise ValueError(f"Invalid Stripe boolean metadata for {key}: {value!r}")
+
+
 class Payment(db.Model):
     __tablename__ = 'payment'
 
@@ -287,14 +300,20 @@ class Payment(db.Model):
         db.session.commit()
         logging.info('PayPal: Payment added. ID: %s.', new_payment.id)
 
-        send_receipt(
-            email=new_payment.email,
-            date=new_payment.payment_date,
-            amount=new_payment.amount,
-            name='%s %s' % (new_payment.first_name, new_payment.last_name),
-            is_donation=new_payment.is_donation,
-            editor_name=new_payment.editor_name,
-        )
+        # The payment is already committed and the duplicate guard above stops a
+        # retried IPN from getting this far, so a mail failure must not bubble up
+        # and fail the webhook.
+        try:
+            send_receipt(
+                email=new_payment.email,
+                date=new_payment.payment_date,
+                amount=new_payment.amount,
+                name='%s %s' % (new_payment.first_name, new_payment.last_name),
+                is_donation=new_payment.is_donation,
+                editor_name=new_payment.editor_name,
+            )
+        except Exception:
+            logging.exception("PayPal: Error sending receipt for payment %s", new_payment.id)
 
     @staticmethod
     def _extract_paypal_ipn_options(form: dict) -> dict:
@@ -366,6 +385,8 @@ class Payment(db.Model):
             current_app.logger.warning("Unsupported currency: ", transaction["currency"])
             return
 
+        is_donation = _stripe_metadata_bool(metadata, "is_donation")
+
         new_donation = cls(
             first_name=details["name"],
             last_name="",
@@ -374,7 +395,7 @@ class Payment(db.Model):
             currency=currency,
             transaction_id=charge["id"],
             payment_method=PAYMENT_METHOD_STRIPE,
-            is_donation=metadata["is_donation"],
+            is_donation=is_donation,
             email=details["email"],
             address_street=address["line1"],  # TODO: stripe also gives line2, should we use it?
             address_city=address["city"],
@@ -383,20 +404,9 @@ class Payment(db.Model):
             address_country=address["country"],
         )
 
-        if metadata["is_donation"] == "True":
-            new_donation.is_donation = 1
-        if metadata["is_donation"] == "False":
-            new_donation.is_donation = 0
-
         if new_donation.is_donation:
-            if metadata["can_contact"] == "True":
-                new_donation.can_contact = 1
-            else:
-                new_donation.can_contact = 0
-            if metadata["anonymous"] == "True":
-                new_donation.anonymous = 1
-            else:
-                new_donation.anonymous = 0
+            new_donation.can_contact = _stripe_metadata_bool(metadata, "can_contact")
+            new_donation.anonymous = _stripe_metadata_bool(metadata, "anonymous")
 
             if "editor" in metadata:
                 new_donation.editor_name = metadata["editor"]
@@ -409,20 +419,23 @@ class Payment(db.Model):
                 new_donation.supporter_id = metadata["supporter_id"]
 
         db.session.add(new_donation)
-        try:
-            db.session.commit()
-            logging.info("Stripe: Payment added. ID: %s.", new_donation.id)
-        except TypeError as err:
-            logging.error("Cannot record payment: ", err)
+        db.session.commit()
+        logging.info("Stripe: Payment added. ID: %s.", new_donation.id)
 
-        send_receipt(
-            email=new_donation.email,
-            date=new_donation.payment_date,
-            amount=new_donation.amount,
-            name=new_donation.first_name,  # Last name is not used with Stripe
-            is_donation=new_donation.is_donation,
-            editor_name=new_donation.editor_name,
-        )
+        # The payment is already committed and the duplicate guard above stops a
+        # retried webhook from getting this far, so a mail failure must not bubble
+        # up and fail the webhook.
+        try:
+            send_receipt(
+                email=new_donation.email,
+                date=new_donation.payment_date,
+                amount=new_donation.amount,
+                name=new_donation.first_name,  # Last name is not used with Stripe
+                is_donation=new_donation.is_donation,
+                editor_name=new_donation.editor_name,
+            )
+        except Exception:
+            logging.exception("Stripe: Error sending receipt for payment %s", new_donation.id)
 
 
 class PaymentAdminView(AdminModelView):

--- a/metabrainz/model/payment_test.py
+++ b/metabrainz/model/payment_test.py
@@ -452,6 +452,24 @@ class PaymentModelStripeTestCase(FlaskTestCase):
         self.assertEqual(len(Payment.query.all()), 1)
 
     @patch("stripe.PaymentIntent")
+    def test_log_stripe_charge_accepts_lowercase_boolean_metadata(self, mock_stripe):
+        payment_intent = self.payment_intent.copy()
+        payment_intent["metadata"] = {
+            "is_donation": "true",
+            "editor": "lucifer",
+            "anonymous": "false",
+            "can_contact": "true",
+        }
+        mock_stripe.retrieve.return_value = payment_intent
+
+        Payment.log_one_time_charge("usd", self.session_without_metadata)
+
+        payment = Payment.query.one()
+        self.assertIs(payment.is_donation, True)
+        self.assertIs(payment.anonymous, False)
+        self.assertIs(payment.can_contact, True)
+
+    @patch("stripe.PaymentIntent")
     def test_log_stripe_charge_payment(self, mock_stripe):
         # Function should execute without any exceptions
         payment_intent = self.payment_intent.copy()

--- a/metabrainz/model/supporter.py
+++ b/metabrainz/model/supporter.py
@@ -2,7 +2,7 @@ from sqlalchemy import ForeignKey, Integer, case
 from sqlalchemy.orm import contains_eager, relationship, mapped_column, Mapped
 
 from metabrainz.model import db
-from brainzutils.mail import send_mail
+from metabrainz.mail import send_mail
 from metabrainz.model.token import Token
 from sqlalchemy.sql.expression import func, or_
 from sqlalchemy.dialects import postgresql

--- a/metabrainz/payments/receipts.py
+++ b/metabrainz/payments/receipts.py
@@ -7,7 +7,7 @@ from reportlab.platypus import SimpleDocTemplate, Spacer
 from reportlab.lib.styles import ParagraphStyle
 from reportlab.platypus import Paragraph
 from reportlab.lib.enums import TA_LEFT, TA_RIGHT, TA_CENTER
-from brainzutils.mail import send_mail
+from metabrainz.mail import send_mail
 from flask import current_app
 import tempfile
 

--- a/metabrainz/supporter/views.py
+++ b/metabrainz/supporter/views.py
@@ -23,6 +23,41 @@ from metabrainz.user.rate_limit import check_signup_rate_limit, increment_signup
 
 supporters_bp = Blueprint('supporters', __name__)
 
+
+def _notify_signup(supporter):
+    """Notify MetaBrainz of a new supporter signup.
+
+    The notification is for us, not the supporter, so a mail outage must not
+    fail the signup request after the supporter has already been committed.
+    """
+    try:
+        send_supporter_signup_notification(supporter)
+    except Exception:
+        current_app.logger.exception(
+            "Error sending supporter signup notification for supporter %s", supporter.id
+        )
+
+
+def _send_signup_verification_email(user, template):
+    """Send the sign up verification email, tolerating a mail outage.
+
+    The user row is already committed by this point, so raising here would
+    leave the user unable to log in or to sign up again with the same name.
+    """
+    try:
+        send_verification_email(user, "[MetaBrainz] Sign up confirmation", template)
+    except Exception:
+        current_app.logger.exception(
+            "Error sending verification email for new user %s", user.id
+        )
+        flash.error(gettext(
+            "The verification email could not be sent. "
+            "Please request a new one from your profile."
+        ))
+        return False
+    return True
+
+
 SESSION_KEY_ACCOUNT_TYPE = 'account_type'
 SESSION_KEY_TIER_ID = 'account_tier'
 SESSION_KEY_MB_USERNAME = 'mb_username'
@@ -163,7 +198,7 @@ def signup_commercial():
             # Existing user becoming a supporter
             supporter = _create_commercial_supporter(form, tier_id, current_user)
             db.session.commit()
-            send_supporter_signup_notification(supporter)
+            _notify_signup(supporter)
 
             flash.success(gettext(
                 "Thanks for becoming a supporter! Your application will be reviewed "
@@ -185,7 +220,7 @@ def signup_commercial():
             user = User.add(name=form.username.data, unconfirmed_email=form.email.data, password=form.password.data)
             supporter = _create_commercial_supporter(form, tier_id, user)
             db.session.commit()
-            send_supporter_signup_notification(supporter)
+            _notify_signup(supporter)
             increment_signup_count()
 
             user.emit_event(EVENT_USER_CREATED)
@@ -193,9 +228,8 @@ def signup_commercial():
                 "Thanks for signing up! Your application will be reviewed "
                 "soon. We will send you updates via email."
             ))
-            send_verification_email(
+            _send_signup_verification_email(
                 user,
-                "[MetaBrainz] Sign up confirmation",
                 "email/supporter-commercial-welcome-email-address-verification.txt"
             )
             login_user(user)
@@ -271,13 +305,11 @@ def signup_noncommercial():
             increment_signup_count()
 
             user.emit_event(EVENT_USER_CREATED)
-            send_verification_email(
+            if _send_signup_verification_email(
                 user,
-                "[MetaBrainz] Sign up confirmation",
                 "email/supporter-noncommercial-welcome-email-address-verification.txt"
-            )
-
-            flash.success(gettext("Thanks for signing up! Please check your inbox to complete verification."))
+            ):
+                flash.success(gettext("Thanks for signing up! Please check your inbox to complete verification."))
 
             login_user(user)
             return redirect(url_for('index.profile'))

--- a/metabrainz/supporter/views_test.py
+++ b/metabrainz/supporter/views_test.py
@@ -807,6 +807,87 @@ class SupportersViewsTestCase(FlaskTestCase):
         self.assertEqual(self.existing_user.email, original_email)
         self.assertEqual(self.existing_user.unconfirmed_email, new_email)
         self.assertEqual(supporter.state, original_state)
+        self.assertMessageFlashed(f"Email verification link sent to {new_email}", "success")
+
+    def test_noncommercial_supporter_profile_edit_email_send_failure(self):
+        """A failure to send the verification email must not fail the profile edit."""
+        self.temporary_login(self.existing_user)
+        response = self._signup_with_ip(
+            is_commercial=False,
+            username=self.existing_user.name,
+            email=self.existing_user.email
+        )
+        self.assertStatus(response, 302)
+
+        original_email = self.existing_user.email
+        new_email = "updated-existing-user@gmail.com"
+        self.client.get(url_for("index.profile_edit"))
+        with patch(
+            "metabrainz.index.views.send_verification_email",
+            side_effect=RuntimeError("SMTP unavailable"),
+        ):
+            response = self.client.post(
+                url_for('index.profile_edit'),
+                data={
+                    "contact_name": "Updated Contact Name",
+                    "email": new_email,
+                    "datasets": self.dataset.id,
+                    "csrf_token": g.csrf_token,
+                },
+                follow_redirects=False
+            )
+        self.assertRedirects(response, url_for("index.profile"))
+
+        supporter = Supporter.get(user_id=self.existing_user.id)
+        self.assertEqual(supporter.contact_name, "Updated Contact Name")
+        self.assertEqual(self.existing_user.email, original_email)
+        self.assertEqual(self.existing_user.unconfirmed_email, new_email)
+        self.assertMessageFlashed(
+            f"The verification email for {new_email} could not be sent. "
+            f"Your email address is unchanged until it is verified. "
+            f"Please request a new verification email from your profile.",
+            "error",
+        )
+
+    def test_profile_edit_email_belongs_to_another_account(self):
+        """An email address already in use must be reported, not silently ignored."""
+        self.temporary_login(self.existing_user)
+        response = self._signup_with_ip(
+            is_commercial=False,
+            username=self.existing_user.name,
+            email=self.existing_user.email
+        )
+        self.assertStatus(response, 302)
+
+        other_user = User(name="other-test-user", email="taken@gmail.com", password="testpassword123")
+        db.session.add(other_user)
+        db.session.commit()
+
+        original_email = self.existing_user.email
+        original_contact_name = self.existing_user.supporter.contact_name
+        self.client.get(url_for("index.profile_edit"))
+        response = self.client.post(
+            url_for('index.profile_edit'),
+            data={
+                "contact_name": "Updated Contact Name",
+                "email": other_user.email,
+                "datasets": self.dataset.id,
+                "csrf_token": g.csrf_token,
+            },
+            follow_redirects=False
+        )
+        # The form is re-rendered with the error instead of redirecting away from it.
+        self.assert200(response)
+        props = json.loads(self.get_context_variable("props"))
+        self.assertIn(
+            f"The given email address ({other_user.email}) is associated with a different account.",
+            props["initial_errors"]["email"]
+        )
+
+        supporter = Supporter.get(user_id=self.existing_user.id)
+        self.assertEqual(supporter.contact_name, original_contact_name)
+        self.assertEqual(self.existing_user.email, original_email)
+        self.assertIsNone(self.existing_user.unconfirmed_email)
 
     def test_commercial_supporter_profile_edit(self):
         """Test that commercial supporters cannot change org info via profile edit."""

--- a/metabrainz/user/email.py
+++ b/metabrainz/user/email.py
@@ -3,7 +3,7 @@ from datetime import datetime
 
 from flask import url_for, request, render_template, current_app
 
-from brainzutils.mail import send_mail
+from metabrainz.mail import send_mail
 from metabrainz.model.user import User
 
 VERIFY_EMAIL = "verify-email"
@@ -18,9 +18,11 @@ def create_email_link_checksum(purpose: str, user_id: int, email: str, timestamp
     return m.hexdigest()
 
 
-def _send_user_email(username: str, email: str, subject: str, content: str):
+def _send_user_email(email: str, subject: str, content: str):
     if not current_app.config["DEBUG"]:
-        send_mail(subject=subject, text=content, recipients=[f"{username} <{email}>"])
+        if not email:
+            raise ValueError("Cannot send user email without a recipient address")
+        send_mail(subject=subject, text=content, recipients=[email])
 
 
 def send_verification_email(user: User, subject, template):
@@ -42,7 +44,7 @@ def send_verification_email(user: User, subject, template):
         verification_link=verification_link,
         ip=request.remote_addr
     )
-    _send_user_email(user.name, email, subject, content)
+    _send_user_email(email, subject, content)
 
 
 def send_forgot_username_email(user: User):
@@ -52,7 +54,7 @@ def send_forgot_username_email(user: User):
         username=user.name,
         forgot_password_link=url_for("users.lost_password")
     )
-    _send_user_email(user.name, user.email, "Lost username", content)
+    _send_user_email(user.get_email_any(), "Lost username", content)
 
 
 def send_forgot_password_email(user: User):
@@ -65,4 +67,4 @@ def send_forgot_password_email(user: User):
         reset_password_link=reset_password_link,
         contact_url="https://metabrainz.org/contact"
     )
-    _send_user_email(user.name, user.get_email_any(), "Password reset request", content)
+    _send_user_email(user.get_email_any(), "Password reset request", content)

--- a/metabrainz/user/email_test.py
+++ b/metabrainz/user/email_test.py
@@ -1,0 +1,69 @@
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from metabrainz import create_app
+from metabrainz.user.email import send_forgot_username_email, send_verification_email
+
+
+class UserEmailTestCase(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.app = create_app(config_path=str(Path(__file__).resolve().parents[2] / "config.py"))
+        cls.app.config.update(DEBUG=False, TESTING=True)
+
+    def setUp(self):
+        self.context = self.app.test_request_context()
+        self.context.push()
+
+    def tearDown(self):
+        self.context.pop()
+
+    @patch("metabrainz.user.email.send_mail")
+    def test_verification_uses_bare_address_for_all_usernames(self, send_mail):
+        usernames = [
+            "person@example.com",
+            "VSR@03",
+            "Michal Babička",
+            "Surname, Given",
+        ]
+
+        for user_id, username in enumerate(usernames, start=1):
+            with self.subTest(username=username):
+                email = f"recipient{user_id}@example.com"
+                user = SimpleNamespace(id=user_id, name=username, unconfirmed_email=email)
+                send_verification_email(
+                    user,
+                    "Please verify your email address",
+                    "email/user-email-address-verification.txt",
+                )
+                self.assertEqual(send_mail.call_args.kwargs["recipients"], [email])
+
+    @patch("metabrainz.user.email.send_mail")
+    def test_forgot_username_uses_pending_address(self, send_mail):
+        user = SimpleNamespace(
+            name="pending-user",
+            email=None,
+            unconfirmed_email="pending@example.com",
+            get_email_any=lambda: "pending@example.com",
+        )
+
+        send_forgot_username_email(user)
+
+        self.assertEqual(send_mail.call_args.kwargs["recipients"], ["pending@example.com"])
+
+    @patch("metabrainz.user.email.send_mail")
+    def test_forgot_username_rejects_missing_address(self, send_mail):
+        user = SimpleNamespace(
+            name="no-address-user",
+            email=None,
+            unconfirmed_email=None,
+            get_email_any=lambda: None,
+        )
+
+        with self.assertRaisesRegex(ValueError, "without a recipient address"):
+            send_forgot_username_email(user)
+
+        send_mail.assert_not_called()

--- a/metabrainz/user/views.py
+++ b/metabrainz/user/views.py
@@ -66,13 +66,24 @@ def signup():
                     increment_signup_count()
                     user.emit_event(EVENT_USER_CREATED)
 
-                    send_verification_email(
-                        user,
-                        "Please verify your email address",
-                        "email/user-email-address-verification.txt"
-                    )
+                    try:
+                        send_verification_email(
+                            user,
+                            "Please verify your email address",
+                            "email/user-email-address-verification.txt"
+                        )
+                    except Exception:
+                        current_app.logger.exception(
+                            "Error sending verification email for new user %s", user.id
+                        )
+                        flash.success("Account created.")
+                        flash.error(
+                            "The verification email could not be sent. "
+                            "Please request a new one from your profile."
+                        )
+                    else:
+                        flash.success("Account created. Please check your inbox to complete verification.")
                     login_user(user)
-                    flash.success("Account created. Please check your inbox to complete verification.")
                     redirect_to = request.args.get("next") or url_for("index.home")
                     return redirect(redirect_to)
                 except UsernameNotAllowedException:
@@ -264,12 +275,19 @@ def check_email():
 def resend_verification_email():
     form = MeBFlaskForm()
     if form.validate_on_submit():
-        send_verification_email(
-            current_user,
-            "Please verify your email address",
-            "email/user-email-address-verification.txt"
-        )
-        flash.success("Verification email sent!")
+        try:
+            send_verification_email(
+                current_user,
+                "Please verify your email address",
+                "email/user-email-address-verification.txt"
+            )
+        except Exception:
+            current_app.logger.exception(
+                "Error resending verification email for user %s", current_user.id
+            )
+            flash.error("The verification email could not be sent. Please try again later.")
+        else:
+            flash.success("Verification email sent!")
     return redirect(url_for("index.profile"))
 
 
@@ -283,9 +301,16 @@ def lost_username():
         if user is None:
             form.email.errors.append(f"The given email address ({form.email.data}) does not exist in our database.")
         else:
-            send_forgot_username_email(user)
-            flash.success("Username recovery email sent!")
-            return redirect(url_for("index.home"))
+            try:
+                send_forgot_username_email(user)
+            except Exception:
+                current_app.logger.exception(
+                    "Error sending username recovery email for user %s", user.id
+                )
+                flash.error("The username recovery email could not be sent. Please try again later.")
+            else:
+                flash.success("Username recovery email sent!")
+                return redirect(url_for("index.home"))
 
     form_errors = {k: ". ".join(v) for k, v in form.errors.items()}
     form_data = dict(**form.data)
@@ -309,9 +334,16 @@ def lost_password():
         if user is None:
             form.email.errors.append(f"User with given username ({form.username.data}) and email ({form.email.data}) combination not found.")
         else:
-            send_forgot_password_email(user)
-            flash.success("Password reset link sent!")
-            return redirect(url_for("index.home"))
+            try:
+                send_forgot_password_email(user)
+            except Exception:
+                current_app.logger.exception(
+                    "Error sending password reset email for user %s", user.id
+                )
+                flash.error("The password reset email could not be sent. Please try again later.")
+            else:
+                flash.success("Password reset link sent!")
+                return redirect(url_for("index.home"))
 
     form_errors = {k: ". ".join(v) for k, v in form.errors.items()}
     form_data = dict(**form.data)

--- a/metabrainz/user/views_test.py
+++ b/metabrainz/user/views_test.py
@@ -1,6 +1,7 @@
 import json
 from datetime import datetime, timezone, timedelta
 from urllib.parse import urlparse, parse_qs
+from unittest.mock import patch
 
 from brainzutils import cache
 from flask import g, url_for
@@ -94,6 +95,25 @@ class UsersViewsTestCase(FlaskTestCase):
         self.assertIsNotNone(user.last_login_at)
         self.assertIsNotNone(user.last_updated)
         self.assertEqual(current_user, user)
+
+    def test_user_signup_survives_verification_email_failure(self):
+        with patch(
+            "metabrainz.user.views.send_verification_email",
+            side_effect=RuntimeError("SMTP unavailable"),
+        ):
+            self._test_user_signup_helper({
+                "username": "test_user_1",
+                "email": "test@example.com",
+                "password": "<PASSWORD>",
+                "confirm_password": "<PASSWORD>",
+            }, 302)
+
+        self.assertIsNotNone(User.get(name="test_user_1"))
+        self.assertMessageFlashed("Account created.", "success")
+        self.assertMessageFlashed(
+            "The verification email could not be sent. Please request a new one from your profile.",
+            "error",
+        )
 
     def test_user_signup_trims_username_whitespace(self):
         self._test_user_signup_helper({
@@ -549,6 +569,26 @@ class UsersViewsTestCase(FlaskTestCase):
         self.assertEqual(response.status_code, 302)
         self.assertTrue(response.location.startswith("/login"))
 
+    def test_resend_verification_email_delivery_failure(self):
+        self.create_user()
+        self.login_test_user()
+        self.client.get(url_for("index.profile"))
+
+        with patch(
+            "metabrainz.user.views.send_verification_email",
+            side_effect=RuntimeError("SMTP unavailable"),
+        ):
+            response = self.client.post(
+                "/resend-verification-email",
+                data={"csrf_token": g.csrf_token},
+            )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertMessageFlashed(
+            "The verification email could not be sent. Please try again later.",
+            "error",
+        )
+
     def test_forgot_username_success(self):
         self.create_user()
 
@@ -560,6 +600,25 @@ class UsersViewsTestCase(FlaskTestCase):
         self.assertEqual(response.status_code, 302)
         self.assertEqual(self.get_context_variable("username"), "test_user_1")
         self.assertMessageFlashed("Username recovery email sent!", "success")
+
+    def test_forgot_username_delivery_failure(self):
+        self.create_user()
+        self.client.get("/lost-username")
+
+        with patch(
+            "metabrainz.user.views.send_forgot_username_email",
+            side_effect=RuntimeError("SMTP unavailable"),
+        ):
+            response = self.client.post("/lost-username", data={
+                "email": "test@example.com",
+                "csrf_token": g.csrf_token,
+            })
+
+        self.assertEqual(response.status_code, 200)
+        self.assertMessageFlashed(
+            "The username recovery email could not be sent. Please try again later.",
+            "error",
+        )
 
     def test_forgot_username_logged_in(self):
         self.create_user()
@@ -640,6 +699,26 @@ class UsersViewsTestCase(FlaskTestCase):
         })
         self.assertEqual(response.status_code, 302)
         self.assertMessageFlashed("Password reset link sent!", "success")
+
+    def test_forgot_password_delivery_failure(self):
+        self.create_user()
+        self.client.get("/lost-password")
+
+        with patch(
+            "metabrainz.user.views.send_forgot_password_email",
+            side_effect=RuntimeError("SMTP unavailable"),
+        ):
+            response = self.client.post("/lost-password", data={
+                "username": "test_user_1",
+                "email": "test@example.com",
+                "csrf_token": g.csrf_token,
+            })
+
+        self.assertEqual(response.status_code, 200)
+        self.assertMessageFlashed(
+            "The password reset email could not be sent. Please try again later.",
+            "error",
+        )
 
     def test_forgot_password_logged_in(self):
         self.create_user()


### PR DESCRIPTION
  - copy the email delivery helper from brainzutils into MetaBrainz
  - use bare recipient addresses for SMTP headers and envelopes
  - add an SMTP timeout and consistently wrap delivery errors
  - support pending email addresses in username recovery
  - prevent email failures from breaking signup, verification, profile, supporter, and payment flows
  - preserve committed payments when receipt delivery fails
  - normalize lowercase Stripe boolean metadata before storing payments
  - display profile email conflicts instead of silently redirecting