### PR TITLE
Fix errors reported in production logs

### DIFF
--- a/docker/oauth/oauth.ini
+++ b/docker/oauth/oauth.ini
@@ -12,6 +12,14 @@ processes = 20
 listen = 1024
 log-x-forwarded-for=true
 disable-logging = true
+; default 4096 byte header buffer rejects requests with large cookies/headers
+; with "invalid request block size"
+buffer-size = 16384
+; clients disconnecting mid-response (usually while fetching static assets) are
+; normal; do not spam the log with SIGPIPE/broken pipe tracebacks for them
+ignore-sigpipe = true
+ignore-write-errors = true
+disable-write-exception = true
 ; quit uwsgi if the python app fails to load
 need-app = true
 die-on-term = true

--- a/docker/web/web.ini
+++ b/docker/web/web.ini
@@ -10,6 +10,14 @@ processes = 20
 listen = 1024
 log-x-forwarded-for=true
 disable-logging = true
+; default 4096 byte header buffer rejects requests with large cookies/headers
+; with "invalid request block size"
+buffer-size = 16384
+; clients disconnecting mid-response (usually while fetching static assets) are
+; normal; do not spam the log with SIGPIPE/broken pipe tracebacks for them
+ignore-sigpipe = true
+ignore-write-errors = true
+disable-write-exception = true
 ; quit uwsgi if the python app fails to load
 need-app = true
 die-on-term = true

--- a/metabrainz/model/payment.py
+++ b/metabrainz/model/payment.py
@@ -20,8 +20,25 @@ PAYMENT_METHOD_WEPAY = 'wepay'  # no longer supported
 PAYMENT_METHOD_CHECK = 'check'
 
 
+class StripeChargeNotReadyError(Exception):
+    """Raised when Stripe has not finished settling a charge we were notified about."""
+
+
+def stripe_get(obj, key):
+    """Read an optional key out of a Stripe object.
+
+    Stripe's StripeObject is not a dict subclass and has no ``get()``, so only
+    the ``in``/``[]`` protocol can be used to read it safely. Fields Stripe drops
+    entirely between API versions are absent rather than null, so subscripting them
+    raises KeyError; this returns None for both cases.
+    """
+    if obj is None or key not in obj:
+        return None
+    return obj[key]
+
+
 def _stripe_metadata_bool(metadata, key):
-    value = metadata.get(key)
+    value = stripe_get(metadata, key)
     if isinstance(value, bool):
         return value
     if isinstance(value, str):
@@ -344,7 +361,11 @@ class Payment(db.Model):
             api_key = current_app.config["STRIPE_KEYS"]["USD"]["SECRET"]
         else:
             api_key = current_app.config["STRIPE_KEYS"]["EUR"]["SECRET"]
-        charge = stripe.Charge.retrieve(invoice["charge"], expand=["balance_transaction"], api_key=api_key)
+        charge_id = stripe_get(invoice, "charge")
+        if not charge_id:
+            raise StripeChargeNotReadyError(f"Invoice {invoice['id']} has no charge yet")
+
+        charge = stripe.Charge.retrieve(charge_id, expand=["balance_transaction"], api_key=api_key)
         metadata = invoice["lines"]["data"][0]["metadata"]
         return cls._log_stripe_charge(charge, metadata)
 
@@ -359,6 +380,11 @@ class Payment(db.Model):
                                                        expand=["latest_charge.balance_transaction"],
                                                        api_key=api_key)
         charge = payment_intent["latest_charge"]
+        if charge is None:
+            raise StripeChargeNotReadyError(
+                f"Payment intent {payment_intent['id']} has no charge yet"
+            )
+
         metadata = payment_intent["metadata"]
         return cls._log_stripe_charge(charge, metadata)
 
@@ -380,6 +406,13 @@ class Payment(db.Model):
         address = details["address"]
 
         transaction = charge["balance_transaction"]
+        if transaction is None:
+            # Stripe sometimes notifies us before the balance transaction exists, and we
+            # need its net/fee amounts. Ask Stripe to redeliver the event later instead.
+            raise StripeChargeNotReadyError(
+                f"Balance transaction for charge {charge['id']} is not available yet"
+            )
+
         currency = transaction["currency"].lower()
         if currency not in SUPPORTED_CURRENCIES:
             current_app.logger.warning("Unsupported currency: ", transaction["currency"])
@@ -408,15 +441,18 @@ class Payment(db.Model):
             new_donation.can_contact = _stripe_metadata_bool(metadata, "can_contact")
             new_donation.anonymous = _stripe_metadata_bool(metadata, "anonymous")
 
-            if "editor" in metadata:
-                new_donation.editor_name = metadata["editor"]
-                new_donation.editor_id = cls.get_user_id(new_donation.editor_name)
+            editor_name = stripe_get(metadata, "editor")
+            if editor_name is not None:
+                new_donation.editor_name = editor_name
+                new_donation.editor_id = cls.get_user_id(editor_name)
 
         else:  # Organization payment
-            if "invoice_number" in metadata:
-                new_donation.invoice_number = metadata["invoice_number"]
-            if "supporter_id" in metadata:
-                new_donation.supporter_id = metadata["supporter_id"]
+            invoice_number = stripe_get(metadata, "invoice_number")
+            if invoice_number is not None:
+                new_donation.invoice_number = invoice_number
+            supporter_id = stripe_get(metadata, "supporter_id")
+            if supporter_id is not None:
+                new_donation.supporter_id = supporter_id
 
         db.session.add(new_donation)
         db.session.commit()

--- a/metabrainz/model/payment_test.py
+++ b/metabrainz/model/payment_test.py
@@ -2,9 +2,10 @@ import copy
 from unittest.mock import patch
 
 from flask import current_app
+from stripe import StripeObject
 
 from metabrainz.model import db
-from metabrainz.model.payment import Payment
+from metabrainz.model.payment import Payment, StripeChargeNotReadyError
 from metabrainz.payments import Currency
 from metabrainz.testing import FlaskTestCase
 
@@ -436,31 +437,41 @@ class PaymentModelStripeTestCase(FlaskTestCase):
             "transfer_group": None
         }
 
+    def stripe_payment_intent(self, metadata=None, **overrides):
+        """Build a PaymentIntent the way the Stripe client hands one back.
+
+        Stripe deserialises responses into StripeObject, which is *not* a dict and
+        does not implement the dict API (notably ``get()``). A fixture left as a
+        plain dict silently tests a type that never reaches production, so every
+        fixture must go through construct_from.
+        """
+        payload = copy.deepcopy(self.payment_intent)
+        if metadata is not None:
+            payload["metadata"] = metadata
+        payload.update(overrides)
+        return StripeObject.construct_from(payload, "sk_test")
+
     @patch("stripe.PaymentIntent")
     def test_log_stripe_charge_donation(self, mock_stripe):
         # Function should execute without any exceptions
-        payment_intent = self.payment_intent.copy()
-        payment_intent["metadata"] = {
+        mock_stripe.retrieve.return_value = self.stripe_payment_intent({
             "is_donation": "True",
             "editor": "lucifer",
             "anonymous": "False",
             "can_contact": "False"
-        }
-        mock_stripe.retrieve.return_value = payment_intent
+        })
         session = self.session_without_metadata.copy()
         Payment.log_one_time_charge("usd", session)
         self.assertEqual(len(Payment.query.all()), 1)
 
     @patch("stripe.PaymentIntent")
     def test_log_stripe_charge_accepts_lowercase_boolean_metadata(self, mock_stripe):
-        payment_intent = self.payment_intent.copy()
-        payment_intent["metadata"] = {
+        mock_stripe.retrieve.return_value = self.stripe_payment_intent({
             "is_donation": "true",
             "editor": "lucifer",
             "anonymous": "false",
             "can_contact": "true",
-        }
-        mock_stripe.retrieve.return_value = payment_intent
+        })
 
         Payment.log_one_time_charge("usd", self.session_without_metadata)
 
@@ -472,24 +483,20 @@ class PaymentModelStripeTestCase(FlaskTestCase):
     @patch("stripe.PaymentIntent")
     def test_log_stripe_charge_payment(self, mock_stripe):
         # Function should execute without any exceptions
-        payment_intent = self.payment_intent.copy()
-        payment_intent["metadata"] = {
+        mock_stripe.retrieve.return_value = self.stripe_payment_intent({
             "is_donation": "False",
             "email": "mail@example.com",
             "invoice_number": 42,
-        }
-        mock_stripe.retrieve.return_value = payment_intent
+        })
         Payment.log_one_time_charge("usd", self.session_without_metadata)
         self.assertEqual(len(Payment.query.all()), 1)
 
     @patch("stripe.PaymentIntent")
     def test_log_stripe_charge_payment_with_invoice_number(self, mock_stripe):
-        payment_intent = self.payment_intent.copy()
-        payment_intent["metadata"] = {
+        mock_stripe.retrieve.return_value = self.stripe_payment_intent({
             "is_donation": "False",
             "invoice_number": 42,
-        }
-        mock_stripe.retrieve.return_value = payment_intent
+        })
         Payment.log_one_time_charge("usd", self.session_without_metadata)
         payments = Payment.query.all()
         self.assertEqual(len(payments), 1)
@@ -497,12 +504,74 @@ class PaymentModelStripeTestCase(FlaskTestCase):
 
     @patch("stripe.PaymentIntent")
     def test_log_stripe_charge_payment_without_invoice_number(self, mock_stripe):
-        payment_intent = self.payment_intent.copy()
-        payment_intent["metadata"] = {
+        mock_stripe.retrieve.return_value = self.stripe_payment_intent({
             "is_donation": "False",
-        }
-        mock_stripe.retrieve.return_value = payment_intent
+        })
         Payment.log_one_time_charge("usd", self.session_without_metadata)
         payments = Payment.query.all()
         self.assertEqual(len(payments), 1)
         self.assertIsNone(payments[0].invoice_number)
+
+    @patch("stripe.PaymentIntent")
+    def test_log_stripe_charge_without_balance_transaction(self, mock_stripe):
+        """Stripe can notify us before the balance transaction has settled."""
+        payment_intent = self.stripe_payment_intent()
+        payment_intent["latest_charge"]["balance_transaction"] = None
+        mock_stripe.retrieve.return_value = payment_intent
+
+        with self.assertRaises(StripeChargeNotReadyError):
+            Payment.log_one_time_charge("usd", self.session_without_metadata)
+
+        self.assertEqual(len(Payment.query.all()), 0)
+
+    @patch("stripe.PaymentIntent")
+    def test_log_stripe_charge_without_charge(self, mock_stripe):
+        mock_stripe.retrieve.return_value = self.stripe_payment_intent(latest_charge=None)
+
+        with self.assertRaises(StripeChargeNotReadyError):
+            Payment.log_one_time_charge("usd", self.session_without_metadata)
+
+        self.assertEqual(len(Payment.query.all()), 0)
+
+    @staticmethod
+    def stripe_invoice(**overrides):
+        """Build an invoice.paid payload the way Stripe hands one back."""
+        payload = {
+            "id": "in_test_1",
+            "object": "invoice",
+            "lines": {"data": [{"metadata": {
+                "is_donation": "True",
+                "editor": "lucifer",
+                "anonymous": "False",
+                "can_contact": "False",
+            }}]},
+        }
+        payload.update(overrides)
+        return StripeObject.construct_from(payload, "sk_test")
+
+    @patch("stripe.Charge")
+    def test_log_subscription_charge(self, mock_charge):
+        mock_charge.retrieve.return_value = self.stripe_payment_intent()["latest_charge"]
+
+        Payment.log_subscription_charge("usd", self.stripe_invoice(charge="ch_test_1"))
+
+        self.assertEqual(mock_charge.retrieve.call_args[0][0], "ch_test_1")
+        self.assertEqual(len(Payment.query.all()), 1)
+
+    @patch("stripe.Charge")
+    def test_log_subscription_charge_without_charge_field(self, mock_charge):
+        """Newer Stripe API versions dropped Invoice.charge, so the key is absent
+        rather than null. Subscripting it raises KeyError before the guard runs."""
+        with self.assertRaises(StripeChargeNotReadyError):
+            Payment.log_subscription_charge("usd", self.stripe_invoice())
+
+        mock_charge.retrieve.assert_not_called()
+        self.assertEqual(len(Payment.query.all()), 0)
+
+    @patch("stripe.Charge")
+    def test_log_subscription_charge_with_null_charge(self, mock_charge):
+        with self.assertRaises(StripeChargeNotReadyError):
+            Payment.log_subscription_charge("usd", self.stripe_invoice(charge=None))
+
+        mock_charge.retrieve.assert_not_called()
+        self.assertEqual(len(Payment.query.all()), 0)

--- a/metabrainz/payments/stripe/views.py
+++ b/metabrainz/payments/stripe/views.py
@@ -2,6 +2,7 @@ from flask import Blueprint, request, current_app, redirect, url_for, jsonify
 from flask_login import current_user
 
 from metabrainz.model import Payment
+from metabrainz.model.payment import StripeChargeNotReadyError
 from metabrainz.payments.forms import DonationForm, PaymentForm
 import stripe
 
@@ -121,11 +122,17 @@ def webhook(currency):
     # for one time payments, mode is payment, and we use the checkout.session.completed event to log charges
     # other option is mode = subscription i.e. recurring payments, for which payment_intent data is unavailable
     # in this webhook. hence, we use invoice.paid event instead which contains it.
-    if event["type"] == "checkout.session.completed":
-        session = event["data"]["object"]
-        if session["mode"] == "payment":
-            Payment.log_one_time_charge(currency, session)
-    elif event["type"] == "invoice.paid":
-        Payment.log_subscription_charge(currency, event["data"]["object"])
+    try:
+        if event["type"] == "checkout.session.completed":
+            session = event["data"]["object"]
+            if session["mode"] == "payment":
+                Payment.log_one_time_charge(currency, session)
+        elif event["type"] == "invoice.paid":
+            Payment.log_subscription_charge(currency, event["data"]["object"])
+    except StripeChargeNotReadyError as e:
+        # Stripe occasionally delivers the event before the charge has settled. Reject
+        # the delivery so that Stripe redelivers it once the missing data is available.
+        current_app.logger.warning("Stripe: event %s is not ready to be processed: %s", event["id"], e)
+        return jsonify({"error": "charge not ready, please retry"}), 503
 
     return jsonify({"status": "ok"})

--- a/metabrainz/payments/stripe/views_test.py
+++ b/metabrainz/payments/stripe/views_test.py
@@ -1,8 +1,13 @@
+import hashlib
+import hmac
+import json
+import time
 from unittest.mock import patch, MagicMock
 
 from flask import url_for
 
 from metabrainz.model import db
+from metabrainz.model.payment import StripeChargeNotReadyError
 from metabrainz.model.supporter import Supporter
 from metabrainz.model.user import User
 from metabrainz.testing import FlaskTestCase
@@ -143,3 +148,123 @@ class StripePayViewTestCase(FlaskTestCase):
         call_kwargs = mock_session.create.call_args[1]
         metadata = call_kwargs["payment_intent_data"]["metadata"]
         self.assertNotIn("supporter_id", metadata)
+
+
+class StripeWebhookViewTestCase(FlaskTestCase):
+    """Tests for the inbound Stripe webhook.
+
+    These drive the endpoint the way Stripe does: a signed JSON body. That makes
+    stripe.Webhook.construct_event deserialise the payload for real, so the event
+    reaching the view is a StripeObject rather than a dict we made up.
+    """
+
+    WEBHOOK_SECRET = "whsec_test_secret"
+
+    @classmethod
+    def create_app(cls):
+        app = super().create_app()
+        app.config["WTF_CSRF_ENABLED"] = False
+        return app
+
+    def setUp(self):
+        super().setUp()
+        for currency in ("USD", "EUR"):
+            self.app.config["STRIPE_KEYS"][currency]["WEBHOOK_SECRET"] = self.WEBHOOK_SECRET
+
+    def post_event(self, event, currency="usd", secret=None):
+        """POST an event with a valid Stripe-Signature header, as Stripe would."""
+        payload = json.dumps(event)
+        timestamp = int(time.time())
+        signature = hmac.new(
+            (secret or self.WEBHOOK_SECRET).encode("utf-8"),
+            msg=f"{timestamp}.{payload}".encode("utf-8"),
+            digestmod=hashlib.sha256,
+        ).hexdigest()
+        return self.client.post(
+            url_for("payments_stripe.webhook", currency=currency),
+            data=payload,
+            content_type="application/json",
+            headers={"Stripe-Signature": f"t={timestamp},v1={signature}"},
+        )
+
+    @staticmethod
+    def checkout_session_completed(mode="payment"):
+        return {
+            "id": "evt_test_webhook",
+            "object": "event",
+            "created": int(time.time()),
+            "type": "checkout.session.completed",
+            "data": {"object": {
+                "id": "cs_test_1",
+                "object": "checkout.session",
+                "mode": mode,
+                "payment_intent": "pi_test_1",
+            }},
+        }
+
+    def test_webhook_rejects_bad_signature(self):
+        response = self.post_event(self.checkout_session_completed(), secret="whsec_wrong")
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json, {"error": "invalid signature"})
+
+    def test_webhook_rejects_unknown_currency(self):
+        response = self.post_event(self.checkout_session_completed(), currency="gbp")
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json, {"error": "invalid currency"})
+
+    @patch("metabrainz.model.Payment.log_one_time_charge")
+    def test_webhook_logs_one_time_charge(self, mock_log):
+        response = self.post_event(self.checkout_session_completed())
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json, {"status": "ok"})
+        mock_log.assert_called_once()
+        currency, session = mock_log.call_args[0]
+        self.assertEqual(currency, "usd")
+        self.assertEqual(session["payment_intent"], "pi_test_1")
+
+    @patch("metabrainz.model.Payment.log_one_time_charge")
+    def test_webhook_ignores_subscription_checkout_session(self, mock_log):
+        response = self.post_event(self.checkout_session_completed(mode="subscription"))
+
+        self.assertEqual(response.status_code, 200)
+        mock_log.assert_not_called()
+
+    @patch("metabrainz.model.Payment.log_subscription_charge")
+    def test_webhook_logs_subscription_charge(self, mock_log):
+        event = {
+            "id": "evt_test_invoice",
+            "object": "event",
+            "created": int(time.time()),
+            "type": "invoice.paid",
+            "data": {"object": {"id": "in_test_1", "object": "invoice", "charge": "ch_test_1"}},
+        }
+        response = self.post_event(event, currency="eur")
+
+        self.assertEqual(response.status_code, 200)
+        mock_log.assert_called_once()
+        self.assertEqual(mock_log.call_args[0][0], "eur")
+
+    @patch("metabrainz.model.Payment.log_one_time_charge")
+    def test_webhook_asks_stripe_to_retry_unsettled_charge(self, mock_log):
+        mock_log.side_effect = StripeChargeNotReadyError("balance transaction missing")
+
+        response = self.post_event(self.checkout_session_completed())
+
+        # 5xx makes Stripe redeliver once the charge has settled.
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.json, {"error": "charge not ready, please retry"})
+
+    @patch("metabrainz.model.Payment.log_one_time_charge")
+    def test_webhook_ignores_unhandled_event_types(self, mock_log):
+        event = {
+            "id": "evt_test_other",
+            "object": "event",
+            "created": int(time.time()),
+            "type": "customer.created",
+            "data": {"object": {"id": "cus_test_1", "object": "customer"}},
+        }
+        response = self.post_event(event)
+
+        self.assertEqual(response.status_code, 200)
+        mock_log.assert_not_called()

--- a/metabrainz/user/views.py
+++ b/metabrainz/user/views.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 from flask import Blueprint, current_app, redirect, render_template, request, url_for, jsonify
 from flask_login import confirm_login, logout_user, login_required, login_user, current_user
 from flask_wtf.csrf import generate_csrf
+from sqlalchemy.exc import IntegrityError
 
 from metabrainz import bcrypt, flash
 from metabrainz.index.forms import MeBFlaskForm
@@ -89,9 +90,16 @@ def signup():
                 except UsernameNotAllowedException:
                     form.username.errors.append("Username is not allowed.")
                     db.session.rollback()
-                except Exception as e:
-                    flash.error(f"An unexpected error occurred: {e}")
-                    current_app.logger.exception("Error creating user", exc_info=True)
+                except IntegrityError:
+                    # Two signups for the same username can race past the check above.
+                    db.session.rollback()
+                    form.username.errors.append(
+                        f"Another user with username '{form.username.data}' exists."
+                    )
+                except Exception:
+                    db.session.rollback()
+                    flash.error("An unexpected error occurred. Please try again later.")
+                    current_app.logger.exception("Error creating user")
 
     form_data = dict(**form.data)
     form_data.pop("csrf_token", None)
@@ -275,6 +283,10 @@ def check_email():
 def resend_verification_email():
     form = MeBFlaskForm()
     if form.validate_on_submit():
+        if not current_user.unconfirmed_email:
+            flash.info("There is no email address awaiting verification on your account.")
+            return redirect(url_for("index.profile"))
+
         try:
             send_verification_email(
                 current_user,

--- a/metabrainz/user/views_test.py
+++ b/metabrainz/user/views_test.py
@@ -219,6 +219,24 @@ class UsersViewsTestCase(FlaskTestCase):
         props = json.loads(self.get_context_variable("props"))
         self.assertEqual(props["initial_errors"], {"username": "Another user with username 'TEST_USER_1' exists."})
 
+    def test_user_signup_username_exists_race(self):
+        """Two concurrent signups can both get past the User.get() check."""
+        self.create_user()
+
+        # Simulate the race window: the pre-check misses the existing user, so the
+        # unique index is what rejects the insert.
+        with patch("metabrainz.user.views.User.get", return_value=None):
+            self._test_user_signup_helper({
+                "username": "test_user_1",
+                "email": "test2@gmail.com",
+                "password": "<PASSWORD>",
+                "confirm_password": "<PASSWORD>",
+            }, 200)
+
+        props = json.loads(self.get_context_variable("props"))
+        self.assertEqual(props["initial_errors"], {"username": "Another user with username 'test_user_1' exists."})
+        self.assertEqual(len(User.query.all()), 1)
+
     def test_user_signup_logged_in(self):
         data = {
             "username": "test_user_1",
@@ -587,6 +605,26 @@ class UsersViewsTestCase(FlaskTestCase):
         self.assertMessageFlashed(
             "The verification email could not be sent. Please try again later.",
             "error",
+        )
+
+    def test_resend_verification_email_without_pending_address(self):
+        self.create_user()
+        self.login_test_user()
+        self.client.get(url_for("index.profile"))
+
+        user = User.get(name="test_user_1")
+        user.unconfirmed_email = None
+        db.session.commit()
+
+        response = self.client.post(
+            "/resend-verification-email",
+            data={"csrf_token": g.csrf_token},
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertMessageFlashed(
+            "There is no email address awaiting verification on your account.",
+            "info",
         )
 
     def test_forgot_username_success(self):

--- a/test.sh
+++ b/test.sh
@@ -15,9 +15,12 @@ function invoke_docker_compose {
 
 invoke_docker_compose up -d meb_db redis
 invoke_docker_compose build web
+# "$@" must be passed as separate argv entries: interpolating it into the bash -c
+# string makes bash split it, so only the first argument reaches pytest and the
+# rest are silently swallowed as the inner shell's $0/$1/...
 invoke_docker_compose run --rm web \
     dockerize -wait tcp://meb_db:5432 -timeout 60s \
-    bash -c "python manage.py init-db --create-db && pytest --junitxml=reports/tests.xml $@"
+    bash -c 'python manage.py init-db --create-db && pytest --junitxml=reports/tests.xml "$@"' _ "$@"
 RET=$?
 invoke_docker_compose down
 exit $RET


### PR DESCRIPTION
Stripe webhooks have been failing since the last deploy, so no charge has been recorded since. Updated the test to use testing helpers from stripe library prevent the same issue. Charges taken since the deploy have been replayed from the Stripe dashboard.

Signup raced past the username check often enough to show up in the logs, and the generic handler neither rolled back nor kept the error off the page: the IntegrityError text, including the bcrypt hash, was rendered to the browser. Catch it and report the username as taken. Resending a verification email with no pending address raised ValueError from _send_user_email; say so instead.

uwsgi: raise buffer-size to 16k so requests with large cookies stop being rejected with "invalid request block size", and silence the SIGPIPE tracebacks from clients that disconnect while fetching static assets.