### PR TITLE
Stop mail clients breaking email links, make reset links single use

### DIFF
--- a/metabrainz/user/email.py
+++ b/metabrainz/user/email.py
@@ -9,13 +9,32 @@ from metabrainz.model.user import User
 VERIFY_EMAIL = "verify-email"
 RESET_PASSWORD = "reset-password"
 
+# The timestamp travels as "ts": "&times" is an HTML entity for × that parsers decode even
+# without the trailing semicolon, so mail clients turned "&timestamp=" into "×tamp=".
 
-def create_email_link_checksum(purpose: str, user_id: int, email: str, timestamp: int) -> str:
-    """ Create a checksum based on user details, time and a secret key for the user's email verification """
+
+def create_email_link_checksum(purpose: str, user_id: int, email: str, timestamp: int, binding: str = None) -> str:
+    """ Create a checksum based on user details, time and a secret key for the user's email verification
+
+    ``binding`` ties the link to account state that changes, invalidating it when that does.
+    """
     text = f"{purpose}; user_id: {user_id}; email: {email}; timestamp: {timestamp}; secret: {current_app.config['EMAIL_VERIFICATION_SECRET_KEY']}"
+    if binding is not None:
+        text = f"{text}; binding: {binding}"
     m = hashlib.sha256()
     m.update(text.encode("utf-8"))
     return m.hexdigest()
+
+
+def create_reset_password_checksum(user: User, timestamp: int) -> str:
+    """ Create the checksum for a user's password reset link.
+
+    Binding it to the password hash makes the link single use: changing the password
+    invalidates every reset link outstanding for the user, including the one just used.
+    """
+    return create_email_link_checksum(
+        RESET_PASSWORD, user.id, user.get_email_any(), timestamp, binding=user.password
+    )
 
 
 def _send_user_email(email: str, subject: str, content: str):
@@ -34,7 +53,7 @@ def send_verification_email(user: User, subject, template):
     verification_link = url_for(
         "users.verify_email",
         user_id=user.id,
-        timestamp=timestamp,
+        ts=timestamp,
         checksum=checksum,
         _external=True
     )
@@ -60,8 +79,8 @@ def send_forgot_username_email(user: User):
 def send_forgot_password_email(user: User):
     """ Send email for resetting the user's password. """
     timestamp = int(datetime.now().timestamp())
-    checksum = create_email_link_checksum(RESET_PASSWORD, user.id, user.get_email_any(), timestamp)
-    reset_password_link = url_for("users.reset_password", user_id=user.id, timestamp=timestamp, checksum=checksum, _external=True)
+    checksum = create_reset_password_checksum(user, timestamp)
+    reset_password_link = url_for("users.reset_password", user_id=user.id, ts=timestamp, checksum=checksum, _external=True)
     content = render_template(
         "email/user-password-reset.txt",
         reset_password_link=reset_password_link,

--- a/metabrainz/user/email.py
+++ b/metabrainz/user/email.py
@@ -1,4 +1,5 @@
 import hashlib
+import hmac
 from datetime import datetime
 
 from flask import url_for, request, render_template, current_app
@@ -13,14 +14,9 @@ RESET_PASSWORD = "reset-password"
 # without the trailing semicolon, so mail clients turned "&timestamp=" into "×tamp=".
 
 
-def create_email_link_checksum(purpose: str, user_id: int, email: str, timestamp: int, binding: str = None) -> str:
-    """ Create a checksum based on user details, time and a secret key for the user's email verification
-
-    ``binding`` ties the link to account state that changes, invalidating it when that does.
-    """
+def create_email_link_checksum(purpose: str, user_id: int, email: str, timestamp: int) -> str:
+    """ Create a checksum based on user details, time and a secret key for the user's email verification """
     text = f"{purpose}; user_id: {user_id}; email: {email}; timestamp: {timestamp}; secret: {current_app.config['EMAIL_VERIFICATION_SECRET_KEY']}"
-    if binding is not None:
-        text = f"{text}; binding: {binding}"
     m = hashlib.sha256()
     m.update(text.encode("utf-8"))
     return m.hexdigest()
@@ -31,10 +27,17 @@ def create_reset_password_checksum(user: User, timestamp: int) -> str:
 
     Binding it to the password hash makes the link single use: changing the password
     invalidates every reset link outstanding for the user, including the one just used.
+    The hash is an input to the digest, never part of the link.
+
+    An HMAC rather than the digest-with-embedded-secret above. Verification links keep the
+    older construction so the ones already in inboxes stay valid.
     """
-    return create_email_link_checksum(
-        RESET_PASSWORD, user.id, user.get_email_any(), timestamp, binding=user.password
-    )
+    message = f"{RESET_PASSWORD}; user_id: {user.id}; email: {user.get_email_any()}; timestamp: {timestamp}; binding: {user.password}"
+    return hmac.new(
+        current_app.config["EMAIL_VERIFICATION_SECRET_KEY"].encode("utf-8"),
+        message.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
 
 
 def _send_user_email(email: str, subject: str, content: str):

--- a/metabrainz/user/email_test.py
+++ b/metabrainz/user/email_test.py
@@ -4,7 +4,8 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 from metabrainz import create_app
-from metabrainz.user.email import send_forgot_username_email, send_verification_email
+from metabrainz.user.email import create_reset_password_checksum, send_forgot_username_email, \
+    send_verification_email
 
 
 class UserEmailTestCase(unittest.TestCase):
@@ -20,6 +21,18 @@ class UserEmailTestCase(unittest.TestCase):
 
     def tearDown(self):
         self.context.pop()
+
+    def test_reset_password_checksum_changes_with_the_password(self):
+        """The checksum is bound to the password hash, which is what makes a reset link
+        unusable once it has been used to set a new one."""
+        user = SimpleNamespace(id=1, password="hash-before", get_email_any=lambda: "user@example.com")
+        timestamp = 1756200000
+
+        before = create_reset_password_checksum(user, timestamp)
+        self.assertEqual(before, create_reset_password_checksum(user, timestamp))
+
+        user.password = "hash-after"
+        self.assertNotEqual(before, create_reset_password_checksum(user, timestamp))
 
     @patch("metabrainz.user.email.send_mail")
     def test_verification_uses_bare_address_for_all_usernames(self, send_mail):

--- a/metabrainz/user/email_test.py
+++ b/metabrainz/user/email_test.py
@@ -1,11 +1,12 @@
+import hashlib
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
 from metabrainz import create_app
-from metabrainz.user.email import create_reset_password_checksum, send_forgot_username_email, \
-    send_verification_email
+from metabrainz.user.email import VERIFY_EMAIL, create_email_link_checksum, \
+    create_reset_password_checksum, send_forgot_username_email, send_verification_email
 
 
 class UserEmailTestCase(unittest.TestCase):
@@ -22,9 +23,29 @@ class UserEmailTestCase(unittest.TestCase):
     def tearDown(self):
         self.context.pop()
 
+    def test_verification_checksum_construction_is_pinned(self):
+        """Changing this invalidates every verification link already sitting in an inbox."""
+        with patch.dict(self.app.config, {"EMAIL_VERIFICATION_SECRET_KEY": "test-secret"}):
+            checksum = create_email_link_checksum(VERIFY_EMAIL, 1, "user@example.com", 1756200000)
+
+        expected = hashlib.sha256(
+            b"verify-email; user_id: 1; email: user@example.com; timestamp: 1756200000;"
+            b" secret: test-secret"
+        ).hexdigest()
+        self.assertEqual(expected, checksum)
+
+    def test_reset_password_checksum_depends_on_the_secret(self):
+        user = SimpleNamespace(id=1, password="hash", get_email_any=lambda: "user@example.com")
+
+        with patch.dict(self.app.config, {"EMAIL_VERIFICATION_SECRET_KEY": "secret-one"}):
+            one = create_reset_password_checksum(user, 1756200000)
+        with patch.dict(self.app.config, {"EMAIL_VERIFICATION_SECRET_KEY": "secret-two"}):
+            two = create_reset_password_checksum(user, 1756200000)
+
+        self.assertNotEqual(one, two)
+
     def test_reset_password_checksum_changes_with_the_password(self):
-        """The checksum is bound to the password hash, which is what makes a reset link
-        unusable once it has been used to set a new one."""
+        """What makes a reset link unusable once it has been used."""
         user = SimpleNamespace(id=1, password="hash-before", get_email_any=lambda: "user@example.com")
         timestamp = 1756200000
 

--- a/metabrainz/user/views.py
+++ b/metabrainz/user/views.py
@@ -1,4 +1,6 @@
+import hmac
 import json
+import re
 from datetime import datetime, timezone
 
 from flask import Blueprint, current_app, redirect, render_template, request, url_for, jsonify
@@ -14,7 +16,7 @@ from metabrainz.model.webhook import EVENT_USER_CREATED, EVENT_USER_UPDATED
 from metabrainz.oauth.registration_request import get_registration_request
 from metabrainz.user import login_forbidden
 from metabrainz.user.email import send_forgot_password_email, send_forgot_username_email, create_email_link_checksum, \
-    VERIFY_EMAIL, RESET_PASSWORD, send_verification_email
+    create_reset_password_checksum, VERIFY_EMAIL, send_verification_email
 from metabrainz.user.forms import UserLoginForm, UserReauthenticationForm, UserSignupForm, ForgotPasswordForm, \
     ForgotUsernameForm, ResetPasswordForm
 from metabrainz.user.rate_limit import check_signup_rate_limit, increment_signup_count
@@ -23,13 +25,40 @@ from metabrainz.user.registration import validate_registration_email
 users_bp = Blueprint("users", __name__)
 
 
-def _parse_link_timestamp(value):
+# Mail clients that decode "&times" hand us "user_id=123×tamp=1699999999" and no timestamp,
+# so pull both back out. Only links predating the "ts" rename can arrive this way.
+_MANGLED_USER_ID_RE = re.compile(r"\A(?P<user_id>\d+)\u00d7tamp=(?P<timestamp>\d+)\Z")
+
+
+def _parse_email_link_args():
+    """Read the user id and timestamp out of an email link.
+
+    Returns ``(user_id, timestamp, created_at)``, or None if the link is unusable. Keeps
+    junk out of the database query, which raises rather than returning no user.
+    """
+    raw_user_id = request.args.get("user_id") or ""
+    raw_timestamp = request.args.get("ts") or request.args.get("timestamp")
+
+    mangled = _MANGLED_USER_ID_RE.match(raw_user_id)
+    if mangled is not None:
+        raw_user_id = mangled.group("user_id")
+        if raw_timestamp is None:
+            raw_timestamp = mangled.group("timestamp")
+
     try:
-        timestamp = int(value)
+        user_id = int(raw_user_id)
+        timestamp = int(raw_timestamp)
         created_at = datetime.fromtimestamp(timestamp, tz=timezone.utc)
     except (OSError, OverflowError, TypeError, ValueError):
         return None
-    return timestamp, created_at
+    return user_id, timestamp, created_at
+
+
+def _checksum_matches(expected: str, received) -> bool:
+    """Compare an email link checksum against the one we expect, in constant time."""
+    if not received:
+        return False
+    return hmac.compare_digest(expected, received)
 
 
 @users_bp.route("/privacy-summary")
@@ -186,13 +215,12 @@ def reauthenticate():
 @users_bp.route("/verify-email")
 def verify_email():
     """ User"s email verification endpoint. """
-    user_id = request.args.get("user_id")
-    parsed_timestamp = _parse_link_timestamp(request.args.get("timestamp"))
-    if parsed_timestamp is None:
+    parsed_link = _parse_email_link_args()
+    if parsed_link is None:
         flash.error("Unable to verify email.")
         return redirect(url_for("index.home"))
 
-    timestamp, created_at = parsed_timestamp
+    user_id, timestamp, created_at = parsed_link
     if created_at + current_app.config["EMAIL_VERIFICATION_EXPIRY"] <= datetime.now(timezone.utc):
         flash.error("Email verification link expired.")
         return redirect(url_for("index.home"))
@@ -205,7 +233,7 @@ def verify_email():
         return redirect(url_for("index.home"))
 
     checksum = create_email_link_checksum(VERIFY_EMAIL, user.id, user.unconfirmed_email, timestamp)
-    if checksum != received_checksum:
+    if not _checksum_matches(checksum, received_checksum):
         flash.error("Unable to verify email.")
         return redirect(url_for("index.home"))
 
@@ -373,14 +401,12 @@ def lost_password():
 @login_forbidden
 def reset_password():
     """ User"s reset password endpoint. """
-    user_id = request.args.get("user_id")
-
-    parsed_timestamp = _parse_link_timestamp(request.args.get("timestamp"))
-    if parsed_timestamp is None:
+    parsed_link = _parse_email_link_args()
+    if parsed_link is None:
         flash.error("Unable to reset password.")
         return redirect(url_for("index.home"))
 
-    timestamp, created_at = parsed_timestamp
+    user_id, timestamp, created_at = parsed_link
     if created_at + current_app.config["EMAIL_RESET_PASSWORD_EXPIRY"] <= datetime.now(timezone.utc):
         flash.error("Password reset link expired.")
         return redirect(url_for("index.home"))
@@ -391,8 +417,9 @@ def reset_password():
         return redirect(url_for("index.home"))
 
     received_checksum = request.args.get("checksum")
-    checksum = create_email_link_checksum(RESET_PASSWORD, user.id, user.get_email_any(), timestamp)
-    if checksum != received_checksum:
+    # bound to the current password hash, so a used link no longer validates
+    checksum = create_reset_password_checksum(user, timestamp)
+    if not _checksum_matches(checksum, received_checksum):
         flash.error("Unable to reset password.")
         return redirect(url_for("index.home"))
 

--- a/metabrainz/user/views_test.py
+++ b/metabrainz/user/views_test.py
@@ -10,6 +10,7 @@ from flask_wtf.csrf import generate_csrf
 from freezegun import freeze_time
 from sqlalchemy import delete
 
+from metabrainz import bcrypt
 from metabrainz.model import db
 from metabrainz.model.domain_blacklist import DomainBlacklist
 from metabrainz.model.old_username import OldUsername
@@ -476,6 +477,46 @@ class UsersViewsTestCase(FlaskTestCase):
                 self.assertRedirects(response, url_for("index.home"))
                 self.assertMessageFlashed("Unable to verify email.", "error")
 
+    def test_user_email_verify_mangled_user_id(self):
+        """Mail clients that decode "&times" weld the timestamp onto the user id."""
+        self.create_user()
+
+        verification_link = self.get_context_variable("verification_link")
+        query = parse_qs(urlparse(verification_link).query)
+        mangled_link = url_for(
+            "users.verify_email",
+            user_id=f"{query['user_id'][0]}\u00d7tamp={query['ts'][0]}",
+            checksum=query["checksum"][0],
+            _external=True,
+        )
+
+        response = self.client.get(mangled_link)
+
+        self.assertEqual(response.status_code, 302)
+        user = User.get(name="test_user_1")
+        self.assertIsNone(user.unconfirmed_email)
+        self.assertEqual(user.email, "test@example.com")
+
+    def test_user_email_verify_legacy_timestamp_param(self):
+        """Links issued before the rename carry the timestamp as "timestamp"."""
+        self.create_user()
+
+        verification_link = self.get_context_variable("verification_link")
+        query = parse_qs(urlparse(verification_link).query)
+        legacy_link = url_for(
+            "users.verify_email",
+            user_id=query["user_id"][0],
+            timestamp=query["ts"][0],
+            checksum=query["checksum"][0],
+            _external=True,
+        )
+
+        response = self.client.get(legacy_link)
+
+        self.assertEqual(response.status_code, 302)
+        user = User.get(name="test_user_1")
+        self.assertEqual(user.email, "test@example.com")
+
     def test_user_email_verify_user_invalid(self):
         self.create_user()
 
@@ -484,7 +525,7 @@ class UsersViewsTestCase(FlaskTestCase):
         url = url_for(
             "users.verify_email",
             user_id=1000,
-            timestamp=query.get("timestamp")[0],
+            ts=query.get("ts")[0],
             checksum=query.get("checksum")[0],
             _external=True
         )
@@ -948,6 +989,89 @@ class UsersViewsTestCase(FlaskTestCase):
             })
             self.assertEqual(response.status_code, 302)
             self.assertMessageFlashed("Password reset link expired.", "error")
+
+    def test_reset_password_link_is_single_use(self):
+        self._test_forgot_password_helper({
+            "username": "test_user_1",
+            "email": "test@example.com",
+        }, 302)
+        reset_password_link = self.get_context_variable("reset_password_link")
+
+        response = self.client.post(reset_password_link, data={
+            "password": "<NEW-PASSWORD>",
+            "confirm_password": "<NEW-PASSWORD>",
+            "csrf_token": g.csrf_token
+        })
+        self.assertEqual(response.status_code, 302)
+        self.assertMessageFlashed("Password reset!", "success")
+
+        # the link is bound to the password it was issued against, so it is dead now
+        response = self.client.get(reset_password_link)
+        self.assertRedirects(response, url_for("index.home"))
+        self.assertMessageFlashed("Unable to reset password.", "error")
+
+        response = self.client.post(reset_password_link, data={
+            "password": "<OTHER-PASSWORD>",
+            "confirm_password": "<OTHER-PASSWORD>",
+            "csrf_token": g.csrf_token
+        })
+        self.assertRedirects(response, url_for("index.home"))
+        self.assertMessageFlashed("Unable to reset password.", "error")
+
+        user = User.get(name="test_user_1")
+        self.assertTrue(bcrypt.check_password_hash(user.password, "<NEW-PASSWORD>"))
+        self.assertFalse(bcrypt.check_password_hash(user.password, "<OTHER-PASSWORD>"))
+
+    def test_reset_password_mangled_user_id(self):
+        """Mail clients that decode "&times" weld the timestamp onto the user id."""
+        self._test_forgot_password_helper({
+            "username": "test_user_1",
+            "email": "test@example.com",
+        }, 302)
+        reset_password_link = self.get_context_variable("reset_password_link")
+        query = parse_qs(urlparse(reset_password_link).query)
+        mangled_link = url_for(
+            "users.reset_password",
+            user_id=f"{query['user_id'][0]}\u00d7tamp={query['ts'][0]}",
+            checksum=query["checksum"][0],
+            _external=True,
+        )
+
+        response = self.client.post(mangled_link, data={
+            "password": "<NEW-PASSWORD>",
+            "confirm_password": "<NEW-PASSWORD>",
+            "csrf_token": g.csrf_token
+        })
+
+        self.assertEqual(response.status_code, 302)
+        self.assertMessageFlashed("Password reset!", "success")
+        user = User.get(name="test_user_1")
+        self.assertTrue(bcrypt.check_password_hash(user.password, "<NEW-PASSWORD>"))
+
+    def test_reset_password_legacy_timestamp_param(self):
+        """Links issued before the rename carry the timestamp as "timestamp"."""
+        self._test_forgot_password_helper({
+            "username": "test_user_1",
+            "email": "test@example.com",
+        }, 302)
+        reset_password_link = self.get_context_variable("reset_password_link")
+        query = parse_qs(urlparse(reset_password_link).query)
+        legacy_link = url_for(
+            "users.reset_password",
+            user_id=query["user_id"][0],
+            timestamp=query["ts"][0],
+            checksum=query["checksum"][0],
+            _external=True,
+        )
+
+        response = self.client.post(legacy_link, data={
+            "password": "<NEW-PASSWORD>",
+            "confirm_password": "<NEW-PASSWORD>",
+            "csrf_token": g.csrf_token
+        })
+
+        self.assertEqual(response.status_code, 302)
+        self.assertMessageFlashed("Password reset!", "success")
 
     def test_user_signup_without_mtcaptcha_not_configured(self):
         self.app.config["MTCAPTCHA_PRIVATE_KEY"] = ""


### PR DESCRIPTION
"&times" is a legacy HTML entity for × that parsers decode even without the trailing semicolon, so mail clients that render our links through one turn "&timestamp=" into "×tamp=". The timestamp is welded onto the user id and the parameter disappears, which is why a subset of users saw "Unable to reset password." every single time they clicked their link: the damage is a property of their mail client, so requesting a new link reproduced it exactly.

Send the timestamp as "ts", which no entity can eat, and reassemble the mangled form for links already sitting in inboxes.

Reset links are also bound to the password hash they were issued against, so completing a reset invalidates the link that was just used along with any older ones still outstanding, without tracking issued links in the database.