### PR TITLE
MEB-190: Localize OAuth authorization pages (ui_locales + error messages)

### DIFF
--- a/docs/oauth/authorization-code-grant.rst
+++ b/docs/oauth/authorization-code-grant.rst
@@ -60,6 +60,15 @@ Redirect the user's browser to the authorization endpoint.
       ``auto``, if the user has already granted the requested scopes to your
       client, consent is skipped and a code is returned immediately. With
       ``force`` the consent screen is always shown.
+   :query ui_locales: Optional. Space-separated list of preferred BCP 47
+      language tags, in order of preference, as defined by `OpenID Connect
+      Core 1.0 section 3.1.2.1
+      <https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest>`_,
+      e.g. ``de-AT de en``. The first tag matching a language MetaBrainz
+      supports is used for the sign in, sign up, consent and error pages of
+      this flow. A language the user has explicitly chosen on the site takes
+      precedence. The supported values are listed as ``ui_locales_supported``
+      in the :doc:`discovery document <openid-connect>`.
 
 Example:
 

--- a/docs/oauth/openid-connect.rst
+++ b/docs/oauth/openid-connect.rst
@@ -45,7 +45,8 @@ Example response:
      "response_modes_supported": ["query", "fragment", "form_post"],
      "grant_types_supported": ["authorization_code", "refresh_token", "implicit"],
      "id_token_signing_alg_values_supported": ["ES256", "none"],
-     "subject_types_supported": ["public"]
+     "subject_types_supported": ["public"],
+     "ui_locales_supported": ["en", "es", "fr", "de"]
    }
 
 The ``issuer`` is ``https://metabrainz.org``. This is the value you must match

--- a/docs/oauth/registration-requests.rst
+++ b/docs/oauth/registration-requests.rst
@@ -70,6 +70,9 @@ authenticate with ``client_secret_basic`` (HTTP Basic) or
    :form response_mode: Optional. Same behavior as the authorization endpoint;
       use ``form_post`` if you need the authorization response posted to your
       ``redirect_uri``.
+   :form ui_locales: Optional. Same behavior as the authorization endpoint. It
+      is carried through the signup page and into the authorization request
+      that follows.
    :reqheader Authorization: Client authentication when using
       ``client_secret_basic``. Alternatively, send ``client_id`` and
       ``client_secret`` as form fields.

--- a/frontend/js/src/OAuthError.tsx
+++ b/frontend/js/src/OAuthError.tsx
@@ -6,6 +6,7 @@ type OAuthErrorProps = {
   error: {
     name: string;
     description: string;
+    message?: string | null;
   };
 };
 
@@ -15,9 +16,11 @@ function OAuthError({ error }: OAuthErrorProps): JSX.Element {
   return (
     <>
       <h1>{t("OAuth2 Error")}</h1>
-      <p>{t("An error occurred during OAuth authentication process.")}</p>
-      <p>
-        {error.name}: {error.description}
+      <p>{error.message || t("An error occurred during OAuth authentication process.")}</p>
+      <p className="text-muted">
+        <small>
+          {error.name}: {error.description}
+        </small>
       </p>
     </>
   );

--- a/frontend/js/src/OAuthError.tsx
+++ b/frontend/js/src/OAuthError.tsx
@@ -16,7 +16,8 @@ function OAuthError({ error }: OAuthErrorProps): JSX.Element {
   return (
     <>
       <h1>{t("OAuth2 Error")}</h1>
-      <p>{error.message || t("An error occurred during OAuth authentication process.")}</p>
+      <p>{t("An error occurred during OAuth authentication process.")}</p>
+      {error.message && <p>{error.message}</p>}
       <p className="text-muted">
         <small>
           {error.name}: {error.description}

--- a/metabrainz/__init__.py
+++ b/metabrainz/__init__.py
@@ -148,8 +148,9 @@ def create_app(debug=None, config_path=None, service=SERVICE_ALL):
     login_manager.init_app(app)
 
     # Templates
-    from metabrainz.utils import reformat_datetime
+    from metabrainz.utils import reformat_datetime, react_props
     app.jinja_env.filters['datetime'] = reformat_datetime
+    app.jinja_env.filters['react_props'] = react_props
     app.jinja_env.filters['nl2br'] = lambda val: val.replace('\n', '<br />') if val else ''
     app.jinja_loader = FileSystemLoader([
         os.path.join(os.path.dirname(os.path.realpath(__file__)), 'templates'),

--- a/metabrainz/errors.py
+++ b/metabrainz/errors.py
@@ -2,6 +2,38 @@ import json
 
 from authlib.oauth2 import OAuth2Error
 from flask import render_template
+from flask_babel import gettext
+
+
+def _oauth_error_message(code):
+    """Return a translated, user-facing message for an OAuth error code.
+
+    OAuth/OIDC error *codes* (e.g. ``access_denied``) are stable ASCII tokens,
+    so they can be safely translated, unlike ``error_description`` which is a
+    developer-facing, ASCII-only field per RFC 6749 section 4.1.2.1. Unknown
+    codes return None so the caller can fall back to the raw description.
+
+    See RFC 6749 sections 4.1.2.1 and 5.2, and OpenID Connect Core 1.0
+    section 3.1.2.6 for the error codes handled here.
+    """
+    # Built at request time so translations reflect the active locale.
+    messages = {
+        "access_denied": gettext("Authorization was declined."),
+        "invalid_request": gettext("The authorization request was invalid."),
+        "invalid_client": gettext("The application could not be authenticated."),
+        "invalid_grant": gettext("The authorization has expired or is no longer valid."),
+        "unauthorized_client": gettext("This application is not allowed to request authorization."),
+        "unsupported_response_type": gettext("The authorization request is not supported."),
+        "unsupported_grant_type": gettext("The authorization request is not supported."),
+        "invalid_scope": gettext("The requested permissions are invalid."),
+        "server_error": gettext("The server encountered an error. Please try again later."),
+        "temporarily_unavailable": gettext("The service is temporarily unavailable. Please try again later."),
+        "interaction_required": gettext("Additional interaction is required to sign in."),
+        "login_required": gettext("You need to sign in to continue."),
+        "consent_required": gettext("Your consent is required to continue."),
+        "account_selection_required": gettext("You need to select an account to continue."),
+    }
+    return messages.get(code)
 
 
 def init_error_handlers(app):
@@ -25,12 +57,16 @@ def init_error_handlers(app):
     @app.errorhandler(503)
     def service_unavailable(error):
         return render_template("errors/503.html", error=error), 503
-    
+
     @app.errorhandler(OAuth2Error)
     def oauth_error_handler(error: OAuth2Error):
         return render_template("oauth/error.html", props=json.dumps({
             "error": {
                 "name": error.error,
-                "description": error.get_error_description()
+                "description": error.get_error_description(),
+                # Translated, user-facing message chosen by the stable error
+                # code; None for unknown codes so the client falls back to the
+                # developer-facing description.
+                "message": _oauth_error_message(error.error),
             }
         }))

--- a/metabrainz/errors.py
+++ b/metabrainz/errors.py
@@ -65,6 +65,10 @@ def init_error_handlers(app):
 
     @app.errorhandler(OAuth2Error)
     def oauth_error_handler(error: OAuth2Error):
+        # Only the status code is carried over from the error. get_headers()
+        # describes a JSON API response (Content-Type, and a WWW-Authenticate
+        # challenge that would pop a browser credentials dialog), none of which
+        # belongs on an HTML page.
         return render_template("oauth/error.html", props=json.dumps({
             "error": {
                 "name": error.error,
@@ -74,4 +78,4 @@ def init_error_handlers(app):
                 # generic translated message.
                 "message": oauth_error_message(error.error),
             }
-        }))
+        })), error.status_code

--- a/metabrainz/errors.py
+++ b/metabrainz/errors.py
@@ -4,36 +4,41 @@ from authlib.oauth2 import OAuth2Error
 from flask import render_template
 from flask_babel import gettext
 
+from metabrainz.i18n import N_
 
-def _oauth_error_message(code):
+# User-facing messages keyed by the OAuth/OIDC error *code*. Codes (e.g.
+# ``access_denied``) are stable ASCII tokens, so they can be translated, unlike
+# ``error_description``, which is a developer-facing, ASCII-only field per RFC
+# 6749 section 4.1.2.1.
+#
+# Only codes that can actually reach this handler are listed: it renders HTML
+# for the authorization endpoint, and authlib handles token endpoint errors
+# (invalid_grant, unsupported_grant_type, ...) internally, never letting them
+# escape as an exception. Unlisted codes fall back to the generic message in
+# the client, so an unreachable entry is only a string translators must
+# needlessly translate. test_error_codes_are_known_to_authlib guards this.
+#
+# See RFC 6749 sections 4.1.2.1 and 5.2, and OpenID Connect Core 1.0
+# section 3.1.2.6 for the error codes handled here.
+OAUTH_ERROR_MESSAGES = {
+    "access_denied": N_("Authorization was declined."),
+    "invalid_request": N_("The authorization request was invalid."),
+    "invalid_client": N_("The application could not be authenticated."),
+    "unauthorized_client": N_("This application is not allowed to request authorization."),
+    "unsupported_response_type": N_("The application asked for a response type this server does not support."),
+    "invalid_scope": N_("The permissions requested by the application are invalid."),
+    "login_required": N_("You need to sign in to continue."),
+    "consent_required": N_("Your consent is required to continue."),
+}
+
+
+def oauth_error_message(code):
     """Return a translated, user-facing message for an OAuth error code.
 
-    OAuth/OIDC error *codes* (e.g. ``access_denied``) are stable ASCII tokens,
-    so they can be safely translated, unlike ``error_description`` which is a
-    developer-facing, ASCII-only field per RFC 6749 section 4.1.2.1. Unknown
-    codes return None so the caller can fall back to the raw description.
-
-    See RFC 6749 sections 4.1.2.1 and 5.2, and OpenID Connect Core 1.0
-    section 3.1.2.6 for the error codes handled here.
+    Unknown codes return None so the caller can fall back to a generic message.
     """
-    # Built at request time so translations reflect the active locale.
-    messages = {
-        "access_denied": gettext("Authorization was declined."),
-        "invalid_request": gettext("The authorization request was invalid."),
-        "invalid_client": gettext("The application could not be authenticated."),
-        "invalid_grant": gettext("The authorization has expired or is no longer valid."),
-        "unauthorized_client": gettext("This application is not allowed to request authorization."),
-        "unsupported_response_type": gettext("The authorization request is not supported."),
-        "unsupported_grant_type": gettext("The authorization request is not supported."),
-        "invalid_scope": gettext("The requested permissions are invalid."),
-        "server_error": gettext("The server encountered an error. Please try again later."),
-        "temporarily_unavailable": gettext("The service is temporarily unavailable. Please try again later."),
-        "interaction_required": gettext("Additional interaction is required to sign in."),
-        "login_required": gettext("You need to sign in to continue."),
-        "consent_required": gettext("Your consent is required to continue."),
-        "account_selection_required": gettext("You need to select an account to continue."),
-    }
-    return messages.get(code)
+    message = OAUTH_ERROR_MESSAGES.get(code)
+    return gettext(message) if message else None
 
 
 def init_error_handlers(app):
@@ -66,7 +71,7 @@ def init_error_handlers(app):
                 "description": error.get_error_description(),
                 # Translated, user-facing message chosen by the stable error
                 # code; None for unknown codes so the client falls back to the
-                # developer-facing description.
-                "message": _oauth_error_message(error.error),
+                # generic translated message.
+                "message": oauth_error_message(error.error),
             }
         }))

--- a/metabrainz/errors_test.py
+++ b/metabrainz/errors_test.py
@@ -1,0 +1,47 @@
+from unittest import TestCase
+
+from flask import Flask
+from flask_babel import Babel
+
+from metabrainz import errors
+
+
+class OAuthErrorMessageTestCase(TestCase):
+
+    def setUp(self):
+        # A minimal app with Babel is enough: _oauth_error_message only calls
+        # gettext, so we avoid the heavier DB-backed FlaskTestCase.
+        self.app = Flask(__name__)
+        Babel(self.app)
+
+    def test_known_codes_return_a_message(self):
+        known = [
+            "access_denied",
+            "invalid_request",
+            "invalid_client",
+            "invalid_grant",
+            "unauthorized_client",
+            "unsupported_response_type",
+            "unsupported_grant_type",
+            "invalid_scope",
+            "server_error",
+            "temporarily_unavailable",
+            "interaction_required",
+            "login_required",
+            "consent_required",
+            "account_selection_required",
+        ]
+        with self.app.test_request_context("/"):
+            for code in known:
+                message = errors._oauth_error_message(code)
+                self.assertTrue(message, f"expected a message for {code!r}")
+                # The user-facing message must not be the raw error code.
+                self.assertNotEqual(message, code)
+
+    def test_unknown_code_returns_none(self):
+        with self.app.test_request_context("/"):
+            self.assertIsNone(errors._oauth_error_message("some_new_code"))
+
+    def test_none_code_returns_none(self):
+        with self.app.test_request_context("/"):
+            self.assertIsNone(errors._oauth_error_message(None))

--- a/metabrainz/errors_test.py
+++ b/metabrainz/errors_test.py
@@ -1,47 +1,64 @@
+import importlib
+import pkgutil
 from unittest import TestCase
 
+import authlib
+from authlib.oauth2 import OAuth2Error
 from flask import Flask
 from flask_babel import Babel
 
 from metabrainz import errors
+from metabrainz.errors import OAUTH_ERROR_MESSAGES
+
+
+def authlib_error_codes():
+    """Every error code declared by an OAuth2Error subclass shipped by authlib."""
+    for module in pkgutil.walk_packages(authlib.__path__, prefix="authlib."):
+        try:
+            importlib.import_module(module.name)
+        except Exception:
+            # Integrations for web frameworks this project does not install.
+            continue
+
+    codes, pending = set(), [OAuth2Error]
+    while pending:
+        error_class = pending.pop()
+        code = getattr(error_class, "error", None)
+        if code:
+            codes.add(code)
+        pending.extend(error_class.__subclasses__())
+    return codes
 
 
 class OAuthErrorMessageTestCase(TestCase):
 
     def setUp(self):
-        # A minimal app with Babel is enough: _oauth_error_message only calls
+        # A minimal app with Babel is enough: oauth_error_message only calls
         # gettext, so we avoid the heavier DB-backed FlaskTestCase.
         self.app = Flask(__name__)
         Babel(self.app)
 
-    def test_known_codes_return_a_message(self):
-        known = [
-            "access_denied",
-            "invalid_request",
-            "invalid_client",
-            "invalid_grant",
-            "unauthorized_client",
-            "unsupported_response_type",
-            "unsupported_grant_type",
-            "invalid_scope",
-            "server_error",
-            "temporarily_unavailable",
-            "interaction_required",
-            "login_required",
-            "consent_required",
-            "account_selection_required",
-        ]
-        with self.app.test_request_context("/"):
-            for code in known:
-                message = errors._oauth_error_message(code)
-                self.assertTrue(message, f"expected a message for {code!r}")
-                # The user-facing message must not be the raw error code.
-                self.assertNotEqual(message, code)
-
     def test_unknown_code_returns_none(self):
         with self.app.test_request_context("/"):
-            self.assertIsNone(errors._oauth_error_message("some_new_code"))
+            self.assertIsNone(errors.oauth_error_message("some_new_code"))
 
     def test_none_code_returns_none(self):
         with self.app.test_request_context("/"):
-            self.assertIsNone(errors._oauth_error_message(None))
+            self.assertIsNone(errors.oauth_error_message(None))
+
+    def test_known_code_returns_its_message(self):
+        with self.app.test_request_context("/"):
+            self.assertEqual(
+                errors.oauth_error_message("access_denied"),
+                OAUTH_ERROR_MESSAGES["access_denied"],
+            )
+
+    def test_error_codes_are_known_to_authlib(self):
+        """Guard against entries for errors nothing can raise.
+
+        An unreachable code is a string every translator has to translate for a
+        page that can never be shown.
+        """
+        known = authlib_error_codes()
+        for code in OAUTH_ERROR_MESSAGES:
+            self.assertIn(code, known)

--- a/metabrainz/errors_test.py
+++ b/metabrainz/errors_test.py
@@ -1,14 +1,19 @@
 import importlib
+import os
 import pkgutil
 from unittest import TestCase
 
 import authlib
 from authlib.oauth2 import OAuth2Error
+from babel.messages.pofile import read_po
 from flask import Flask
 from flask_babel import Babel
 
 from metabrainz import errors
 from metabrainz.errors import OAUTH_ERROR_MESSAGES
+from metabrainz.oauth.scopes import SCOPE_DESCRIPTIONS
+
+POT_FILE = os.path.join(os.path.dirname(__file__), "messages.pot")
 
 
 def authlib_error_codes():
@@ -28,6 +33,11 @@ def authlib_error_codes():
             codes.add(code)
         pending.extend(error_class.__subclasses__())
     return codes
+
+
+def extracted_message_ids():
+    with open(POT_FILE, "rb") as pot:
+        return {message.id for message in read_po(pot) if message.id}
 
 
 class OAuthErrorMessageTestCase(TestCase):
@@ -62,3 +72,22 @@ class OAuthErrorMessageTestCase(TestCase):
         known = authlib_error_codes()
         for code in OAUTH_ERROR_MESSAGES:
             self.assertIn(code, known)
+
+
+class TranslatableStringsTestCase(TestCase):
+    """The catalogs are what actually make these strings translated.
+
+    A message that was never extracted is returned unchanged by gettext, so the
+    feature silently ships in English. These tests fail until
+    `python manage.py extract_strings` has been run and its output committed.
+    """
+
+    def test_error_messages_are_extracted(self):
+        extracted = extracted_message_ids()
+        for message in OAUTH_ERROR_MESSAGES.values():
+            self.assertIn(message, extracted)
+
+    def test_scope_descriptions_are_extracted(self):
+        extracted = extracted_message_ids()
+        for description in SCOPE_DESCRIPTIONS.values():
+            self.assertIn(description, extracted)

--- a/metabrainz/i18n.py
+++ b/metabrainz/i18n.py
@@ -16,11 +16,42 @@ def get_supported_locale_codes():
     return [language["code"] for language in SUPPORTED_LANGUAGES]
 
 
+def match_ui_locales(ui_locales):
+    """Return the first supported locale requested via OIDC ``ui_locales``.
+
+    ``ui_locales`` is a space-separated, preference-ordered list of BCP 47
+    language tags (e.g. ``"fr-CA fr en"``), as defined by OpenID Connect Core
+    1.0 section 3.1.2.1. Matching is done on the primary language subtag
+    against the supported locale codes. Returns None if nothing matches.
+    """
+    if not ui_locales:
+        return None
+    supported = get_supported_locale_codes()
+    for tag in ui_locales.split():
+        primary_subtag = tag.replace("_", "-").split("-")[0].lower()
+        if primary_subtag in supported:
+            return primary_subtag
+    return None
+
+
 def get_locale():
-    """Return the active locale from the language cookie"""
+    """Return the active locale.
+
+    Precedence:
+      1. The user's explicit language cookie (their site-wide choice).
+      2. The OpenID Connect ``ui_locales`` request hint, e.g. from an OAuth
+         client such as MusicBrainz Picard (section 3.1.2.1). This lets the
+         authorization/consent and error pages match the client's language
+         when the user has not set their own preference here.
+      3. The default locale.
+    """
     cookie_locale = request.cookies.get(LANGUAGE_COOKIE_NAME)
     if cookie_locale in get_supported_locale_codes():
         return cookie_locale
+
+    ui_locale = match_ui_locales(request.args.get("ui_locales"))
+    if ui_locale:
+        return ui_locale
 
     return DEFAULT_LOCALE
 

--- a/metabrainz/i18n.py
+++ b/metabrainz/i18n.py
@@ -1,8 +1,12 @@
-from flask import Blueprint, abort, redirect, request, url_for
+from babel import negotiate_locale
+from flask import Blueprint, abort, redirect, request, session, url_for
 
 
 LANGUAGE_COOKIE_NAME = "lang"
 DEFAULT_LOCALE = "en"
+# Where a locale negotiated from an OIDC ``ui_locales`` hint is remembered for
+# the rest of the browser session, see remember_ui_locales().
+UI_LOCALE_SESSION_KEY = "ui_locale"
 i18n_bp = Blueprint("i18n", __name__)
 SUPPORTED_LANGUAGES = (
     {"code": "en", "name": "English"},
@@ -21,17 +25,33 @@ def match_ui_locales(ui_locales):
 
     ``ui_locales`` is a space-separated, preference-ordered list of BCP 47
     language tags (e.g. ``"fr-CA fr en"``), as defined by OpenID Connect Core
-    1.0 section 3.1.2.1. Matching is done on the primary language subtag
-    against the supported locale codes. Returns None if nothing matches.
+    1.0 section 3.1.2.1. Returns None if nothing matches.
     """
     if not ui_locales:
         return None
-    supported = get_supported_locale_codes()
-    for tag in ui_locales.split():
-        primary_subtag = tag.replace("_", "-").split("-")[0].lower()
-        if primary_subtag in supported:
-            return primary_subtag
-    return None
+
+    # negotiate_locale() matches an exact tag first and only then falls back to
+    # the primary subtag, so a regional catalog (say pt_BR) is preferred over
+    # its base language when both are supported. Both sides are normalised to
+    # lowercase and "-" separators because it compares tags verbatim.
+    canonical = {code.replace("_", "-").lower(): code for code in get_supported_locale_codes()}
+    preferred = [tag.replace("_", "-").lower() for tag in ui_locales.split()]
+    matched = negotiate_locale(preferred, list(canonical), sep="-")
+    return canonical.get(matched)
+
+
+def remember_ui_locales(ui_locales):
+    """Remember the locale an OAuth client asked for via ``ui_locales``.
+
+    The hint only appears on the authorization request itself, but the pages
+    that follow it (sign in, sign up, consent, errors) are separate requests on
+    other blueprints, so it is negotiated once here and kept in the session for
+    the rest of the flow. The user's own language cookie still wins.
+    """
+    locale = match_ui_locales(ui_locales)
+    if locale:
+        session[UI_LOCALE_SESSION_KEY] = locale
+    return locale
 
 
 def get_locale():
@@ -39,18 +59,17 @@ def get_locale():
 
     Precedence:
       1. The user's explicit language cookie (their site-wide choice).
-      2. The OpenID Connect ``ui_locales`` request hint, e.g. from an OAuth
-         client such as MusicBrainz Picard (section 3.1.2.1). This lets the
-         authorization/consent and error pages match the client's language
-         when the user has not set their own preference here.
+      2. A locale remembered from an OpenID Connect ``ui_locales`` hint sent by
+         an OAuth client such as MusicBrainz Picard (section 3.1.2.1), so the
+         sign in, consent and error pages of that flow match the client.
       3. The default locale.
     """
     cookie_locale = request.cookies.get(LANGUAGE_COOKIE_NAME)
     if cookie_locale in get_supported_locale_codes():
         return cookie_locale
 
-    ui_locale = match_ui_locales(request.args.get("ui_locales"))
-    if ui_locale:
+    ui_locale = session.get(UI_LOCALE_SESSION_KEY)
+    if ui_locale in get_supported_locale_codes():
         return ui_locale
 
     return DEFAULT_LOCALE

--- a/metabrainz/i18n.py
+++ b/metabrainz/i18n.py
@@ -60,7 +60,7 @@ def get_locale():
 def set_language(locale):
     """Set the language cookie and redirect back to the originating page."""
     returnto = request.args.get("returnto", url_for("index.home"))
-    if not returnto.startswith("/") or returnto.startswith("//"):
+    if not _is_safe_returnto(returnto):
         abort(400)
 
     if locale not in get_supported_locale_codes():
@@ -78,6 +78,19 @@ def set_language(locale):
     return response
 
 
+def _is_safe_returnto(returnto):
+    """Return True if returnto is a path on this site and not a redirect off it.
+
+    Browsers normalise a backslash to a forward slash while parsing a URL (per
+    the WHATWG URL standard), so "/\\evil.example.com" is treated as the
+    protocol-relative "//evil.example.com" and navigates cross-origin. Reject
+    backslashes outright rather than trying to spot every such spelling.
+    """
+    if not returnto or "\\" in returnto:
+        return False
+    return returnto.startswith("/") and not returnto.startswith("//")
+
+
 def get_locale_context():
     """Provide locale variables and helpers to Jinja templates."""
     locale = get_locale()
@@ -89,4 +102,11 @@ def get_locale_context():
 
 
 def get_language_url(locale):
-    return url_for("i18n.set_language", locale=locale, returnto=request.full_path.rstrip("?"))
+    # The language switcher is a link, so it can only return the user to a URL
+    # that answers GET. A page rendered in response to a POST (the OAuth error
+    # page, for one) would answer 405, so send those back to the home page.
+    if request.method == "GET":
+        returnto = request.full_path.rstrip("?")
+    else:
+        returnto = url_for("index.home")
+    return url_for("i18n.set_language", locale=locale, returnto=returnto)

--- a/metabrainz/i18n.py
+++ b/metabrainz/i18n.py
@@ -16,6 +16,18 @@ SUPPORTED_LANGUAGES = (
 )
 
 
+def N_(string):
+    """Mark a string for translation without translating it here.
+
+    ``N_`` is one of pybabel's default extraction keywords, so strings wrapped
+    in it end up in messages.pot and can be translated later, at a point where
+    a request (and therefore an active locale) exists. For example, module level
+    strings. lazy_gettext can be used but requires extra handling with pybabel
+    and json.dumps.
+    """
+    return string
+
+
 def get_supported_locale_codes():
     return [language["code"] for language in SUPPORTED_LANGUAGES]
 

--- a/metabrainz/i18n_test.py
+++ b/metabrainz/i18n_test.py
@@ -1,0 +1,65 @@
+from unittest import TestCase
+
+from flask import Flask
+
+from metabrainz import i18n
+
+
+class MatchUiLocalesTestCase(TestCase):
+
+    def test_none_or_empty(self):
+        self.assertIsNone(i18n.match_ui_locales(None))
+        self.assertIsNone(i18n.match_ui_locales(""))
+
+    def test_supported_language(self):
+        self.assertEqual(i18n.match_ui_locales("fr"), "fr")
+        self.assertEqual(i18n.match_ui_locales("de"), "de")
+
+    def test_primary_subtag_of_regional_tag(self):
+        # BCP 47 regional tags match on their primary subtag.
+        self.assertEqual(i18n.match_ui_locales("fr-CA"), "fr")
+        self.assertEqual(i18n.match_ui_locales("es-419"), "es")
+
+    def test_posix_style_separator(self):
+        self.assertEqual(i18n.match_ui_locales("fr_FR"), "fr")
+
+    def test_preference_order(self):
+        # First supported tag in the ordered list wins.
+        self.assertEqual(i18n.match_ui_locales("zh nl fr en"), "fr")
+
+    def test_case_insensitive(self):
+        self.assertEqual(i18n.match_ui_locales("FR-ca"), "fr")
+
+    def test_unsupported_returns_none(self):
+        self.assertIsNone(i18n.match_ui_locales("zh ja ko"))
+
+
+class GetLocaleTestCase(TestCase):
+
+    def setUp(self):
+        # A minimal app is enough: get_locale() only reads request cookies and
+        # args, so we avoid the heavier DB-backed FlaskTestCase.
+        self.app = Flask(__name__)
+
+    def test_default_locale_when_nothing_provided(self):
+        with self.app.test_request_context("/"):
+            self.assertEqual(i18n.get_locale(), i18n.DEFAULT_LOCALE)
+
+    def test_cookie_takes_precedence(self):
+        headers = {"Cookie": f"{i18n.LANGUAGE_COOKIE_NAME}=fr"}
+        with self.app.test_request_context("/?ui_locales=de", headers=headers):
+            self.assertEqual(i18n.get_locale(), "fr")
+
+    def test_ui_locales_used_without_cookie(self):
+        with self.app.test_request_context("/?ui_locales=fr-CA"):
+            self.assertEqual(i18n.get_locale(), "fr")
+
+    def test_ui_locales_ignored_when_cookie_unsupported(self):
+        # An unsupported cookie value falls through to the ui_locales hint.
+        headers = {"Cookie": f"{i18n.LANGUAGE_COOKIE_NAME}=zz"}
+        with self.app.test_request_context("/?ui_locales=de", headers=headers):
+            self.assertEqual(i18n.get_locale(), "de")
+
+    def test_unsupported_ui_locales_falls_back_to_default(self):
+        with self.app.test_request_context("/?ui_locales=ja"):
+            self.assertEqual(i18n.get_locale(), i18n.DEFAULT_LOCALE)

--- a/metabrainz/i18n_test.py
+++ b/metabrainz/i18n_test.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from flask import Blueprint, Flask
+from flask import Blueprint, Flask, session
 
 from metabrainz import i18n
 
@@ -16,7 +16,7 @@ class MatchUiLocalesTestCase(TestCase):
         self.assertEqual(i18n.match_ui_locales("de"), "de")
 
     def test_primary_subtag_of_regional_tag(self):
-        # BCP 47 regional tags match on their primary subtag.
+        # BCP 47 regional tags fall back to their primary subtag.
         self.assertEqual(i18n.match_ui_locales("fr-CA"), "fr")
         self.assertEqual(i18n.match_ui_locales("es-419"), "es")
 
@@ -33,13 +33,25 @@ class MatchUiLocalesTestCase(TestCase):
     def test_unsupported_returns_none(self):
         self.assertIsNone(i18n.match_ui_locales("zh ja ko"))
 
+    def test_regional_catalog_preferred_over_its_base_language(self):
+        # A regional catalog must win over its own base language when the
+        # client asked for it exactly, rather than being cut down to "pt".
+        supported = i18n.SUPPORTED_LANGUAGES
+        i18n.SUPPORTED_LANGUAGES = supported + ({"code": "pt_BR", "name": "Português"},)
+        try:
+            self.assertEqual(i18n.match_ui_locales("pt-BR"), "pt_BR")
+            self.assertEqual(i18n.match_ui_locales("pt_BR"), "pt_BR")
+        finally:
+            i18n.SUPPORTED_LANGUAGES = supported
+
 
 class GetLocaleTestCase(TestCase):
 
     def setUp(self):
-        # A minimal app is enough: get_locale() only reads request cookies and
-        # args, so we avoid the heavier DB-backed FlaskTestCase.
+        # A minimal app is enough: get_locale() only reads the language cookie
+        # and the session, so we avoid the heavier DB-backed FlaskTestCase.
         self.app = Flask(__name__)
+        self.app.secret_key = "i18n-test"
 
     def test_default_locale_when_nothing_provided(self):
         with self.app.test_request_context("/"):
@@ -47,22 +59,59 @@ class GetLocaleTestCase(TestCase):
 
     def test_cookie_takes_precedence(self):
         headers = {"Cookie": f"{i18n.LANGUAGE_COOKIE_NAME}=fr"}
-        with self.app.test_request_context("/?ui_locales=de", headers=headers):
+        with self.app.test_request_context("/", headers=headers):
+            session[i18n.UI_LOCALE_SESSION_KEY] = "de"
             self.assertEqual(i18n.get_locale(), "fr")
 
-    def test_ui_locales_used_without_cookie(self):
-        with self.app.test_request_context("/?ui_locales=fr-CA"):
-            self.assertEqual(i18n.get_locale(), "fr")
-
-    def test_ui_locales_ignored_when_cookie_unsupported(self):
-        # An unsupported cookie value falls through to the ui_locales hint.
-        headers = {"Cookie": f"{i18n.LANGUAGE_COOKIE_NAME}=zz"}
-        with self.app.test_request_context("/?ui_locales=de", headers=headers):
+    def test_remembered_ui_locale_used_without_cookie(self):
+        with self.app.test_request_context("/"):
+            session[i18n.UI_LOCALE_SESSION_KEY] = "de"
             self.assertEqual(i18n.get_locale(), "de")
 
-    def test_unsupported_ui_locales_falls_back_to_default(self):
-        with self.app.test_request_context("/?ui_locales=ja"):
+    def test_remembered_ui_locale_used_when_cookie_unsupported(self):
+        headers = {"Cookie": f"{i18n.LANGUAGE_COOKIE_NAME}=zz"}
+        with self.app.test_request_context("/", headers=headers):
+            session[i18n.UI_LOCALE_SESSION_KEY] = "de"
+            self.assertEqual(i18n.get_locale(), "de")
+
+    def test_unsupported_remembered_locale_falls_back_to_default(self):
+        # A locale that has since been dropped from SUPPORTED_LANGUAGES must
+        # not linger in an old session.
+        with self.app.test_request_context("/"):
+            session[i18n.UI_LOCALE_SESSION_KEY] = "ja"
             self.assertEqual(i18n.get_locale(), i18n.DEFAULT_LOCALE)
+
+    def test_ui_locales_query_param_alone_does_not_change_locale(self):
+        # ui_locales is an OIDC authorization request parameter, not a
+        # site-wide language switch: it only takes effect once an OAuth
+        # endpoint has recorded it with remember_ui_locales().
+        with self.app.test_request_context("/donate?ui_locales=de"):
+            self.assertEqual(i18n.get_locale(), i18n.DEFAULT_LOCALE)
+
+
+class RememberUiLocalesTestCase(TestCase):
+
+    def setUp(self):
+        self.app = Flask(__name__)
+        self.app.secret_key = "i18n-test"
+
+    def test_supported_hint_is_remembered(self):
+        with self.app.test_request_context("/"):
+            self.assertEqual(i18n.remember_ui_locales("de-AT fr"), "de")
+            self.assertEqual(session[i18n.UI_LOCALE_SESSION_KEY], "de")
+            self.assertEqual(i18n.get_locale(), "de")
+
+    def test_unsupported_hint_leaves_the_session_untouched(self):
+        with self.app.test_request_context("/"):
+            session[i18n.UI_LOCALE_SESSION_KEY] = "fr"
+            self.assertIsNone(i18n.remember_ui_locales("ja"))
+            self.assertEqual(session[i18n.UI_LOCALE_SESSION_KEY], "fr")
+
+    def test_missing_hint_leaves_the_session_untouched(self):
+        with self.app.test_request_context("/"):
+            session[i18n.UI_LOCALE_SESSION_KEY] = "fr"
+            self.assertIsNone(i18n.remember_ui_locales(None))
+            self.assertEqual(session[i18n.UI_LOCALE_SESSION_KEY], "fr")
 
 
 class SetLanguageTestCase(TestCase):

--- a/metabrainz/i18n_test.py
+++ b/metabrainz/i18n_test.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from flask import Flask
+from flask import Blueprint, Flask
 
 from metabrainz import i18n
 
@@ -63,3 +63,42 @@ class GetLocaleTestCase(TestCase):
     def test_unsupported_ui_locales_falls_back_to_default(self):
         with self.app.test_request_context("/?ui_locales=ja"):
             self.assertEqual(i18n.get_locale(), i18n.DEFAULT_LOCALE)
+
+
+class SetLanguageTestCase(TestCase):
+
+    def setUp(self):
+        self.app = Flask(__name__)
+        self.app.secret_key = "i18n-test"
+        # set_language falls back to the home page, so that endpoint has to exist.
+        index_bp = Blueprint("index", __name__)
+        index_bp.add_url_rule("/", "home", lambda: "")
+        self.app.register_blueprint(index_bp)
+        self.app.register_blueprint(i18n.i18n_bp)
+        self.client = self.app.test_client()
+
+    def test_sets_cookie_and_redirects(self):
+        response = self.client.get("/set-language/fr?returnto=/donate")
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.headers["Location"], "/donate")
+        self.assertIn(f"{i18n.LANGUAGE_COOKIE_NAME}=fr", response.headers["Set-Cookie"])
+
+    def test_unsupported_locale_is_rejected(self):
+        response = self.client.get("/set-language/ja?returnto=/donate")
+        self.assertEqual(response.status_code, 404)
+
+    def test_absolute_url_is_rejected(self):
+        response = self.client.get("/set-language/fr?returnto=https://evil.example.com")
+        self.assertEqual(response.status_code, 400)
+
+    def test_protocol_relative_url_is_rejected(self):
+        response = self.client.get("/set-language/fr?returnto=//evil.example.com")
+        self.assertEqual(response.status_code, 400)
+
+    def test_backslash_url_is_rejected(self):
+        # Browsers normalise "\" to "/" while parsing a URL, so this would
+        # otherwise navigate to //evil.example.com.
+        response = self.client.get("/set-language/fr?returnto=/\\evil.example.com")
+        self.assertEqual(response.status_code, 400)
+        response = self.client.get("/set-language/fr?returnto=\\\\evil.example.com")
+        self.assertEqual(response.status_code, 400)

--- a/metabrainz/index/views.py
+++ b/metabrainz/index/views.py
@@ -21,6 +21,7 @@ from metabrainz.model.user import User
 from metabrainz.model.webhook import EVENT_USER_DELETED
 from metabrainz.oauth.forms import ApplicationForm, DeleteApplicationForm
 from metabrainz.oauth.generator import create_client_id, create_client_secret
+from metabrainz.oauth.scopes import scope_description
 from metabrainz.user.email import send_verification_email
 
 
@@ -322,7 +323,7 @@ def profile_applications():
             "name": token.client.name,
             "scopes": [{
                 "name": scope.name,
-                "description": scope.description
+                "description": scope_description(scope)
             } for scope in token.scopes],
             "client_id": token.client.client_id,
             "website": token.client.website,

--- a/metabrainz/messages.pot
+++ b/metabrainz/messages.pot
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: metabrainz.org VERSION\n"
 "Report-Msgid-Bugs-To: support@metabrainz.org\n"
-"POT-Creation-Date: 2026-07-25 16:21+0200\n"
+"POT-Creation-Date: 2026-09-08 11:18+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,162 +18,247 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.18.0\n"
 
-#: metabrainz/index/forms.py:46
+#: metabrainz/errors.py:24
+msgid "Authorization was declined."
+msgstr ""
+
+#: metabrainz/errors.py:25
+msgid "The authorization request was invalid."
+msgstr ""
+
+#: metabrainz/errors.py:26
+msgid "The application could not be authenticated."
+msgstr ""
+
+#: metabrainz/errors.py:27
+msgid "This application is not allowed to request authorization."
+msgstr ""
+
+#: metabrainz/errors.py:28
+msgid "The application asked for a response type this server does not support."
+msgstr ""
+
+#: metabrainz/errors.py:29
+msgid "The permissions requested by the application are invalid."
+msgstr ""
+
+#: metabrainz/errors.py:30
+msgid "You need to sign in to continue."
+msgstr ""
+
+#: metabrainz/errors.py:31
+msgid "Your consent is required to continue."
+msgstr ""
+
+#: metabrainz/password.py:12
+#, python-format
+msgid "Password must not exceed %(max_bytes)s bytes."
+msgstr ""
+
+#: metabrainz/index/forms.py:48
 #, python-format
 msgid "'%(value)s' is not a valid choice for this field"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileEdit.tsx:27
-#: frontend/js/src/forms/SignupCommercial.tsx:154
+#: frontend/js/src/forms/SignupCommercial.tsx:159
 #: frontend/js/src/forms/SignupNonCommercial.tsx:85
-#: frontend/js/src/forms/SignupUser.tsx:70
-#: frontend/js/src/hooks/useEmailValidation.ts:78 metabrainz/index/forms.py:57
-#: metabrainz/user/forms.py:25 metabrainz/user/forms.py:57
-#: metabrainz/user/forms.py:63
+#: frontend/js/src/forms/SignupUser.tsx:76
+#: frontend/js/src/hooks/useEmailValidation.ts:78 metabrainz/index/forms.py:59
+#: metabrainz/user/forms.py:31 metabrainz/user/forms.py:70
+#: metabrainz/user/forms.py:76
 msgid "Email address is required!"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:34
-#: metabrainz/index/forms.py:63
+#: metabrainz/index/forms.py:65
 msgid "Current password is required!"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:43
 #: frontend/js/src/forms/ProfileChangePassword.tsx:37
 #: frontend/js/src/forms/ResetPassword.tsx:39
-#: frontend/js/src/forms/SignupCommercial.tsx:156
+#: frontend/js/src/forms/SignupCommercial.tsx:161
 #: frontend/js/src/forms/SignupNonCommercial.tsx:87
-#: frontend/js/src/forms/SignupUser.tsx:72 metabrainz/index/forms.py:66
-#: metabrainz/user/forms.py:29 metabrainz/user/forms.py:46
-#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:69
+#: frontend/js/src/forms/SignupUser.tsx:78 metabrainz/index/forms.py:69
+#: metabrainz/user/forms.py:35 metabrainz/user/forms.py:54
+#: metabrainz/user/forms.py:63 metabrainz/user/forms.py:82
 msgid "Password is required!"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:41
-#: frontend/js/src/forms/SignupCommercial.tsx:160
+#: frontend/js/src/forms/SignupCommercial.tsx:165
 #: frontend/js/src/forms/SignupNonCommercial.tsx:91
-#: frontend/js/src/forms/SignupUser.tsx:76 metabrainz/index/forms.py:70
-#: metabrainz/user/forms.py:33 metabrainz/user/forms.py:73
+#: frontend/js/src/forms/SignupUser.tsx:82 metabrainz/index/forms.py:74
+#: metabrainz/user/forms.py:40 metabrainz/user/forms.py:87
 msgid "Confirm Password is required!"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:46
 #: frontend/js/src/forms/ResetPassword.tsx:48
-#: frontend/js/src/forms/SignupCommercial.tsx:165
+#: frontend/js/src/forms/SignupCommercial.tsx:170
 #: frontend/js/src/forms/SignupNonCommercial.tsx:96
-#: frontend/js/src/forms/SignupUser.tsx:81 metabrainz/index/forms.py:72
-#: metabrainz/user/forms.py:35 metabrainz/user/forms.py:75
+#: frontend/js/src/forms/SignupUser.tsx:87 metabrainz/index/forms.py:76
+#: metabrainz/user/forms.py:42 metabrainz/user/forms.py:89
 msgid "Confirm Password should match password!"
 msgstr ""
 
 #: frontend/js/src/Applications.tsx:56 frontend/js/src/Applications.tsx:86
 #: frontend/js/src/Profile.tsx:272 frontend/js/src/Profile.tsx:482
-#: metabrainz/index/forms.py:78
+#: metabrainz/index/forms.py:82
 msgid "Name"
 msgstr ""
 
-#: metabrainz/index/forms.py:79
+#: metabrainz/index/forms.py:83
 msgid "Contact name field is empty."
 msgstr ""
 
-#: metabrainz/index/views.py:234
+#: metabrainz/index/views.py:251
 msgid "Profile updated successfully."
 msgstr ""
 
-#: metabrainz/index/views.py:261
+#: metabrainz/index/views.py:278
 msgid "Current password is incorrect."
 msgstr ""
 
-#: metabrainz/index/views.py:266
+#: metabrainz/index/views.py:283
 msgid "Password changed successfully."
 msgstr ""
 
-#: metabrainz/index/views.py:372
+#: metabrainz/index/views.py:389
 msgid "You have updated an application!"
 msgstr ""
 
-#: metabrainz/index/views.py:424
+#: metabrainz/index/views.py:441
 msgid "You have deleted an application."
 msgstr ""
 
-#: metabrainz/index/views.py:426
+#: metabrainz/index/views.py:443
 msgid "Failed to delete an application."
 msgstr ""
 
-#: metabrainz/index/views.py:449
+#: metabrainz/index/views.py:466
 msgid "Revoked tokens successfully!"
 msgstr ""
 
-#: metabrainz/index/views.py:478
+#: metabrainz/index/views.py:495
 msgid "Your account has been deleted."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:106 metabrainz/oauth/forms.py:58
+#: frontend/js/src/forms/CreateApplication.tsx:106 metabrainz/oauth/forms.py:57
 msgid "Application Name"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:59
+#: metabrainz/oauth/forms.py:58
 msgid "Application name field is empty."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:60 metabrainz/oauth/forms.py:60
+#: frontend/js/src/forms/CreateApplication.tsx:60 metabrainz/oauth/forms.py:59
 msgid "Application name needs to be at least 3 characters long."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:64 metabrainz/oauth/forms.py:61
+#: frontend/js/src/forms/CreateApplication.tsx:64 metabrainz/oauth/forms.py:60
 msgid "Application name needs to be at most 64 characters long."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:114 metabrainz/oauth/forms.py:63
+#: frontend/js/src/forms/CreateApplication.tsx:114 metabrainz/oauth/forms.py:62
 msgid "Description"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:64
+#: metabrainz/oauth/forms.py:63
 msgid "Client description field is empty."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:65
+#: metabrainz/oauth/forms.py:64
 msgid "Client description needs to be at least 3 characters long."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:66
+#: metabrainz/oauth/forms.py:65
 msgid "Client description needs to be at most 512 characters long."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:122 metabrainz/oauth/forms.py:68
+#: frontend/js/src/forms/CreateApplication.tsx:122 metabrainz/oauth/forms.py:67
 msgid "Homepage"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:69
+#: metabrainz/oauth/forms.py:68
 msgid "Homepage field is empty."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:70
+#: metabrainz/oauth/forms.py:69
 msgid "Homepage is not a valid URI."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:71
+#: metabrainz/oauth/forms.py:70
 msgid "Homepage URL must use http or https"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:73
+#: metabrainz/oauth/forms.py:72
 msgid "Authorization callback URL"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:74
+#: metabrainz/oauth/forms.py:73
 msgid "Authorization callback URL field is empty."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:75
+#: metabrainz/oauth/forms.py:74
 msgid "Authorization callback URL is invalid."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:76
+#: metabrainz/oauth/forms.py:75
 msgid "Authorization callback URL must use http or https."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:81 metabrainz/oauth/forms.py:85
+#: metabrainz/oauth/forms.py:80 metabrainz/oauth/forms.py:84
 msgid "Confirm"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:15
+msgid "View your public account information"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:16
+msgid "View your email address"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:17
+msgid "View and modify your private tags"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:18
+msgid "View and modify your private ratings"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:19
+msgid "View and modify your private collections"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:20
+msgid "Submit new ISRCs to the database"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:21
+msgid "Submit new barcodes to the database"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:22
+msgid "Sign you in and view your unique user id"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:23
+msgid "Submit listens to ListenBrainz."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:24
+msgid "Create and modify CritiqueBrainz reviews."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:25
+msgid "Submit and delete votes on CritiqueBrainz reviews."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:26
+msgid "Modify profile info and delete profile on CritiqueBrainz."
 msgstr ""
 
 #: metabrainz/payments/views.py:164
@@ -218,178 +303,185 @@ msgid "Requested annual report was not found."
 msgstr ""
 
 #: frontend/js/src/forms/ProfileEdit.tsx:30
-#: frontend/js/src/forms/SignupCommercial.tsx:139
+#: frontend/js/src/forms/SignupCommercial.tsx:144
 #: frontend/js/src/forms/SignupNonCommercial.tsx:70
-#: metabrainz/supporter/forms.py:13
+#: metabrainz/supporter/forms.py:15
 msgid "Contact name is required!"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:437
+#: frontend/js/src/forms/SignupCommercial.tsx:441
 #: frontend/js/src/forms/SignupNonCommercial.tsx:264
-#: metabrainz/supporter/forms.py:15
+#: metabrainz/supporter/forms.py:17
 msgid ""
 "Can you please tell us more about the project in which you'd like to use "
 "our data? Do you plan to self host the data or use our APIs?"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:137
+#: frontend/js/src/forms/SignupCommercial.tsx:142
 #: frontend/js/src/forms/SignupNonCommercial.tsx:68
-#: metabrainz/supporter/forms.py:17
+#: metabrainz/supporter/forms.py:19
 msgid "Please, tell us how you (will) use our data."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:138
+#: frontend/js/src/forms/SignupCommercial.tsx:143
 #: frontend/js/src/forms/SignupNonCommercial.tsx:69
-#: metabrainz/supporter/forms.py:18
+#: metabrainz/supporter/forms.py:20
 msgid "Please, limit usage description to 500 characters."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:141
-#: frontend/js/src/forms/SignupCommercial.tsx:142
+#: frontend/js/src/forms/SignupCommercial.tsx:146
+#: frontend/js/src/forms/SignupCommercial.tsx:147
 #: frontend/js/src/forms/SignupNonCommercial.tsx:72
 #: frontend/js/src/forms/SignupNonCommercial.tsx:73
-#: frontend/js/src/forms/SignupUser.tsx:84
-#: frontend/js/src/forms/SignupUser.tsx:85 metabrainz/supporter/forms.py:21
-#: metabrainz/user/forms.py:38
+#: frontend/js/src/forms/SignupUser.tsx:90
+#: frontend/js/src/forms/SignupUser.tsx:91 metabrainz/supporter/forms.py:23
+#: metabrainz/user/forms.py:45
 msgid "You need to accept the agreement!"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:342
-#: metabrainz/supporter/forms.py:27
+#: frontend/js/src/forms/SignupCommercial.tsx:347
+#: metabrainz/supporter/forms.py:29
 msgid "Organization name"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:113
-#: metabrainz/supporter/forms.py:28
+#: frontend/js/src/forms/SignupCommercial.tsx:115
+#: metabrainz/supporter/forms.py:30
 msgid "You need to specify the name of your organization."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:373
-#: metabrainz/supporter/forms.py:30
+#: frontend/js/src/forms/SignupCommercial.tsx:378
+#: metabrainz/supporter/forms.py:32
 msgid "Organization description"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:116
-#: metabrainz/supporter/forms.py:31
+#: frontend/js/src/forms/SignupCommercial.tsx:118
+#: metabrainz/supporter/forms.py:33
 msgid "You need to provide description of your organization."
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:278
-#: frontend/js/src/forms/SignupCommercial.tsx:396
-#: metabrainz/supporter/forms.py:34
+#: frontend/js/src/forms/SignupCommercial.tsx:401
+#: metabrainz/supporter/forms.py:36
 msgid "Website URL"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:119
-#: metabrainz/supporter/forms.py:35
-msgid "You need to specify website of the organization."
+#: frontend/js/src/forms/SignupCommercial.tsx:121
+#: frontend/js/src/forms/SignupCommercial.tsx:123
+#: metabrainz/supporter/forms.py:38 metabrainz/supporter/forms.py:42
+msgid "Website URL must be a valid URL."
 msgstr ""
 
-#: metabrainz/supporter/forms.py:37
+#: metabrainz/supporter/forms.py:45
 msgid "Logo image URL"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:284
-#: frontend/js/src/forms/SignupCommercial.tsx:418
-#: metabrainz/supporter/forms.py:38
+#: frontend/js/src/forms/SignupCommercial.tsx:422
+#: metabrainz/supporter/forms.py:46
 msgid "API URL"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:457
-#: metabrainz/supporter/forms.py:40
+#: frontend/js/src/forms/SignupCommercial.tsx:461
+#: metabrainz/supporter/forms.py:48
 msgid "Street"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:123
-#: metabrainz/supporter/forms.py:41
+#: frontend/js/src/forms/SignupCommercial.tsx:128
+#: metabrainz/supporter/forms.py:49
 msgid "You need to specify street."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:465
-#: metabrainz/supporter/forms.py:43
+#: frontend/js/src/forms/SignupCommercial.tsx:469
+#: metabrainz/supporter/forms.py:51
 msgid "City"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:124
-#: metabrainz/supporter/forms.py:44
+#: frontend/js/src/forms/SignupCommercial.tsx:129
+#: metabrainz/supporter/forms.py:52
 msgid "You need to specify city."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:473
-#: metabrainz/supporter/forms.py:46
+#: frontend/js/src/forms/SignupCommercial.tsx:477
+#: metabrainz/supporter/forms.py:54
 msgid "State / Province"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:126
-#: metabrainz/supporter/forms.py:47
+#: frontend/js/src/forms/SignupCommercial.tsx:131
+#: metabrainz/supporter/forms.py:55
 msgid "You need to specify state/province."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:481
-#: metabrainz/supporter/forms.py:49
+#: frontend/js/src/forms/SignupCommercial.tsx:485
+#: metabrainz/supporter/forms.py:57
 msgid "Postcode"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:128
-#: metabrainz/supporter/forms.py:50
+#: frontend/js/src/forms/SignupCommercial.tsx:133
+#: metabrainz/supporter/forms.py:58
 msgid "You need to specify postcode."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:489
-#: metabrainz/supporter/forms.py:52
+#: frontend/js/src/forms/SignupCommercial.tsx:493
+#: metabrainz/supporter/forms.py:60
 msgid "Country"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:129
-#: metabrainz/supporter/forms.py:53
+#: frontend/js/src/forms/SignupCommercial.tsx:134
+#: metabrainz/supporter/forms.py:61
 msgid "You need to specify country."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:132
-#: metabrainz/supporter/forms.py:64
+#: frontend/js/src/forms/SignupCommercial.tsx:137
+#: metabrainz/supporter/forms.py:72
 msgid ""
 "Custom amount must be more than threshold amount for selected tier or "
 "equal to it!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:46 metabrainz/supporter/views.py:119
-#: metabrainz/supporter/views.py:220
+#: metabrainz/supporter/views.py:54
+msgid ""
+"The verification email could not be sent. Please request a new one from "
+"your profile."
+msgstr ""
+
+#: metabrainz/supporter/views.py:85 metabrainz/supporter/views.py:158
+#: metabrainz/supporter/views.py:260
 msgid "You are already a supporter."
 msgstr ""
 
-#: metabrainz/supporter/views.py:61
+#: metabrainz/supporter/views.py:100
 msgid "Can't find tier with a specified ID."
 msgstr ""
 
-#: metabrainz/supporter/views.py:127
+#: metabrainz/supporter/views.py:166
 msgid "You need to choose support tier before signing up!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:137
+#: metabrainz/supporter/views.py:176
 msgid "You need to choose existing tier before signing up!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:164
+#: metabrainz/supporter/views.py:204
 msgid ""
 "Thanks for becoming a supporter! Your application will be reviewed soon. "
 "We will send you updates via email."
 msgstr ""
 
-#: metabrainz/supporter/views.py:187
+#: metabrainz/supporter/views.py:228
 msgid ""
 "Thanks for signing up! Your application will be reviewed soon. We will "
 "send you updates via email."
 msgstr ""
 
-#: metabrainz/supporter/views.py:248
+#: metabrainz/supporter/views.py:288
 msgid "Thanks for becoming a supporter!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:274
+#: metabrainz/supporter/views.py:312
 msgid "Thanks for signing up! Please check your inbox to complete verification."
 msgstr ""
 
-#: metabrainz/supporter/views.py:302
+#: metabrainz/supporter/views.py:340
 msgid "Can't generate new token unless account is active."
 msgstr ""
 
@@ -423,7 +515,7 @@ msgstr ""
 msgid "Policies"
 msgstr ""
 
-#: metabrainz/templates/base.html:55 metabrainz/templates/index/gdpr.html:178
+#: metabrainz/templates/base.html:55
 #: metabrainz/templates/index/social-contract.html:3
 #: metabrainz/templates/index/social-contract.html:6
 #: metabrainz/templates/navbar.html:34
@@ -433,14 +525,15 @@ msgstr ""
 #: metabrainz/templates/base.html:56
 #: metabrainz/templates/index/code-of-conduct.html:3
 #: metabrainz/templates/index/code-of-conduct.html:16
-#: metabrainz/templates/index/gdpr.html:181 metabrainz/templates/navbar.html:35
+#: metabrainz/templates/navbar.html:35
 msgid "Code of Conduct"
 msgstr ""
 
+#: frontend/js/src/PrivacySummary.tsx:11
 #: frontend/js/src/forms/ConditionsModal.tsx:21
-#: metabrainz/templates/base.html:57 metabrainz/templates/index/gdpr.html:184
-#: metabrainz/templates/index/privacy.html:6
+#: metabrainz/templates/base.html:57 metabrainz/templates/index/privacy.html:6
 #: metabrainz/templates/navbar.html:36
+#: metabrainz/templates/users/privacy-summary.html:3
 msgid "Privacy Policy"
 msgstr ""
 
@@ -473,10 +566,7 @@ msgstr ""
 msgid "Supporters"
 msgstr ""
 
-#: frontend/js/src/forms/LoginUser.tsx:103
-#: frontend/js/src/forms/SignupCommercial.tsx:574
-#: frontend/js/src/forms/SignupNonCommercial.tsx:339
-#: frontend/js/src/forms/SignupUser.tsx:232 metabrainz/templates/base.html:73
+#: frontend/js/src/forms/LoginUser.tsx:103 metabrainz/templates/base.html:73
 #: metabrainz/templates/navbar.html:66 metabrainz/templates/users/login.html:3
 msgid "Sign in"
 msgstr ""
@@ -498,26 +588,26 @@ msgid "Contact us"
 msgstr ""
 
 #: metabrainz/templates/base.html:85
-#: metabrainz/templates/index/contact.html:105
+#: metabrainz/templates/index/contact.html:106
 msgid "Blog"
 msgstr ""
 
-#: metabrainz/templates/base.html:86 metabrainz/templates/index/contact.html:90
+#: metabrainz/templates/base.html:86 metabrainz/templates/index/contact.html:91
 msgid "Chat"
 msgstr ""
 
 #: metabrainz/templates/base.html:87
-#: metabrainz/templates/index/contact.html:106
+#: metabrainz/templates/index/contact.html:107
 msgid "Mastodon"
 msgstr ""
 
 #: metabrainz/templates/base.html:88
-#: metabrainz/templates/index/contact.html:107
+#: metabrainz/templates/index/contact.html:108
 msgid "Bluesky"
 msgstr ""
 
 #: metabrainz/templates/base.html:89
-#: metabrainz/templates/index/contact.html:108
+#: metabrainz/templates/index/contact.html:109
 msgid "Instagram"
 msgstr ""
 
@@ -573,15 +663,14 @@ msgstr ""
 msgid "Donate"
 msgstr ""
 
-#: frontend/js/src/forms/LoginUser.tsx:110
-#: frontend/js/src/forms/SignupCommercial.tsx:175
-#: frontend/js/src/forms/SignupCommercial.tsx:555
+#: frontend/js/src/forms/SignupCommercial.tsx:180
+#: frontend/js/src/forms/SignupCommercial.tsx:559
 #: frontend/js/src/forms/SignupNonCommercial.tsx:106
 #: frontend/js/src/forms/SignupNonCommercial.tsx:319
 #: metabrainz/templates/navbar.html:65
-#: metabrainz/templates/supporters/account-type.html:51
-#: metabrainz/templates/supporters/account-type.html:93
-#: metabrainz/templates/supporters/account-type.html:144
+#: metabrainz/templates/supporters/account-type.html:47
+#: metabrainz/templates/supporters/account-type.html:84
+#: metabrainz/templates/supporters/account-type.html:130
 #: metabrainz/templates/users/signup.html:3
 msgid "Sign up"
 msgstr ""
@@ -888,8 +977,430 @@ msgstr ""
 msgid "Introduction"
 msgstr ""
 
-#: metabrainz/templates/index/conflict-policy.html:55
+#: metabrainz/templates/index/conflict-policy.html:17
+msgid ""
+"Conflicts between people arise in open source projects constantly and the"
+" projects by the \n"
+"    MetaBrainz Foundation are no different. This policy aims to establish"
+" a clear and unambiguous \n"
+"    policy for reporting and addressing conflicts in our community. In "
+"this policy we aim to \n"
+"    establish a fair practice that balances the need for confidentiality "
+"and our desire for \n"
+"    transparency in our operations."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:25
+#, python-format
+msgid ""
+"Before you continue to read this policy, we encourage you to review our "
+"existing community policies \n"
+"    including our <a href=\"%(social_contract_url)s\">Social "
+"Contract</a>, \n"
+"    <a href=\"%(code_of_conduct_url)s\">the Code of Conduct</a>, \n"
+"    and our <a href=\"%(privacy_policy_url)s\">Privacy Policy</a>. These "
+"policies establish the norms and rules for \n"
+"    participation in our projects; these policies apply equally to the "
+"contractors of the MetaBrainz \n"
+"    Foundation and any participants in our projects."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:37
+msgid ""
+"This policy divides conflicts into two categories: Private and public. "
+"Private conflicts are conflicts \n"
+"    that involve *confidential* information regarding contributors, "
+"contractors or supporters. Otherwise, any conflicts \n"
+"    that do not involve confidential information are considered to be "
+"public conflicts. For instance, a \n"
+"    conflict between a contractor and the Executive Director (aka BDFL) "
+"that involves contractor pay is \n"
+"    considered a private conflict because pay rates are confidential "
+"information. A public conflict in edit \n"
+"    notes between two editors in our community does not involve "
+"confidential information and therefore should \n"
+"    be considered a public conflict."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:47
+msgid ""
+"When conflicts arise we aim to disclose as much information as possible "
+"about the conflict in a timely \n"
+"    fashion. When conflicts contain confidential matters we will aim to "
+"disclose as much information as \n"
+"    possible, while fully respecting the confidentiality of the people "
+"involved in the conflict. With any \n"
+"    private conflict we will aim to extract the relevant lessons for the "
+"team and community in an effort to \n"
+"    evolve our policies to prevent future conflicts. Should the involved "
+"parties disagree whether a conflict \n"
+"    is private or public, the question about the nature of the conflict "
+"will be presented for the next higher \n"
+"    level in the chain of command to decide. (e.g. if a community member "
+"and the community manager disagree on \n"
+"    a conflict being public or private, the Executive Director shall "
+"decide if the conflict is public or private)."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:58
 msgid "Reporting and Response"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:61
+msgid ""
+"We aim to not have conflict in our community, but we recognize that in "
+"reality conflicts will arise and we \n"
+"    must be prepared to address them in a fair manner. When conflicts "
+"arise, we prefer to have community or team \n"
+"    members resolve the conflicts among themselves, using our existing "
+"policies as guidelines for resolving the \n"
+"    conflict."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:69
+msgid ""
+"If you do not feel comfortable resolving a conflict on your own, you "
+"should feel free to report the conflict to \n"
+"    us. How you address the conflict depends on who is involved in the "
+"conflict and your comfort level. Please see \n"
+"    the detailed sections below on how and with whom to address your "
+"conflict. We aim to address conflicts as soon \n"
+"    as possible in an effort to prevent them from escalating "
+"unnecessarily."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:75
+msgid "Direct conflict resolution"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:78
+msgid ""
+"In direct conflict resolution, the involved parties will attempt to "
+"resolve the conflict themselves without \n"
+"   involving any MetaBrainz Foundation team member. You should aim to use"
+" direct resolution when the conflict does \n"
+"   not involve the violation of one of our policies or if the conflict is"
+" minor."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:84
+#, python-format
+msgid ""
+"For instance, if a user uses a rude tone, is disruptive or flagrantly "
+"ignores our project guidelines, we suggest \n"
+"    that you use direct conflict resolution to resolve the conflict. Some"
+" resources that might give you some suggestions \n"
+"    on how to go about resolving the conflict might be this <a "
+"href=\"%(conflict_resolution_primer_url)s\">\n"
+"    conflict resolution primer</a> and <a "
+"href=\"%(difficult_conversations_url)s\">how to\n"
+"    have difficult conversations at work</a>."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:93
+msgid "Informal reporting"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:96
+msgid ""
+"You may use informal reporting of a conflict if you aim to communicate a "
+"concern or incident without \n"
+"    seeking a corrective outcome. Informal reporting may also be an "
+"option if you have not been personally \n"
+"    victimized, but you’ve witnessed a violation of our policies or where"
+" you wish to maintain confidentiality \n"
+"    throughout the entire reporting process."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:103
+msgid ""
+"For editing in MusicBrainz you may informally report a user using the "
+"“Report this user for bad behavior” \n"
+"    link from the user’s profile. For reporting bad user behavior in "
+"other of our projects, please report them to our \n"
+"    community manager by mailing <span class=\"backemail\">gro.zniarbatem"
+"@reganam-ytinummoc</span> . For conflicts \n"
+"    that involve the community manager, report them by mailing <span "
+"class=\"backemail\">gro.zniarbatem@de</span> ."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:110
+msgid ""
+"Depending the the severity of the issue, repeated informal complaints may"
+" eventually require a formal response \n"
+"    from the MetaBrainz team. If an involved party requires anonymity, "
+"the conflict becomes a private conflict. If at \n"
+"    all possible minor issues should be resolved in a public forum in "
+"order for all people to witness and learn from \n"
+"    the issue at hand."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:116
+msgid "Formal complaint process"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:119
+msgid ""
+"All complaints about conflicts should be submitted via email. To whom a "
+"complaint should be mailed and who will \n"
+"    carry out the investigation will be described in the next section."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:124
+msgid "All complaint submissions to the Foundation should include the following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:128
+msgid ""
+"Contact info, if it is different than the email used to submit the "
+"conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:129
+msgid "Who was involved in the conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:130
+msgid "Where and when the incident happened"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:131
+msgid ""
+"A description of what happened -- ideally with links (e.g. chatlogs, edit"
+" notes) that outlines what \n"
+"         happened so that the persons evaluating the conflict may "
+"understand the issue at hand"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:133
+msgid ""
+"Any related pieces of information that provide more context on the "
+"conflict (e.g. links, screenshots)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:134
+msgid "An indication if this conflict is ongoing or not"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:139
+msgid "The investigation that follows aims to determine:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:143
+msgid "The nature and severity of the incident"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:144
+msgid ""
+"Whether or not the incident is considered a violation of MetaBrainz’ "
+"conduct policies or core values"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:145
+msgid ""
+"The amount of harm experienced by the person who submitted the complaint "
+"and the broader MetaBrainz community \n"
+"         as a result of the incident"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:147
+msgid ""
+"Whether there have been prior complaints against the individual or "
+"individuals reported"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:148
+msgid "Whether the incident is ongoing"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:152
+msgid ""
+"The following potential forms of resolution may apply to any team members"
+" involved in the conflict:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:155
+#: metabrainz/templates/index/conflict-policy.html:168
+msgid "Nothing (if it has been found no violation occurred)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:156
+msgid "Creating a plan to improve the performance"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:157
+msgid "Creating a negative performance evaluation"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:158
+msgid "Mediation, an intervention by a third party to resolve the conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:159
+msgid "Suspension or forced leave"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:160
+msgid "Termination of contract"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:164
+msgid ""
+"The following potential forms of resolution may apply to non team members"
+" involved in the conflict:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:169
+msgid "A reprimand, either public or private"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:170
+msgid "Suspension of the users’ account"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:171
+msgid "Deletion of the users’ account"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:172
+msgid ""
+"Removal of user privileges (e.g. if an auto editor commits a serious "
+"offence, they may lose their auto editor status)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:175
+msgid "Filing a complaint"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:178
+msgid ""
+"NOTE: For complaints not about MetaBrainz staff, please see the "
+"<em>Informal reporting</em> section above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:182
+msgid ""
+"If the complaint does not involve the Executive Director (ED), do the "
+"following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:186
+msgid ""
+"If team member has directly violated conduct policies or engaged in "
+"otherwise harmful behavior, a formal complaint should be filed."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:187
+msgid ""
+"Mail <span class=\"backemail\">gro.zniarbatem@de</span> and include the "
+"complaint information outlined above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:188
+msgid ""
+"You should expect a response within a working day acknowledging the "
+"complaint."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:189
+msgid ""
+"The complaint will be investigated by the ED, member(s) of the board of "
+"directors or a neutral third party."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:190
+msgid ""
+"Once the investigation has been completed, the ED, with the support of "
+"others involved in the investigation will respond. The \n"
+"        ED will respond to incidents no later than 7 working days after a"
+" complaint has been filed with either a resolution or an \n"
+"        explanation of why the process must be extended."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:196
+msgid "If a complaint involves the Executive Director, do the following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:200
+msgid ""
+"If the Executive Director has directly violated conduct policies or "
+"engaged in otherwise harmful behavior, \n"
+"        a formal complaint should be filed with the board of directors."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:202
+msgid ""
+"Mail <span class=\"backemail\">gro.zniarbatem@noituloser-tcilfnoc</span> "
+"and include the complaint information outlined above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:203
+msgid ""
+"You should get a response within 5 working days acknowledging the "
+"complaint."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:204
+msgid ""
+"The complaint will be investigated by the member(s) of the board of "
+"directors, the community manager, a neutral \n"
+"        third party or a combination thereof."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:206
+msgid ""
+"Once the investigation has been completed, the board, with the support of"
+" others involved in the investigation \n"
+"        will respond. The board will aim to respond to incidents no later"
+" than 15 working days after a complaint has been filed \n"
+"        with either a resolution or an explanation of why the process "
+"must be extended."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:211
+msgid "Confidentiality"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:214
+msgid ""
+"Confidentiality is an important aspect of conflict resolution and all of "
+"the conflicts brought to the attention of the foundation \n"
+"    will be evaluated with confidentiality in mind and acted upon "
+"accordingly."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:219
+msgid ""
+"We work hard to make all of the actions of the foundation as transparent "
+"and open as possible. In cases where we cannot \n"
+"    disclose all aspects of a conflict we will disclose that a conflict "
+"is or has occurred and we will attempt to disclose the \n"
+"    appropriate amount of information about the conflict while balancing "
+"the need for confidentiality and our desire to learn \n"
+"    from conflicts so that we as a foundation and community can learn "
+"from these conflicts and improve our policies to avoid the \n"
+"    conflicts in the future."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:227
+msgid ""
+"Any breaches of confidentiality will be treated as severe breaches of our"
+" conduct policies."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:230
+msgid "Retaliation"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:233
+msgid ""
+"We will not allow retaliation for any contractor or volunteer that files "
+"a complaint or is involved in an investigation. If you \n"
+"    believe that you are being treated negatively because of your "
+"involvement in a complaint please report this complaint directly \n"
+"    to the ED at <span class=\"backemail\">gro.zniarbatem@de</span> or "
+"the board at \n"
+"    <span class=\"backemail\">gro.zniarbatem@noituloser-tcilfnoc</span>."
 msgstr ""
 
 #: metabrainz/templates/index/contact.html:3
@@ -970,7 +1481,7 @@ msgstr ""
 msgid ""
 "We are currently evaluating our overall online advertising strategy. We "
 "are evaluating advertising, traffic optimization,\n"
-"    search engine optimization and software monitization technologies. If"
+"    search engine optimization and software monetization technologies. If"
 " you provide these professional services, please provide a detailed\n"
 "    deck of your comprehensive services to the following email address. "
 "<em>Please respect our other non-media teams and do not contact us \n"
@@ -1045,11 +1556,11 @@ msgstr ""
 #, python-format
 msgid ""
 "Please come ask your questions at our <a "
-"href=\"%(forums_url)s\">forums</a>! We would love to\n"
-"    answer any questions you may have."
+"href=\"%(forums_url)s\">forums</a>!\n"
+"    The community and the team will be more than happy to help you."
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:92
+#: metabrainz/templates/index/contact.html:93
 #, python-format
 msgid ""
 "The MetaBrainz/MusicBrainz/ListenBrainz team and community hang out\n"
@@ -1059,15 +1570,15 @@ msgid ""
 "    <a href=\"%(chatlogs_url)s\">chat log archives</a>."
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:101
+#: metabrainz/templates/index/contact.html:102
 msgid "Social media"
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:103
+#: metabrainz/templates/index/contact.html:104
 msgid "You can follow us on these social channels:"
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:112
+#: metabrainz/templates/index/contact.html:113
 msgid "Mailing address"
 msgstr ""
 
@@ -1080,33 +1591,349 @@ msgstr ""
 msgid "GDPR Compliance Statement"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:37
+#: metabrainz/templates/index/gdpr.html:10
+msgid ""
+"The General Data Protection Regulation is a complex EU regulation that "
+"stipulates many points for protecting private data of\n"
+"    users on the Internet. Even though this is an EU regulation, it has a"
+" worldwide impact due to the nature of the Internet.\n"
+"    The MetaBrainz Foundation with its collection of projects is also "
+"affected by this regulation. We’ve been learning and adapting\n"
+"    our sites to be compliant with the GDPR – sadly this regulation isn’t"
+" entirely black and white and there is an incredible\n"
+"    amount of room left for interpretation of these rules."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:17
+msgid ""
+"The good news is that this regulation is roughly in line with our "
+"established practices: We’ve always held private information\n"
+"    in a high regard and applied the sort of rules to ourselves as we "
+"wish to have our own private data treated. Luckily, this\n"
+"    makes our compliance effort considerably easier. We’ve made two "
+"significant changes to how we treat your data and also adopted\n"
+"    terminology as used in the GDPR in order to use the same languages "
+"that many other sites are now adopting. Please keep reading\n"
+"    to find out the exact details of what we are doing to comply."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:24
+#, python-format
+msgid ""
+"However, we do ask for your compassion and help in our process of "
+"complying with the GDPR. As we already mentioned, the GDPR is\n"
+"    a complex set of rules that are not fully clarified yet. We’ve taken "
+"action on the steps that are clear to us and we’re following\n"
+"    ongoing conversations on points that are in gray zones or unclear to "
+"us. We’ve made our best initial effort on compliance and\n"
+"    promise to keep working on it as the picture becomes more clear. If "
+"you believe that we could improve our compliance, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a> and let us know what we "
+"can do to improve. It would also help us if you\n"
+"    could provide concrete discussion or examples to help us understand "
+"and take action on your suggestion."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:33
+msgid ""
+"Finally, below are the key sections of the GDPR as we understand them and"
+" how they affect your data in our ecosystem. Where\n"
+"    possible, we provide links for deeper understanding, links for you to"
+" examine our relevant code and links to tickets to follow\n"
+"    the process of improving our compliance."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:38
 msgid "Right to be forgotten"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:77
+#: metabrainz/templates/index/gdpr.html:41
+msgid ""
+"Summary: <i>Provide the user with the ability to remove their private "
+"data from our services</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:44
+msgid ""
+"The most important aspect of the right to be forgotten is the ability to "
+"delete your account. Once you request for us to delete\n"
+"    your account, we will remove any personally identifying information "
+"you may have provided us from your account (name, email\n"
+"    address, gender, biography, URL, etc.). The visible name on your "
+"account will be changed to “Deleted User #####” and effectively\n"
+"    the account will no longer be identifiable as your account."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:50
+msgid ""
+"However, given the nature of our projects where we work on collaborative "
+"databases, your contributions that are not personally\n"
+"    identifying are valuable assets to our database and these "
+"contributions will not be removed from our databases. But we will\n"
+"    ensure that these contributions no longer contain personally "
+"identifying data."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:55
+#, python-format
+msgid ""
+"Our process of automatically deleting your accounts across the MetaBrainz"
+" ecosystem is not complete yet (see below for a set of\n"
+"    tickets where you can track our progress). If you would like to "
+"delete your accounts in the MetaBrainz ecosystem or mark a\n"
+"    donation that is currently public as a private donation, please <a "
+"href=\"%(contact_url)s\">contact us</a>\n"
+"    and we will address your request as soon as possible."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:62
+#: metabrainz/templates/index/gdpr.html:182
+msgid "Links:"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:66
+#, python-format
+msgid ""
+"<a href=\"%(editor_deletion_doc_url)s\">How we delete accounts\n"
+"       in MusicBrainz</a> (warning, geek content ahead!)"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:70
+msgid ""
+"Implement sitewide user account deletion in\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/MBS-9680\">MusicBrainz</a>,"
+"\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/AB-337\">AcousticBrainz</a>,"
+"\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/BB-260\">BookBrainz</a>,\n"
+"         <a href=\"https://tickets.metabrainz.org/browse/MEB-103\">the "
+"MetaBrainz Site</a>,\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/LB-354\">ListenBrainz</a>, "
+"and\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/CB-307\">CritiqueBrainz</a>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:80
 msgid "Restriction of processing"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:110
+#: metabrainz/templates/index/gdpr.html:83
+msgid ""
+"Summary: <i>To allow the user to control how their personally identifying"
+" data is being used.</i>"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:86
+msgid ""
+"Except for the ListenBrainz and AcousticBrainz projects, we do not "
+"process personally identifying data. Any personally\n"
+"    identifying data that our projects store is for the purpose of being "
+"able to contact you about your contributions to our database\n"
+"    (email address) or for voluntarily showing information about you to "
+"other users (biography, homepage, location, etc)."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:91
+#, python-format
+msgid ""
+"The ListenBrainz project differs in that the Listens (metadata about what"
+" music you have listened to) are stored on our servers\n"
+"    and <a href=\"%(listenbrainz_data_url)s\">made available to the "
+"public</a>. We believe Listens to be personally identifying\n"
+"    data and furthermore, we have goals of creating open source "
+"recommendation engines with this data, which involves processing the\n"
+"    user’s data. These two points are fundamental goals of the "
+"ListenBrainz project and we do not see a reasonable way to reach another"
+"\n"
+"    compromise position."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:99
+msgid ""
+"Because of this, we are going to require users to either acknowledge that"
+" we may process their Listen data or alternatively to\n"
+"    delete their account, including all of their Listens. Please note "
+"that if you decide to delete your ListenBrainz account, it may\n"
+"    take up to two weeks for all of your listens to no longer be included"
+" in our efforts to build a recommendation engine."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:104
+msgid ""
+"We have always made it clear that the data in ListenBrainz was to be "
+"public and that we plan to build new tools with your data, so\n"
+"    this should not come as a surprise to our users."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:108
+msgid ""
+"The AcousticBrainz project does not track who submits data to the "
+"database. If you create an account and use our data creation\n"
+"    tools (e.g. create a dataset or participate in a challenge) then we "
+"link your participation and the things that you create to\n"
+"    your account. If you choose to delete your account then we keep the "
+"non personally identifying data that you create, but anonymize\n"
+"    it so that it cannot be linked back to you."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:114
 msgid "Right to data portability / exporting your data"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:150
+#: metabrainz/templates/index/gdpr.html:117
+msgid ""
+"Summary: <i>You have the right to access/download the data we store about"
+" you</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:120
+msgid ""
+"Except for the ListenBrainz and AcousticBrainz projects, we do not store "
+"personally identifying data beyond the\n"
+"    information that is available in your public profile on each of our "
+"projects. Since this data is plainly available in your\n"
+"    profile we do not provide a means for you to export this data."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:125
+msgid "There are the following exceptions to this:"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:129
+msgid ""
+"<b>IP addresses</b>: If you visit one of our sites the IP address of your"
+" computer is stored in our web logs for 7 days\n"
+"        before our servers automatically delete them. This data is almost"
+" never used by anyone: the only time we look at the\n"
+"        IP addresses is if our sites are adversely impacted by the "
+"actions of some unknown users. In that case, we may investigate\n"
+"        the logs to identify the IP address that needs to be blocked in "
+"order to restore the stability of our service.\n"
+"        This data is not available to anyone but the contractors of the "
+"MetaBrainz Foundation and is not available to download\n"
+"        to anyone at all."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:137
+#, python-format
+msgid ""
+"<b>ListenBrainz Listen data</b>: Users may <a "
+"href=\"%(listenbrainz_export_url)s\">export their ListenBrainz Listen\n"
+"        data</a> directly from the site. The user Listen data is also "
+"included in the <a href=\"%(listenbrainz_data_url)s\">ListenBrainz\n"
+"        data dumps</a> that are available for public download."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:146
+msgid ""
+"All of the non personally identifying data, such as your metadata "
+"contributions, are publicly visible, available for download\n"
+"    and available via the project APIs. For details about this data, "
+"downloads and APIs please check the documentation for the\n"
+"    respective projects you are interested in."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:151
+#, python-format
+msgid ""
+"Anyone wishing to get a list of financial donations they have made to the"
+" MetaBrainz Foundation, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a> and provide your "
+"MusicBrainz editor name so that we can look up\n"
+"    your donations."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:157
 msgid "Right to rectification"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:165
+#: metabrainz/templates/index/gdpr.html:160
+msgid "Summary: <i>You have the right to correct your data</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:163
+msgid ""
+"All of our projects allow their users to update their personally "
+"identifying information in their profiles. Furthermore, most\n"
+"    of our projects allow the editing of their own metadata "
+"contributions. If you find that some of your data is incorrect, please\n"
+"    feel free to edit the data since we provide the tools to do so."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:168
+#, python-format
+msgid ""
+"If anyone who has made a financial donation to the MetaBrainz Foundation "
+"would like to make their donation private, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:173
 msgid "Right to be informed"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:188
+#: metabrainz/templates/index/gdpr.html:175
+msgid ""
+"Summary: <i>You have the right to be informed about how we use your data "
+"in plain English</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:178
+msgid ""
+"Our privacy policy, as well as other policies, have always been written "
+"by humans for human consumption. We abhor legalese and\n"
+"    not speaking in direct terms."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:186
+msgid "Social contract"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:189
+msgid "Code of conduct"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:192
+msgid "Privacy policy"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:196
 msgid "Right to access"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:198
-#: metabrainz/templates/index/privacy.html:166
+#: metabrainz/templates/index/gdpr.html:199
+msgid ""
+"Summary: <i>You have the right to access the data that we collect about "
+"you</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:202
+msgid ""
+"All of our projects make all of the data we collect on your behalf, "
+"privately identifying or not, available to you. The\n"
+"    only exception to this are the IP addresses we store for 7 days – see"
+" above for details."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:206
+#: metabrainz/templates/index/privacy.html:168
 msgid "Privacy/GDPR Representative"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:209
+#, python-format
+msgid ""
+"If you have any questions about our privacy policy, please <a "
+"href=\"%(contact_url)s\">contact us</a>. To report\n"
+"   any privacy problems, violations or leaks, our GDPR representative is "
+"our Interim Executive Director Nicolás Tamargo and for\n"
+"   privacy issues contact him at <strong><a "
+"href=\"mailto:gdpr@metabrainz.org\">gdpr@metabrainz.org</a></strong>."
 msgstr ""
 
 #: metabrainz/templates/index/index.html:6
@@ -1211,13 +2038,51 @@ msgid ""
 "      <a href=\"%(about_url)s\">about</a> page."
 msgstr ""
 
-#: frontend/js/src/forms/ConditionsModal.tsx:43
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:32
 #: metabrainz/templates/index/privacy.html:3
 msgid "Privacy"
 msgstr ""
 
 #: metabrainz/templates/index/privacy.html:8
 msgid "Summary"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:12
+msgid ""
+"You do not have to provide any personal data to be able to browse the "
+"contents of the databases published by MetaBrainz."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:15
+msgid ""
+"You do not have to provide any personally-identifying information if you "
+"choose not to."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:18
+msgid ""
+"We will never reveal your email address on MetaBrainz controlled web "
+"sites."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:22
+msgid ""
+"In order to get maximum value out of the MetaBrainz projects, you may "
+"want to create an account and log in. \n"
+"    Doing so grants you the ability to: edit the databases, contribute "
+"your own data, communicate with other users, and keep track \n"
+"    of recently released music from artists in your MusicBrainz "
+"collection. If you choose to create an account then the minimum we \n"
+"    ask is that you: choose a unique username and password, use a web "
+"browser that accepts \"session\" cookies, and provide a verified \n"
+"    email address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:29
+msgid ""
+"If you do not create an account (or are not logged in) you will not have "
+"access to the above listed features, however, you will \n"
+"    still have full access to browse and examine the databases."
 msgstr ""
 
 #: metabrainz/templates/index/privacy.html:33
@@ -1228,39 +2093,197 @@ msgstr ""
 msgid "Cookies"
 msgstr ""
 
+#: metabrainz/templates/index/privacy.html:37
+msgid "We use two cookies that contain sensitive information:"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:42
+msgid ""
+"<b>remember_login</b>: If you choose the \"Log in permanently\" option "
+"when logging in to one of our sites; the cookie will be used to \n"
+"      remember your login details."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:46
+msgid ""
+"<b>musicbrainz_server_session, session, or connect.sid</b>: If you are "
+"logged into one of our sites, your current session ID is stored in this "
+"cookie."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:51
+msgid ""
+"We may store dynamic preference information in other cookies, but these "
+"do not contain any sensitive information."
+msgstr ""
+
 #: metabrainz/templates/index/privacy.html:54
 msgid "Web and FTP access logs"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:57
+msgid ""
+"In a practice similar to other web sites (and APIs) we keep logs of all "
+"web requests made against our servers. These logs include: your IP\n"
+"    address, your browser's (or API client's) \"User-Agent\" string, and "
+"which page (or API endpoint) you requested with which parameters. "
+"Aggregate information about web and FTP traffic is\n"
+"    made available to the public via our site usage pages."
 msgstr ""
 
 #: metabrainz/templates/index/privacy.html:62
 msgid "Third-Party content"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:92
+#: metabrainz/templates/index/privacy.html:64
+msgid ""
+"Our projects' web pages may load some third-party content. Some, but "
+"possibly not all sites are listed below:"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:69
+#, python-format
+msgid ""
+"Cover art and other images: These are provided by the various cover art "
+"sites that have given MusicBrainz permission to do so and our own \n"
+"      <a href=\"%(caa_url)s\">Cover Art Archive</a>. This means that the "
+"relevant site will know (if they want to) your IP \n"
+"      address, User-Agent string, etc., and which MusicBrainz web page "
+"you were visiting (the one which included the cover art image)."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:75
+msgid ""
+"AcoustID: Our fingerprints tab loads fingerprint information from "
+"acoustid.org."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:78
+msgid ""
+"MTCaptcha: Our account creation page loads third party content in order "
+"to prevent spammers from creating accounts."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:83
+msgid ""
+"<i>The above information assumes that you are using \"normal\" web "
+"browser settings, whereby images are always loaded and HTTP referrer \n"
+"    information is always sent.</i>"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:88
+msgid ""
+"It is impractical to constantly modify this privacy policy when "
+"MetaBrainz projects change which third party content they utilize. We "
+"will \n"
+"    aim to use common sense, respect to our community and community "
+"review when adding more content from third party sites. We will also \n"
+"    periodically review our policy to ensure that it remains current."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:93
 msgid "Applicable to account holders"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:94
+#: metabrainz/templates/index/privacy.html:95
 msgid "Account creation"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:108
+#: metabrainz/templates/index/privacy.html:97
+msgid ""
+"When creating an account with a MetaBrainz project you need to pick a "
+"unique username and choose a password, the username you pick is the \n"
+"    only name associated with your account and will be what other "
+"MetaBrainz users know you as. You may optionally also tell us other \n"
+"    information about yourself that will be displayed to other MetaBrainz"
+" users and the public."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:103
+msgid ""
+"Additionally, in order to edit the databases you will need to provide a "
+"confirmed email address. This email address will be held in \n"
+"    confidence, the only method of revealing your email address to "
+"another user is if you choose to send a message to another \n"
+"    user and enable the option to \"reveal my email address\". Changing "
+"the email address stored with your account will require you to \n"
+"    verify the new address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:109
 msgid "Edits and Notes"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:114
+#: metabrainz/templates/index/privacy.html:111
+msgid ""
+"If you make any changes to a MetaBrainz project database, such as adding "
+"any data, the details of those changes will be visible to \n"
+"    other logged-in users and the change will be associated with your "
+"username."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:115
 msgid "Subscriptions on MusicBrainz"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:131
+#: metabrainz/templates/index/privacy.html:117
+msgid ""
+"As a logged-in user you can subscribe to one or more artists, labels, "
+"collections or other editors. The act of subscribing causes \n"
+"    any edits made to (or by in the case of another editor) those "
+"entities to be emailed to you. By default, other users can see your \n"
+"    list of subscriptions, however, you can opt out of this by editing "
+"the appropriate preference."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:123
+msgid ""
+"This does not provide \"perfect\" privacy though, in some cases it will "
+"be possible to infer information about the contents of your \n"
+"    subscription list even though you have disallowed others from viewing"
+" that list directly. This imperfection arises because various \n"
+"    parts of the system behave differently depending on whether or not an"
+" entity has any subscribers; also, the number of users \n"
+"    subscribed to each artist is available via the artist pages. In the "
+"most extreme (possibly contrived) example, imagine that all \n"
+"    users have their subscriptions set to \"public\", except for exactly "
+"one user whose list is \"private\". In that case, any discrepancy \n"
+"    for a given artist between the shown list of subscribers and the "
+"total number of subscribers must be down to that one user. Thus, \n"
+"    you can infer what artists are on that user's list."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:132
 msgid "Third-party sites"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:145
-msgid "MetaBrainz donors"
+#: metabrainz/templates/index/privacy.html:134
+#, python-format
+msgid ""
+"Our code reviews are done on GitHub, which is not under the control of "
+"MetaBrainz. Participating in code reviews or other\n"
+"    tasks carried out on GitHub are subject to <a "
+"href=\"%(github_url)s\">GitHub's privacy policy</a>."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:140
+#, python-format
+msgid ""
+"Our translations platform is provided and hosted by Weblate, which has a "
+"data processing agreement with MetaBrainz.\n"
+"    Participating in translations is subject to <a "
+"href=\"%(weblate_url)s\">dedicated legal terms</a>.\n"
+"    Any translations you make will be submitted to our Git repositories "
+"and publicly associated with your username;\n"
+"    if you so choose, you can also publicly associate them with your own "
+"verified email address."
 msgstr ""
 
 #: metabrainz/templates/index/privacy.html:147
+msgid "MetaBrainz donors"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:149
 msgid ""
 "When you make a donation to the MetaBrainz Foundation, we are legally\n"
 "    required to collect your personal information and keep it in our "
@@ -1270,7 +2293,7 @@ msgid ""
 "    information to anyone else, ever."
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:153
+#: metabrainz/templates/index/privacy.html:155
 msgid ""
 "We believe in transparent finances, which means that we list all "
 "donations\n"
@@ -1280,11 +2303,34 @@ msgid ""
 "process."
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:158
+#: metabrainz/templates/index/privacy.html:160
 msgid "Exceptions"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:598
+#: metabrainz/templates/index/privacy.html:162
+msgid ""
+"<i><b>Please note</b>: Reasonable exceptions may apply to the above "
+"policy, for example to comply with applicable laws.\n"
+"    Also, members of the MetaBrainz team and other personnel contracted "
+"to provide services to MetaBrainz may have access to\n"
+"    our infrastructure and could therefore view any information contained"
+" therein. However all personnel are contractually bound\n"
+"    by non-disclosure clauses which prevent them from making any such "
+"information available to others."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:171
+#, python-format
+msgid ""
+"If you have any questions about our GDPR statement, please <a "
+"href=\"%(contact_url)s\">contact us</a>. To report\n"
+"   any privacy problems, violations or leaks, our GDPR representative is "
+"our Interim Executive Director Nicolás Tamargo and for\n"
+"   privacy issues contact him at <strong><a "
+"href=\"mailto:gdpr@metabrainz.org\">gdpr@metabrainz.org</a></strong>."
+msgstr ""
+
+#: frontend/js/src/Profile.tsx:603
 #: frontend/js/src/forms/ProfileChangePassword.tsx:22
 #: frontend/js/src/forms/ProfileChangePassword.tsx:111
 #: metabrainz/templates/index/profile-change-password.html:3
@@ -1528,6 +2574,11 @@ msgstr ""
 
 #: metabrainz/templates/index/team.html:26
 msgid "He lives on in our hearts and in open source."
+msgstr ""
+
+#: metabrainz/templates/index/team.html:29
+#: metabrainz/templates/index/team.html:315
+msgid "you’re welcome to try"
 msgstr ""
 
 #: metabrainz/templates/index/team.html:39
@@ -2025,8 +3076,10 @@ msgstr ""
 
 #: metabrainz/templates/payments/donate.html:146
 msgid ""
-"Due to the increased unreliability of the US Postal Service we have "
-"stopped accepting paper checks. Sorry!"
+"Due to the increased unreliability of the US Postal Service and the "
+"relatively large fees involved, we ask you to only send a paper check if "
+"it is the only possible option. Due to the fees, we will not cash checks "
+"for less than $25."
 msgstr ""
 
 #: metabrainz/templates/payments/donate.html:241
@@ -2910,8 +3963,8 @@ msgid "Monthly balance sheets"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:520
-#: frontend/js/src/forms/SignupCommercial.tsx:175
-#: frontend/js/src/forms/SignupCommercial.tsx:554
+#: frontend/js/src/forms/SignupCommercial.tsx:180
+#: frontend/js/src/forms/SignupCommercial.tsx:558
 #: frontend/js/src/forms/SignupNonCommercial.tsx:106
 #: frontend/js/src/forms/SignupNonCommercial.tsx:318
 #: metabrainz/templates/supporters/account-type.html:3
@@ -2932,6 +3985,7 @@ msgid "Non-commercial / Personal"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:235
+#: frontend/js/src/forms/SignupNonCommercial.tsx:107
 #: frontend/js/src/forms/SignupNonCommercial.tsx:151
 #: metabrainz/templates/supporters/account-type.html:42
 msgid "Non-commercial"
@@ -2945,55 +3999,45 @@ msgstr ""
 msgid "Personal or university assignment user."
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:48
-#: metabrainz/templates/supporters/account-type.html:90
-#: metabrainz/templates/supporters/account-type.html:141
-msgid "Upgrade"
-msgstr ""
-
 #: frontend/js/src/Profile.tsx:235
-#: frontend/js/src/forms/SignupCommercial.tsx:176
-#: frontend/js/src/forms/SignupCommercial.tsx:228
-#: metabrainz/templates/supporters/account-type.html:61
+#: frontend/js/src/forms/SignupCommercial.tsx:181
+#: frontend/js/src/forms/SignupCommercial.tsx:233
+#: metabrainz/templates/supporters/account-type.html:56
 msgid "Commercial"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:83
-#: metabrainz/templates/supporters/account-type.html:135
+#: metabrainz/templates/supporters/account-type.html:78
+#: metabrainz/templates/supporters/account-type.html:125
 #, python-format
 msgid "$%(tier_price)s/month and up"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:87
-#: metabrainz/templates/supporters/account-type.html:138
+#: metabrainz/templates/supporters/account-type.html:82
+#: metabrainz/templates/supporters/account-type.html:128
 msgid "More info"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:104
+#: metabrainz/templates/supporters/account-type.html:94
 msgid "View all tiers"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:112
+#: metabrainz/templates/supporters/account-type.html:102
 msgid "Some of our Unicorn members"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:123
+#: metabrainz/templates/supporters/account-type.html:113
 msgid "See all our supporters"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:151
+#: metabrainz/templates/supporters/account-type.html:136
 msgid "View featured tiers"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:158
+#: metabrainz/templates/supporters/account-type.html:143
 #, python-format
 msgid ""
 "If you are not sure which tier to pick, please\n"
 "      <a href=\"%(contact_url)s\">contact us</a>."
-msgstr ""
-
-#: metabrainz/templates/supporters/account-type.html:166
-msgid "Back to Profile"
 msgstr ""
 
 #: metabrainz/templates/supporters/bad-standing.html:3
@@ -3055,9 +4099,9 @@ msgid "Forgot your username"
 msgstr ""
 
 #: frontend/js/src/forms/ResetPassword.tsx:79
-#: frontend/js/src/forms/SignupCommercial.tsx:320
+#: frontend/js/src/forms/SignupCommercial.tsx:325
 #: frontend/js/src/forms/SignupNonCommercial.tsx:227
-#: frontend/js/src/forms/SignupUser.tsx:169
+#: frontend/js/src/forms/SignupUser.tsx:175
 #: metabrainz/templates/users/reauthenticate.html:3
 #: metabrainz/templates/users/reauthenticate.html:6
 msgid "Confirm Password"
@@ -3067,17 +4111,22 @@ msgstr ""
 msgid "Please re-enter your password to continue."
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:108
+#: frontend/js/src/ProfileDelete.tsx:110
 #: frontend/js/src/forms/DeleteApplication.tsx:53
 #: frontend/js/src/forms/OAuthPrompt.tsx:54
 #: frontend/js/src/forms/ProfileChangePassword.tsx:104
 #: frontend/js/src/forms/ProfileEdit.tsx:105
-#: metabrainz/templates/users/reauthenticate.html:23
+#: metabrainz/templates/users/reauthenticate.html:28
 msgid "Cancel"
 msgstr ""
 
-#: metabrainz/templates/users/reauthenticate.html:24
+#: metabrainz/templates/users/reauthenticate.html:29
 msgid "Continue"
+msgstr ""
+
+#: frontend/js/src/forms/utils.tsx:202
+#: metabrainz/templates/users/reauthenticate.html:40
+msgid "Password must not exceed 72 bytes."
 msgstr ""
 
 #: frontend/js/src/forms/ResetPassword.tsx:27
@@ -3085,38 +4134,38 @@ msgstr ""
 msgid "Reset your password"
 msgstr ""
 
-#: frontend/js/src/hooks/useEmailValidation.ts:41 metabrainz/user/forms.py:15
+#: frontend/js/src/hooks/useEmailValidation.ts:41 metabrainz/user/forms.py:16
 msgid "Registration from this email domain is not allowed."
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:50
 #: frontend/js/src/forms/LostPassword.tsx:45
-#: frontend/js/src/forms/SignupCommercial.tsx:270
+#: frontend/js/src/forms/SignupCommercial.tsx:275
 #: frontend/js/src/forms/SignupNonCommercial.tsx:175
-#: frontend/js/src/forms/SignupUser.tsx:114 metabrainz/user/forms.py:20
-#: metabrainz/user/forms.py:45 metabrainz/user/forms.py:62
+#: frontend/js/src/forms/SignupUser.tsx:120 metabrainz/user/forms.py:22
+#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:75
 msgid "Username"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:42
 #: frontend/js/src/forms/LostPassword.tsx:37
-#: frontend/js/src/forms/SignupCommercial.tsx:153
+#: frontend/js/src/forms/SignupCommercial.tsx:158
 #: frontend/js/src/forms/SignupNonCommercial.tsx:84
-#: frontend/js/src/forms/SignupUser.tsx:67 metabrainz/user/forms.py:21
-#: metabrainz/user/forms.py:45 metabrainz/user/forms.py:62
+#: frontend/js/src/forms/SignupUser.tsx:73 metabrainz/user/forms.py:26
+#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:75
 msgid "Username is required!"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:63
 #: frontend/js/src/forms/ResetPassword.tsx:72
-#: frontend/js/src/forms/SignupCommercial.tsx:308
+#: frontend/js/src/forms/SignupCommercial.tsx:313
 #: frontend/js/src/forms/SignupNonCommercial.tsx:214
-#: frontend/js/src/forms/SignupUser.tsx:157 metabrainz/user/forms.py:46
-#: metabrainz/user/forms.py:52
+#: frontend/js/src/forms/SignupUser.tsx:163 metabrainz/user/forms.py:53
+#: metabrainz/user/forms.py:62
 msgid "Password"
 msgstr ""
 
-#: frontend/js/src/forms/LoginUser.tsx:76 metabrainz/user/forms.py:47
+#: frontend/js/src/forms/LoginUser.tsx:76 metabrainz/user/forms.py:57
 msgid "Remember me"
 msgstr ""
 
@@ -3128,11 +4177,11 @@ msgstr ""
 msgid "Username contains invalid or invisible characters."
 msgstr ""
 
-#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:181
+#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:220
 msgid "Hide password"
 msgstr ""
 
-#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:181
+#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:220
 msgid "Show password"
 msgstr ""
 
@@ -3189,11 +4238,11 @@ msgstr ""
 msgid "Revoke access"
 msgstr ""
 
-#: frontend/js/src/OAuthError.tsx:17
+#: frontend/js/src/OAuthError.tsx:18
 msgid "OAuth2 Error"
 msgstr ""
 
-#: frontend/js/src/OAuthError.tsx:18
+#: frontend/js/src/OAuthError.tsx:19
 msgid "An error occurred during OAuth authentication process."
 msgstr ""
 
@@ -3223,8 +4272,8 @@ msgstr ""
 
 #: frontend/js/src/Profile.tsx:109
 msgid ""
-"Are you sure you want to generate new access token? Current token will be"
-" revoked!"
+"Are you sure you want to generate a new access token? The current token "
+"will be revoked!"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:118
@@ -3339,8 +4388,8 @@ msgid "Contact Information"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:310 frontend/js/src/forms/ProfileEdit.tsx:70
-#: frontend/js/src/forms/SignupCommercial.tsx:284
-#: frontend/js/src/forms/SignupCommercial.tsx:333
+#: frontend/js/src/forms/SignupCommercial.tsx:289
+#: frontend/js/src/forms/SignupCommercial.tsx:338
 #: frontend/js/src/forms/SignupNonCommercial.tsx:189
 #: frontend/js/src/forms/SignupNonCommercial.tsx:241
 msgid "Contact name"
@@ -3455,7 +4504,7 @@ msgstr ""
 msgid "Once you delete your account, there is no going back. Please be certain."
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:550 frontend/js/src/ProfileDelete.tsx:105
+#: frontend/js/src/Profile.tsx:550 frontend/js/src/ProfileDelete.tsx:107
 msgid "Delete My Account"
 msgstr ""
 
@@ -3467,39 +4516,39 @@ msgstr ""
 msgid "Need to delete your account?"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:574
+#: frontend/js/src/Profile.tsx:575
 msgid ""
 "Deletion of supporter accounts requires manual review. Please contact us "
-"at"
+"at <email />."
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:594
+#: frontend/js/src/Profile.tsx:599
 msgid "Security"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:626
+#: frontend/js/src/Profile.tsx:631
 msgid "MetaBrainz Applications"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:630
+#: frontend/js/src/Profile.tsx:635
 msgid ""
 "With your MetaBrainz account, you can access every project in the "
 "MetaBrainz family:"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:643
+#: frontend/js/src/Profile.tsx:648
 msgid "The open-source music encyclopedia"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:655
+#: frontend/js/src/Profile.tsx:660
 msgid "Track, visualise and share the music you listen to"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:667
+#: frontend/js/src/Profile.tsx:672
 msgid "The open-source book database"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:679
+#: frontend/js/src/Profile.tsx:684
 msgid "Creative Commons licensed reviews"
 msgstr ""
 
@@ -3522,7 +4571,7 @@ msgid "Permanently remove all your account information"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:64
-msgid "Revoke all your API tokens and access"
+msgid "Revoke all your tokens and access to the replication API"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:65
@@ -3534,14 +4583,16 @@ msgid "Log you out of all MetaBrainz services"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:70
-msgid "Your username will be reserved and cannot be reused."
+msgid ""
+"Your username will be reserved and cannot be reused without the "
+"intervention of an administrator."
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:82
+#: frontend/js/src/ProfileDelete.tsx:84
 msgid "To confirm, type your username '<username />' below:"
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:105
+#: frontend/js/src/ProfileDelete.tsx:107
 msgid "Deleting..."
 msgstr ""
 
@@ -3553,64 +4604,7 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: frontend/js/src/forms/ConditionsModal.tsx:23
-msgid "Licensing"
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:25
-msgid ""
-"Any contributions you make to any MetaBrainz service will be released "
-"into the Public Domain and/or licensed under a Creative Commons by-nc-sa "
-"license. Furthermore, you give the MetaBrainz Foundation the right to "
-"license this data for commercial use."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:30
-msgid "Please read our <licenseLink>license page</licenseLink> for more details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:45
-msgid ""
-"MetaBrainz strongly believes in the privacy of its users. Any personal "
-"information you choose to provide will not be sold or shared with anyone "
-"else."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:50
-msgid ""
-"Please read our <privacyLink>privacy policy</privacyLink> for more "
-"details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:59
-msgid "GDPR compliance"
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:61
-msgid ""
-"You may remove your personal information from our services anytime by "
-"deleting your account."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:66
-msgid ""
-"Please read our <gdprLink>GDPR compliance statement</gdprLink> for more "
-"details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:78
-msgid ""
-"Creating an account on MetaBrainz will give you access to all of our "
-"projects, such as MusicBrainz, ListenBrainz, BookBrainz, and more."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:82
-msgid ""
-"We create a placeholder account for all the MetaBrainz projects when you "
-"sign up, and you are one log-in away from activating them."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:91
+#: frontend/js/src/forms/ConditionsModal.tsx:29
 msgid "Sounds good"
 msgstr ""
 
@@ -3696,8 +4690,8 @@ msgstr ""
 msgid "Forgot your password?"
 msgstr ""
 
-#: frontend/js/src/forms/LoginUser.tsx:109
-msgid "Don't have an account?"
+#: frontend/js/src/forms/LoginUser.tsx:110
+msgid "Don't have an account? <signupLink>Sign up</signupLink>"
 msgstr ""
 
 #: frontend/js/src/forms/LostPassword.tsx:38
@@ -3726,15 +4720,72 @@ msgstr ""
 msgid "Allow access"
 msgstr ""
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:71
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:10
+msgid "Licensing"
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:12
+msgid ""
+"Any contributions you make to any MetaBrainz service will be released "
+"into the Public Domain and/or licensed under a Creative Commons by-nc-sa "
+"license. Furthermore, you give the MetaBrainz Foundation the right to "
+"license this data for commercial use."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:17
+msgid "Please read our <licenseLink>license page</licenseLink> for more details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:34
+msgid ""
+"MetaBrainz strongly believes in the privacy of its users. Any personal "
+"information you choose to provide will not be sold or shared with anyone "
+"else."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:39
+msgid ""
+"Please read our <privacyLink>privacy policy</privacyLink> for more "
+"details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:50
+msgid "GDPR compliance"
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:52
+msgid ""
+"You may remove your personal information from our services anytime by "
+"deleting your account."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:57
+msgid ""
+"Please read our <gdprLink>GDPR compliance statement</gdprLink> for more "
+"details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:71
+msgid ""
+"Creating an account on MetaBrainz will give you access to all of our "
+"projects, such as MusicBrainz, ListenBrainz, BookBrainz, and more."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:75
+msgid ""
+"We create a placeholder account for all the MetaBrainz projects when you "
+"sign up, and you are one log-in away from activating them."
+msgstr ""
+
+#: frontend/js/src/forms/ProfileChangePassword.tsx:70
 msgid "Current Password"
 msgstr ""
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:80
+#: frontend/js/src/forms/ProfileChangePassword.tsx:79
 msgid "New Password"
 msgstr ""
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:89
+#: frontend/js/src/forms/ProfileChangePassword.tsx:88
 msgid "Confirm New Password"
 msgstr ""
 
@@ -3746,190 +4797,180 @@ msgstr ""
 msgid "Reset Password"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:38
-msgid "If you would like to support us with more than $"
+#: frontend/js/src/forms/SignupCommercial.tsx:40
+msgid ""
+"If you would like to support us with more than ${{minPledge}}, please "
+"enter the actual amount here:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:39
-msgid ", please enter the actual amount here:"
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:144
+#: frontend/js/src/forms/SignupCommercial.tsx:149
 #: frontend/js/src/forms/SignupNonCommercial.tsx:75
-#: frontend/js/src/forms/SignupUser.tsx:87
+#: frontend/js/src/forms/SignupUser.tsx:93
 msgid "Captcha is required!"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:179
+#: frontend/js/src/forms/SignupCommercial.tsx:184
 #: frontend/js/src/forms/SignupNonCommercial.tsx:110
 #: frontend/js/src/forms/SignupUser.tsx:46
 msgid "Access all MetaBrainz projects"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:182
+#: frontend/js/src/forms/SignupCommercial.tsx:187
 msgid "Note:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:184
+#: frontend/js/src/forms/SignupCommercial.tsx:189
 msgid ""
 "Signing up for any tier other than the <italic>Stealth startup</italic> "
 "tier will publicly list your company on this web site. However, we will "
 "not publish any of your private details."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:221
+#: frontend/js/src/forms/SignupCommercial.tsx:226
 #: frontend/js/src/forms/SignupNonCommercial.tsx:145
 msgid "Account type"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:234
+#: frontend/js/src/forms/SignupCommercial.tsx:239
 msgid "Selected tier"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:242
-msgid "month and up"
+#: frontend/js/src/forms/SignupCommercial.tsx:247
+msgid "${{tierPrice}}/month and up"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:250
+#: frontend/js/src/forms/SignupCommercial.tsx:255
 msgid "Change account type or tier"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:261
+#: frontend/js/src/forms/SignupCommercial.tsx:266
 #: frontend/js/src/forms/SignupNonCommercial.tsx:166
 msgid "Your account:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:271
+#: frontend/js/src/forms/SignupCommercial.tsx:276
 #: frontend/js/src/forms/SignupNonCommercial.tsx:176
-#: frontend/js/src/forms/SignupUser.tsx:114
+#: frontend/js/src/forms/SignupUser.tsx:120
 msgid "(public)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:291
+#: frontend/js/src/forms/SignupCommercial.tsx:296
 #: frontend/js/src/forms/SignupNonCommercial.tsx:196
-#: frontend/js/src/forms/SignupUser.tsx:127
+#: frontend/js/src/forms/SignupUser.tsx:133
 msgid "E-mail address"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:295
+#: frontend/js/src/forms/SignupCommercial.tsx:300
 #: frontend/js/src/forms/SignupNonCommercial.tsx:200
-#: frontend/js/src/forms/SignupUser.tsx:131
+#: frontend/js/src/forms/SignupUser.tsx:137
 msgid "(checking...)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:314
+#: frontend/js/src/forms/SignupCommercial.tsx:319
 #: frontend/js/src/forms/SignupNonCommercial.tsx:220
-#: frontend/js/src/forms/SignupUser.tsx:163
+#: frontend/js/src/forms/SignupUser.tsx:169
 msgid "Must be at least 8 characters"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:348
+#: frontend/js/src/forms/SignupCommercial.tsx:353
 msgid ""
 "If you don't have an organization name, you probably want to become a "
 "supporter as a <nonCommercialLink>Non-commercial / "
 "Personal</nonCommercialLink> supporter."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:358
+#: frontend/js/src/forms/SignupCommercial.tsx:363
 msgid ""
 "If you don't have an organization name, you probably want to sign up as a"
 " <nonCommercialLink>Non-commercial / Personal</nonCommercialLink> user."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:378
+#: frontend/js/src/forms/SignupCommercial.tsx:383
 msgid ""
 "Please tell us a little about your company and whether you plan to use "
 "our <apiLink>API</apiLink> or to <hostLink>host your own copy</hostLink> "
 "of the data."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:404
+#: frontend/js/src/forms/SignupCommercial.tsx:408
 msgid "Logo URL"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:405
+#: frontend/js/src/forms/SignupCommercial.tsx:409
 msgid "(preferably in SVG format)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:408
+#: frontend/js/src/forms/SignupCommercial.tsx:412
 msgid ""
 "Image should be about 250 pixels wide on a white or transparent "
 "background. We will host it on our site."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:421
+#: frontend/js/src/forms/SignupCommercial.tsx:425
 msgid ""
 "URL to where developers can use your APIs using MusicBrainz IDs, if "
-"available.."
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:430
-msgid "Your project"
+"available."
 msgstr ""
 
 #: frontend/js/src/forms/SignupCommercial.tsx:434
+msgid "Your project"
+msgstr ""
+
+#: frontend/js/src/forms/SignupCommercial.tsx:438
 #: frontend/js/src/forms/SignupNonCommercial.tsx:261
 msgid "(max 150 characters)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:451
+#: frontend/js/src/forms/SignupCommercial.tsx:455
 msgid "Billing address"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:502
+#: frontend/js/src/forms/SignupCommercial.tsx:506
 msgid ""
 "I agree to support the MetaBrainz Foundation when my organization is able"
 " to do so."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:507
+#: frontend/js/src/forms/SignupCommercial.tsx:511
+#: frontend/js/src/forms/SignupNonCommercial.tsx:284
 msgid ""
-"I also agree that if I generate a Live Data Feed access token, that I "
-"treat my access token as a secret and will not share this token publicly "
-"or commit it to a source code repository."
+"I also agree that if I generate a Live Data Feed access token, then I "
+"will treat my access token as a secret and will not share this token "
+"publicly or commit it to a source code repository."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:515
+#: frontend/js/src/forms/SignupCommercial.tsx:519
 msgid ""
 "The following information will be shown publicly: organization name, "
 "logo, website and API URLs, data usage description."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:520
+#: frontend/js/src/forms/SignupCommercial.tsx:524
 msgid ""
 "We'll send you more details about payment process once your application "
 "is approved."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:552
+#: frontend/js/src/forms/SignupCommercial.tsx:556
 #: frontend/js/src/forms/SignupNonCommercial.tsx:316
-#: frontend/js/src/forms/SignupUser.tsx:224
+#: frontend/js/src/forms/SignupUser.tsx:230
 msgid "Validating..."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:564
+#: frontend/js/src/forms/SignupCommercial.tsx:568
 #: frontend/js/src/forms/SignupNonCommercial.tsx:329
 msgid "Back to profile"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:569
-#: frontend/js/src/forms/SignupNonCommercial.tsx:334
-msgid "Not a supporter?"
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:570
+#: frontend/js/src/forms/SignupCommercial.tsx:574
 #: frontend/js/src/forms/SignupNonCommercial.tsx:335
-msgid "Create a user account"
+msgid "Not a supporter? <signupLink>Create a user account</signupLink>"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:573
-#: frontend/js/src/forms/SignupNonCommercial.tsx:338
-#: frontend/js/src/forms/SignupUser.tsx:231
-msgid "Already have an account?"
-msgstr ""
-
-#: frontend/js/src/forms/SignupNonCommercial.tsx:107
-msgid "non-commercial"
+#: frontend/js/src/forms/SignupCommercial.tsx:583
+#: frontend/js/src/forms/SignupNonCommercial.tsx:344
+#: frontend/js/src/forms/SignupUser.tsx:238
+msgid "Already have an account? <loginLink>Sign in</loginLink>"
 msgstr ""
 
 #: frontend/js/src/forms/SignupNonCommercial.tsx:113
@@ -3957,46 +4998,40 @@ msgid ""
 "income per year) or personal uses only."
 msgstr ""
 
-#: frontend/js/src/forms/SignupNonCommercial.tsx:284
-msgid ""
-"I also agree that if I generate a Live Data Feed access token, then I "
-"will treat my access token as a secret and will not share this token "
-"publicly or commit it to a source code repository."
-msgstr ""
-
 #: frontend/js/src/forms/SignupUser.tsx:43
 msgid "Create your account"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:50
-msgid "Registration started by"
+#: frontend/js/src/forms/SignupUser.tsx:51
+msgid "Registration started by <client />"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:69
+#: frontend/js/src/forms/SignupUser.tsx:75
+#: frontend/js/src/hooks/useEmailValidation.ts:82
 msgid "Invalid email address."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:150
+#: frontend/js/src/forms/SignupUser.tsx:156
 msgid ""
 "This username and email were provided by the app that started "
 "registration. You can change them later from MetaBrainz settings."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:182
+#: frontend/js/src/forms/SignupUser.tsx:188
 msgid ""
 "I accept that my contributions will be released into the public domain or"
 " licensed for use."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:191
+#: frontend/js/src/forms/SignupUser.tsx:197
 msgid "We will never share your personal information."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:200
+#: frontend/js/src/forms/SignupUser.tsx:206
 msgid "Click here to read more"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:224
+#: frontend/js/src/forms/SignupUser.tsx:230
 msgid "Create account"
 msgstr ""
 
@@ -4006,9 +5041,5 @@ msgstr ""
 
 #: frontend/js/src/hooks/useEmailValidation.ts:47
 msgid "Email validation failed"
-msgstr ""
-
-#: frontend/js/src/hooks/useEmailValidation.ts:82
-msgid "Invalid email address"
 msgstr ""
 

--- a/metabrainz/oauth/scopes.py
+++ b/metabrainz/oauth/scopes.py
@@ -1,0 +1,33 @@
+"""Translatable descriptions for the OAuth scopes seeded into oauth.scope.
+
+The descriptions are stored in the database (see
+admin/sql/oauth/create_tables.sql), so string extraction cannot find them
+there. Mirroring them here lets the consent screen -- where the user decides
+what access to hand over, and so the one page that most needs to be understood
+-- be shown in their own language. A scope with no entry here falls back to the
+description held in the database.
+"""
+from flask_babel import gettext
+
+from metabrainz.i18n import N_
+
+SCOPE_DESCRIPTIONS = {
+    "profile": N_("View your public account information"),
+    "email": N_("View your email address"),
+    "musicbrainz:tag": N_("View and modify your private tags"),
+    "musicbrainz:rating": N_("View and modify your private ratings"),
+    "musicbrainz:collection": N_("View and modify your private collections"),
+    "musicbrainz:submit_isrc": N_("Submit new ISRCs to the database"),
+    "musicbrainz:submit_barcode": N_("Submit new barcodes to the database"),
+    "openid": N_("Sign you in and view your unique user id"),
+    "listenbrainz:submit-listens": N_("Submit listens to ListenBrainz."),
+    "critiquebrainz:review": N_("Create and modify CritiqueBrainz reviews."),
+    "critiquebrainz:vote": N_("Submit and delete votes on CritiqueBrainz reviews."),
+    "critiquebrainz:profile": N_("Modify profile info and delete profile on CritiqueBrainz."),
+}
+
+
+def scope_description(scope):
+    """Return the translated description of a scope for display to a user."""
+    description = SCOPE_DESCRIPTIONS.get(scope.name)
+    return gettext(description) if description else scope.description

--- a/metabrainz/oauth/tests/__init__.py
+++ b/metabrainz/oauth/tests/__init__.py
@@ -5,6 +5,7 @@ from flask import g
 from flask_login import logout_user
 from sqlalchemy import delete
 
+from metabrainz.errors import OAUTH_ERROR_MESSAGES
 from metabrainz.model.user import User
 from metabrainz.testing import FlaskTestCase
 from metabrainz.model import db, OAuth2AccessToken, OAuth2RefreshToken, OAuth2Client, OAuth2AuthorizationCode
@@ -218,14 +219,17 @@ class OAuthTestCase(FlaskTestCase):
         self.assertEqual(parsed.fragment, "_")
         return query_args["code"][0]
 
-    def authorize_error_helper(self, user, query_string, error):
+    def authorize_error_helper(self, user, query_string, error, confirm_succeeds=False):
+        expected = {**error, "message": OAUTH_ERROR_MESSAGES.get(error["name"])}
+
         response = self.client.get(
             "/oauth2/authorize",
             query_string=query_string,
         )
+        self.assertEqual(response.status_code, 400)
         self.assertTemplateUsed("oauth/error.html")
         props = json.loads(self.get_context_variable("props"))
-        self.assertEqual(props["error"], error)
+        self.assertEqual(props["error"], expected)
 
         response = self.client.post(
             "/oauth2/authorize/confirm",
@@ -235,9 +239,18 @@ class OAuthTestCase(FlaskTestCase):
                 "csrf_token": g.csrf_token
             }
         )
-        self.assertTemplateUsed("oauth/error.html")
-        props = json.loads(self.get_context_variable("props"))
-        self.assertEqual(props["error"], error)
+        if response.status_code == 302:
+            location = urlparse(response.location)
+            reported = parse_qs(location.query or location.fragment)
+            if confirm_succeeds:
+                self.assertNotIn("error", reported)
+            else:
+                self.assertEqual(reported["error"], [error["name"]])
+        else:
+            self.assertEqual(response.status_code, 400)
+            self.assertTemplateUsed("oauth/error.html")
+            props = json.loads(self.get_context_variable("props"))
+            self.assertEqual(props["error"], expected)
 
         self.assert_security_headers(response)
 

--- a/metabrainz/oauth/tests/test_oauth_authorization_code.py
+++ b/metabrainz/oauth/tests/test_oauth_authorization_code.py
@@ -704,7 +704,7 @@ class AuthorizationCodeGrantTestCase(OAuthTestCase):
             "approval_prompt": "invalid",
         }
         error = {"name": "invalid_request", "description": "Invalid 'approval_prompt' in request."}
-        self.authorize_error_helper(self.user2, query_string, error)
+        self.authorize_error_helper(self.user2, query_string, error, confirm_succeeds=True)
 
     def test_oauth_approval_prompt_scope_mismatch(self):
         redirect_uri1 = "https://example.com/callback1"

--- a/metabrainz/oauth/tests/test_oauth_implicit.py
+++ b/metabrainz/oauth/tests/test_oauth_implicit.py
@@ -289,7 +289,7 @@ class ImplicitGrantTestCase(OAuthTestCase):
         error = {"name": "invalid_request", "description": "Invalid 'approval_prompt' in request."}
 
         self.temporary_login(self.user2)
-        self.authorize_error_helper(self.user2, query_string, error)
+        self.authorize_error_helper(self.user2, query_string, error, confirm_succeeds=True)
 
     def test_oauth_approval_prompt_scope_mismatch(self):
         redirect_uri1 = "https://example.com/callback1"

--- a/metabrainz/oauth/tests/test_oauth_registration_request.py
+++ b/metabrainz/oauth/tests/test_oauth_registration_request.py
@@ -296,6 +296,36 @@ class OAuthRegistrationRequestTestCase(OAuthTestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json["error"], "invalid_request")
 
+    def test_registration_request_carries_ui_locales_through_signup(self):
+        application = self.create_oauth_app()
+        self._allow_registration_request_client(application)
+
+        response = self._create_registration_request(application, ui_locales="de-AT de")
+        self.assertEqual(response.status_code, 201)
+        cached_request = cache.get(response.json["request_id"], namespace=REGISTRATION_REQUEST_NAMESPACE)
+        self.assertEqual(cached_request["ui_locales"], "de-AT de")
+
+        signup_url = self._assert_redirects_to_signup(response.json["redirect_to"])
+        self.client.get(signup_url)
+        global_props = json.loads(self.get_context_variable("global_props"))
+        self.assertEqual(global_props["locale"], "de")
+
+    def test_registration_request_without_ui_locales_uses_the_default_locale(self):
+        self.client.delete_cookie(self.app.config["SESSION_COOKIE_NAME"])
+
+        application = self.create_oauth_app()
+        self._allow_registration_request_client(application)
+
+        response = self._create_registration_request(application)
+        self.assertEqual(response.status_code, 201)
+        self.assertNotIn("ui_locales", cache.get(
+            response.json["request_id"], namespace=REGISTRATION_REQUEST_NAMESPACE))
+
+        signup_url = self._assert_redirects_to_signup(response.json["redirect_to"])
+        self.client.get(signup_url)
+        global_props = json.loads(self.get_context_variable("global_props"))
+        self.assertEqual(global_props["locale"], "en")
+
     def test_registration_request_expired(self):
         application = self.create_oauth_app()
         self._allow_registration_request_client(application)

--- a/metabrainz/oauth/tests/test_oauth_registration_request.py
+++ b/metabrainz/oauth/tests/test_oauth_registration_request.py
@@ -7,6 +7,7 @@ from urllib.parse import parse_qs, urlparse
 from brainzutils import cache
 from flask import g
 
+from metabrainz.errors import OAUTH_ERROR_MESSAGES
 from metabrainz.model import OAuth2AuthorizationCode, OAuth2Client, db
 from metabrainz.model.oauth.client import OAuth2ClientPrivilege
 from metabrainz.model.domain_blacklist import DomainBlacklist
@@ -336,3 +337,9 @@ class OAuthRegistrationRequestTestCase(OAuthTestCase):
         response = self.client.get(response.json["redirect_to"])
         self.assertEqual(response.status_code, 400)
         self.assertTemplateUsed("oauth/error.html")
+        props = json.loads(self.get_context_variable("props"))
+        self.assertEqual(props["error"], {
+            "name": "invalid_request",
+            "description": "Registration request is invalid or expired.",
+            "message": OAUTH_ERROR_MESSAGES["invalid_request"],
+        })

--- a/metabrainz/oauth/views.py
+++ b/metabrainz/oauth/views.py
@@ -14,6 +14,7 @@ from metabrainz.model.user import User
 from metabrainz.oauth.authorization_server import authorization_server
 from metabrainz.oauth.forms import AuthorizationForm
 from metabrainz.oauth.oidc_grant import build_user_info
+from metabrainz.oauth.scopes import scope_description
 from metabrainz.oauth.registration_request import (
     create_registration_request,
     delete_registration_request,
@@ -281,7 +282,7 @@ def authorize():
         "client_name": grant.client.name,
         "scopes": [{
             "name": scope.name,
-            "description": scope.description
+            "description": scope_description(scope)
         } for scope in scopes],
         "cancel_url": cancel_url,
         "csrf_token": generate_csrf(),

--- a/metabrainz/oauth/views.py
+++ b/metabrainz/oauth/views.py
@@ -218,12 +218,7 @@ def create_oauth_registration_request():
 def begin_registration_request(request_id):
     registration_request = get_registration_request(request_id)
     if registration_request is None:
-        return render_template("oauth/error.html", props=json.dumps({
-            "error": {
-                "name": "invalid_request",
-                "description": "Registration request is invalid or expired.",
-            }
-        })), 400
+        raise InvalidRequestError(description="Registration request is invalid or expired.")
 
     # The hint was sent when the registration request was created, not on this
     # URL, so it has to be picked up from the stored request.

--- a/metabrainz/oauth/views.py
+++ b/metabrainz/oauth/views.py
@@ -7,6 +7,7 @@ from flask_login import login_required, current_user
 from flask_wtf.csrf import generate_csrf
 
 from metabrainz.decorators import nocache, crossdomain
+from metabrainz.i18n import remember_ui_locales
 from metabrainz.model import db, OAuth2Scope, get_scopes, OAuth2AccessToken
 from metabrainz.model.oauth.client import OAuth2ClientPrivilege
 from metabrainz.model.user import User
@@ -34,11 +35,23 @@ REGISTRATION_REQUEST_AUTHORIZE_KEYS = {
     "code_challenge_method",
     "nonce",
     "response_mode",
+    "ui_locales",
 }
 REGISTRATION_REQUEST_STORED_AUTHORIZE_KEYS = REGISTRATION_REQUEST_AUTHORIZE_KEYS | {
     "approval_prompt",
     "login_hint",
 }
+
+
+@oauth2_bp.before_request
+def before_oauth2_request():
+    """Remember the client's ``ui_locales`` hint for the rest of the flow.
+
+    This runs before the view, and so before @login_required can redirect an
+    anonymous user to the sign in or sign up page, where the hint is no longer
+    part of the query string.
+    """
+    remember_ui_locales(request.args.get("ui_locales"))
 
 
 @oauth2_bp.after_request
@@ -210,6 +223,10 @@ def begin_registration_request(request_id):
                 "description": "Registration request is invalid or expired.",
             }
         })), 400
+
+    # The hint was sent when the registration request was created, not on this
+    # URL, so it has to be picked up from the stored request.
+    remember_ui_locales(registration_request.get("ui_locales"))
 
     next_url = url_for(".begin_registration_request", request_id=request_id)
     if current_user.is_anonymous:

--- a/metabrainz/oauth/views.py
+++ b/metabrainz/oauth/views.py
@@ -7,7 +7,7 @@ from flask_login import login_required, current_user
 from flask_wtf.csrf import generate_csrf
 
 from metabrainz.decorators import nocache, crossdomain
-from metabrainz.i18n import remember_ui_locales
+from metabrainz.i18n import get_supported_locale_codes, remember_ui_locales
 from metabrainz.model import db, OAuth2Scope, get_scopes, OAuth2AccessToken
 from metabrainz.model.oauth.client import OAuth2ClientPrivilege
 from metabrainz.model.user import User
@@ -387,4 +387,5 @@ def well_known_oauth_authorization_server():
         "grant_types_supported": ["authorization_code", "refresh_token", "implicit"],
         "id_token_signing_alg_values_supported": ["ES256", "none"],
         "subject_types_supported": ["public"],
+        "ui_locales_supported": get_supported_locale_codes(),
     }

--- a/metabrainz/templates/base-react.html
+++ b/metabrainz/templates/base-react.html
@@ -7,6 +7,6 @@
 
 {% block scripts %}
   {{ super() }}
-  <script id="global-react-props" type="application/json">{{ global_props|safe }}</script>
-  <script id="page-react-props" type="application/json">{{ props|safe }}</script>
+  <script id="global-react-props" type="application/json">{{ global_props|react_props }}</script>
+  <script id="page-react-props" type="application/json">{{ props|react_props }}</script>
 {% endblock %}

--- a/metabrainz/translations/bg/LC_MESSAGES/messages.po
+++ b/metabrainz/translations/bg/LC_MESSAGES/messages.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-07-25 16:21+0200\n"
+"POT-Creation-Date: 2026-09-08 11:18+0200\n"
 "PO-Revision-Date: 2026-06-12 00:51+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: bg\n"
@@ -21,162 +21,247 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.18.0\n"
 
-#: metabrainz/index/forms.py:46
+#: metabrainz/errors.py:24
+msgid "Authorization was declined."
+msgstr ""
+
+#: metabrainz/errors.py:25
+msgid "The authorization request was invalid."
+msgstr ""
+
+#: metabrainz/errors.py:26
+msgid "The application could not be authenticated."
+msgstr ""
+
+#: metabrainz/errors.py:27
+msgid "This application is not allowed to request authorization."
+msgstr ""
+
+#: metabrainz/errors.py:28
+msgid "The application asked for a response type this server does not support."
+msgstr ""
+
+#: metabrainz/errors.py:29
+msgid "The permissions requested by the application are invalid."
+msgstr ""
+
+#: metabrainz/errors.py:30
+msgid "You need to sign in to continue."
+msgstr ""
+
+#: metabrainz/errors.py:31
+msgid "Your consent is required to continue."
+msgstr ""
+
+#: metabrainz/password.py:12
+#, python-format
+msgid "Password must not exceed %(max_bytes)s bytes."
+msgstr ""
+
+#: metabrainz/index/forms.py:48
 #, python-format
 msgid "'%(value)s' is not a valid choice for this field"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileEdit.tsx:27
-#: frontend/js/src/forms/SignupCommercial.tsx:154
+#: frontend/js/src/forms/SignupCommercial.tsx:159
 #: frontend/js/src/forms/SignupNonCommercial.tsx:85
-#: frontend/js/src/forms/SignupUser.tsx:70
-#: frontend/js/src/hooks/useEmailValidation.ts:78 metabrainz/index/forms.py:57
-#: metabrainz/user/forms.py:25 metabrainz/user/forms.py:57
-#: metabrainz/user/forms.py:63
+#: frontend/js/src/forms/SignupUser.tsx:76
+#: frontend/js/src/hooks/useEmailValidation.ts:78 metabrainz/index/forms.py:59
+#: metabrainz/user/forms.py:31 metabrainz/user/forms.py:70
+#: metabrainz/user/forms.py:76
 msgid "Email address is required!"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:34
-#: metabrainz/index/forms.py:63
+#: metabrainz/index/forms.py:65
 msgid "Current password is required!"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:43
 #: frontend/js/src/forms/ProfileChangePassword.tsx:37
 #: frontend/js/src/forms/ResetPassword.tsx:39
-#: frontend/js/src/forms/SignupCommercial.tsx:156
+#: frontend/js/src/forms/SignupCommercial.tsx:161
 #: frontend/js/src/forms/SignupNonCommercial.tsx:87
-#: frontend/js/src/forms/SignupUser.tsx:72 metabrainz/index/forms.py:66
-#: metabrainz/user/forms.py:29 metabrainz/user/forms.py:46
-#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:69
+#: frontend/js/src/forms/SignupUser.tsx:78 metabrainz/index/forms.py:69
+#: metabrainz/user/forms.py:35 metabrainz/user/forms.py:54
+#: metabrainz/user/forms.py:63 metabrainz/user/forms.py:82
 msgid "Password is required!"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:41
-#: frontend/js/src/forms/SignupCommercial.tsx:160
+#: frontend/js/src/forms/SignupCommercial.tsx:165
 #: frontend/js/src/forms/SignupNonCommercial.tsx:91
-#: frontend/js/src/forms/SignupUser.tsx:76 metabrainz/index/forms.py:70
-#: metabrainz/user/forms.py:33 metabrainz/user/forms.py:73
+#: frontend/js/src/forms/SignupUser.tsx:82 metabrainz/index/forms.py:74
+#: metabrainz/user/forms.py:40 metabrainz/user/forms.py:87
 msgid "Confirm Password is required!"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:46
 #: frontend/js/src/forms/ResetPassword.tsx:48
-#: frontend/js/src/forms/SignupCommercial.tsx:165
+#: frontend/js/src/forms/SignupCommercial.tsx:170
 #: frontend/js/src/forms/SignupNonCommercial.tsx:96
-#: frontend/js/src/forms/SignupUser.tsx:81 metabrainz/index/forms.py:72
-#: metabrainz/user/forms.py:35 metabrainz/user/forms.py:75
+#: frontend/js/src/forms/SignupUser.tsx:87 metabrainz/index/forms.py:76
+#: metabrainz/user/forms.py:42 metabrainz/user/forms.py:89
 msgid "Confirm Password should match password!"
 msgstr ""
 
 #: frontend/js/src/Applications.tsx:56 frontend/js/src/Applications.tsx:86
 #: frontend/js/src/Profile.tsx:272 frontend/js/src/Profile.tsx:482
-#: metabrainz/index/forms.py:78
+#: metabrainz/index/forms.py:82
 msgid "Name"
 msgstr ""
 
-#: metabrainz/index/forms.py:79
+#: metabrainz/index/forms.py:83
 msgid "Contact name field is empty."
 msgstr ""
 
-#: metabrainz/index/views.py:234
+#: metabrainz/index/views.py:251
 msgid "Profile updated successfully."
 msgstr ""
 
-#: metabrainz/index/views.py:261
+#: metabrainz/index/views.py:278
 msgid "Current password is incorrect."
 msgstr ""
 
-#: metabrainz/index/views.py:266
+#: metabrainz/index/views.py:283
 msgid "Password changed successfully."
 msgstr ""
 
-#: metabrainz/index/views.py:372
+#: metabrainz/index/views.py:389
 msgid "You have updated an application!"
 msgstr ""
 
-#: metabrainz/index/views.py:424
+#: metabrainz/index/views.py:441
 msgid "You have deleted an application."
 msgstr ""
 
-#: metabrainz/index/views.py:426
+#: metabrainz/index/views.py:443
 msgid "Failed to delete an application."
 msgstr ""
 
-#: metabrainz/index/views.py:449
+#: metabrainz/index/views.py:466
 msgid "Revoked tokens successfully!"
 msgstr ""
 
-#: metabrainz/index/views.py:478
+#: metabrainz/index/views.py:495
 msgid "Your account has been deleted."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:106 metabrainz/oauth/forms.py:58
+#: frontend/js/src/forms/CreateApplication.tsx:106 metabrainz/oauth/forms.py:57
 msgid "Application Name"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:59
+#: metabrainz/oauth/forms.py:58
 msgid "Application name field is empty."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:60 metabrainz/oauth/forms.py:60
+#: frontend/js/src/forms/CreateApplication.tsx:60 metabrainz/oauth/forms.py:59
 msgid "Application name needs to be at least 3 characters long."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:64 metabrainz/oauth/forms.py:61
+#: frontend/js/src/forms/CreateApplication.tsx:64 metabrainz/oauth/forms.py:60
 msgid "Application name needs to be at most 64 characters long."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:114 metabrainz/oauth/forms.py:63
+#: frontend/js/src/forms/CreateApplication.tsx:114 metabrainz/oauth/forms.py:62
 msgid "Description"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:64
+#: metabrainz/oauth/forms.py:63
 msgid "Client description field is empty."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:65
+#: metabrainz/oauth/forms.py:64
 msgid "Client description needs to be at least 3 characters long."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:66
+#: metabrainz/oauth/forms.py:65
 msgid "Client description needs to be at most 512 characters long."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:122 metabrainz/oauth/forms.py:68
+#: frontend/js/src/forms/CreateApplication.tsx:122 metabrainz/oauth/forms.py:67
 msgid "Homepage"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:69
+#: metabrainz/oauth/forms.py:68
 msgid "Homepage field is empty."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:70
+#: metabrainz/oauth/forms.py:69
 msgid "Homepage is not a valid URI."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:71
+#: metabrainz/oauth/forms.py:70
 msgid "Homepage URL must use http or https"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:73
+#: metabrainz/oauth/forms.py:72
 msgid "Authorization callback URL"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:74
+#: metabrainz/oauth/forms.py:73
 msgid "Authorization callback URL field is empty."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:75
+#: metabrainz/oauth/forms.py:74
 msgid "Authorization callback URL is invalid."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:76
+#: metabrainz/oauth/forms.py:75
 msgid "Authorization callback URL must use http or https."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:81 metabrainz/oauth/forms.py:85
+#: metabrainz/oauth/forms.py:80 metabrainz/oauth/forms.py:84
 msgid "Confirm"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:15
+msgid "View your public account information"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:16
+msgid "View your email address"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:17
+msgid "View and modify your private tags"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:18
+msgid "View and modify your private ratings"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:19
+msgid "View and modify your private collections"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:20
+msgid "Submit new ISRCs to the database"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:21
+msgid "Submit new barcodes to the database"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:22
+msgid "Sign you in and view your unique user id"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:23
+msgid "Submit listens to ListenBrainz."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:24
+msgid "Create and modify CritiqueBrainz reviews."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:25
+msgid "Submit and delete votes on CritiqueBrainz reviews."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:26
+msgid "Modify profile info and delete profile on CritiqueBrainz."
 msgstr ""
 
 #: metabrainz/payments/views.py:164
@@ -234,178 +319,185 @@ msgid "Requested annual report was not found."
 msgstr "Заявеният годишен доклад не бе намерен."
 
 #: frontend/js/src/forms/ProfileEdit.tsx:30
-#: frontend/js/src/forms/SignupCommercial.tsx:139
+#: frontend/js/src/forms/SignupCommercial.tsx:144
 #: frontend/js/src/forms/SignupNonCommercial.tsx:70
-#: metabrainz/supporter/forms.py:13
+#: metabrainz/supporter/forms.py:15
 msgid "Contact name is required!"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:437
+#: frontend/js/src/forms/SignupCommercial.tsx:441
 #: frontend/js/src/forms/SignupNonCommercial.tsx:264
-#: metabrainz/supporter/forms.py:15
+#: metabrainz/supporter/forms.py:17
 msgid ""
 "Can you please tell us more about the project in which you'd like to use "
 "our data? Do you plan to self host the data or use our APIs?"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:137
+#: frontend/js/src/forms/SignupCommercial.tsx:142
 #: frontend/js/src/forms/SignupNonCommercial.tsx:68
-#: metabrainz/supporter/forms.py:17
+#: metabrainz/supporter/forms.py:19
 msgid "Please, tell us how you (will) use our data."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:138
+#: frontend/js/src/forms/SignupCommercial.tsx:143
 #: frontend/js/src/forms/SignupNonCommercial.tsx:69
-#: metabrainz/supporter/forms.py:18
+#: metabrainz/supporter/forms.py:20
 msgid "Please, limit usage description to 500 characters."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:141
-#: frontend/js/src/forms/SignupCommercial.tsx:142
+#: frontend/js/src/forms/SignupCommercial.tsx:146
+#: frontend/js/src/forms/SignupCommercial.tsx:147
 #: frontend/js/src/forms/SignupNonCommercial.tsx:72
 #: frontend/js/src/forms/SignupNonCommercial.tsx:73
-#: frontend/js/src/forms/SignupUser.tsx:84
-#: frontend/js/src/forms/SignupUser.tsx:85 metabrainz/supporter/forms.py:21
-#: metabrainz/user/forms.py:38
+#: frontend/js/src/forms/SignupUser.tsx:90
+#: frontend/js/src/forms/SignupUser.tsx:91 metabrainz/supporter/forms.py:23
+#: metabrainz/user/forms.py:45
 msgid "You need to accept the agreement!"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:342
-#: metabrainz/supporter/forms.py:27
+#: frontend/js/src/forms/SignupCommercial.tsx:347
+#: metabrainz/supporter/forms.py:29
 msgid "Organization name"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:113
-#: metabrainz/supporter/forms.py:28
+#: frontend/js/src/forms/SignupCommercial.tsx:115
+#: metabrainz/supporter/forms.py:30
 msgid "You need to specify the name of your organization."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:373
-#: metabrainz/supporter/forms.py:30
+#: frontend/js/src/forms/SignupCommercial.tsx:378
+#: metabrainz/supporter/forms.py:32
 msgid "Organization description"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:116
-#: metabrainz/supporter/forms.py:31
+#: frontend/js/src/forms/SignupCommercial.tsx:118
+#: metabrainz/supporter/forms.py:33
 msgid "You need to provide description of your organization."
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:278
-#: frontend/js/src/forms/SignupCommercial.tsx:396
-#: metabrainz/supporter/forms.py:34
+#: frontend/js/src/forms/SignupCommercial.tsx:401
+#: metabrainz/supporter/forms.py:36
 msgid "Website URL"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:119
-#: metabrainz/supporter/forms.py:35
-msgid "You need to specify website of the organization."
+#: frontend/js/src/forms/SignupCommercial.tsx:121
+#: frontend/js/src/forms/SignupCommercial.tsx:123
+#: metabrainz/supporter/forms.py:38 metabrainz/supporter/forms.py:42
+msgid "Website URL must be a valid URL."
 msgstr ""
 
-#: metabrainz/supporter/forms.py:37
+#: metabrainz/supporter/forms.py:45
 msgid "Logo image URL"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:284
-#: frontend/js/src/forms/SignupCommercial.tsx:418
-#: metabrainz/supporter/forms.py:38
+#: frontend/js/src/forms/SignupCommercial.tsx:422
+#: metabrainz/supporter/forms.py:46
 msgid "API URL"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:457
-#: metabrainz/supporter/forms.py:40
+#: frontend/js/src/forms/SignupCommercial.tsx:461
+#: metabrainz/supporter/forms.py:48
 msgid "Street"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:123
-#: metabrainz/supporter/forms.py:41
+#: frontend/js/src/forms/SignupCommercial.tsx:128
+#: metabrainz/supporter/forms.py:49
 msgid "You need to specify street."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:465
-#: metabrainz/supporter/forms.py:43
+#: frontend/js/src/forms/SignupCommercial.tsx:469
+#: metabrainz/supporter/forms.py:51
 msgid "City"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:124
-#: metabrainz/supporter/forms.py:44
+#: frontend/js/src/forms/SignupCommercial.tsx:129
+#: metabrainz/supporter/forms.py:52
 msgid "You need to specify city."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:473
-#: metabrainz/supporter/forms.py:46
+#: frontend/js/src/forms/SignupCommercial.tsx:477
+#: metabrainz/supporter/forms.py:54
 msgid "State / Province"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:126
-#: metabrainz/supporter/forms.py:47
+#: frontend/js/src/forms/SignupCommercial.tsx:131
+#: metabrainz/supporter/forms.py:55
 msgid "You need to specify state/province."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:481
-#: metabrainz/supporter/forms.py:49
+#: frontend/js/src/forms/SignupCommercial.tsx:485
+#: metabrainz/supporter/forms.py:57
 msgid "Postcode"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:128
-#: metabrainz/supporter/forms.py:50
+#: frontend/js/src/forms/SignupCommercial.tsx:133
+#: metabrainz/supporter/forms.py:58
 msgid "You need to specify postcode."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:489
-#: metabrainz/supporter/forms.py:52
+#: frontend/js/src/forms/SignupCommercial.tsx:493
+#: metabrainz/supporter/forms.py:60
 msgid "Country"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:129
-#: metabrainz/supporter/forms.py:53
+#: frontend/js/src/forms/SignupCommercial.tsx:134
+#: metabrainz/supporter/forms.py:61
 msgid "You need to specify country."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:132
-#: metabrainz/supporter/forms.py:64
+#: frontend/js/src/forms/SignupCommercial.tsx:137
+#: metabrainz/supporter/forms.py:72
 msgid ""
 "Custom amount must be more than threshold amount for selected tier or "
 "equal to it!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:46 metabrainz/supporter/views.py:119
-#: metabrainz/supporter/views.py:220
+#: metabrainz/supporter/views.py:54
+msgid ""
+"The verification email could not be sent. Please request a new one from "
+"your profile."
+msgstr ""
+
+#: metabrainz/supporter/views.py:85 metabrainz/supporter/views.py:158
+#: metabrainz/supporter/views.py:260
 msgid "You are already a supporter."
 msgstr ""
 
-#: metabrainz/supporter/views.py:61
+#: metabrainz/supporter/views.py:100
 msgid "Can't find tier with a specified ID."
 msgstr ""
 
-#: metabrainz/supporter/views.py:127
+#: metabrainz/supporter/views.py:166
 msgid "You need to choose support tier before signing up!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:137
+#: metabrainz/supporter/views.py:176
 msgid "You need to choose existing tier before signing up!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:164
+#: metabrainz/supporter/views.py:204
 msgid ""
 "Thanks for becoming a supporter! Your application will be reviewed soon. "
 "We will send you updates via email."
 msgstr ""
 
-#: metabrainz/supporter/views.py:187
+#: metabrainz/supporter/views.py:228
 msgid ""
 "Thanks for signing up! Your application will be reviewed soon. We will "
 "send you updates via email."
 msgstr ""
 
-#: metabrainz/supporter/views.py:248
+#: metabrainz/supporter/views.py:288
 msgid "Thanks for becoming a supporter!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:274
+#: metabrainz/supporter/views.py:312
 msgid "Thanks for signing up! Please check your inbox to complete verification."
 msgstr ""
 
-#: metabrainz/supporter/views.py:302
+#: metabrainz/supporter/views.py:340
 msgid "Can't generate new token unless account is active."
 msgstr ""
 
@@ -439,7 +531,7 @@ msgstr ""
 msgid "Policies"
 msgstr ""
 
-#: metabrainz/templates/base.html:55 metabrainz/templates/index/gdpr.html:178
+#: metabrainz/templates/base.html:55
 #: metabrainz/templates/index/social-contract.html:3
 #: metabrainz/templates/index/social-contract.html:6
 #: metabrainz/templates/navbar.html:34
@@ -449,14 +541,15 @@ msgstr ""
 #: metabrainz/templates/base.html:56
 #: metabrainz/templates/index/code-of-conduct.html:3
 #: metabrainz/templates/index/code-of-conduct.html:16
-#: metabrainz/templates/index/gdpr.html:181 metabrainz/templates/navbar.html:35
+#: metabrainz/templates/navbar.html:35
 msgid "Code of Conduct"
 msgstr ""
 
+#: frontend/js/src/PrivacySummary.tsx:11
 #: frontend/js/src/forms/ConditionsModal.tsx:21
-#: metabrainz/templates/base.html:57 metabrainz/templates/index/gdpr.html:184
-#: metabrainz/templates/index/privacy.html:6
+#: metabrainz/templates/base.html:57 metabrainz/templates/index/privacy.html:6
 #: metabrainz/templates/navbar.html:36
+#: metabrainz/templates/users/privacy-summary.html:3
 msgid "Privacy Policy"
 msgstr "Политика за поверителност"
 
@@ -490,10 +583,7 @@ msgstr "Спонсори"
 msgid "Supporters"
 msgstr "Поддръжници"
 
-#: frontend/js/src/forms/LoginUser.tsx:103
-#: frontend/js/src/forms/SignupCommercial.tsx:574
-#: frontend/js/src/forms/SignupNonCommercial.tsx:339
-#: frontend/js/src/forms/SignupUser.tsx:232 metabrainz/templates/base.html:73
+#: frontend/js/src/forms/LoginUser.tsx:103 metabrainz/templates/base.html:73
 #: metabrainz/templates/navbar.html:66 metabrainz/templates/users/login.html:3
 msgid "Sign in"
 msgstr "Вписване"
@@ -515,26 +605,26 @@ msgid "Contact us"
 msgstr "Свържете се с нас"
 
 #: metabrainz/templates/base.html:85
-#: metabrainz/templates/index/contact.html:105
+#: metabrainz/templates/index/contact.html:106
 msgid "Blog"
 msgstr "Блог"
 
-#: metabrainz/templates/base.html:86 metabrainz/templates/index/contact.html:90
+#: metabrainz/templates/base.html:86 metabrainz/templates/index/contact.html:91
 msgid "Chat"
 msgstr ""
 
 #: metabrainz/templates/base.html:87
-#: metabrainz/templates/index/contact.html:106
+#: metabrainz/templates/index/contact.html:107
 msgid "Mastodon"
 msgstr ""
 
 #: metabrainz/templates/base.html:88
-#: metabrainz/templates/index/contact.html:107
+#: metabrainz/templates/index/contact.html:108
 msgid "Bluesky"
 msgstr ""
 
 #: metabrainz/templates/base.html:89
-#: metabrainz/templates/index/contact.html:108
+#: metabrainz/templates/index/contact.html:109
 msgid "Instagram"
 msgstr ""
 
@@ -593,15 +683,14 @@ msgstr "Финансови доклади"
 msgid "Donate"
 msgstr "Дари"
 
-#: frontend/js/src/forms/LoginUser.tsx:110
-#: frontend/js/src/forms/SignupCommercial.tsx:175
-#: frontend/js/src/forms/SignupCommercial.tsx:555
+#: frontend/js/src/forms/SignupCommercial.tsx:180
+#: frontend/js/src/forms/SignupCommercial.tsx:559
 #: frontend/js/src/forms/SignupNonCommercial.tsx:106
 #: frontend/js/src/forms/SignupNonCommercial.tsx:319
 #: metabrainz/templates/navbar.html:65
-#: metabrainz/templates/supporters/account-type.html:51
-#: metabrainz/templates/supporters/account-type.html:93
-#: metabrainz/templates/supporters/account-type.html:144
+#: metabrainz/templates/supporters/account-type.html:47
+#: metabrainz/templates/supporters/account-type.html:84
+#: metabrainz/templates/supporters/account-type.html:130
 #: metabrainz/templates/users/signup.html:3
 msgid "Sign up"
 msgstr "Запишете се"
@@ -924,8 +1013,430 @@ msgstr ""
 msgid "Introduction"
 msgstr ""
 
-#: metabrainz/templates/index/conflict-policy.html:55
+#: metabrainz/templates/index/conflict-policy.html:17
+msgid ""
+"Conflicts between people arise in open source projects constantly and the"
+" projects by the \n"
+"    MetaBrainz Foundation are no different. This policy aims to establish"
+" a clear and unambiguous \n"
+"    policy for reporting and addressing conflicts in our community. In "
+"this policy we aim to \n"
+"    establish a fair practice that balances the need for confidentiality "
+"and our desire for \n"
+"    transparency in our operations."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:25
+#, python-format
+msgid ""
+"Before you continue to read this policy, we encourage you to review our "
+"existing community policies \n"
+"    including our <a href=\"%(social_contract_url)s\">Social "
+"Contract</a>, \n"
+"    <a href=\"%(code_of_conduct_url)s\">the Code of Conduct</a>, \n"
+"    and our <a href=\"%(privacy_policy_url)s\">Privacy Policy</a>. These "
+"policies establish the norms and rules for \n"
+"    participation in our projects; these policies apply equally to the "
+"contractors of the MetaBrainz \n"
+"    Foundation and any participants in our projects."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:37
+msgid ""
+"This policy divides conflicts into two categories: Private and public. "
+"Private conflicts are conflicts \n"
+"    that involve *confidential* information regarding contributors, "
+"contractors or supporters. Otherwise, any conflicts \n"
+"    that do not involve confidential information are considered to be "
+"public conflicts. For instance, a \n"
+"    conflict between a contractor and the Executive Director (aka BDFL) "
+"that involves contractor pay is \n"
+"    considered a private conflict because pay rates are confidential "
+"information. A public conflict in edit \n"
+"    notes between two editors in our community does not involve "
+"confidential information and therefore should \n"
+"    be considered a public conflict."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:47
+msgid ""
+"When conflicts arise we aim to disclose as much information as possible "
+"about the conflict in a timely \n"
+"    fashion. When conflicts contain confidential matters we will aim to "
+"disclose as much information as \n"
+"    possible, while fully respecting the confidentiality of the people "
+"involved in the conflict. With any \n"
+"    private conflict we will aim to extract the relevant lessons for the "
+"team and community in an effort to \n"
+"    evolve our policies to prevent future conflicts. Should the involved "
+"parties disagree whether a conflict \n"
+"    is private or public, the question about the nature of the conflict "
+"will be presented for the next higher \n"
+"    level in the chain of command to decide. (e.g. if a community member "
+"and the community manager disagree on \n"
+"    a conflict being public or private, the Executive Director shall "
+"decide if the conflict is public or private)."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:58
 msgid "Reporting and Response"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:61
+msgid ""
+"We aim to not have conflict in our community, but we recognize that in "
+"reality conflicts will arise and we \n"
+"    must be prepared to address them in a fair manner. When conflicts "
+"arise, we prefer to have community or team \n"
+"    members resolve the conflicts among themselves, using our existing "
+"policies as guidelines for resolving the \n"
+"    conflict."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:69
+msgid ""
+"If you do not feel comfortable resolving a conflict on your own, you "
+"should feel free to report the conflict to \n"
+"    us. How you address the conflict depends on who is involved in the "
+"conflict and your comfort level. Please see \n"
+"    the detailed sections below on how and with whom to address your "
+"conflict. We aim to address conflicts as soon \n"
+"    as possible in an effort to prevent them from escalating "
+"unnecessarily."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:75
+msgid "Direct conflict resolution"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:78
+msgid ""
+"In direct conflict resolution, the involved parties will attempt to "
+"resolve the conflict themselves without \n"
+"   involving any MetaBrainz Foundation team member. You should aim to use"
+" direct resolution when the conflict does \n"
+"   not involve the violation of one of our policies or if the conflict is"
+" minor."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:84
+#, python-format
+msgid ""
+"For instance, if a user uses a rude tone, is disruptive or flagrantly "
+"ignores our project guidelines, we suggest \n"
+"    that you use direct conflict resolution to resolve the conflict. Some"
+" resources that might give you some suggestions \n"
+"    on how to go about resolving the conflict might be this <a "
+"href=\"%(conflict_resolution_primer_url)s\">\n"
+"    conflict resolution primer</a> and <a "
+"href=\"%(difficult_conversations_url)s\">how to\n"
+"    have difficult conversations at work</a>."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:93
+msgid "Informal reporting"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:96
+msgid ""
+"You may use informal reporting of a conflict if you aim to communicate a "
+"concern or incident without \n"
+"    seeking a corrective outcome. Informal reporting may also be an "
+"option if you have not been personally \n"
+"    victimized, but you’ve witnessed a violation of our policies or where"
+" you wish to maintain confidentiality \n"
+"    throughout the entire reporting process."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:103
+msgid ""
+"For editing in MusicBrainz you may informally report a user using the "
+"“Report this user for bad behavior” \n"
+"    link from the user’s profile. For reporting bad user behavior in "
+"other of our projects, please report them to our \n"
+"    community manager by mailing <span class=\"backemail\">gro.zniarbatem"
+"@reganam-ytinummoc</span> . For conflicts \n"
+"    that involve the community manager, report them by mailing <span "
+"class=\"backemail\">gro.zniarbatem@de</span> ."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:110
+msgid ""
+"Depending the the severity of the issue, repeated informal complaints may"
+" eventually require a formal response \n"
+"    from the MetaBrainz team. If an involved party requires anonymity, "
+"the conflict becomes a private conflict. If at \n"
+"    all possible minor issues should be resolved in a public forum in "
+"order for all people to witness and learn from \n"
+"    the issue at hand."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:116
+msgid "Formal complaint process"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:119
+msgid ""
+"All complaints about conflicts should be submitted via email. To whom a "
+"complaint should be mailed and who will \n"
+"    carry out the investigation will be described in the next section."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:124
+msgid "All complaint submissions to the Foundation should include the following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:128
+msgid ""
+"Contact info, if it is different than the email used to submit the "
+"conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:129
+msgid "Who was involved in the conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:130
+msgid "Where and when the incident happened"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:131
+msgid ""
+"A description of what happened -- ideally with links (e.g. chatlogs, edit"
+" notes) that outlines what \n"
+"         happened so that the persons evaluating the conflict may "
+"understand the issue at hand"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:133
+msgid ""
+"Any related pieces of information that provide more context on the "
+"conflict (e.g. links, screenshots)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:134
+msgid "An indication if this conflict is ongoing or not"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:139
+msgid "The investigation that follows aims to determine:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:143
+msgid "The nature and severity of the incident"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:144
+msgid ""
+"Whether or not the incident is considered a violation of MetaBrainz’ "
+"conduct policies or core values"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:145
+msgid ""
+"The amount of harm experienced by the person who submitted the complaint "
+"and the broader MetaBrainz community \n"
+"         as a result of the incident"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:147
+msgid ""
+"Whether there have been prior complaints against the individual or "
+"individuals reported"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:148
+msgid "Whether the incident is ongoing"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:152
+msgid ""
+"The following potential forms of resolution may apply to any team members"
+" involved in the conflict:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:155
+#: metabrainz/templates/index/conflict-policy.html:168
+msgid "Nothing (if it has been found no violation occurred)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:156
+msgid "Creating a plan to improve the performance"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:157
+msgid "Creating a negative performance evaluation"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:158
+msgid "Mediation, an intervention by a third party to resolve the conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:159
+msgid "Suspension or forced leave"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:160
+msgid "Termination of contract"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:164
+msgid ""
+"The following potential forms of resolution may apply to non team members"
+" involved in the conflict:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:169
+msgid "A reprimand, either public or private"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:170
+msgid "Suspension of the users’ account"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:171
+msgid "Deletion of the users’ account"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:172
+msgid ""
+"Removal of user privileges (e.g. if an auto editor commits a serious "
+"offence, they may lose their auto editor status)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:175
+msgid "Filing a complaint"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:178
+msgid ""
+"NOTE: For complaints not about MetaBrainz staff, please see the "
+"<em>Informal reporting</em> section above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:182
+msgid ""
+"If the complaint does not involve the Executive Director (ED), do the "
+"following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:186
+msgid ""
+"If team member has directly violated conduct policies or engaged in "
+"otherwise harmful behavior, a formal complaint should be filed."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:187
+msgid ""
+"Mail <span class=\"backemail\">gro.zniarbatem@de</span> and include the "
+"complaint information outlined above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:188
+msgid ""
+"You should expect a response within a working day acknowledging the "
+"complaint."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:189
+msgid ""
+"The complaint will be investigated by the ED, member(s) of the board of "
+"directors or a neutral third party."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:190
+msgid ""
+"Once the investigation has been completed, the ED, with the support of "
+"others involved in the investigation will respond. The \n"
+"        ED will respond to incidents no later than 7 working days after a"
+" complaint has been filed with either a resolution or an \n"
+"        explanation of why the process must be extended."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:196
+msgid "If a complaint involves the Executive Director, do the following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:200
+msgid ""
+"If the Executive Director has directly violated conduct policies or "
+"engaged in otherwise harmful behavior, \n"
+"        a formal complaint should be filed with the board of directors."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:202
+msgid ""
+"Mail <span class=\"backemail\">gro.zniarbatem@noituloser-tcilfnoc</span> "
+"and include the complaint information outlined above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:203
+msgid ""
+"You should get a response within 5 working days acknowledging the "
+"complaint."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:204
+msgid ""
+"The complaint will be investigated by the member(s) of the board of "
+"directors, the community manager, a neutral \n"
+"        third party or a combination thereof."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:206
+msgid ""
+"Once the investigation has been completed, the board, with the support of"
+" others involved in the investigation \n"
+"        will respond. The board will aim to respond to incidents no later"
+" than 15 working days after a complaint has been filed \n"
+"        with either a resolution or an explanation of why the process "
+"must be extended."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:211
+msgid "Confidentiality"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:214
+msgid ""
+"Confidentiality is an important aspect of conflict resolution and all of "
+"the conflicts brought to the attention of the foundation \n"
+"    will be evaluated with confidentiality in mind and acted upon "
+"accordingly."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:219
+msgid ""
+"We work hard to make all of the actions of the foundation as transparent "
+"and open as possible. In cases where we cannot \n"
+"    disclose all aspects of a conflict we will disclose that a conflict "
+"is or has occurred and we will attempt to disclose the \n"
+"    appropriate amount of information about the conflict while balancing "
+"the need for confidentiality and our desire to learn \n"
+"    from conflicts so that we as a foundation and community can learn "
+"from these conflicts and improve our policies to avoid the \n"
+"    conflicts in the future."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:227
+msgid ""
+"Any breaches of confidentiality will be treated as severe breaches of our"
+" conduct policies."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:230
+msgid "Retaliation"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:233
+msgid ""
+"We will not allow retaliation for any contractor or volunteer that files "
+"a complaint or is involved in an investigation. If you \n"
+"    believe that you are being treated negatively because of your "
+"involvement in a complaint please report this complaint directly \n"
+"    to the ED at <span class=\"backemail\">gro.zniarbatem@de</span> or "
+"the board at \n"
+"    <span class=\"backemail\">gro.zniarbatem@noituloser-tcilfnoc</span>."
 msgstr ""
 
 #: metabrainz/templates/index/contact.html:3
@@ -1006,7 +1517,7 @@ msgstr ""
 msgid ""
 "We are currently evaluating our overall online advertising strategy. We "
 "are evaluating advertising, traffic optimization,\n"
-"    search engine optimization and software monitization technologies. If"
+"    search engine optimization and software monetization technologies. If"
 " you provide these professional services, please provide a detailed\n"
 "    deck of your comprehensive services to the following email address. "
 "<em>Please respect our other non-media teams and do not contact us \n"
@@ -1081,11 +1592,11 @@ msgstr ""
 #, python-format
 msgid ""
 "Please come ask your questions at our <a "
-"href=\"%(forums_url)s\">forums</a>! We would love to\n"
-"    answer any questions you may have."
+"href=\"%(forums_url)s\">forums</a>!\n"
+"    The community and the team will be more than happy to help you."
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:92
+#: metabrainz/templates/index/contact.html:93
 #, python-format
 msgid ""
 "The MetaBrainz/MusicBrainz/ListenBrainz team and community hang out\n"
@@ -1095,15 +1606,15 @@ msgid ""
 "    <a href=\"%(chatlogs_url)s\">chat log archives</a>."
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:101
+#: metabrainz/templates/index/contact.html:102
 msgid "Social media"
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:103
+#: metabrainz/templates/index/contact.html:104
 msgid "You can follow us on these social channels:"
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:112
+#: metabrainz/templates/index/contact.html:113
 msgid "Mailing address"
 msgstr ""
 
@@ -1116,33 +1627,349 @@ msgstr ""
 msgid "GDPR Compliance Statement"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:37
+#: metabrainz/templates/index/gdpr.html:10
+msgid ""
+"The General Data Protection Regulation is a complex EU regulation that "
+"stipulates many points for protecting private data of\n"
+"    users on the Internet. Even though this is an EU regulation, it has a"
+" worldwide impact due to the nature of the Internet.\n"
+"    The MetaBrainz Foundation with its collection of projects is also "
+"affected by this regulation. We’ve been learning and adapting\n"
+"    our sites to be compliant with the GDPR – sadly this regulation isn’t"
+" entirely black and white and there is an incredible\n"
+"    amount of room left for interpretation of these rules."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:17
+msgid ""
+"The good news is that this regulation is roughly in line with our "
+"established practices: We’ve always held private information\n"
+"    in a high regard and applied the sort of rules to ourselves as we "
+"wish to have our own private data treated. Luckily, this\n"
+"    makes our compliance effort considerably easier. We’ve made two "
+"significant changes to how we treat your data and also adopted\n"
+"    terminology as used in the GDPR in order to use the same languages "
+"that many other sites are now adopting. Please keep reading\n"
+"    to find out the exact details of what we are doing to comply."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:24
+#, python-format
+msgid ""
+"However, we do ask for your compassion and help in our process of "
+"complying with the GDPR. As we already mentioned, the GDPR is\n"
+"    a complex set of rules that are not fully clarified yet. We’ve taken "
+"action on the steps that are clear to us and we’re following\n"
+"    ongoing conversations on points that are in gray zones or unclear to "
+"us. We’ve made our best initial effort on compliance and\n"
+"    promise to keep working on it as the picture becomes more clear. If "
+"you believe that we could improve our compliance, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a> and let us know what we "
+"can do to improve. It would also help us if you\n"
+"    could provide concrete discussion or examples to help us understand "
+"and take action on your suggestion."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:33
+msgid ""
+"Finally, below are the key sections of the GDPR as we understand them and"
+" how they affect your data in our ecosystem. Where\n"
+"    possible, we provide links for deeper understanding, links for you to"
+" examine our relevant code and links to tickets to follow\n"
+"    the process of improving our compliance."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:38
 msgid "Right to be forgotten"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:77
+#: metabrainz/templates/index/gdpr.html:41
+msgid ""
+"Summary: <i>Provide the user with the ability to remove their private "
+"data from our services</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:44
+msgid ""
+"The most important aspect of the right to be forgotten is the ability to "
+"delete your account. Once you request for us to delete\n"
+"    your account, we will remove any personally identifying information "
+"you may have provided us from your account (name, email\n"
+"    address, gender, biography, URL, etc.). The visible name on your "
+"account will be changed to “Deleted User #####” and effectively\n"
+"    the account will no longer be identifiable as your account."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:50
+msgid ""
+"However, given the nature of our projects where we work on collaborative "
+"databases, your contributions that are not personally\n"
+"    identifying are valuable assets to our database and these "
+"contributions will not be removed from our databases. But we will\n"
+"    ensure that these contributions no longer contain personally "
+"identifying data."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:55
+#, python-format
+msgid ""
+"Our process of automatically deleting your accounts across the MetaBrainz"
+" ecosystem is not complete yet (see below for a set of\n"
+"    tickets where you can track our progress). If you would like to "
+"delete your accounts in the MetaBrainz ecosystem or mark a\n"
+"    donation that is currently public as a private donation, please <a "
+"href=\"%(contact_url)s\">contact us</a>\n"
+"    and we will address your request as soon as possible."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:62
+#: metabrainz/templates/index/gdpr.html:182
+msgid "Links:"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:66
+#, python-format
+msgid ""
+"<a href=\"%(editor_deletion_doc_url)s\">How we delete accounts\n"
+"       in MusicBrainz</a> (warning, geek content ahead!)"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:70
+msgid ""
+"Implement sitewide user account deletion in\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/MBS-9680\">MusicBrainz</a>,"
+"\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/AB-337\">AcousticBrainz</a>,"
+"\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/BB-260\">BookBrainz</a>,\n"
+"         <a href=\"https://tickets.metabrainz.org/browse/MEB-103\">the "
+"MetaBrainz Site</a>,\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/LB-354\">ListenBrainz</a>, "
+"and\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/CB-307\">CritiqueBrainz</a>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:80
 msgid "Restriction of processing"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:110
+#: metabrainz/templates/index/gdpr.html:83
+msgid ""
+"Summary: <i>To allow the user to control how their personally identifying"
+" data is being used.</i>"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:86
+msgid ""
+"Except for the ListenBrainz and AcousticBrainz projects, we do not "
+"process personally identifying data. Any personally\n"
+"    identifying data that our projects store is for the purpose of being "
+"able to contact you about your contributions to our database\n"
+"    (email address) or for voluntarily showing information about you to "
+"other users (biography, homepage, location, etc)."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:91
+#, python-format
+msgid ""
+"The ListenBrainz project differs in that the Listens (metadata about what"
+" music you have listened to) are stored on our servers\n"
+"    and <a href=\"%(listenbrainz_data_url)s\">made available to the "
+"public</a>. We believe Listens to be personally identifying\n"
+"    data and furthermore, we have goals of creating open source "
+"recommendation engines with this data, which involves processing the\n"
+"    user’s data. These two points are fundamental goals of the "
+"ListenBrainz project and we do not see a reasonable way to reach another"
+"\n"
+"    compromise position."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:99
+msgid ""
+"Because of this, we are going to require users to either acknowledge that"
+" we may process their Listen data or alternatively to\n"
+"    delete their account, including all of their Listens. Please note "
+"that if you decide to delete your ListenBrainz account, it may\n"
+"    take up to two weeks for all of your listens to no longer be included"
+" in our efforts to build a recommendation engine."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:104
+msgid ""
+"We have always made it clear that the data in ListenBrainz was to be "
+"public and that we plan to build new tools with your data, so\n"
+"    this should not come as a surprise to our users."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:108
+msgid ""
+"The AcousticBrainz project does not track who submits data to the "
+"database. If you create an account and use our data creation\n"
+"    tools (e.g. create a dataset or participate in a challenge) then we "
+"link your participation and the things that you create to\n"
+"    your account. If you choose to delete your account then we keep the "
+"non personally identifying data that you create, but anonymize\n"
+"    it so that it cannot be linked back to you."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:114
 msgid "Right to data portability / exporting your data"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:150
+#: metabrainz/templates/index/gdpr.html:117
+msgid ""
+"Summary: <i>You have the right to access/download the data we store about"
+" you</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:120
+msgid ""
+"Except for the ListenBrainz and AcousticBrainz projects, we do not store "
+"personally identifying data beyond the\n"
+"    information that is available in your public profile on each of our "
+"projects. Since this data is plainly available in your\n"
+"    profile we do not provide a means for you to export this data."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:125
+msgid "There are the following exceptions to this:"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:129
+msgid ""
+"<b>IP addresses</b>: If you visit one of our sites the IP address of your"
+" computer is stored in our web logs for 7 days\n"
+"        before our servers automatically delete them. This data is almost"
+" never used by anyone: the only time we look at the\n"
+"        IP addresses is if our sites are adversely impacted by the "
+"actions of some unknown users. In that case, we may investigate\n"
+"        the logs to identify the IP address that needs to be blocked in "
+"order to restore the stability of our service.\n"
+"        This data is not available to anyone but the contractors of the "
+"MetaBrainz Foundation and is not available to download\n"
+"        to anyone at all."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:137
+#, python-format
+msgid ""
+"<b>ListenBrainz Listen data</b>: Users may <a "
+"href=\"%(listenbrainz_export_url)s\">export their ListenBrainz Listen\n"
+"        data</a> directly from the site. The user Listen data is also "
+"included in the <a href=\"%(listenbrainz_data_url)s\">ListenBrainz\n"
+"        data dumps</a> that are available for public download."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:146
+msgid ""
+"All of the non personally identifying data, such as your metadata "
+"contributions, are publicly visible, available for download\n"
+"    and available via the project APIs. For details about this data, "
+"downloads and APIs please check the documentation for the\n"
+"    respective projects you are interested in."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:151
+#, python-format
+msgid ""
+"Anyone wishing to get a list of financial donations they have made to the"
+" MetaBrainz Foundation, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a> and provide your "
+"MusicBrainz editor name so that we can look up\n"
+"    your donations."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:157
 msgid "Right to rectification"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:165
+#: metabrainz/templates/index/gdpr.html:160
+msgid "Summary: <i>You have the right to correct your data</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:163
+msgid ""
+"All of our projects allow their users to update their personally "
+"identifying information in their profiles. Furthermore, most\n"
+"    of our projects allow the editing of their own metadata "
+"contributions. If you find that some of your data is incorrect, please\n"
+"    feel free to edit the data since we provide the tools to do so."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:168
+#, python-format
+msgid ""
+"If anyone who has made a financial donation to the MetaBrainz Foundation "
+"would like to make their donation private, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:173
 msgid "Right to be informed"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:188
+#: metabrainz/templates/index/gdpr.html:175
+msgid ""
+"Summary: <i>You have the right to be informed about how we use your data "
+"in plain English</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:178
+msgid ""
+"Our privacy policy, as well as other policies, have always been written "
+"by humans for human consumption. We abhor legalese and\n"
+"    not speaking in direct terms."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:186
+msgid "Social contract"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:189
+msgid "Code of conduct"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:192
+msgid "Privacy policy"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:196
 msgid "Right to access"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:198
-#: metabrainz/templates/index/privacy.html:166
+#: metabrainz/templates/index/gdpr.html:199
+msgid ""
+"Summary: <i>You have the right to access the data that we collect about "
+"you</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:202
+msgid ""
+"All of our projects make all of the data we collect on your behalf, "
+"privately identifying or not, available to you. The\n"
+"    only exception to this are the IP addresses we store for 7 days – see"
+" above for details."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:206
+#: metabrainz/templates/index/privacy.html:168
 msgid "Privacy/GDPR Representative"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:209
+#, python-format
+msgid ""
+"If you have any questions about our privacy policy, please <a "
+"href=\"%(contact_url)s\">contact us</a>. To report\n"
+"   any privacy problems, violations or leaks, our GDPR representative is "
+"our Interim Executive Director Nicolás Tamargo and for\n"
+"   privacy issues contact him at <strong><a "
+"href=\"mailto:gdpr@metabrainz.org\">gdpr@metabrainz.org</a></strong>."
 msgstr ""
 
 #: metabrainz/templates/index/index.html:6
@@ -1261,13 +2088,51 @@ msgid ""
 "      <a href=\"%(about_url)s\">about</a> page."
 msgstr ""
 
-#: frontend/js/src/forms/ConditionsModal.tsx:43
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:32
 #: metabrainz/templates/index/privacy.html:3
 msgid "Privacy"
 msgstr ""
 
 #: metabrainz/templates/index/privacy.html:8
 msgid "Summary"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:12
+msgid ""
+"You do not have to provide any personal data to be able to browse the "
+"contents of the databases published by MetaBrainz."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:15
+msgid ""
+"You do not have to provide any personally-identifying information if you "
+"choose not to."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:18
+msgid ""
+"We will never reveal your email address on MetaBrainz controlled web "
+"sites."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:22
+msgid ""
+"In order to get maximum value out of the MetaBrainz projects, you may "
+"want to create an account and log in. \n"
+"    Doing so grants you the ability to: edit the databases, contribute "
+"your own data, communicate with other users, and keep track \n"
+"    of recently released music from artists in your MusicBrainz "
+"collection. If you choose to create an account then the minimum we \n"
+"    ask is that you: choose a unique username and password, use a web "
+"browser that accepts \"session\" cookies, and provide a verified \n"
+"    email address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:29
+msgid ""
+"If you do not create an account (or are not logged in) you will not have "
+"access to the above listed features, however, you will \n"
+"    still have full access to browse and examine the databases."
 msgstr ""
 
 #: metabrainz/templates/index/privacy.html:33
@@ -1278,39 +2143,197 @@ msgstr ""
 msgid "Cookies"
 msgstr ""
 
+#: metabrainz/templates/index/privacy.html:37
+msgid "We use two cookies that contain sensitive information:"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:42
+msgid ""
+"<b>remember_login</b>: If you choose the \"Log in permanently\" option "
+"when logging in to one of our sites; the cookie will be used to \n"
+"      remember your login details."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:46
+msgid ""
+"<b>musicbrainz_server_session, session, or connect.sid</b>: If you are "
+"logged into one of our sites, your current session ID is stored in this "
+"cookie."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:51
+msgid ""
+"We may store dynamic preference information in other cookies, but these "
+"do not contain any sensitive information."
+msgstr ""
+
 #: metabrainz/templates/index/privacy.html:54
 msgid "Web and FTP access logs"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:57
+msgid ""
+"In a practice similar to other web sites (and APIs) we keep logs of all "
+"web requests made against our servers. These logs include: your IP\n"
+"    address, your browser's (or API client's) \"User-Agent\" string, and "
+"which page (or API endpoint) you requested with which parameters. "
+"Aggregate information about web and FTP traffic is\n"
+"    made available to the public via our site usage pages."
 msgstr ""
 
 #: metabrainz/templates/index/privacy.html:62
 msgid "Third-Party content"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:92
+#: metabrainz/templates/index/privacy.html:64
+msgid ""
+"Our projects' web pages may load some third-party content. Some, but "
+"possibly not all sites are listed below:"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:69
+#, python-format
+msgid ""
+"Cover art and other images: These are provided by the various cover art "
+"sites that have given MusicBrainz permission to do so and our own \n"
+"      <a href=\"%(caa_url)s\">Cover Art Archive</a>. This means that the "
+"relevant site will know (if they want to) your IP \n"
+"      address, User-Agent string, etc., and which MusicBrainz web page "
+"you were visiting (the one which included the cover art image)."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:75
+msgid ""
+"AcoustID: Our fingerprints tab loads fingerprint information from "
+"acoustid.org."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:78
+msgid ""
+"MTCaptcha: Our account creation page loads third party content in order "
+"to prevent spammers from creating accounts."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:83
+msgid ""
+"<i>The above information assumes that you are using \"normal\" web "
+"browser settings, whereby images are always loaded and HTTP referrer \n"
+"    information is always sent.</i>"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:88
+msgid ""
+"It is impractical to constantly modify this privacy policy when "
+"MetaBrainz projects change which third party content they utilize. We "
+"will \n"
+"    aim to use common sense, respect to our community and community "
+"review when adding more content from third party sites. We will also \n"
+"    periodically review our policy to ensure that it remains current."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:93
 msgid "Applicable to account holders"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:94
+#: metabrainz/templates/index/privacy.html:95
 msgid "Account creation"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:108
+#: metabrainz/templates/index/privacy.html:97
+msgid ""
+"When creating an account with a MetaBrainz project you need to pick a "
+"unique username and choose a password, the username you pick is the \n"
+"    only name associated with your account and will be what other "
+"MetaBrainz users know you as. You may optionally also tell us other \n"
+"    information about yourself that will be displayed to other MetaBrainz"
+" users and the public."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:103
+msgid ""
+"Additionally, in order to edit the databases you will need to provide a "
+"confirmed email address. This email address will be held in \n"
+"    confidence, the only method of revealing your email address to "
+"another user is if you choose to send a message to another \n"
+"    user and enable the option to \"reveal my email address\". Changing "
+"the email address stored with your account will require you to \n"
+"    verify the new address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:109
 msgid "Edits and Notes"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:114
+#: metabrainz/templates/index/privacy.html:111
+msgid ""
+"If you make any changes to a MetaBrainz project database, such as adding "
+"any data, the details of those changes will be visible to \n"
+"    other logged-in users and the change will be associated with your "
+"username."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:115
 msgid "Subscriptions on MusicBrainz"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:131
+#: metabrainz/templates/index/privacy.html:117
+msgid ""
+"As a logged-in user you can subscribe to one or more artists, labels, "
+"collections or other editors. The act of subscribing causes \n"
+"    any edits made to (or by in the case of another editor) those "
+"entities to be emailed to you. By default, other users can see your \n"
+"    list of subscriptions, however, you can opt out of this by editing "
+"the appropriate preference."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:123
+msgid ""
+"This does not provide \"perfect\" privacy though, in some cases it will "
+"be possible to infer information about the contents of your \n"
+"    subscription list even though you have disallowed others from viewing"
+" that list directly. This imperfection arises because various \n"
+"    parts of the system behave differently depending on whether or not an"
+" entity has any subscribers; also, the number of users \n"
+"    subscribed to each artist is available via the artist pages. In the "
+"most extreme (possibly contrived) example, imagine that all \n"
+"    users have their subscriptions set to \"public\", except for exactly "
+"one user whose list is \"private\". In that case, any discrepancy \n"
+"    for a given artist between the shown list of subscribers and the "
+"total number of subscribers must be down to that one user. Thus, \n"
+"    you can infer what artists are on that user's list."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:132
 msgid "Third-party sites"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:145
-msgid "MetaBrainz donors"
+#: metabrainz/templates/index/privacy.html:134
+#, python-format
+msgid ""
+"Our code reviews are done on GitHub, which is not under the control of "
+"MetaBrainz. Participating in code reviews or other\n"
+"    tasks carried out on GitHub are subject to <a "
+"href=\"%(github_url)s\">GitHub's privacy policy</a>."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:140
+#, python-format
+msgid ""
+"Our translations platform is provided and hosted by Weblate, which has a "
+"data processing agreement with MetaBrainz.\n"
+"    Participating in translations is subject to <a "
+"href=\"%(weblate_url)s\">dedicated legal terms</a>.\n"
+"    Any translations you make will be submitted to our Git repositories "
+"and publicly associated with your username;\n"
+"    if you so choose, you can also publicly associate them with your own "
+"verified email address."
 msgstr ""
 
 #: metabrainz/templates/index/privacy.html:147
+msgid "MetaBrainz donors"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:149
 msgid ""
 "When you make a donation to the MetaBrainz Foundation, we are legally\n"
 "    required to collect your personal information and keep it in our "
@@ -1320,7 +2343,7 @@ msgid ""
 "    information to anyone else, ever."
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:153
+#: metabrainz/templates/index/privacy.html:155
 msgid ""
 "We believe in transparent finances, which means that we list all "
 "donations\n"
@@ -1330,11 +2353,34 @@ msgid ""
 "process."
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:158
+#: metabrainz/templates/index/privacy.html:160
 msgid "Exceptions"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:598
+#: metabrainz/templates/index/privacy.html:162
+msgid ""
+"<i><b>Please note</b>: Reasonable exceptions may apply to the above "
+"policy, for example to comply with applicable laws.\n"
+"    Also, members of the MetaBrainz team and other personnel contracted "
+"to provide services to MetaBrainz may have access to\n"
+"    our infrastructure and could therefore view any information contained"
+" therein. However all personnel are contractually bound\n"
+"    by non-disclosure clauses which prevent them from making any such "
+"information available to others."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:171
+#, python-format
+msgid ""
+"If you have any questions about our GDPR statement, please <a "
+"href=\"%(contact_url)s\">contact us</a>. To report\n"
+"   any privacy problems, violations or leaks, our GDPR representative is "
+"our Interim Executive Director Nicolás Tamargo and for\n"
+"   privacy issues contact him at <strong><a "
+"href=\"mailto:gdpr@metabrainz.org\">gdpr@metabrainz.org</a></strong>."
+msgstr ""
+
+#: frontend/js/src/Profile.tsx:603
 #: frontend/js/src/forms/ProfileChangePassword.tsx:22
 #: frontend/js/src/forms/ProfileChangePassword.tsx:111
 #: metabrainz/templates/index/profile-change-password.html:3
@@ -1578,6 +2624,11 @@ msgstr ""
 
 #: metabrainz/templates/index/team.html:26
 msgid "He lives on in our hearts and in open source."
+msgstr ""
+
+#: metabrainz/templates/index/team.html:29
+#: metabrainz/templates/index/team.html:315
+msgid "you’re welcome to try"
 msgstr ""
 
 #: metabrainz/templates/index/team.html:39
@@ -2076,8 +3127,10 @@ msgstr ""
 
 #: metabrainz/templates/payments/donate.html:146
 msgid ""
-"Due to the increased unreliability of the US Postal Service we have "
-"stopped accepting paper checks. Sorry!"
+"Due to the increased unreliability of the US Postal Service and the "
+"relatively large fees involved, we ask you to only send a paper check if "
+"it is the only possible option. Due to the fees, we will not cash checks "
+"for less than $25."
 msgstr ""
 
 #: metabrainz/templates/payments/donate.html:241
@@ -2961,8 +4014,8 @@ msgid "Monthly balance sheets"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:520
-#: frontend/js/src/forms/SignupCommercial.tsx:175
-#: frontend/js/src/forms/SignupCommercial.tsx:554
+#: frontend/js/src/forms/SignupCommercial.tsx:180
+#: frontend/js/src/forms/SignupCommercial.tsx:558
 #: frontend/js/src/forms/SignupNonCommercial.tsx:106
 #: frontend/js/src/forms/SignupNonCommercial.tsx:318
 #: metabrainz/templates/supporters/account-type.html:3
@@ -2984,6 +4037,7 @@ msgid "Non-commercial / Personal"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:235
+#: frontend/js/src/forms/SignupNonCommercial.tsx:107
 #: frontend/js/src/forms/SignupNonCommercial.tsx:151
 #: metabrainz/templates/supporters/account-type.html:42
 msgid "Non-commercial"
@@ -2997,57 +4051,46 @@ msgstr ""
 msgid "Personal or university assignment user."
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:48
-#: metabrainz/templates/supporters/account-type.html:90
-#: metabrainz/templates/supporters/account-type.html:141
-msgid "Upgrade"
-msgstr ""
-
 #: frontend/js/src/Profile.tsx:235
-#: frontend/js/src/forms/SignupCommercial.tsx:176
-#: frontend/js/src/forms/SignupCommercial.tsx:228
-#: metabrainz/templates/supporters/account-type.html:61
+#: frontend/js/src/forms/SignupCommercial.tsx:181
+#: frontend/js/src/forms/SignupCommercial.tsx:233
+#: metabrainz/templates/supporters/account-type.html:56
 msgid "Commercial"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:83
-#: metabrainz/templates/supporters/account-type.html:135
+#: metabrainz/templates/supporters/account-type.html:78
+#: metabrainz/templates/supporters/account-type.html:125
 #, python-format
 msgid "$%(tier_price)s/month and up"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:87
-#: metabrainz/templates/supporters/account-type.html:138
+#: metabrainz/templates/supporters/account-type.html:82
+#: metabrainz/templates/supporters/account-type.html:128
 msgid "More info"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:104
+#: metabrainz/templates/supporters/account-type.html:94
 msgid "View all tiers"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:112
+#: metabrainz/templates/supporters/account-type.html:102
 msgid "Some of our Unicorn members"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:123
+#: metabrainz/templates/supporters/account-type.html:113
 msgid "See all our supporters"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:151
+#: metabrainz/templates/supporters/account-type.html:136
 msgid "View featured tiers"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:158
+#: metabrainz/templates/supporters/account-type.html:143
 #, python-format
 msgid ""
 "If you are not sure which tier to pick, please\n"
 "      <a href=\"%(contact_url)s\">contact us</a>."
 msgstr ""
-
-#: metabrainz/templates/supporters/account-type.html:166
-#, fuzzy
-msgid "Back to Profile"
-msgstr "Вашия профил"
 
 #: metabrainz/templates/supporters/bad-standing.html:3
 #: metabrainz/templates/supporters/bad-standing.html:6
@@ -3108,9 +4151,9 @@ msgid "Forgot your username"
 msgstr ""
 
 #: frontend/js/src/forms/ResetPassword.tsx:79
-#: frontend/js/src/forms/SignupCommercial.tsx:320
+#: frontend/js/src/forms/SignupCommercial.tsx:325
 #: frontend/js/src/forms/SignupNonCommercial.tsx:227
-#: frontend/js/src/forms/SignupUser.tsx:169
+#: frontend/js/src/forms/SignupUser.tsx:175
 #: metabrainz/templates/users/reauthenticate.html:3
 #: metabrainz/templates/users/reauthenticate.html:6
 msgid "Confirm Password"
@@ -3120,17 +4163,22 @@ msgstr ""
 msgid "Please re-enter your password to continue."
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:108
+#: frontend/js/src/ProfileDelete.tsx:110
 #: frontend/js/src/forms/DeleteApplication.tsx:53
 #: frontend/js/src/forms/OAuthPrompt.tsx:54
 #: frontend/js/src/forms/ProfileChangePassword.tsx:104
 #: frontend/js/src/forms/ProfileEdit.tsx:105
-#: metabrainz/templates/users/reauthenticate.html:23
+#: metabrainz/templates/users/reauthenticate.html:28
 msgid "Cancel"
 msgstr ""
 
-#: metabrainz/templates/users/reauthenticate.html:24
+#: metabrainz/templates/users/reauthenticate.html:29
 msgid "Continue"
+msgstr ""
+
+#: frontend/js/src/forms/utils.tsx:202
+#: metabrainz/templates/users/reauthenticate.html:40
+msgid "Password must not exceed 72 bytes."
 msgstr ""
 
 #: frontend/js/src/forms/ResetPassword.tsx:27
@@ -3138,38 +4186,38 @@ msgstr ""
 msgid "Reset your password"
 msgstr ""
 
-#: frontend/js/src/hooks/useEmailValidation.ts:41 metabrainz/user/forms.py:15
+#: frontend/js/src/hooks/useEmailValidation.ts:41 metabrainz/user/forms.py:16
 msgid "Registration from this email domain is not allowed."
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:50
 #: frontend/js/src/forms/LostPassword.tsx:45
-#: frontend/js/src/forms/SignupCommercial.tsx:270
+#: frontend/js/src/forms/SignupCommercial.tsx:275
 #: frontend/js/src/forms/SignupNonCommercial.tsx:175
-#: frontend/js/src/forms/SignupUser.tsx:114 metabrainz/user/forms.py:20
-#: metabrainz/user/forms.py:45 metabrainz/user/forms.py:62
+#: frontend/js/src/forms/SignupUser.tsx:120 metabrainz/user/forms.py:22
+#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:75
 msgid "Username"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:42
 #: frontend/js/src/forms/LostPassword.tsx:37
-#: frontend/js/src/forms/SignupCommercial.tsx:153
+#: frontend/js/src/forms/SignupCommercial.tsx:158
 #: frontend/js/src/forms/SignupNonCommercial.tsx:84
-#: frontend/js/src/forms/SignupUser.tsx:67 metabrainz/user/forms.py:21
-#: metabrainz/user/forms.py:45 metabrainz/user/forms.py:62
+#: frontend/js/src/forms/SignupUser.tsx:73 metabrainz/user/forms.py:26
+#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:75
 msgid "Username is required!"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:63
 #: frontend/js/src/forms/ResetPassword.tsx:72
-#: frontend/js/src/forms/SignupCommercial.tsx:308
+#: frontend/js/src/forms/SignupCommercial.tsx:313
 #: frontend/js/src/forms/SignupNonCommercial.tsx:214
-#: frontend/js/src/forms/SignupUser.tsx:157 metabrainz/user/forms.py:46
-#: metabrainz/user/forms.py:52
+#: frontend/js/src/forms/SignupUser.tsx:163 metabrainz/user/forms.py:53
+#: metabrainz/user/forms.py:62
 msgid "Password"
 msgstr ""
 
-#: frontend/js/src/forms/LoginUser.tsx:76 metabrainz/user/forms.py:47
+#: frontend/js/src/forms/LoginUser.tsx:76 metabrainz/user/forms.py:57
 msgid "Remember me"
 msgstr ""
 
@@ -3181,11 +4229,11 @@ msgstr ""
 msgid "Username contains invalid or invisible characters."
 msgstr ""
 
-#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:181
+#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:220
 msgid "Hide password"
 msgstr ""
 
-#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:181
+#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:220
 msgid "Show password"
 msgstr ""
 
@@ -3242,11 +4290,11 @@ msgstr ""
 msgid "Revoke access"
 msgstr ""
 
-#: frontend/js/src/OAuthError.tsx:17
+#: frontend/js/src/OAuthError.tsx:18
 msgid "OAuth2 Error"
 msgstr ""
 
-#: frontend/js/src/OAuthError.tsx:18
+#: frontend/js/src/OAuthError.tsx:19
 msgid "An error occurred during OAuth authentication process."
 msgstr ""
 
@@ -3276,8 +4324,8 @@ msgstr ""
 
 #: frontend/js/src/Profile.tsx:109
 msgid ""
-"Are you sure you want to generate new access token? Current token will be"
-" revoked!"
+"Are you sure you want to generate a new access token? The current token "
+"will be revoked!"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:118
@@ -3392,8 +4440,8 @@ msgid "Contact Information"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:310 frontend/js/src/forms/ProfileEdit.tsx:70
-#: frontend/js/src/forms/SignupCommercial.tsx:284
-#: frontend/js/src/forms/SignupCommercial.tsx:333
+#: frontend/js/src/forms/SignupCommercial.tsx:289
+#: frontend/js/src/forms/SignupCommercial.tsx:338
 #: frontend/js/src/forms/SignupNonCommercial.tsx:189
 #: frontend/js/src/forms/SignupNonCommercial.tsx:241
 msgid "Contact name"
@@ -3508,7 +4556,7 @@ msgstr ""
 msgid "Once you delete your account, there is no going back. Please be certain."
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:550 frontend/js/src/ProfileDelete.tsx:105
+#: frontend/js/src/Profile.tsx:550 frontend/js/src/ProfileDelete.tsx:107
 msgid "Delete My Account"
 msgstr ""
 
@@ -3520,39 +4568,39 @@ msgstr ""
 msgid "Need to delete your account?"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:574
+#: frontend/js/src/Profile.tsx:575
 msgid ""
 "Deletion of supporter accounts requires manual review. Please contact us "
-"at"
+"at <email />."
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:594
+#: frontend/js/src/Profile.tsx:599
 msgid "Security"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:626
+#: frontend/js/src/Profile.tsx:631
 msgid "MetaBrainz Applications"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:630
+#: frontend/js/src/Profile.tsx:635
 msgid ""
 "With your MetaBrainz account, you can access every project in the "
 "MetaBrainz family:"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:643
+#: frontend/js/src/Profile.tsx:648
 msgid "The open-source music encyclopedia"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:655
+#: frontend/js/src/Profile.tsx:660
 msgid "Track, visualise and share the music you listen to"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:667
+#: frontend/js/src/Profile.tsx:672
 msgid "The open-source book database"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:679
+#: frontend/js/src/Profile.tsx:684
 msgid "Creative Commons licensed reviews"
 msgstr ""
 
@@ -3575,7 +4623,7 @@ msgid "Permanently remove all your account information"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:64
-msgid "Revoke all your API tokens and access"
+msgid "Revoke all your tokens and access to the replication API"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:65
@@ -3587,14 +4635,16 @@ msgid "Log you out of all MetaBrainz services"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:70
-msgid "Your username will be reserved and cannot be reused."
+msgid ""
+"Your username will be reserved and cannot be reused without the "
+"intervention of an administrator."
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:82
+#: frontend/js/src/ProfileDelete.tsx:84
 msgid "To confirm, type your username '<username />' below:"
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:105
+#: frontend/js/src/ProfileDelete.tsx:107
 msgid "Deleting..."
 msgstr ""
 
@@ -3607,64 +4657,7 @@ msgstr "Вашия профил"
 msgid "Close"
 msgstr ""
 
-#: frontend/js/src/forms/ConditionsModal.tsx:23
-msgid "Licensing"
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:25
-msgid ""
-"Any contributions you make to any MetaBrainz service will be released "
-"into the Public Domain and/or licensed under a Creative Commons by-nc-sa "
-"license. Furthermore, you give the MetaBrainz Foundation the right to "
-"license this data for commercial use."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:30
-msgid "Please read our <licenseLink>license page</licenseLink> for more details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:45
-msgid ""
-"MetaBrainz strongly believes in the privacy of its users. Any personal "
-"information you choose to provide will not be sold or shared with anyone "
-"else."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:50
-msgid ""
-"Please read our <privacyLink>privacy policy</privacyLink> for more "
-"details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:59
-msgid "GDPR compliance"
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:61
-msgid ""
-"You may remove your personal information from our services anytime by "
-"deleting your account."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:66
-msgid ""
-"Please read our <gdprLink>GDPR compliance statement</gdprLink> for more "
-"details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:78
-msgid ""
-"Creating an account on MetaBrainz will give you access to all of our "
-"projects, such as MusicBrainz, ListenBrainz, BookBrainz, and more."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:82
-msgid ""
-"We create a placeholder account for all the MetaBrainz projects when you "
-"sign up, and you are one log-in away from activating them."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:91
+#: frontend/js/src/forms/ConditionsModal.tsx:29
 msgid "Sounds good"
 msgstr ""
 
@@ -3750,8 +4743,8 @@ msgstr ""
 msgid "Forgot your password?"
 msgstr ""
 
-#: frontend/js/src/forms/LoginUser.tsx:109
-msgid "Don't have an account?"
+#: frontend/js/src/forms/LoginUser.tsx:110
+msgid "Don't have an account? <signupLink>Sign up</signupLink>"
 msgstr ""
 
 #: frontend/js/src/forms/LostPassword.tsx:38
@@ -3780,15 +4773,72 @@ msgstr ""
 msgid "Allow access"
 msgstr ""
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:71
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:10
+msgid "Licensing"
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:12
+msgid ""
+"Any contributions you make to any MetaBrainz service will be released "
+"into the Public Domain and/or licensed under a Creative Commons by-nc-sa "
+"license. Furthermore, you give the MetaBrainz Foundation the right to "
+"license this data for commercial use."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:17
+msgid "Please read our <licenseLink>license page</licenseLink> for more details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:34
+msgid ""
+"MetaBrainz strongly believes in the privacy of its users. Any personal "
+"information you choose to provide will not be sold or shared with anyone "
+"else."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:39
+msgid ""
+"Please read our <privacyLink>privacy policy</privacyLink> for more "
+"details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:50
+msgid "GDPR compliance"
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:52
+msgid ""
+"You may remove your personal information from our services anytime by "
+"deleting your account."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:57
+msgid ""
+"Please read our <gdprLink>GDPR compliance statement</gdprLink> for more "
+"details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:71
+msgid ""
+"Creating an account on MetaBrainz will give you access to all of our "
+"projects, such as MusicBrainz, ListenBrainz, BookBrainz, and more."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:75
+msgid ""
+"We create a placeholder account for all the MetaBrainz projects when you "
+"sign up, and you are one log-in away from activating them."
+msgstr ""
+
+#: frontend/js/src/forms/ProfileChangePassword.tsx:70
 msgid "Current Password"
 msgstr ""
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:80
+#: frontend/js/src/forms/ProfileChangePassword.tsx:79
 msgid "New Password"
 msgstr ""
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:89
+#: frontend/js/src/forms/ProfileChangePassword.tsx:88
 msgid "Confirm New Password"
 msgstr ""
 
@@ -3800,191 +4850,181 @@ msgstr ""
 msgid "Reset Password"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:38
-msgid "If you would like to support us with more than $"
+#: frontend/js/src/forms/SignupCommercial.tsx:40
+msgid ""
+"If you would like to support us with more than ${{minPledge}}, please "
+"enter the actual amount here:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:39
-msgid ", please enter the actual amount here:"
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:144
+#: frontend/js/src/forms/SignupCommercial.tsx:149
 #: frontend/js/src/forms/SignupNonCommercial.tsx:75
-#: frontend/js/src/forms/SignupUser.tsx:87
+#: frontend/js/src/forms/SignupUser.tsx:93
 msgid "Captcha is required!"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:179
+#: frontend/js/src/forms/SignupCommercial.tsx:184
 #: frontend/js/src/forms/SignupNonCommercial.tsx:110
 #: frontend/js/src/forms/SignupUser.tsx:46
 msgid "Access all MetaBrainz projects"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:182
+#: frontend/js/src/forms/SignupCommercial.tsx:187
 msgid "Note:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:184
+#: frontend/js/src/forms/SignupCommercial.tsx:189
 msgid ""
 "Signing up for any tier other than the <italic>Stealth startup</italic> "
 "tier will publicly list your company on this web site. However, we will "
 "not publish any of your private details."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:221
+#: frontend/js/src/forms/SignupCommercial.tsx:226
 #: frontend/js/src/forms/SignupNonCommercial.tsx:145
 msgid "Account type"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:234
+#: frontend/js/src/forms/SignupCommercial.tsx:239
 msgid "Selected tier"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:242
-msgid "month and up"
+#: frontend/js/src/forms/SignupCommercial.tsx:247
+msgid "${{tierPrice}}/month and up"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:250
+#: frontend/js/src/forms/SignupCommercial.tsx:255
 msgid "Change account type or tier"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:261
+#: frontend/js/src/forms/SignupCommercial.tsx:266
 #: frontend/js/src/forms/SignupNonCommercial.tsx:166
 msgid "Your account:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:271
+#: frontend/js/src/forms/SignupCommercial.tsx:276
 #: frontend/js/src/forms/SignupNonCommercial.tsx:176
-#: frontend/js/src/forms/SignupUser.tsx:114
+#: frontend/js/src/forms/SignupUser.tsx:120
 msgid "(public)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:291
+#: frontend/js/src/forms/SignupCommercial.tsx:296
 #: frontend/js/src/forms/SignupNonCommercial.tsx:196
-#: frontend/js/src/forms/SignupUser.tsx:127
+#: frontend/js/src/forms/SignupUser.tsx:133
 msgid "E-mail address"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:295
+#: frontend/js/src/forms/SignupCommercial.tsx:300
 #: frontend/js/src/forms/SignupNonCommercial.tsx:200
-#: frontend/js/src/forms/SignupUser.tsx:131
+#: frontend/js/src/forms/SignupUser.tsx:137
 msgid "(checking...)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:314
+#: frontend/js/src/forms/SignupCommercial.tsx:319
 #: frontend/js/src/forms/SignupNonCommercial.tsx:220
-#: frontend/js/src/forms/SignupUser.tsx:163
+#: frontend/js/src/forms/SignupUser.tsx:169
 msgid "Must be at least 8 characters"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:348
+#: frontend/js/src/forms/SignupCommercial.tsx:353
 msgid ""
 "If you don't have an organization name, you probably want to become a "
 "supporter as a <nonCommercialLink>Non-commercial / "
 "Personal</nonCommercialLink> supporter."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:358
+#: frontend/js/src/forms/SignupCommercial.tsx:363
 msgid ""
 "If you don't have an organization name, you probably want to sign up as a"
 " <nonCommercialLink>Non-commercial / Personal</nonCommercialLink> user."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:378
+#: frontend/js/src/forms/SignupCommercial.tsx:383
 msgid ""
 "Please tell us a little about your company and whether you plan to use "
 "our <apiLink>API</apiLink> or to <hostLink>host your own copy</hostLink> "
 "of the data."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:404
+#: frontend/js/src/forms/SignupCommercial.tsx:408
 msgid "Logo URL"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:405
+#: frontend/js/src/forms/SignupCommercial.tsx:409
 msgid "(preferably in SVG format)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:408
+#: frontend/js/src/forms/SignupCommercial.tsx:412
 msgid ""
 "Image should be about 250 pixels wide on a white or transparent "
 "background. We will host it on our site."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:421
+#: frontend/js/src/forms/SignupCommercial.tsx:425
 msgid ""
 "URL to where developers can use your APIs using MusicBrainz IDs, if "
-"available.."
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:430
-msgid "Your project"
+"available."
 msgstr ""
 
 #: frontend/js/src/forms/SignupCommercial.tsx:434
+msgid "Your project"
+msgstr ""
+
+#: frontend/js/src/forms/SignupCommercial.tsx:438
 #: frontend/js/src/forms/SignupNonCommercial.tsx:261
 msgid "(max 150 characters)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:451
+#: frontend/js/src/forms/SignupCommercial.tsx:455
 msgid "Billing address"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:502
+#: frontend/js/src/forms/SignupCommercial.tsx:506
 msgid ""
 "I agree to support the MetaBrainz Foundation when my organization is able"
 " to do so."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:507
+#: frontend/js/src/forms/SignupCommercial.tsx:511
+#: frontend/js/src/forms/SignupNonCommercial.tsx:284
 msgid ""
-"I also agree that if I generate a Live Data Feed access token, that I "
-"treat my access token as a secret and will not share this token publicly "
-"or commit it to a source code repository."
+"I also agree that if I generate a Live Data Feed access token, then I "
+"will treat my access token as a secret and will not share this token "
+"publicly or commit it to a source code repository."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:515
+#: frontend/js/src/forms/SignupCommercial.tsx:519
 msgid ""
 "The following information will be shown publicly: organization name, "
 "logo, website and API URLs, data usage description."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:520
+#: frontend/js/src/forms/SignupCommercial.tsx:524
 msgid ""
 "We'll send you more details about payment process once your application "
 "is approved."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:552
+#: frontend/js/src/forms/SignupCommercial.tsx:556
 #: frontend/js/src/forms/SignupNonCommercial.tsx:316
-#: frontend/js/src/forms/SignupUser.tsx:224
+#: frontend/js/src/forms/SignupUser.tsx:230
 msgid "Validating..."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:564
+#: frontend/js/src/forms/SignupCommercial.tsx:568
 #: frontend/js/src/forms/SignupNonCommercial.tsx:329
 #, fuzzy
 msgid "Back to profile"
 msgstr "Вашия профил"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:569
-#: frontend/js/src/forms/SignupNonCommercial.tsx:334
-msgid "Not a supporter?"
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:570
+#: frontend/js/src/forms/SignupCommercial.tsx:574
 #: frontend/js/src/forms/SignupNonCommercial.tsx:335
-msgid "Create a user account"
+msgid "Not a supporter? <signupLink>Create a user account</signupLink>"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:573
-#: frontend/js/src/forms/SignupNonCommercial.tsx:338
-#: frontend/js/src/forms/SignupUser.tsx:231
-msgid "Already have an account?"
-msgstr ""
-
-#: frontend/js/src/forms/SignupNonCommercial.tsx:107
-msgid "non-commercial"
+#: frontend/js/src/forms/SignupCommercial.tsx:583
+#: frontend/js/src/forms/SignupNonCommercial.tsx:344
+#: frontend/js/src/forms/SignupUser.tsx:238
+msgid "Already have an account? <loginLink>Sign in</loginLink>"
 msgstr ""
 
 #: frontend/js/src/forms/SignupNonCommercial.tsx:113
@@ -4012,46 +5052,40 @@ msgid ""
 "income per year) or personal uses only."
 msgstr ""
 
-#: frontend/js/src/forms/SignupNonCommercial.tsx:284
-msgid ""
-"I also agree that if I generate a Live Data Feed access token, then I "
-"will treat my access token as a secret and will not share this token "
-"publicly or commit it to a source code repository."
-msgstr ""
-
 #: frontend/js/src/forms/SignupUser.tsx:43
 msgid "Create your account"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:50
-msgid "Registration started by"
+#: frontend/js/src/forms/SignupUser.tsx:51
+msgid "Registration started by <client />"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:69
+#: frontend/js/src/forms/SignupUser.tsx:75
+#: frontend/js/src/hooks/useEmailValidation.ts:82
 msgid "Invalid email address."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:150
+#: frontend/js/src/forms/SignupUser.tsx:156
 msgid ""
 "This username and email were provided by the app that started "
 "registration. You can change them later from MetaBrainz settings."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:182
+#: frontend/js/src/forms/SignupUser.tsx:188
 msgid ""
 "I accept that my contributions will be released into the public domain or"
 " licensed for use."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:191
+#: frontend/js/src/forms/SignupUser.tsx:197
 msgid "We will never share your personal information."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:200
+#: frontend/js/src/forms/SignupUser.tsx:206
 msgid "Click here to read more"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:224
+#: frontend/js/src/forms/SignupUser.tsx:230
 msgid "Create account"
 msgstr ""
 
@@ -4061,10 +5095,6 @@ msgstr ""
 
 #: frontend/js/src/hooks/useEmailValidation.ts:47
 msgid "Email validation failed"
-msgstr ""
-
-#: frontend/js/src/hooks/useEmailValidation.ts:82
-msgid "Invalid email address"
 msgstr ""
 
 #~ msgid "You need to specify amount!"
@@ -5298,4 +6328,96 @@ msgstr ""
 
 #~ msgid "Privacy policy"
 #~ msgstr "Политика за поверителност"
+
+#~ msgid "You need to specify website of the organization."
+#~ msgstr ""
+
+#~ msgid ""
+#~ "We are currently evaluating our overall"
+#~ " online advertising strategy. We are "
+#~ "evaluating advertising, traffic optimization,\n"
+#~ ""
+#~ "    search engine optimization and "
+#~ "software monitization technologies. If you "
+#~ "provide these professional services, please"
+#~ " provide a detailed\n"
+#~ "    deck of your comprehensive services"
+#~ " to the following email address. "
+#~ "<em>Please respect our other non-media"
+#~ " teams and do not contact us \n"
+#~ "    regarding these services on any "
+#~ "other of our email addresses. We "
+#~ "will disregard the entirety of your "
+#~ "submissions if you contact us any "
+#~ "other way!</em>"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Please come ask your questions at "
+#~ "our <a href=\"%(forums_url)s\">forums</a>! We "
+#~ "would love to\n"
+#~ "    answer any questions you may have."
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Due to the increased unreliability of"
+#~ " the US Postal Service we have "
+#~ "stopped accepting paper checks. Sorry!"
+#~ msgstr ""
+
+#~ msgid "Upgrade"
+#~ msgstr ""
+
+#~ msgid "Back to Profile"
+#~ msgstr "Вашия профил"
+
+#~ msgid ""
+#~ "Deletion of supporter accounts requires "
+#~ "manual review. Please contact us at"
+#~ msgstr ""
+
+#~ msgid "Revoke all your API tokens and access"
+#~ msgstr ""
+
+#~ msgid "Your username will be reserved and cannot be reused."
+#~ msgstr ""
+
+#~ msgid "Don't have an account?"
+#~ msgstr ""
+
+#~ msgid "If you would like to support us with more than $"
+#~ msgstr ""
+
+#~ msgid ", please enter the actual amount here:"
+#~ msgstr ""
+
+#~ msgid "month and up"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "I also agree that if I generate"
+#~ " a Live Data Feed access token, "
+#~ "that I treat my access token as"
+#~ " a secret and will not share "
+#~ "this token publicly or commit it "
+#~ "to a source code repository."
+#~ msgstr ""
+
+#~ msgid "Not a supporter?"
+#~ msgstr ""
+
+#~ msgid "Create a user account"
+#~ msgstr ""
+
+#~ msgid "Already have an account?"
+#~ msgstr ""
+
+#~ msgid "non-commercial"
+#~ msgstr ""
+
+#~ msgid "Registration started by"
+#~ msgstr ""
+
+#~ msgid "Invalid email address"
+#~ msgstr ""
 

--- a/metabrainz/translations/bn/LC_MESSAGES/messages.po
+++ b/metabrainz/translations/bn/LC_MESSAGES/messages.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-07-25 16:21+0200\n"
+"POT-Creation-Date: 2026-09-08 11:18+0200\n"
 "PO-Revision-Date: 2026-06-12 00:51+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: bn\n"
@@ -21,162 +21,247 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.18.0\n"
 
-#: metabrainz/index/forms.py:46
+#: metabrainz/errors.py:24
+msgid "Authorization was declined."
+msgstr ""
+
+#: metabrainz/errors.py:25
+msgid "The authorization request was invalid."
+msgstr ""
+
+#: metabrainz/errors.py:26
+msgid "The application could not be authenticated."
+msgstr ""
+
+#: metabrainz/errors.py:27
+msgid "This application is not allowed to request authorization."
+msgstr ""
+
+#: metabrainz/errors.py:28
+msgid "The application asked for a response type this server does not support."
+msgstr ""
+
+#: metabrainz/errors.py:29
+msgid "The permissions requested by the application are invalid."
+msgstr ""
+
+#: metabrainz/errors.py:30
+msgid "You need to sign in to continue."
+msgstr ""
+
+#: metabrainz/errors.py:31
+msgid "Your consent is required to continue."
+msgstr ""
+
+#: metabrainz/password.py:12
+#, python-format
+msgid "Password must not exceed %(max_bytes)s bytes."
+msgstr ""
+
+#: metabrainz/index/forms.py:48
 #, python-format
 msgid "'%(value)s' is not a valid choice for this field"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileEdit.tsx:27
-#: frontend/js/src/forms/SignupCommercial.tsx:154
+#: frontend/js/src/forms/SignupCommercial.tsx:159
 #: frontend/js/src/forms/SignupNonCommercial.tsx:85
-#: frontend/js/src/forms/SignupUser.tsx:70
-#: frontend/js/src/hooks/useEmailValidation.ts:78 metabrainz/index/forms.py:57
-#: metabrainz/user/forms.py:25 metabrainz/user/forms.py:57
-#: metabrainz/user/forms.py:63
+#: frontend/js/src/forms/SignupUser.tsx:76
+#: frontend/js/src/hooks/useEmailValidation.ts:78 metabrainz/index/forms.py:59
+#: metabrainz/user/forms.py:31 metabrainz/user/forms.py:70
+#: metabrainz/user/forms.py:76
 msgid "Email address is required!"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:34
-#: metabrainz/index/forms.py:63
+#: metabrainz/index/forms.py:65
 msgid "Current password is required!"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:43
 #: frontend/js/src/forms/ProfileChangePassword.tsx:37
 #: frontend/js/src/forms/ResetPassword.tsx:39
-#: frontend/js/src/forms/SignupCommercial.tsx:156
+#: frontend/js/src/forms/SignupCommercial.tsx:161
 #: frontend/js/src/forms/SignupNonCommercial.tsx:87
-#: frontend/js/src/forms/SignupUser.tsx:72 metabrainz/index/forms.py:66
-#: metabrainz/user/forms.py:29 metabrainz/user/forms.py:46
-#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:69
+#: frontend/js/src/forms/SignupUser.tsx:78 metabrainz/index/forms.py:69
+#: metabrainz/user/forms.py:35 metabrainz/user/forms.py:54
+#: metabrainz/user/forms.py:63 metabrainz/user/forms.py:82
 msgid "Password is required!"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:41
-#: frontend/js/src/forms/SignupCommercial.tsx:160
+#: frontend/js/src/forms/SignupCommercial.tsx:165
 #: frontend/js/src/forms/SignupNonCommercial.tsx:91
-#: frontend/js/src/forms/SignupUser.tsx:76 metabrainz/index/forms.py:70
-#: metabrainz/user/forms.py:33 metabrainz/user/forms.py:73
+#: frontend/js/src/forms/SignupUser.tsx:82 metabrainz/index/forms.py:74
+#: metabrainz/user/forms.py:40 metabrainz/user/forms.py:87
 msgid "Confirm Password is required!"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:46
 #: frontend/js/src/forms/ResetPassword.tsx:48
-#: frontend/js/src/forms/SignupCommercial.tsx:165
+#: frontend/js/src/forms/SignupCommercial.tsx:170
 #: frontend/js/src/forms/SignupNonCommercial.tsx:96
-#: frontend/js/src/forms/SignupUser.tsx:81 metabrainz/index/forms.py:72
-#: metabrainz/user/forms.py:35 metabrainz/user/forms.py:75
+#: frontend/js/src/forms/SignupUser.tsx:87 metabrainz/index/forms.py:76
+#: metabrainz/user/forms.py:42 metabrainz/user/forms.py:89
 msgid "Confirm Password should match password!"
 msgstr ""
 
 #: frontend/js/src/Applications.tsx:56 frontend/js/src/Applications.tsx:86
 #: frontend/js/src/Profile.tsx:272 frontend/js/src/Profile.tsx:482
-#: metabrainz/index/forms.py:78
+#: metabrainz/index/forms.py:82
 msgid "Name"
 msgstr ""
 
-#: metabrainz/index/forms.py:79
+#: metabrainz/index/forms.py:83
 msgid "Contact name field is empty."
 msgstr ""
 
-#: metabrainz/index/views.py:234
+#: metabrainz/index/views.py:251
 msgid "Profile updated successfully."
 msgstr ""
 
-#: metabrainz/index/views.py:261
+#: metabrainz/index/views.py:278
 msgid "Current password is incorrect."
 msgstr ""
 
-#: metabrainz/index/views.py:266
+#: metabrainz/index/views.py:283
 msgid "Password changed successfully."
 msgstr ""
 
-#: metabrainz/index/views.py:372
+#: metabrainz/index/views.py:389
 msgid "You have updated an application!"
 msgstr ""
 
-#: metabrainz/index/views.py:424
+#: metabrainz/index/views.py:441
 msgid "You have deleted an application."
 msgstr ""
 
-#: metabrainz/index/views.py:426
+#: metabrainz/index/views.py:443
 msgid "Failed to delete an application."
 msgstr ""
 
-#: metabrainz/index/views.py:449
+#: metabrainz/index/views.py:466
 msgid "Revoked tokens successfully!"
 msgstr ""
 
-#: metabrainz/index/views.py:478
+#: metabrainz/index/views.py:495
 msgid "Your account has been deleted."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:106 metabrainz/oauth/forms.py:58
+#: frontend/js/src/forms/CreateApplication.tsx:106 metabrainz/oauth/forms.py:57
 msgid "Application Name"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:59
+#: metabrainz/oauth/forms.py:58
 msgid "Application name field is empty."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:60 metabrainz/oauth/forms.py:60
+#: frontend/js/src/forms/CreateApplication.tsx:60 metabrainz/oauth/forms.py:59
 msgid "Application name needs to be at least 3 characters long."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:64 metabrainz/oauth/forms.py:61
+#: frontend/js/src/forms/CreateApplication.tsx:64 metabrainz/oauth/forms.py:60
 msgid "Application name needs to be at most 64 characters long."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:114 metabrainz/oauth/forms.py:63
+#: frontend/js/src/forms/CreateApplication.tsx:114 metabrainz/oauth/forms.py:62
 msgid "Description"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:64
+#: metabrainz/oauth/forms.py:63
 msgid "Client description field is empty."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:65
+#: metabrainz/oauth/forms.py:64
 msgid "Client description needs to be at least 3 characters long."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:66
+#: metabrainz/oauth/forms.py:65
 msgid "Client description needs to be at most 512 characters long."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:122 metabrainz/oauth/forms.py:68
+#: frontend/js/src/forms/CreateApplication.tsx:122 metabrainz/oauth/forms.py:67
 msgid "Homepage"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:69
+#: metabrainz/oauth/forms.py:68
 msgid "Homepage field is empty."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:70
+#: metabrainz/oauth/forms.py:69
 msgid "Homepage is not a valid URI."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:71
+#: metabrainz/oauth/forms.py:70
 msgid "Homepage URL must use http or https"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:73
+#: metabrainz/oauth/forms.py:72
 msgid "Authorization callback URL"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:74
+#: metabrainz/oauth/forms.py:73
 msgid "Authorization callback URL field is empty."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:75
+#: metabrainz/oauth/forms.py:74
 msgid "Authorization callback URL is invalid."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:76
+#: metabrainz/oauth/forms.py:75
 msgid "Authorization callback URL must use http or https."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:81 metabrainz/oauth/forms.py:85
+#: metabrainz/oauth/forms.py:80 metabrainz/oauth/forms.py:84
 msgid "Confirm"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:15
+msgid "View your public account information"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:16
+msgid "View your email address"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:17
+msgid "View and modify your private tags"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:18
+msgid "View and modify your private ratings"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:19
+msgid "View and modify your private collections"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:20
+msgid "Submit new ISRCs to the database"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:21
+msgid "Submit new barcodes to the database"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:22
+msgid "Sign you in and view your unique user id"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:23
+msgid "Submit listens to ListenBrainz."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:24
+msgid "Create and modify CritiqueBrainz reviews."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:25
+msgid "Submit and delete votes on CritiqueBrainz reviews."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:26
+msgid "Modify profile info and delete profile on CritiqueBrainz."
 msgstr ""
 
 #: metabrainz/payments/views.py:164
@@ -221,178 +306,185 @@ msgid "Requested annual report was not found."
 msgstr ""
 
 #: frontend/js/src/forms/ProfileEdit.tsx:30
-#: frontend/js/src/forms/SignupCommercial.tsx:139
+#: frontend/js/src/forms/SignupCommercial.tsx:144
 #: frontend/js/src/forms/SignupNonCommercial.tsx:70
-#: metabrainz/supporter/forms.py:13
+#: metabrainz/supporter/forms.py:15
 msgid "Contact name is required!"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:437
+#: frontend/js/src/forms/SignupCommercial.tsx:441
 #: frontend/js/src/forms/SignupNonCommercial.tsx:264
-#: metabrainz/supporter/forms.py:15
+#: metabrainz/supporter/forms.py:17
 msgid ""
 "Can you please tell us more about the project in which you'd like to use "
 "our data? Do you plan to self host the data or use our APIs?"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:137
+#: frontend/js/src/forms/SignupCommercial.tsx:142
 #: frontend/js/src/forms/SignupNonCommercial.tsx:68
-#: metabrainz/supporter/forms.py:17
+#: metabrainz/supporter/forms.py:19
 msgid "Please, tell us how you (will) use our data."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:138
+#: frontend/js/src/forms/SignupCommercial.tsx:143
 #: frontend/js/src/forms/SignupNonCommercial.tsx:69
-#: metabrainz/supporter/forms.py:18
+#: metabrainz/supporter/forms.py:20
 msgid "Please, limit usage description to 500 characters."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:141
-#: frontend/js/src/forms/SignupCommercial.tsx:142
+#: frontend/js/src/forms/SignupCommercial.tsx:146
+#: frontend/js/src/forms/SignupCommercial.tsx:147
 #: frontend/js/src/forms/SignupNonCommercial.tsx:72
 #: frontend/js/src/forms/SignupNonCommercial.tsx:73
-#: frontend/js/src/forms/SignupUser.tsx:84
-#: frontend/js/src/forms/SignupUser.tsx:85 metabrainz/supporter/forms.py:21
-#: metabrainz/user/forms.py:38
+#: frontend/js/src/forms/SignupUser.tsx:90
+#: frontend/js/src/forms/SignupUser.tsx:91 metabrainz/supporter/forms.py:23
+#: metabrainz/user/forms.py:45
 msgid "You need to accept the agreement!"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:342
-#: metabrainz/supporter/forms.py:27
+#: frontend/js/src/forms/SignupCommercial.tsx:347
+#: metabrainz/supporter/forms.py:29
 msgid "Organization name"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:113
-#: metabrainz/supporter/forms.py:28
+#: frontend/js/src/forms/SignupCommercial.tsx:115
+#: metabrainz/supporter/forms.py:30
 msgid "You need to specify the name of your organization."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:373
-#: metabrainz/supporter/forms.py:30
+#: frontend/js/src/forms/SignupCommercial.tsx:378
+#: metabrainz/supporter/forms.py:32
 msgid "Organization description"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:116
-#: metabrainz/supporter/forms.py:31
+#: frontend/js/src/forms/SignupCommercial.tsx:118
+#: metabrainz/supporter/forms.py:33
 msgid "You need to provide description of your organization."
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:278
-#: frontend/js/src/forms/SignupCommercial.tsx:396
-#: metabrainz/supporter/forms.py:34
+#: frontend/js/src/forms/SignupCommercial.tsx:401
+#: metabrainz/supporter/forms.py:36
 msgid "Website URL"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:119
-#: metabrainz/supporter/forms.py:35
-msgid "You need to specify website of the organization."
+#: frontend/js/src/forms/SignupCommercial.tsx:121
+#: frontend/js/src/forms/SignupCommercial.tsx:123
+#: metabrainz/supporter/forms.py:38 metabrainz/supporter/forms.py:42
+msgid "Website URL must be a valid URL."
 msgstr ""
 
-#: metabrainz/supporter/forms.py:37
+#: metabrainz/supporter/forms.py:45
 msgid "Logo image URL"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:284
-#: frontend/js/src/forms/SignupCommercial.tsx:418
-#: metabrainz/supporter/forms.py:38
+#: frontend/js/src/forms/SignupCommercial.tsx:422
+#: metabrainz/supporter/forms.py:46
 msgid "API URL"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:457
-#: metabrainz/supporter/forms.py:40
+#: frontend/js/src/forms/SignupCommercial.tsx:461
+#: metabrainz/supporter/forms.py:48
 msgid "Street"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:123
-#: metabrainz/supporter/forms.py:41
+#: frontend/js/src/forms/SignupCommercial.tsx:128
+#: metabrainz/supporter/forms.py:49
 msgid "You need to specify street."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:465
-#: metabrainz/supporter/forms.py:43
+#: frontend/js/src/forms/SignupCommercial.tsx:469
+#: metabrainz/supporter/forms.py:51
 msgid "City"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:124
-#: metabrainz/supporter/forms.py:44
+#: frontend/js/src/forms/SignupCommercial.tsx:129
+#: metabrainz/supporter/forms.py:52
 msgid "You need to specify city."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:473
-#: metabrainz/supporter/forms.py:46
+#: frontend/js/src/forms/SignupCommercial.tsx:477
+#: metabrainz/supporter/forms.py:54
 msgid "State / Province"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:126
-#: metabrainz/supporter/forms.py:47
+#: frontend/js/src/forms/SignupCommercial.tsx:131
+#: metabrainz/supporter/forms.py:55
 msgid "You need to specify state/province."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:481
-#: metabrainz/supporter/forms.py:49
+#: frontend/js/src/forms/SignupCommercial.tsx:485
+#: metabrainz/supporter/forms.py:57
 msgid "Postcode"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:128
-#: metabrainz/supporter/forms.py:50
+#: frontend/js/src/forms/SignupCommercial.tsx:133
+#: metabrainz/supporter/forms.py:58
 msgid "You need to specify postcode."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:489
-#: metabrainz/supporter/forms.py:52
+#: frontend/js/src/forms/SignupCommercial.tsx:493
+#: metabrainz/supporter/forms.py:60
 msgid "Country"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:129
-#: metabrainz/supporter/forms.py:53
+#: frontend/js/src/forms/SignupCommercial.tsx:134
+#: metabrainz/supporter/forms.py:61
 msgid "You need to specify country."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:132
-#: metabrainz/supporter/forms.py:64
+#: frontend/js/src/forms/SignupCommercial.tsx:137
+#: metabrainz/supporter/forms.py:72
 msgid ""
 "Custom amount must be more than threshold amount for selected tier or "
 "equal to it!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:46 metabrainz/supporter/views.py:119
-#: metabrainz/supporter/views.py:220
+#: metabrainz/supporter/views.py:54
+msgid ""
+"The verification email could not be sent. Please request a new one from "
+"your profile."
+msgstr ""
+
+#: metabrainz/supporter/views.py:85 metabrainz/supporter/views.py:158
+#: metabrainz/supporter/views.py:260
 msgid "You are already a supporter."
 msgstr ""
 
-#: metabrainz/supporter/views.py:61
+#: metabrainz/supporter/views.py:100
 msgid "Can't find tier with a specified ID."
 msgstr ""
 
-#: metabrainz/supporter/views.py:127
+#: metabrainz/supporter/views.py:166
 msgid "You need to choose support tier before signing up!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:137
+#: metabrainz/supporter/views.py:176
 msgid "You need to choose existing tier before signing up!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:164
+#: metabrainz/supporter/views.py:204
 msgid ""
 "Thanks for becoming a supporter! Your application will be reviewed soon. "
 "We will send you updates via email."
 msgstr ""
 
-#: metabrainz/supporter/views.py:187
+#: metabrainz/supporter/views.py:228
 msgid ""
 "Thanks for signing up! Your application will be reviewed soon. We will "
 "send you updates via email."
 msgstr ""
 
-#: metabrainz/supporter/views.py:248
+#: metabrainz/supporter/views.py:288
 msgid "Thanks for becoming a supporter!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:274
+#: metabrainz/supporter/views.py:312
 msgid "Thanks for signing up! Please check your inbox to complete verification."
 msgstr ""
 
-#: metabrainz/supporter/views.py:302
+#: metabrainz/supporter/views.py:340
 msgid "Can't generate new token unless account is active."
 msgstr ""
 
@@ -426,7 +518,7 @@ msgstr ""
 msgid "Policies"
 msgstr ""
 
-#: metabrainz/templates/base.html:55 metabrainz/templates/index/gdpr.html:178
+#: metabrainz/templates/base.html:55
 #: metabrainz/templates/index/social-contract.html:3
 #: metabrainz/templates/index/social-contract.html:6
 #: metabrainz/templates/navbar.html:34
@@ -436,14 +528,15 @@ msgstr ""
 #: metabrainz/templates/base.html:56
 #: metabrainz/templates/index/code-of-conduct.html:3
 #: metabrainz/templates/index/code-of-conduct.html:16
-#: metabrainz/templates/index/gdpr.html:181 metabrainz/templates/navbar.html:35
+#: metabrainz/templates/navbar.html:35
 msgid "Code of Conduct"
 msgstr ""
 
+#: frontend/js/src/PrivacySummary.tsx:11
 #: frontend/js/src/forms/ConditionsModal.tsx:21
-#: metabrainz/templates/base.html:57 metabrainz/templates/index/gdpr.html:184
-#: metabrainz/templates/index/privacy.html:6
+#: metabrainz/templates/base.html:57 metabrainz/templates/index/privacy.html:6
 #: metabrainz/templates/navbar.html:36
+#: metabrainz/templates/users/privacy-summary.html:3
 msgid "Privacy Policy"
 msgstr ""
 
@@ -476,10 +569,7 @@ msgstr ""
 msgid "Supporters"
 msgstr ""
 
-#: frontend/js/src/forms/LoginUser.tsx:103
-#: frontend/js/src/forms/SignupCommercial.tsx:574
-#: frontend/js/src/forms/SignupNonCommercial.tsx:339
-#: frontend/js/src/forms/SignupUser.tsx:232 metabrainz/templates/base.html:73
+#: frontend/js/src/forms/LoginUser.tsx:103 metabrainz/templates/base.html:73
 #: metabrainz/templates/navbar.html:66 metabrainz/templates/users/login.html:3
 msgid "Sign in"
 msgstr ""
@@ -501,26 +591,26 @@ msgid "Contact us"
 msgstr "যোগাযোগ করুন"
 
 #: metabrainz/templates/base.html:85
-#: metabrainz/templates/index/contact.html:105
+#: metabrainz/templates/index/contact.html:106
 msgid "Blog"
 msgstr ""
 
-#: metabrainz/templates/base.html:86 metabrainz/templates/index/contact.html:90
+#: metabrainz/templates/base.html:86 metabrainz/templates/index/contact.html:91
 msgid "Chat"
 msgstr ""
 
 #: metabrainz/templates/base.html:87
-#: metabrainz/templates/index/contact.html:106
+#: metabrainz/templates/index/contact.html:107
 msgid "Mastodon"
 msgstr ""
 
 #: metabrainz/templates/base.html:88
-#: metabrainz/templates/index/contact.html:107
+#: metabrainz/templates/index/contact.html:108
 msgid "Bluesky"
 msgstr ""
 
 #: metabrainz/templates/base.html:89
-#: metabrainz/templates/index/contact.html:108
+#: metabrainz/templates/index/contact.html:109
 msgid "Instagram"
 msgstr ""
 
@@ -576,15 +666,14 @@ msgstr ""
 msgid "Donate"
 msgstr ""
 
-#: frontend/js/src/forms/LoginUser.tsx:110
-#: frontend/js/src/forms/SignupCommercial.tsx:175
-#: frontend/js/src/forms/SignupCommercial.tsx:555
+#: frontend/js/src/forms/SignupCommercial.tsx:180
+#: frontend/js/src/forms/SignupCommercial.tsx:559
 #: frontend/js/src/forms/SignupNonCommercial.tsx:106
 #: frontend/js/src/forms/SignupNonCommercial.tsx:319
 #: metabrainz/templates/navbar.html:65
-#: metabrainz/templates/supporters/account-type.html:51
-#: metabrainz/templates/supporters/account-type.html:93
-#: metabrainz/templates/supporters/account-type.html:144
+#: metabrainz/templates/supporters/account-type.html:47
+#: metabrainz/templates/supporters/account-type.html:84
+#: metabrainz/templates/supporters/account-type.html:130
 #: metabrainz/templates/users/signup.html:3
 msgid "Sign up"
 msgstr ""
@@ -891,8 +980,430 @@ msgstr ""
 msgid "Introduction"
 msgstr ""
 
-#: metabrainz/templates/index/conflict-policy.html:55
+#: metabrainz/templates/index/conflict-policy.html:17
+msgid ""
+"Conflicts between people arise in open source projects constantly and the"
+" projects by the \n"
+"    MetaBrainz Foundation are no different. This policy aims to establish"
+" a clear and unambiguous \n"
+"    policy for reporting and addressing conflicts in our community. In "
+"this policy we aim to \n"
+"    establish a fair practice that balances the need for confidentiality "
+"and our desire for \n"
+"    transparency in our operations."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:25
+#, python-format
+msgid ""
+"Before you continue to read this policy, we encourage you to review our "
+"existing community policies \n"
+"    including our <a href=\"%(social_contract_url)s\">Social "
+"Contract</a>, \n"
+"    <a href=\"%(code_of_conduct_url)s\">the Code of Conduct</a>, \n"
+"    and our <a href=\"%(privacy_policy_url)s\">Privacy Policy</a>. These "
+"policies establish the norms and rules for \n"
+"    participation in our projects; these policies apply equally to the "
+"contractors of the MetaBrainz \n"
+"    Foundation and any participants in our projects."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:37
+msgid ""
+"This policy divides conflicts into two categories: Private and public. "
+"Private conflicts are conflicts \n"
+"    that involve *confidential* information regarding contributors, "
+"contractors or supporters. Otherwise, any conflicts \n"
+"    that do not involve confidential information are considered to be "
+"public conflicts. For instance, a \n"
+"    conflict between a contractor and the Executive Director (aka BDFL) "
+"that involves contractor pay is \n"
+"    considered a private conflict because pay rates are confidential "
+"information. A public conflict in edit \n"
+"    notes between two editors in our community does not involve "
+"confidential information and therefore should \n"
+"    be considered a public conflict."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:47
+msgid ""
+"When conflicts arise we aim to disclose as much information as possible "
+"about the conflict in a timely \n"
+"    fashion. When conflicts contain confidential matters we will aim to "
+"disclose as much information as \n"
+"    possible, while fully respecting the confidentiality of the people "
+"involved in the conflict. With any \n"
+"    private conflict we will aim to extract the relevant lessons for the "
+"team and community in an effort to \n"
+"    evolve our policies to prevent future conflicts. Should the involved "
+"parties disagree whether a conflict \n"
+"    is private or public, the question about the nature of the conflict "
+"will be presented for the next higher \n"
+"    level in the chain of command to decide. (e.g. if a community member "
+"and the community manager disagree on \n"
+"    a conflict being public or private, the Executive Director shall "
+"decide if the conflict is public or private)."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:58
 msgid "Reporting and Response"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:61
+msgid ""
+"We aim to not have conflict in our community, but we recognize that in "
+"reality conflicts will arise and we \n"
+"    must be prepared to address them in a fair manner. When conflicts "
+"arise, we prefer to have community or team \n"
+"    members resolve the conflicts among themselves, using our existing "
+"policies as guidelines for resolving the \n"
+"    conflict."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:69
+msgid ""
+"If you do not feel comfortable resolving a conflict on your own, you "
+"should feel free to report the conflict to \n"
+"    us. How you address the conflict depends on who is involved in the "
+"conflict and your comfort level. Please see \n"
+"    the detailed sections below on how and with whom to address your "
+"conflict. We aim to address conflicts as soon \n"
+"    as possible in an effort to prevent them from escalating "
+"unnecessarily."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:75
+msgid "Direct conflict resolution"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:78
+msgid ""
+"In direct conflict resolution, the involved parties will attempt to "
+"resolve the conflict themselves without \n"
+"   involving any MetaBrainz Foundation team member. You should aim to use"
+" direct resolution when the conflict does \n"
+"   not involve the violation of one of our policies or if the conflict is"
+" minor."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:84
+#, python-format
+msgid ""
+"For instance, if a user uses a rude tone, is disruptive or flagrantly "
+"ignores our project guidelines, we suggest \n"
+"    that you use direct conflict resolution to resolve the conflict. Some"
+" resources that might give you some suggestions \n"
+"    on how to go about resolving the conflict might be this <a "
+"href=\"%(conflict_resolution_primer_url)s\">\n"
+"    conflict resolution primer</a> and <a "
+"href=\"%(difficult_conversations_url)s\">how to\n"
+"    have difficult conversations at work</a>."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:93
+msgid "Informal reporting"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:96
+msgid ""
+"You may use informal reporting of a conflict if you aim to communicate a "
+"concern or incident without \n"
+"    seeking a corrective outcome. Informal reporting may also be an "
+"option if you have not been personally \n"
+"    victimized, but you’ve witnessed a violation of our policies or where"
+" you wish to maintain confidentiality \n"
+"    throughout the entire reporting process."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:103
+msgid ""
+"For editing in MusicBrainz you may informally report a user using the "
+"“Report this user for bad behavior” \n"
+"    link from the user’s profile. For reporting bad user behavior in "
+"other of our projects, please report them to our \n"
+"    community manager by mailing <span class=\"backemail\">gro.zniarbatem"
+"@reganam-ytinummoc</span> . For conflicts \n"
+"    that involve the community manager, report them by mailing <span "
+"class=\"backemail\">gro.zniarbatem@de</span> ."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:110
+msgid ""
+"Depending the the severity of the issue, repeated informal complaints may"
+" eventually require a formal response \n"
+"    from the MetaBrainz team. If an involved party requires anonymity, "
+"the conflict becomes a private conflict. If at \n"
+"    all possible minor issues should be resolved in a public forum in "
+"order for all people to witness and learn from \n"
+"    the issue at hand."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:116
+msgid "Formal complaint process"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:119
+msgid ""
+"All complaints about conflicts should be submitted via email. To whom a "
+"complaint should be mailed and who will \n"
+"    carry out the investigation will be described in the next section."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:124
+msgid "All complaint submissions to the Foundation should include the following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:128
+msgid ""
+"Contact info, if it is different than the email used to submit the "
+"conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:129
+msgid "Who was involved in the conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:130
+msgid "Where and when the incident happened"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:131
+msgid ""
+"A description of what happened -- ideally with links (e.g. chatlogs, edit"
+" notes) that outlines what \n"
+"         happened so that the persons evaluating the conflict may "
+"understand the issue at hand"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:133
+msgid ""
+"Any related pieces of information that provide more context on the "
+"conflict (e.g. links, screenshots)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:134
+msgid "An indication if this conflict is ongoing or not"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:139
+msgid "The investigation that follows aims to determine:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:143
+msgid "The nature and severity of the incident"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:144
+msgid ""
+"Whether or not the incident is considered a violation of MetaBrainz’ "
+"conduct policies or core values"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:145
+msgid ""
+"The amount of harm experienced by the person who submitted the complaint "
+"and the broader MetaBrainz community \n"
+"         as a result of the incident"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:147
+msgid ""
+"Whether there have been prior complaints against the individual or "
+"individuals reported"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:148
+msgid "Whether the incident is ongoing"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:152
+msgid ""
+"The following potential forms of resolution may apply to any team members"
+" involved in the conflict:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:155
+#: metabrainz/templates/index/conflict-policy.html:168
+msgid "Nothing (if it has been found no violation occurred)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:156
+msgid "Creating a plan to improve the performance"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:157
+msgid "Creating a negative performance evaluation"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:158
+msgid "Mediation, an intervention by a third party to resolve the conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:159
+msgid "Suspension or forced leave"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:160
+msgid "Termination of contract"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:164
+msgid ""
+"The following potential forms of resolution may apply to non team members"
+" involved in the conflict:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:169
+msgid "A reprimand, either public or private"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:170
+msgid "Suspension of the users’ account"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:171
+msgid "Deletion of the users’ account"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:172
+msgid ""
+"Removal of user privileges (e.g. if an auto editor commits a serious "
+"offence, they may lose their auto editor status)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:175
+msgid "Filing a complaint"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:178
+msgid ""
+"NOTE: For complaints not about MetaBrainz staff, please see the "
+"<em>Informal reporting</em> section above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:182
+msgid ""
+"If the complaint does not involve the Executive Director (ED), do the "
+"following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:186
+msgid ""
+"If team member has directly violated conduct policies or engaged in "
+"otherwise harmful behavior, a formal complaint should be filed."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:187
+msgid ""
+"Mail <span class=\"backemail\">gro.zniarbatem@de</span> and include the "
+"complaint information outlined above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:188
+msgid ""
+"You should expect a response within a working day acknowledging the "
+"complaint."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:189
+msgid ""
+"The complaint will be investigated by the ED, member(s) of the board of "
+"directors or a neutral third party."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:190
+msgid ""
+"Once the investigation has been completed, the ED, with the support of "
+"others involved in the investigation will respond. The \n"
+"        ED will respond to incidents no later than 7 working days after a"
+" complaint has been filed with either a resolution or an \n"
+"        explanation of why the process must be extended."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:196
+msgid "If a complaint involves the Executive Director, do the following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:200
+msgid ""
+"If the Executive Director has directly violated conduct policies or "
+"engaged in otherwise harmful behavior, \n"
+"        a formal complaint should be filed with the board of directors."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:202
+msgid ""
+"Mail <span class=\"backemail\">gro.zniarbatem@noituloser-tcilfnoc</span> "
+"and include the complaint information outlined above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:203
+msgid ""
+"You should get a response within 5 working days acknowledging the "
+"complaint."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:204
+msgid ""
+"The complaint will be investigated by the member(s) of the board of "
+"directors, the community manager, a neutral \n"
+"        third party or a combination thereof."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:206
+msgid ""
+"Once the investigation has been completed, the board, with the support of"
+" others involved in the investigation \n"
+"        will respond. The board will aim to respond to incidents no later"
+" than 15 working days after a complaint has been filed \n"
+"        with either a resolution or an explanation of why the process "
+"must be extended."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:211
+msgid "Confidentiality"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:214
+msgid ""
+"Confidentiality is an important aspect of conflict resolution and all of "
+"the conflicts brought to the attention of the foundation \n"
+"    will be evaluated with confidentiality in mind and acted upon "
+"accordingly."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:219
+msgid ""
+"We work hard to make all of the actions of the foundation as transparent "
+"and open as possible. In cases where we cannot \n"
+"    disclose all aspects of a conflict we will disclose that a conflict "
+"is or has occurred and we will attempt to disclose the \n"
+"    appropriate amount of information about the conflict while balancing "
+"the need for confidentiality and our desire to learn \n"
+"    from conflicts so that we as a foundation and community can learn "
+"from these conflicts and improve our policies to avoid the \n"
+"    conflicts in the future."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:227
+msgid ""
+"Any breaches of confidentiality will be treated as severe breaches of our"
+" conduct policies."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:230
+msgid "Retaliation"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:233
+msgid ""
+"We will not allow retaliation for any contractor or volunteer that files "
+"a complaint or is involved in an investigation. If you \n"
+"    believe that you are being treated negatively because of your "
+"involvement in a complaint please report this complaint directly \n"
+"    to the ED at <span class=\"backemail\">gro.zniarbatem@de</span> or "
+"the board at \n"
+"    <span class=\"backemail\">gro.zniarbatem@noituloser-tcilfnoc</span>."
 msgstr ""
 
 #: metabrainz/templates/index/contact.html:3
@@ -973,7 +1484,7 @@ msgstr ""
 msgid ""
 "We are currently evaluating our overall online advertising strategy. We "
 "are evaluating advertising, traffic optimization,\n"
-"    search engine optimization and software monitization technologies. If"
+"    search engine optimization and software monetization technologies. If"
 " you provide these professional services, please provide a detailed\n"
 "    deck of your comprehensive services to the following email address. "
 "<em>Please respect our other non-media teams and do not contact us \n"
@@ -1048,11 +1559,11 @@ msgstr ""
 #, python-format
 msgid ""
 "Please come ask your questions at our <a "
-"href=\"%(forums_url)s\">forums</a>! We would love to\n"
-"    answer any questions you may have."
+"href=\"%(forums_url)s\">forums</a>!\n"
+"    The community and the team will be more than happy to help you."
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:92
+#: metabrainz/templates/index/contact.html:93
 #, python-format
 msgid ""
 "The MetaBrainz/MusicBrainz/ListenBrainz team and community hang out\n"
@@ -1062,15 +1573,15 @@ msgid ""
 "    <a href=\"%(chatlogs_url)s\">chat log archives</a>."
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:101
+#: metabrainz/templates/index/contact.html:102
 msgid "Social media"
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:103
+#: metabrainz/templates/index/contact.html:104
 msgid "You can follow us on these social channels:"
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:112
+#: metabrainz/templates/index/contact.html:113
 msgid "Mailing address"
 msgstr ""
 
@@ -1083,33 +1594,349 @@ msgstr ""
 msgid "GDPR Compliance Statement"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:37
+#: metabrainz/templates/index/gdpr.html:10
+msgid ""
+"The General Data Protection Regulation is a complex EU regulation that "
+"stipulates many points for protecting private data of\n"
+"    users on the Internet. Even though this is an EU regulation, it has a"
+" worldwide impact due to the nature of the Internet.\n"
+"    The MetaBrainz Foundation with its collection of projects is also "
+"affected by this regulation. We’ve been learning and adapting\n"
+"    our sites to be compliant with the GDPR – sadly this regulation isn’t"
+" entirely black and white and there is an incredible\n"
+"    amount of room left for interpretation of these rules."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:17
+msgid ""
+"The good news is that this regulation is roughly in line with our "
+"established practices: We’ve always held private information\n"
+"    in a high regard and applied the sort of rules to ourselves as we "
+"wish to have our own private data treated. Luckily, this\n"
+"    makes our compliance effort considerably easier. We’ve made two "
+"significant changes to how we treat your data and also adopted\n"
+"    terminology as used in the GDPR in order to use the same languages "
+"that many other sites are now adopting. Please keep reading\n"
+"    to find out the exact details of what we are doing to comply."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:24
+#, python-format
+msgid ""
+"However, we do ask for your compassion and help in our process of "
+"complying with the GDPR. As we already mentioned, the GDPR is\n"
+"    a complex set of rules that are not fully clarified yet. We’ve taken "
+"action on the steps that are clear to us and we’re following\n"
+"    ongoing conversations on points that are in gray zones or unclear to "
+"us. We’ve made our best initial effort on compliance and\n"
+"    promise to keep working on it as the picture becomes more clear. If "
+"you believe that we could improve our compliance, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a> and let us know what we "
+"can do to improve. It would also help us if you\n"
+"    could provide concrete discussion or examples to help us understand "
+"and take action on your suggestion."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:33
+msgid ""
+"Finally, below are the key sections of the GDPR as we understand them and"
+" how they affect your data in our ecosystem. Where\n"
+"    possible, we provide links for deeper understanding, links for you to"
+" examine our relevant code and links to tickets to follow\n"
+"    the process of improving our compliance."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:38
 msgid "Right to be forgotten"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:77
+#: metabrainz/templates/index/gdpr.html:41
+msgid ""
+"Summary: <i>Provide the user with the ability to remove their private "
+"data from our services</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:44
+msgid ""
+"The most important aspect of the right to be forgotten is the ability to "
+"delete your account. Once you request for us to delete\n"
+"    your account, we will remove any personally identifying information "
+"you may have provided us from your account (name, email\n"
+"    address, gender, biography, URL, etc.). The visible name on your "
+"account will be changed to “Deleted User #####” and effectively\n"
+"    the account will no longer be identifiable as your account."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:50
+msgid ""
+"However, given the nature of our projects where we work on collaborative "
+"databases, your contributions that are not personally\n"
+"    identifying are valuable assets to our database and these "
+"contributions will not be removed from our databases. But we will\n"
+"    ensure that these contributions no longer contain personally "
+"identifying data."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:55
+#, python-format
+msgid ""
+"Our process of automatically deleting your accounts across the MetaBrainz"
+" ecosystem is not complete yet (see below for a set of\n"
+"    tickets where you can track our progress). If you would like to "
+"delete your accounts in the MetaBrainz ecosystem or mark a\n"
+"    donation that is currently public as a private donation, please <a "
+"href=\"%(contact_url)s\">contact us</a>\n"
+"    and we will address your request as soon as possible."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:62
+#: metabrainz/templates/index/gdpr.html:182
+msgid "Links:"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:66
+#, python-format
+msgid ""
+"<a href=\"%(editor_deletion_doc_url)s\">How we delete accounts\n"
+"       in MusicBrainz</a> (warning, geek content ahead!)"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:70
+msgid ""
+"Implement sitewide user account deletion in\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/MBS-9680\">MusicBrainz</a>,"
+"\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/AB-337\">AcousticBrainz</a>,"
+"\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/BB-260\">BookBrainz</a>,\n"
+"         <a href=\"https://tickets.metabrainz.org/browse/MEB-103\">the "
+"MetaBrainz Site</a>,\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/LB-354\">ListenBrainz</a>, "
+"and\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/CB-307\">CritiqueBrainz</a>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:80
 msgid "Restriction of processing"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:110
+#: metabrainz/templates/index/gdpr.html:83
+msgid ""
+"Summary: <i>To allow the user to control how their personally identifying"
+" data is being used.</i>"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:86
+msgid ""
+"Except for the ListenBrainz and AcousticBrainz projects, we do not "
+"process personally identifying data. Any personally\n"
+"    identifying data that our projects store is for the purpose of being "
+"able to contact you about your contributions to our database\n"
+"    (email address) or for voluntarily showing information about you to "
+"other users (biography, homepage, location, etc)."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:91
+#, python-format
+msgid ""
+"The ListenBrainz project differs in that the Listens (metadata about what"
+" music you have listened to) are stored on our servers\n"
+"    and <a href=\"%(listenbrainz_data_url)s\">made available to the "
+"public</a>. We believe Listens to be personally identifying\n"
+"    data and furthermore, we have goals of creating open source "
+"recommendation engines with this data, which involves processing the\n"
+"    user’s data. These two points are fundamental goals of the "
+"ListenBrainz project and we do not see a reasonable way to reach another"
+"\n"
+"    compromise position."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:99
+msgid ""
+"Because of this, we are going to require users to either acknowledge that"
+" we may process their Listen data or alternatively to\n"
+"    delete their account, including all of their Listens. Please note "
+"that if you decide to delete your ListenBrainz account, it may\n"
+"    take up to two weeks for all of your listens to no longer be included"
+" in our efforts to build a recommendation engine."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:104
+msgid ""
+"We have always made it clear that the data in ListenBrainz was to be "
+"public and that we plan to build new tools with your data, so\n"
+"    this should not come as a surprise to our users."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:108
+msgid ""
+"The AcousticBrainz project does not track who submits data to the "
+"database. If you create an account and use our data creation\n"
+"    tools (e.g. create a dataset or participate in a challenge) then we "
+"link your participation and the things that you create to\n"
+"    your account. If you choose to delete your account then we keep the "
+"non personally identifying data that you create, but anonymize\n"
+"    it so that it cannot be linked back to you."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:114
 msgid "Right to data portability / exporting your data"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:150
+#: metabrainz/templates/index/gdpr.html:117
+msgid ""
+"Summary: <i>You have the right to access/download the data we store about"
+" you</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:120
+msgid ""
+"Except for the ListenBrainz and AcousticBrainz projects, we do not store "
+"personally identifying data beyond the\n"
+"    information that is available in your public profile on each of our "
+"projects. Since this data is plainly available in your\n"
+"    profile we do not provide a means for you to export this data."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:125
+msgid "There are the following exceptions to this:"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:129
+msgid ""
+"<b>IP addresses</b>: If you visit one of our sites the IP address of your"
+" computer is stored in our web logs for 7 days\n"
+"        before our servers automatically delete them. This data is almost"
+" never used by anyone: the only time we look at the\n"
+"        IP addresses is if our sites are adversely impacted by the "
+"actions of some unknown users. In that case, we may investigate\n"
+"        the logs to identify the IP address that needs to be blocked in "
+"order to restore the stability of our service.\n"
+"        This data is not available to anyone but the contractors of the "
+"MetaBrainz Foundation and is not available to download\n"
+"        to anyone at all."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:137
+#, python-format
+msgid ""
+"<b>ListenBrainz Listen data</b>: Users may <a "
+"href=\"%(listenbrainz_export_url)s\">export their ListenBrainz Listen\n"
+"        data</a> directly from the site. The user Listen data is also "
+"included in the <a href=\"%(listenbrainz_data_url)s\">ListenBrainz\n"
+"        data dumps</a> that are available for public download."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:146
+msgid ""
+"All of the non personally identifying data, such as your metadata "
+"contributions, are publicly visible, available for download\n"
+"    and available via the project APIs. For details about this data, "
+"downloads and APIs please check the documentation for the\n"
+"    respective projects you are interested in."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:151
+#, python-format
+msgid ""
+"Anyone wishing to get a list of financial donations they have made to the"
+" MetaBrainz Foundation, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a> and provide your "
+"MusicBrainz editor name so that we can look up\n"
+"    your donations."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:157
 msgid "Right to rectification"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:165
+#: metabrainz/templates/index/gdpr.html:160
+msgid "Summary: <i>You have the right to correct your data</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:163
+msgid ""
+"All of our projects allow their users to update their personally "
+"identifying information in their profiles. Furthermore, most\n"
+"    of our projects allow the editing of their own metadata "
+"contributions. If you find that some of your data is incorrect, please\n"
+"    feel free to edit the data since we provide the tools to do so."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:168
+#, python-format
+msgid ""
+"If anyone who has made a financial donation to the MetaBrainz Foundation "
+"would like to make their donation private, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:173
 msgid "Right to be informed"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:188
+#: metabrainz/templates/index/gdpr.html:175
+msgid ""
+"Summary: <i>You have the right to be informed about how we use your data "
+"in plain English</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:178
+msgid ""
+"Our privacy policy, as well as other policies, have always been written "
+"by humans for human consumption. We abhor legalese and\n"
+"    not speaking in direct terms."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:186
+msgid "Social contract"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:189
+msgid "Code of conduct"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:192
+msgid "Privacy policy"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:196
 msgid "Right to access"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:198
-#: metabrainz/templates/index/privacy.html:166
+#: metabrainz/templates/index/gdpr.html:199
+msgid ""
+"Summary: <i>You have the right to access the data that we collect about "
+"you</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:202
+msgid ""
+"All of our projects make all of the data we collect on your behalf, "
+"privately identifying or not, available to you. The\n"
+"    only exception to this are the IP addresses we store for 7 days – see"
+" above for details."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:206
+#: metabrainz/templates/index/privacy.html:168
 msgid "Privacy/GDPR Representative"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:209
+#, python-format
+msgid ""
+"If you have any questions about our privacy policy, please <a "
+"href=\"%(contact_url)s\">contact us</a>. To report\n"
+"   any privacy problems, violations or leaks, our GDPR representative is "
+"our Interim Executive Director Nicolás Tamargo and for\n"
+"   privacy issues contact him at <strong><a "
+"href=\"mailto:gdpr@metabrainz.org\">gdpr@metabrainz.org</a></strong>."
 msgstr ""
 
 #: metabrainz/templates/index/index.html:6
@@ -1214,13 +2041,51 @@ msgid ""
 "      <a href=\"%(about_url)s\">about</a> page."
 msgstr ""
 
-#: frontend/js/src/forms/ConditionsModal.tsx:43
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:32
 #: metabrainz/templates/index/privacy.html:3
 msgid "Privacy"
 msgstr ""
 
 #: metabrainz/templates/index/privacy.html:8
 msgid "Summary"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:12
+msgid ""
+"You do not have to provide any personal data to be able to browse the "
+"contents of the databases published by MetaBrainz."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:15
+msgid ""
+"You do not have to provide any personally-identifying information if you "
+"choose not to."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:18
+msgid ""
+"We will never reveal your email address on MetaBrainz controlled web "
+"sites."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:22
+msgid ""
+"In order to get maximum value out of the MetaBrainz projects, you may "
+"want to create an account and log in. \n"
+"    Doing so grants you the ability to: edit the databases, contribute "
+"your own data, communicate with other users, and keep track \n"
+"    of recently released music from artists in your MusicBrainz "
+"collection. If you choose to create an account then the minimum we \n"
+"    ask is that you: choose a unique username and password, use a web "
+"browser that accepts \"session\" cookies, and provide a verified \n"
+"    email address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:29
+msgid ""
+"If you do not create an account (or are not logged in) you will not have "
+"access to the above listed features, however, you will \n"
+"    still have full access to browse and examine the databases."
 msgstr ""
 
 #: metabrainz/templates/index/privacy.html:33
@@ -1231,39 +2096,197 @@ msgstr ""
 msgid "Cookies"
 msgstr ""
 
+#: metabrainz/templates/index/privacy.html:37
+msgid "We use two cookies that contain sensitive information:"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:42
+msgid ""
+"<b>remember_login</b>: If you choose the \"Log in permanently\" option "
+"when logging in to one of our sites; the cookie will be used to \n"
+"      remember your login details."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:46
+msgid ""
+"<b>musicbrainz_server_session, session, or connect.sid</b>: If you are "
+"logged into one of our sites, your current session ID is stored in this "
+"cookie."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:51
+msgid ""
+"We may store dynamic preference information in other cookies, but these "
+"do not contain any sensitive information."
+msgstr ""
+
 #: metabrainz/templates/index/privacy.html:54
 msgid "Web and FTP access logs"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:57
+msgid ""
+"In a practice similar to other web sites (and APIs) we keep logs of all "
+"web requests made against our servers. These logs include: your IP\n"
+"    address, your browser's (or API client's) \"User-Agent\" string, and "
+"which page (or API endpoint) you requested with which parameters. "
+"Aggregate information about web and FTP traffic is\n"
+"    made available to the public via our site usage pages."
 msgstr ""
 
 #: metabrainz/templates/index/privacy.html:62
 msgid "Third-Party content"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:92
+#: metabrainz/templates/index/privacy.html:64
+msgid ""
+"Our projects' web pages may load some third-party content. Some, but "
+"possibly not all sites are listed below:"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:69
+#, python-format
+msgid ""
+"Cover art and other images: These are provided by the various cover art "
+"sites that have given MusicBrainz permission to do so and our own \n"
+"      <a href=\"%(caa_url)s\">Cover Art Archive</a>. This means that the "
+"relevant site will know (if they want to) your IP \n"
+"      address, User-Agent string, etc., and which MusicBrainz web page "
+"you were visiting (the one which included the cover art image)."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:75
+msgid ""
+"AcoustID: Our fingerprints tab loads fingerprint information from "
+"acoustid.org."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:78
+msgid ""
+"MTCaptcha: Our account creation page loads third party content in order "
+"to prevent spammers from creating accounts."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:83
+msgid ""
+"<i>The above information assumes that you are using \"normal\" web "
+"browser settings, whereby images are always loaded and HTTP referrer \n"
+"    information is always sent.</i>"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:88
+msgid ""
+"It is impractical to constantly modify this privacy policy when "
+"MetaBrainz projects change which third party content they utilize. We "
+"will \n"
+"    aim to use common sense, respect to our community and community "
+"review when adding more content from third party sites. We will also \n"
+"    periodically review our policy to ensure that it remains current."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:93
 msgid "Applicable to account holders"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:94
+#: metabrainz/templates/index/privacy.html:95
 msgid "Account creation"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:108
+#: metabrainz/templates/index/privacy.html:97
+msgid ""
+"When creating an account with a MetaBrainz project you need to pick a "
+"unique username and choose a password, the username you pick is the \n"
+"    only name associated with your account and will be what other "
+"MetaBrainz users know you as. You may optionally also tell us other \n"
+"    information about yourself that will be displayed to other MetaBrainz"
+" users and the public."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:103
+msgid ""
+"Additionally, in order to edit the databases you will need to provide a "
+"confirmed email address. This email address will be held in \n"
+"    confidence, the only method of revealing your email address to "
+"another user is if you choose to send a message to another \n"
+"    user and enable the option to \"reveal my email address\". Changing "
+"the email address stored with your account will require you to \n"
+"    verify the new address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:109
 msgid "Edits and Notes"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:114
+#: metabrainz/templates/index/privacy.html:111
+msgid ""
+"If you make any changes to a MetaBrainz project database, such as adding "
+"any data, the details of those changes will be visible to \n"
+"    other logged-in users and the change will be associated with your "
+"username."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:115
 msgid "Subscriptions on MusicBrainz"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:131
+#: metabrainz/templates/index/privacy.html:117
+msgid ""
+"As a logged-in user you can subscribe to one or more artists, labels, "
+"collections or other editors. The act of subscribing causes \n"
+"    any edits made to (or by in the case of another editor) those "
+"entities to be emailed to you. By default, other users can see your \n"
+"    list of subscriptions, however, you can opt out of this by editing "
+"the appropriate preference."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:123
+msgid ""
+"This does not provide \"perfect\" privacy though, in some cases it will "
+"be possible to infer information about the contents of your \n"
+"    subscription list even though you have disallowed others from viewing"
+" that list directly. This imperfection arises because various \n"
+"    parts of the system behave differently depending on whether or not an"
+" entity has any subscribers; also, the number of users \n"
+"    subscribed to each artist is available via the artist pages. In the "
+"most extreme (possibly contrived) example, imagine that all \n"
+"    users have their subscriptions set to \"public\", except for exactly "
+"one user whose list is \"private\". In that case, any discrepancy \n"
+"    for a given artist between the shown list of subscribers and the "
+"total number of subscribers must be down to that one user. Thus, \n"
+"    you can infer what artists are on that user's list."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:132
 msgid "Third-party sites"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:145
-msgid "MetaBrainz donors"
+#: metabrainz/templates/index/privacy.html:134
+#, python-format
+msgid ""
+"Our code reviews are done on GitHub, which is not under the control of "
+"MetaBrainz. Participating in code reviews or other\n"
+"    tasks carried out on GitHub are subject to <a "
+"href=\"%(github_url)s\">GitHub's privacy policy</a>."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:140
+#, python-format
+msgid ""
+"Our translations platform is provided and hosted by Weblate, which has a "
+"data processing agreement with MetaBrainz.\n"
+"    Participating in translations is subject to <a "
+"href=\"%(weblate_url)s\">dedicated legal terms</a>.\n"
+"    Any translations you make will be submitted to our Git repositories "
+"and publicly associated with your username;\n"
+"    if you so choose, you can also publicly associate them with your own "
+"verified email address."
 msgstr ""
 
 #: metabrainz/templates/index/privacy.html:147
+msgid "MetaBrainz donors"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:149
 msgid ""
 "When you make a donation to the MetaBrainz Foundation, we are legally\n"
 "    required to collect your personal information and keep it in our "
@@ -1273,7 +2296,7 @@ msgid ""
 "    information to anyone else, ever."
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:153
+#: metabrainz/templates/index/privacy.html:155
 msgid ""
 "We believe in transparent finances, which means that we list all "
 "donations\n"
@@ -1283,11 +2306,34 @@ msgid ""
 "process."
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:158
+#: metabrainz/templates/index/privacy.html:160
 msgid "Exceptions"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:598
+#: metabrainz/templates/index/privacy.html:162
+msgid ""
+"<i><b>Please note</b>: Reasonable exceptions may apply to the above "
+"policy, for example to comply with applicable laws.\n"
+"    Also, members of the MetaBrainz team and other personnel contracted "
+"to provide services to MetaBrainz may have access to\n"
+"    our infrastructure and could therefore view any information contained"
+" therein. However all personnel are contractually bound\n"
+"    by non-disclosure clauses which prevent them from making any such "
+"information available to others."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:171
+#, python-format
+msgid ""
+"If you have any questions about our GDPR statement, please <a "
+"href=\"%(contact_url)s\">contact us</a>. To report\n"
+"   any privacy problems, violations or leaks, our GDPR representative is "
+"our Interim Executive Director Nicolás Tamargo and for\n"
+"   privacy issues contact him at <strong><a "
+"href=\"mailto:gdpr@metabrainz.org\">gdpr@metabrainz.org</a></strong>."
+msgstr ""
+
+#: frontend/js/src/Profile.tsx:603
 #: frontend/js/src/forms/ProfileChangePassword.tsx:22
 #: frontend/js/src/forms/ProfileChangePassword.tsx:111
 #: metabrainz/templates/index/profile-change-password.html:3
@@ -1531,6 +2577,11 @@ msgstr ""
 
 #: metabrainz/templates/index/team.html:26
 msgid "He lives on in our hearts and in open source."
+msgstr ""
+
+#: metabrainz/templates/index/team.html:29
+#: metabrainz/templates/index/team.html:315
+msgid "you’re welcome to try"
 msgstr ""
 
 #: metabrainz/templates/index/team.html:39
@@ -2028,8 +3079,10 @@ msgstr ""
 
 #: metabrainz/templates/payments/donate.html:146
 msgid ""
-"Due to the increased unreliability of the US Postal Service we have "
-"stopped accepting paper checks. Sorry!"
+"Due to the increased unreliability of the US Postal Service and the "
+"relatively large fees involved, we ask you to only send a paper check if "
+"it is the only possible option. Due to the fees, we will not cash checks "
+"for less than $25."
 msgstr ""
 
 #: metabrainz/templates/payments/donate.html:241
@@ -2913,8 +3966,8 @@ msgid "Monthly balance sheets"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:520
-#: frontend/js/src/forms/SignupCommercial.tsx:175
-#: frontend/js/src/forms/SignupCommercial.tsx:554
+#: frontend/js/src/forms/SignupCommercial.tsx:180
+#: frontend/js/src/forms/SignupCommercial.tsx:558
 #: frontend/js/src/forms/SignupNonCommercial.tsx:106
 #: frontend/js/src/forms/SignupNonCommercial.tsx:318
 #: metabrainz/templates/supporters/account-type.html:3
@@ -2935,6 +3988,7 @@ msgid "Non-commercial / Personal"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:235
+#: frontend/js/src/forms/SignupNonCommercial.tsx:107
 #: frontend/js/src/forms/SignupNonCommercial.tsx:151
 #: metabrainz/templates/supporters/account-type.html:42
 msgid "Non-commercial"
@@ -2948,55 +4002,45 @@ msgstr ""
 msgid "Personal or university assignment user."
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:48
-#: metabrainz/templates/supporters/account-type.html:90
-#: metabrainz/templates/supporters/account-type.html:141
-msgid "Upgrade"
-msgstr ""
-
 #: frontend/js/src/Profile.tsx:235
-#: frontend/js/src/forms/SignupCommercial.tsx:176
-#: frontend/js/src/forms/SignupCommercial.tsx:228
-#: metabrainz/templates/supporters/account-type.html:61
+#: frontend/js/src/forms/SignupCommercial.tsx:181
+#: frontend/js/src/forms/SignupCommercial.tsx:233
+#: metabrainz/templates/supporters/account-type.html:56
 msgid "Commercial"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:83
-#: metabrainz/templates/supporters/account-type.html:135
+#: metabrainz/templates/supporters/account-type.html:78
+#: metabrainz/templates/supporters/account-type.html:125
 #, python-format
 msgid "$%(tier_price)s/month and up"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:87
-#: metabrainz/templates/supporters/account-type.html:138
+#: metabrainz/templates/supporters/account-type.html:82
+#: metabrainz/templates/supporters/account-type.html:128
 msgid "More info"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:104
+#: metabrainz/templates/supporters/account-type.html:94
 msgid "View all tiers"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:112
+#: metabrainz/templates/supporters/account-type.html:102
 msgid "Some of our Unicorn members"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:123
+#: metabrainz/templates/supporters/account-type.html:113
 msgid "See all our supporters"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:151
+#: metabrainz/templates/supporters/account-type.html:136
 msgid "View featured tiers"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:158
+#: metabrainz/templates/supporters/account-type.html:143
 #, python-format
 msgid ""
 "If you are not sure which tier to pick, please\n"
 "      <a href=\"%(contact_url)s\">contact us</a>."
-msgstr ""
-
-#: metabrainz/templates/supporters/account-type.html:166
-msgid "Back to Profile"
 msgstr ""
 
 #: metabrainz/templates/supporters/bad-standing.html:3
@@ -3058,9 +4102,9 @@ msgid "Forgot your username"
 msgstr ""
 
 #: frontend/js/src/forms/ResetPassword.tsx:79
-#: frontend/js/src/forms/SignupCommercial.tsx:320
+#: frontend/js/src/forms/SignupCommercial.tsx:325
 #: frontend/js/src/forms/SignupNonCommercial.tsx:227
-#: frontend/js/src/forms/SignupUser.tsx:169
+#: frontend/js/src/forms/SignupUser.tsx:175
 #: metabrainz/templates/users/reauthenticate.html:3
 #: metabrainz/templates/users/reauthenticate.html:6
 msgid "Confirm Password"
@@ -3070,17 +4114,22 @@ msgstr ""
 msgid "Please re-enter your password to continue."
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:108
+#: frontend/js/src/ProfileDelete.tsx:110
 #: frontend/js/src/forms/DeleteApplication.tsx:53
 #: frontend/js/src/forms/OAuthPrompt.tsx:54
 #: frontend/js/src/forms/ProfileChangePassword.tsx:104
 #: frontend/js/src/forms/ProfileEdit.tsx:105
-#: metabrainz/templates/users/reauthenticate.html:23
+#: metabrainz/templates/users/reauthenticate.html:28
 msgid "Cancel"
 msgstr ""
 
-#: metabrainz/templates/users/reauthenticate.html:24
+#: metabrainz/templates/users/reauthenticate.html:29
 msgid "Continue"
+msgstr ""
+
+#: frontend/js/src/forms/utils.tsx:202
+#: metabrainz/templates/users/reauthenticate.html:40
+msgid "Password must not exceed 72 bytes."
 msgstr ""
 
 #: frontend/js/src/forms/ResetPassword.tsx:27
@@ -3088,38 +4137,38 @@ msgstr ""
 msgid "Reset your password"
 msgstr ""
 
-#: frontend/js/src/hooks/useEmailValidation.ts:41 metabrainz/user/forms.py:15
+#: frontend/js/src/hooks/useEmailValidation.ts:41 metabrainz/user/forms.py:16
 msgid "Registration from this email domain is not allowed."
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:50
 #: frontend/js/src/forms/LostPassword.tsx:45
-#: frontend/js/src/forms/SignupCommercial.tsx:270
+#: frontend/js/src/forms/SignupCommercial.tsx:275
 #: frontend/js/src/forms/SignupNonCommercial.tsx:175
-#: frontend/js/src/forms/SignupUser.tsx:114 metabrainz/user/forms.py:20
-#: metabrainz/user/forms.py:45 metabrainz/user/forms.py:62
+#: frontend/js/src/forms/SignupUser.tsx:120 metabrainz/user/forms.py:22
+#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:75
 msgid "Username"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:42
 #: frontend/js/src/forms/LostPassword.tsx:37
-#: frontend/js/src/forms/SignupCommercial.tsx:153
+#: frontend/js/src/forms/SignupCommercial.tsx:158
 #: frontend/js/src/forms/SignupNonCommercial.tsx:84
-#: frontend/js/src/forms/SignupUser.tsx:67 metabrainz/user/forms.py:21
-#: metabrainz/user/forms.py:45 metabrainz/user/forms.py:62
+#: frontend/js/src/forms/SignupUser.tsx:73 metabrainz/user/forms.py:26
+#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:75
 msgid "Username is required!"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:63
 #: frontend/js/src/forms/ResetPassword.tsx:72
-#: frontend/js/src/forms/SignupCommercial.tsx:308
+#: frontend/js/src/forms/SignupCommercial.tsx:313
 #: frontend/js/src/forms/SignupNonCommercial.tsx:214
-#: frontend/js/src/forms/SignupUser.tsx:157 metabrainz/user/forms.py:46
-#: metabrainz/user/forms.py:52
+#: frontend/js/src/forms/SignupUser.tsx:163 metabrainz/user/forms.py:53
+#: metabrainz/user/forms.py:62
 msgid "Password"
 msgstr ""
 
-#: frontend/js/src/forms/LoginUser.tsx:76 metabrainz/user/forms.py:47
+#: frontend/js/src/forms/LoginUser.tsx:76 metabrainz/user/forms.py:57
 msgid "Remember me"
 msgstr ""
 
@@ -3131,11 +4180,11 @@ msgstr ""
 msgid "Username contains invalid or invisible characters."
 msgstr ""
 
-#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:181
+#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:220
 msgid "Hide password"
 msgstr ""
 
-#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:181
+#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:220
 msgid "Show password"
 msgstr ""
 
@@ -3192,11 +4241,11 @@ msgstr ""
 msgid "Revoke access"
 msgstr ""
 
-#: frontend/js/src/OAuthError.tsx:17
+#: frontend/js/src/OAuthError.tsx:18
 msgid "OAuth2 Error"
 msgstr ""
 
-#: frontend/js/src/OAuthError.tsx:18
+#: frontend/js/src/OAuthError.tsx:19
 msgid "An error occurred during OAuth authentication process."
 msgstr ""
 
@@ -3226,8 +4275,8 @@ msgstr ""
 
 #: frontend/js/src/Profile.tsx:109
 msgid ""
-"Are you sure you want to generate new access token? Current token will be"
-" revoked!"
+"Are you sure you want to generate a new access token? The current token "
+"will be revoked!"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:118
@@ -3342,8 +4391,8 @@ msgid "Contact Information"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:310 frontend/js/src/forms/ProfileEdit.tsx:70
-#: frontend/js/src/forms/SignupCommercial.tsx:284
-#: frontend/js/src/forms/SignupCommercial.tsx:333
+#: frontend/js/src/forms/SignupCommercial.tsx:289
+#: frontend/js/src/forms/SignupCommercial.tsx:338
 #: frontend/js/src/forms/SignupNonCommercial.tsx:189
 #: frontend/js/src/forms/SignupNonCommercial.tsx:241
 msgid "Contact name"
@@ -3458,7 +4507,7 @@ msgstr ""
 msgid "Once you delete your account, there is no going back. Please be certain."
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:550 frontend/js/src/ProfileDelete.tsx:105
+#: frontend/js/src/Profile.tsx:550 frontend/js/src/ProfileDelete.tsx:107
 msgid "Delete My Account"
 msgstr ""
 
@@ -3470,39 +4519,39 @@ msgstr ""
 msgid "Need to delete your account?"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:574
+#: frontend/js/src/Profile.tsx:575
 msgid ""
 "Deletion of supporter accounts requires manual review. Please contact us "
-"at"
+"at <email />."
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:594
+#: frontend/js/src/Profile.tsx:599
 msgid "Security"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:626
+#: frontend/js/src/Profile.tsx:631
 msgid "MetaBrainz Applications"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:630
+#: frontend/js/src/Profile.tsx:635
 msgid ""
 "With your MetaBrainz account, you can access every project in the "
 "MetaBrainz family:"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:643
+#: frontend/js/src/Profile.tsx:648
 msgid "The open-source music encyclopedia"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:655
+#: frontend/js/src/Profile.tsx:660
 msgid "Track, visualise and share the music you listen to"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:667
+#: frontend/js/src/Profile.tsx:672
 msgid "The open-source book database"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:679
+#: frontend/js/src/Profile.tsx:684
 msgid "Creative Commons licensed reviews"
 msgstr ""
 
@@ -3525,7 +4574,7 @@ msgid "Permanently remove all your account information"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:64
-msgid "Revoke all your API tokens and access"
+msgid "Revoke all your tokens and access to the replication API"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:65
@@ -3537,14 +4586,16 @@ msgid "Log you out of all MetaBrainz services"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:70
-msgid "Your username will be reserved and cannot be reused."
+msgid ""
+"Your username will be reserved and cannot be reused without the "
+"intervention of an administrator."
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:82
+#: frontend/js/src/ProfileDelete.tsx:84
 msgid "To confirm, type your username '<username />' below:"
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:105
+#: frontend/js/src/ProfileDelete.tsx:107
 msgid "Deleting..."
 msgstr ""
 
@@ -3556,64 +4607,7 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: frontend/js/src/forms/ConditionsModal.tsx:23
-msgid "Licensing"
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:25
-msgid ""
-"Any contributions you make to any MetaBrainz service will be released "
-"into the Public Domain and/or licensed under a Creative Commons by-nc-sa "
-"license. Furthermore, you give the MetaBrainz Foundation the right to "
-"license this data for commercial use."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:30
-msgid "Please read our <licenseLink>license page</licenseLink> for more details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:45
-msgid ""
-"MetaBrainz strongly believes in the privacy of its users. Any personal "
-"information you choose to provide will not be sold or shared with anyone "
-"else."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:50
-msgid ""
-"Please read our <privacyLink>privacy policy</privacyLink> for more "
-"details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:59
-msgid "GDPR compliance"
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:61
-msgid ""
-"You may remove your personal information from our services anytime by "
-"deleting your account."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:66
-msgid ""
-"Please read our <gdprLink>GDPR compliance statement</gdprLink> for more "
-"details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:78
-msgid ""
-"Creating an account on MetaBrainz will give you access to all of our "
-"projects, such as MusicBrainz, ListenBrainz, BookBrainz, and more."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:82
-msgid ""
-"We create a placeholder account for all the MetaBrainz projects when you "
-"sign up, and you are one log-in away from activating them."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:91
+#: frontend/js/src/forms/ConditionsModal.tsx:29
 msgid "Sounds good"
 msgstr ""
 
@@ -3699,8 +4693,8 @@ msgstr ""
 msgid "Forgot your password?"
 msgstr ""
 
-#: frontend/js/src/forms/LoginUser.tsx:109
-msgid "Don't have an account?"
+#: frontend/js/src/forms/LoginUser.tsx:110
+msgid "Don't have an account? <signupLink>Sign up</signupLink>"
 msgstr ""
 
 #: frontend/js/src/forms/LostPassword.tsx:38
@@ -3729,15 +4723,72 @@ msgstr ""
 msgid "Allow access"
 msgstr ""
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:71
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:10
+msgid "Licensing"
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:12
+msgid ""
+"Any contributions you make to any MetaBrainz service will be released "
+"into the Public Domain and/or licensed under a Creative Commons by-nc-sa "
+"license. Furthermore, you give the MetaBrainz Foundation the right to "
+"license this data for commercial use."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:17
+msgid "Please read our <licenseLink>license page</licenseLink> for more details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:34
+msgid ""
+"MetaBrainz strongly believes in the privacy of its users. Any personal "
+"information you choose to provide will not be sold or shared with anyone "
+"else."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:39
+msgid ""
+"Please read our <privacyLink>privacy policy</privacyLink> for more "
+"details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:50
+msgid "GDPR compliance"
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:52
+msgid ""
+"You may remove your personal information from our services anytime by "
+"deleting your account."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:57
+msgid ""
+"Please read our <gdprLink>GDPR compliance statement</gdprLink> for more "
+"details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:71
+msgid ""
+"Creating an account on MetaBrainz will give you access to all of our "
+"projects, such as MusicBrainz, ListenBrainz, BookBrainz, and more."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:75
+msgid ""
+"We create a placeholder account for all the MetaBrainz projects when you "
+"sign up, and you are one log-in away from activating them."
+msgstr ""
+
+#: frontend/js/src/forms/ProfileChangePassword.tsx:70
 msgid "Current Password"
 msgstr ""
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:80
+#: frontend/js/src/forms/ProfileChangePassword.tsx:79
 msgid "New Password"
 msgstr ""
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:89
+#: frontend/js/src/forms/ProfileChangePassword.tsx:88
 msgid "Confirm New Password"
 msgstr ""
 
@@ -3749,190 +4800,180 @@ msgstr ""
 msgid "Reset Password"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:38
-msgid "If you would like to support us with more than $"
+#: frontend/js/src/forms/SignupCommercial.tsx:40
+msgid ""
+"If you would like to support us with more than ${{minPledge}}, please "
+"enter the actual amount here:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:39
-msgid ", please enter the actual amount here:"
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:144
+#: frontend/js/src/forms/SignupCommercial.tsx:149
 #: frontend/js/src/forms/SignupNonCommercial.tsx:75
-#: frontend/js/src/forms/SignupUser.tsx:87
+#: frontend/js/src/forms/SignupUser.tsx:93
 msgid "Captcha is required!"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:179
+#: frontend/js/src/forms/SignupCommercial.tsx:184
 #: frontend/js/src/forms/SignupNonCommercial.tsx:110
 #: frontend/js/src/forms/SignupUser.tsx:46
 msgid "Access all MetaBrainz projects"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:182
+#: frontend/js/src/forms/SignupCommercial.tsx:187
 msgid "Note:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:184
+#: frontend/js/src/forms/SignupCommercial.tsx:189
 msgid ""
 "Signing up for any tier other than the <italic>Stealth startup</italic> "
 "tier will publicly list your company on this web site. However, we will "
 "not publish any of your private details."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:221
+#: frontend/js/src/forms/SignupCommercial.tsx:226
 #: frontend/js/src/forms/SignupNonCommercial.tsx:145
 msgid "Account type"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:234
+#: frontend/js/src/forms/SignupCommercial.tsx:239
 msgid "Selected tier"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:242
-msgid "month and up"
+#: frontend/js/src/forms/SignupCommercial.tsx:247
+msgid "${{tierPrice}}/month and up"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:250
+#: frontend/js/src/forms/SignupCommercial.tsx:255
 msgid "Change account type or tier"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:261
+#: frontend/js/src/forms/SignupCommercial.tsx:266
 #: frontend/js/src/forms/SignupNonCommercial.tsx:166
 msgid "Your account:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:271
+#: frontend/js/src/forms/SignupCommercial.tsx:276
 #: frontend/js/src/forms/SignupNonCommercial.tsx:176
-#: frontend/js/src/forms/SignupUser.tsx:114
+#: frontend/js/src/forms/SignupUser.tsx:120
 msgid "(public)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:291
+#: frontend/js/src/forms/SignupCommercial.tsx:296
 #: frontend/js/src/forms/SignupNonCommercial.tsx:196
-#: frontend/js/src/forms/SignupUser.tsx:127
+#: frontend/js/src/forms/SignupUser.tsx:133
 msgid "E-mail address"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:295
+#: frontend/js/src/forms/SignupCommercial.tsx:300
 #: frontend/js/src/forms/SignupNonCommercial.tsx:200
-#: frontend/js/src/forms/SignupUser.tsx:131
+#: frontend/js/src/forms/SignupUser.tsx:137
 msgid "(checking...)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:314
+#: frontend/js/src/forms/SignupCommercial.tsx:319
 #: frontend/js/src/forms/SignupNonCommercial.tsx:220
-#: frontend/js/src/forms/SignupUser.tsx:163
+#: frontend/js/src/forms/SignupUser.tsx:169
 msgid "Must be at least 8 characters"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:348
+#: frontend/js/src/forms/SignupCommercial.tsx:353
 msgid ""
 "If you don't have an organization name, you probably want to become a "
 "supporter as a <nonCommercialLink>Non-commercial / "
 "Personal</nonCommercialLink> supporter."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:358
+#: frontend/js/src/forms/SignupCommercial.tsx:363
 msgid ""
 "If you don't have an organization name, you probably want to sign up as a"
 " <nonCommercialLink>Non-commercial / Personal</nonCommercialLink> user."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:378
+#: frontend/js/src/forms/SignupCommercial.tsx:383
 msgid ""
 "Please tell us a little about your company and whether you plan to use "
 "our <apiLink>API</apiLink> or to <hostLink>host your own copy</hostLink> "
 "of the data."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:404
+#: frontend/js/src/forms/SignupCommercial.tsx:408
 msgid "Logo URL"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:405
+#: frontend/js/src/forms/SignupCommercial.tsx:409
 msgid "(preferably in SVG format)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:408
+#: frontend/js/src/forms/SignupCommercial.tsx:412
 msgid ""
 "Image should be about 250 pixels wide on a white or transparent "
 "background. We will host it on our site."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:421
+#: frontend/js/src/forms/SignupCommercial.tsx:425
 msgid ""
 "URL to where developers can use your APIs using MusicBrainz IDs, if "
-"available.."
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:430
-msgid "Your project"
+"available."
 msgstr ""
 
 #: frontend/js/src/forms/SignupCommercial.tsx:434
+msgid "Your project"
+msgstr ""
+
+#: frontend/js/src/forms/SignupCommercial.tsx:438
 #: frontend/js/src/forms/SignupNonCommercial.tsx:261
 msgid "(max 150 characters)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:451
+#: frontend/js/src/forms/SignupCommercial.tsx:455
 msgid "Billing address"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:502
+#: frontend/js/src/forms/SignupCommercial.tsx:506
 msgid ""
 "I agree to support the MetaBrainz Foundation when my organization is able"
 " to do so."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:507
+#: frontend/js/src/forms/SignupCommercial.tsx:511
+#: frontend/js/src/forms/SignupNonCommercial.tsx:284
 msgid ""
-"I also agree that if I generate a Live Data Feed access token, that I "
-"treat my access token as a secret and will not share this token publicly "
-"or commit it to a source code repository."
+"I also agree that if I generate a Live Data Feed access token, then I "
+"will treat my access token as a secret and will not share this token "
+"publicly or commit it to a source code repository."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:515
+#: frontend/js/src/forms/SignupCommercial.tsx:519
 msgid ""
 "The following information will be shown publicly: organization name, "
 "logo, website and API URLs, data usage description."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:520
+#: frontend/js/src/forms/SignupCommercial.tsx:524
 msgid ""
 "We'll send you more details about payment process once your application "
 "is approved."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:552
+#: frontend/js/src/forms/SignupCommercial.tsx:556
 #: frontend/js/src/forms/SignupNonCommercial.tsx:316
-#: frontend/js/src/forms/SignupUser.tsx:224
+#: frontend/js/src/forms/SignupUser.tsx:230
 msgid "Validating..."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:564
+#: frontend/js/src/forms/SignupCommercial.tsx:568
 #: frontend/js/src/forms/SignupNonCommercial.tsx:329
 msgid "Back to profile"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:569
-#: frontend/js/src/forms/SignupNonCommercial.tsx:334
-msgid "Not a supporter?"
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:570
+#: frontend/js/src/forms/SignupCommercial.tsx:574
 #: frontend/js/src/forms/SignupNonCommercial.tsx:335
-msgid "Create a user account"
+msgid "Not a supporter? <signupLink>Create a user account</signupLink>"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:573
-#: frontend/js/src/forms/SignupNonCommercial.tsx:338
-#: frontend/js/src/forms/SignupUser.tsx:231
-msgid "Already have an account?"
-msgstr ""
-
-#: frontend/js/src/forms/SignupNonCommercial.tsx:107
-msgid "non-commercial"
+#: frontend/js/src/forms/SignupCommercial.tsx:583
+#: frontend/js/src/forms/SignupNonCommercial.tsx:344
+#: frontend/js/src/forms/SignupUser.tsx:238
+msgid "Already have an account? <loginLink>Sign in</loginLink>"
 msgstr ""
 
 #: frontend/js/src/forms/SignupNonCommercial.tsx:113
@@ -3960,46 +5001,40 @@ msgid ""
 "income per year) or personal uses only."
 msgstr ""
 
-#: frontend/js/src/forms/SignupNonCommercial.tsx:284
-msgid ""
-"I also agree that if I generate a Live Data Feed access token, then I "
-"will treat my access token as a secret and will not share this token "
-"publicly or commit it to a source code repository."
-msgstr ""
-
 #: frontend/js/src/forms/SignupUser.tsx:43
 msgid "Create your account"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:50
-msgid "Registration started by"
+#: frontend/js/src/forms/SignupUser.tsx:51
+msgid "Registration started by <client />"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:69
+#: frontend/js/src/forms/SignupUser.tsx:75
+#: frontend/js/src/hooks/useEmailValidation.ts:82
 msgid "Invalid email address."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:150
+#: frontend/js/src/forms/SignupUser.tsx:156
 msgid ""
 "This username and email were provided by the app that started "
 "registration. You can change them later from MetaBrainz settings."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:182
+#: frontend/js/src/forms/SignupUser.tsx:188
 msgid ""
 "I accept that my contributions will be released into the public domain or"
 " licensed for use."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:191
+#: frontend/js/src/forms/SignupUser.tsx:197
 msgid "We will never share your personal information."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:200
+#: frontend/js/src/forms/SignupUser.tsx:206
 msgid "Click here to read more"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:224
+#: frontend/js/src/forms/SignupUser.tsx:230
 msgid "Create account"
 msgstr ""
 
@@ -4009,10 +5044,6 @@ msgstr ""
 
 #: frontend/js/src/hooks/useEmailValidation.ts:47
 msgid "Email validation failed"
-msgstr ""
-
-#: frontend/js/src/hooks/useEmailValidation.ts:82
-msgid "Invalid email address"
 msgstr ""
 
 #~ msgid "You need to specify amount!"
@@ -5308,5 +6339,97 @@ msgstr ""
 #~ msgstr ""
 
 #~ msgid "Privacy policy"
+#~ msgstr ""
+
+#~ msgid "You need to specify website of the organization."
+#~ msgstr ""
+
+#~ msgid ""
+#~ "We are currently evaluating our overall"
+#~ " online advertising strategy. We are "
+#~ "evaluating advertising, traffic optimization,\n"
+#~ ""
+#~ "    search engine optimization and "
+#~ "software monitization technologies. If you "
+#~ "provide these professional services, please"
+#~ " provide a detailed\n"
+#~ "    deck of your comprehensive services"
+#~ " to the following email address. "
+#~ "<em>Please respect our other non-media"
+#~ " teams and do not contact us \n"
+#~ "    regarding these services on any "
+#~ "other of our email addresses. We "
+#~ "will disregard the entirety of your "
+#~ "submissions if you contact us any "
+#~ "other way!</em>"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Please come ask your questions at "
+#~ "our <a href=\"%(forums_url)s\">forums</a>! We "
+#~ "would love to\n"
+#~ "    answer any questions you may have."
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Due to the increased unreliability of"
+#~ " the US Postal Service we have "
+#~ "stopped accepting paper checks. Sorry!"
+#~ msgstr ""
+
+#~ msgid "Upgrade"
+#~ msgstr ""
+
+#~ msgid "Back to Profile"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Deletion of supporter accounts requires "
+#~ "manual review. Please contact us at"
+#~ msgstr ""
+
+#~ msgid "Revoke all your API tokens and access"
+#~ msgstr ""
+
+#~ msgid "Your username will be reserved and cannot be reused."
+#~ msgstr ""
+
+#~ msgid "Don't have an account?"
+#~ msgstr ""
+
+#~ msgid "If you would like to support us with more than $"
+#~ msgstr ""
+
+#~ msgid ", please enter the actual amount here:"
+#~ msgstr ""
+
+#~ msgid "month and up"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "I also agree that if I generate"
+#~ " a Live Data Feed access token, "
+#~ "that I treat my access token as"
+#~ " a secret and will not share "
+#~ "this token publicly or commit it "
+#~ "to a source code repository."
+#~ msgstr ""
+
+#~ msgid "Not a supporter?"
+#~ msgstr ""
+
+#~ msgid "Create a user account"
+#~ msgstr ""
+
+#~ msgid "Already have an account?"
+#~ msgstr ""
+
+#~ msgid "non-commercial"
+#~ msgstr ""
+
+#~ msgid "Registration started by"
+#~ msgstr ""
+
+#~ msgid "Invalid email address"
 #~ msgstr ""
 

--- a/metabrainz/translations/ca/LC_MESSAGES/messages.po
+++ b/metabrainz/translations/ca/LC_MESSAGES/messages.po
@@ -8,176 +8,260 @@ msgid ""
 msgstr ""
 "Project-Id-Version: metabrainz.org VERSION\n"
 "Report-Msgid-Bugs-To: support@metabrainz.org\n"
-"POT-Creation-Date: 2026-07-25 16:21+0200\n"
+"POT-Creation-Date: 2026-09-08 11:18+0200\n"
 "PO-Revision-Date: 2026-08-27 13:12+0000\n"
 "Last-Translator: Marc Riera <marc@marcriera.cat>\n"
 "Language: ca\n"
-"Language-Team: Catalan <https://translations.metabrainz.org/projects/"
-"metabrainz/website/ca/>\n"
+"Language-Team: Catalan "
+"<https://translations.metabrainz.org/projects/metabrainz/website/ca/>\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.18.0\n"
-"X-Generator: Weblate 2026.8.1\n"
 
-#: metabrainz/index/forms.py:46
+#: metabrainz/errors.py:24
+msgid "Authorization was declined."
+msgstr ""
+
+#: metabrainz/errors.py:25
+msgid "The authorization request was invalid."
+msgstr ""
+
+#: metabrainz/errors.py:26
+msgid "The application could not be authenticated."
+msgstr ""
+
+#: metabrainz/errors.py:27
+msgid "This application is not allowed to request authorization."
+msgstr ""
+
+#: metabrainz/errors.py:28
+msgid "The application asked for a response type this server does not support."
+msgstr ""
+
+#: metabrainz/errors.py:29
+msgid "The permissions requested by the application are invalid."
+msgstr ""
+
+#: metabrainz/errors.py:30
+msgid "You need to sign in to continue."
+msgstr ""
+
+#: metabrainz/errors.py:31
+msgid "Your consent is required to continue."
+msgstr ""
+
+#: metabrainz/password.py:12
+#, python-format
+msgid "Password must not exceed %(max_bytes)s bytes."
+msgstr ""
+
+#: metabrainz/index/forms.py:48
 #, python-format
 msgid "'%(value)s' is not a valid choice for this field"
 msgstr "«%(value)s» no és una selecció vàlida per a aquest camp"
 
 #: frontend/js/src/forms/ProfileEdit.tsx:27
-#: frontend/js/src/forms/SignupCommercial.tsx:154
+#: frontend/js/src/forms/SignupCommercial.tsx:159
 #: frontend/js/src/forms/SignupNonCommercial.tsx:85
-#: frontend/js/src/forms/SignupUser.tsx:70
-#: frontend/js/src/hooks/useEmailValidation.ts:78 metabrainz/index/forms.py:57
-#: metabrainz/user/forms.py:25 metabrainz/user/forms.py:57
-#: metabrainz/user/forms.py:63
+#: frontend/js/src/forms/SignupUser.tsx:76
+#: frontend/js/src/hooks/useEmailValidation.ts:78 metabrainz/index/forms.py:59
+#: metabrainz/user/forms.py:31 metabrainz/user/forms.py:70
+#: metabrainz/user/forms.py:76
 msgid "Email address is required!"
 msgstr "L'adreça electrònica és obligatòria!"
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:34
-#: metabrainz/index/forms.py:63
+#: metabrainz/index/forms.py:65
 msgid "Current password is required!"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:43
 #: frontend/js/src/forms/ProfileChangePassword.tsx:37
 #: frontend/js/src/forms/ResetPassword.tsx:39
-#: frontend/js/src/forms/SignupCommercial.tsx:156
+#: frontend/js/src/forms/SignupCommercial.tsx:161
 #: frontend/js/src/forms/SignupNonCommercial.tsx:87
-#: frontend/js/src/forms/SignupUser.tsx:72 metabrainz/index/forms.py:66
-#: metabrainz/user/forms.py:29 metabrainz/user/forms.py:46
-#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:69
+#: frontend/js/src/forms/SignupUser.tsx:78 metabrainz/index/forms.py:69
+#: metabrainz/user/forms.py:35 metabrainz/user/forms.py:54
+#: metabrainz/user/forms.py:63 metabrainz/user/forms.py:82
 msgid "Password is required!"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:41
-#: frontend/js/src/forms/SignupCommercial.tsx:160
+#: frontend/js/src/forms/SignupCommercial.tsx:165
 #: frontend/js/src/forms/SignupNonCommercial.tsx:91
-#: frontend/js/src/forms/SignupUser.tsx:76 metabrainz/index/forms.py:70
-#: metabrainz/user/forms.py:33 metabrainz/user/forms.py:73
+#: frontend/js/src/forms/SignupUser.tsx:82 metabrainz/index/forms.py:74
+#: metabrainz/user/forms.py:40 metabrainz/user/forms.py:87
 msgid "Confirm Password is required!"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:46
 #: frontend/js/src/forms/ResetPassword.tsx:48
-#: frontend/js/src/forms/SignupCommercial.tsx:165
+#: frontend/js/src/forms/SignupCommercial.tsx:170
 #: frontend/js/src/forms/SignupNonCommercial.tsx:96
-#: frontend/js/src/forms/SignupUser.tsx:81 metabrainz/index/forms.py:72
-#: metabrainz/user/forms.py:35 metabrainz/user/forms.py:75
+#: frontend/js/src/forms/SignupUser.tsx:87 metabrainz/index/forms.py:76
+#: metabrainz/user/forms.py:42 metabrainz/user/forms.py:89
 msgid "Confirm Password should match password!"
 msgstr ""
 
 #: frontend/js/src/Applications.tsx:56 frontend/js/src/Applications.tsx:86
 #: frontend/js/src/Profile.tsx:272 frontend/js/src/Profile.tsx:482
-#: metabrainz/index/forms.py:78
+#: metabrainz/index/forms.py:82
 msgid "Name"
 msgstr "Nom"
 
-#: metabrainz/index/forms.py:79
+#: metabrainz/index/forms.py:83
 msgid "Contact name field is empty."
 msgstr "El camp de nom del contacte és buit."
 
-#: metabrainz/index/views.py:234
+#: metabrainz/index/views.py:251
 msgid "Profile updated successfully."
 msgstr "El perfil s'ha actualitzat correctament."
 
-#: metabrainz/index/views.py:261
+#: metabrainz/index/views.py:278
 msgid "Current password is incorrect."
 msgstr ""
 
-#: metabrainz/index/views.py:266
+#: metabrainz/index/views.py:283
 msgid "Password changed successfully."
 msgstr ""
 
-#: metabrainz/index/views.py:372
+#: metabrainz/index/views.py:389
 msgid "You have updated an application!"
 msgstr "Heu actualitzat una aplicació!"
 
-#: metabrainz/index/views.py:424
+#: metabrainz/index/views.py:441
 msgid "You have deleted an application."
 msgstr "Heu suprimit una aplicació."
 
-#: metabrainz/index/views.py:426
+#: metabrainz/index/views.py:443
 msgid "Failed to delete an application."
 msgstr "No s'ha pogut suprimir una aplicació."
 
-#: metabrainz/index/views.py:449
+#: metabrainz/index/views.py:466
 msgid "Revoked tokens successfully!"
 msgstr "Els testimonis s'han revocat correctament!"
 
-#: metabrainz/index/views.py:478
+#: metabrainz/index/views.py:495
 msgid "Your account has been deleted."
 msgstr "S'ha suprimit el compte."
 
-#: frontend/js/src/forms/CreateApplication.tsx:106 metabrainz/oauth/forms.py:58
+#: frontend/js/src/forms/CreateApplication.tsx:106 metabrainz/oauth/forms.py:57
 msgid "Application Name"
 msgstr "Nom de l'aplicació"
 
-#: metabrainz/oauth/forms.py:59
+#: metabrainz/oauth/forms.py:58
 msgid "Application name field is empty."
 msgstr "El camp de nom de l'aplicació és buit."
 
-#: frontend/js/src/forms/CreateApplication.tsx:60 metabrainz/oauth/forms.py:60
+#: frontend/js/src/forms/CreateApplication.tsx:60 metabrainz/oauth/forms.py:59
 msgid "Application name needs to be at least 3 characters long."
 msgstr "El nom de l'aplicació ha de tenir 3 caràcters de longitud com a mínim."
 
-#: frontend/js/src/forms/CreateApplication.tsx:64 metabrainz/oauth/forms.py:61
+#: frontend/js/src/forms/CreateApplication.tsx:64 metabrainz/oauth/forms.py:60
 msgid "Application name needs to be at most 64 characters long."
 msgstr "El nom de l'aplicació pot tenir 64 caràcters de longitud com a màxim."
 
-#: frontend/js/src/forms/CreateApplication.tsx:114 metabrainz/oauth/forms.py:63
+#: frontend/js/src/forms/CreateApplication.tsx:114 metabrainz/oauth/forms.py:62
 msgid "Description"
 msgstr "Descripció"
 
-#: metabrainz/oauth/forms.py:64
+#: metabrainz/oauth/forms.py:63
 msgid "Client description field is empty."
 msgstr "El camp de descripció del client és buit."
 
-#: metabrainz/oauth/forms.py:65
+#: metabrainz/oauth/forms.py:64
 msgid "Client description needs to be at least 3 characters long."
 msgstr "La descripció del client ha de tenir 3 caràcters de longitud com a mínim."
 
-#: metabrainz/oauth/forms.py:66
+#: metabrainz/oauth/forms.py:65
 msgid "Client description needs to be at most 512 characters long."
 msgstr "La descripció del client pot tenir 512 caràcters de longitud com a màxim."
 
-#: frontend/js/src/forms/CreateApplication.tsx:122 metabrainz/oauth/forms.py:68
+#: frontend/js/src/forms/CreateApplication.tsx:122 metabrainz/oauth/forms.py:67
 msgid "Homepage"
 msgstr "Pàgina d'inici"
 
-#: metabrainz/oauth/forms.py:69
+#: metabrainz/oauth/forms.py:68
 msgid "Homepage field is empty."
 msgstr "El camp de pàgina d'inici és buit."
 
-#: metabrainz/oauth/forms.py:70
+#: metabrainz/oauth/forms.py:69
 msgid "Homepage is not a valid URI."
 msgstr "La pàgina d'inici no és un URI vàlid."
 
-#: metabrainz/oauth/forms.py:71
+#: metabrainz/oauth/forms.py:70
 msgid "Homepage URL must use http or https"
 msgstr "L'URL de la pàgina d'inici ha de fer servir HTTP o HTTPS."
 
-#: metabrainz/oauth/forms.py:73
+#: metabrainz/oauth/forms.py:72
 msgid "Authorization callback URL"
 msgstr "URL de resposta de trucada d'autorització"
 
-#: metabrainz/oauth/forms.py:74
+#: metabrainz/oauth/forms.py:73
 msgid "Authorization callback URL field is empty."
 msgstr "El camp d'URL de resposta de trucada d'autorització és buit."
 
-#: metabrainz/oauth/forms.py:75
+#: metabrainz/oauth/forms.py:74
 msgid "Authorization callback URL is invalid."
 msgstr "L'URL de resposta de trucada d'autorització no és vàlid."
 
-#: metabrainz/oauth/forms.py:76
+#: metabrainz/oauth/forms.py:75
 msgid "Authorization callback URL must use http or https."
 msgstr "L'URL de resposta de trucada d'autorització ha de fer servir HTTP o HTTPS."
 
-#: metabrainz/oauth/forms.py:81 metabrainz/oauth/forms.py:85
+#: metabrainz/oauth/forms.py:80 metabrainz/oauth/forms.py:84
 msgid "Confirm"
 msgstr "Confirma"
+
+#: metabrainz/oauth/scopes.py:15
+msgid "View your public account information"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:16
+msgid "View your email address"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:17
+msgid "View and modify your private tags"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:18
+msgid "View and modify your private ratings"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:19
+msgid "View and modify your private collections"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:20
+msgid "Submit new ISRCs to the database"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:21
+msgid "Submit new barcodes to the database"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:22
+msgid "Sign you in and view your unique user id"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:23
+msgid "Submit listens to ListenBrainz."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:24
+msgid "Create and modify CritiqueBrainz reviews."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:25
+msgid "Submit and delete votes on CritiqueBrainz reviews."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:26
+msgid "Modify profile info and delete profile on CritiqueBrainz."
+msgstr ""
 
 #: metabrainz/payments/views.py:164
 msgid ""
@@ -230,15 +314,15 @@ msgid "Requested annual report was not found."
 msgstr "No s'ha trobat l'informe anual sol·licitat."
 
 #: frontend/js/src/forms/ProfileEdit.tsx:30
-#: frontend/js/src/forms/SignupCommercial.tsx:139
+#: frontend/js/src/forms/SignupCommercial.tsx:144
 #: frontend/js/src/forms/SignupNonCommercial.tsx:70
-#: metabrainz/supporter/forms.py:13
+#: metabrainz/supporter/forms.py:15
 msgid "Contact name is required!"
 msgstr "El nom del contacte és obligatori!"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:437
+#: frontend/js/src/forms/SignupCommercial.tsx:441
 #: frontend/js/src/forms/SignupNonCommercial.tsx:264
-#: metabrainz/supporter/forms.py:15
+#: metabrainz/supporter/forms.py:17
 msgid ""
 "Can you please tell us more about the project in which you'd like to use "
 "our data? Do you plan to self host the data or use our APIs?"
@@ -247,121 +331,122 @@ msgstr ""
 "nostres dades? Teniu pensat allotjar les dades pel vostre compte o fer "
 "servir les nostres API?"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:137
+#: frontend/js/src/forms/SignupCommercial.tsx:142
 #: frontend/js/src/forms/SignupNonCommercial.tsx:68
-#: metabrainz/supporter/forms.py:17
+#: metabrainz/supporter/forms.py:19
 msgid "Please, tell us how you (will) use our data."
 msgstr "Indiqueu-nos com feu o fareu servir les nostres dades."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:138
+#: frontend/js/src/forms/SignupCommercial.tsx:143
 #: frontend/js/src/forms/SignupNonCommercial.tsx:69
-#: metabrainz/supporter/forms.py:18
+#: metabrainz/supporter/forms.py:20
 msgid "Please, limit usage description to 500 characters."
 msgstr "Limiteu la descripció d'ús a 500 caràcters."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:141
-#: frontend/js/src/forms/SignupCommercial.tsx:142
+#: frontend/js/src/forms/SignupCommercial.tsx:146
+#: frontend/js/src/forms/SignupCommercial.tsx:147
 #: frontend/js/src/forms/SignupNonCommercial.tsx:72
 #: frontend/js/src/forms/SignupNonCommercial.tsx:73
-#: frontend/js/src/forms/SignupUser.tsx:84
-#: frontend/js/src/forms/SignupUser.tsx:85 metabrainz/supporter/forms.py:21
-#: metabrainz/user/forms.py:38
+#: frontend/js/src/forms/SignupUser.tsx:90
+#: frontend/js/src/forms/SignupUser.tsx:91 metabrainz/supporter/forms.py:23
+#: metabrainz/user/forms.py:45
 msgid "You need to accept the agreement!"
 msgstr "Cal que accepteu l'acord!"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:342
-#: metabrainz/supporter/forms.py:27
+#: frontend/js/src/forms/SignupCommercial.tsx:347
+#: metabrainz/supporter/forms.py:29
 msgid "Organization name"
 msgstr "Nom de l'organització"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:113
-#: metabrainz/supporter/forms.py:28
+#: frontend/js/src/forms/SignupCommercial.tsx:115
+#: metabrainz/supporter/forms.py:30
 msgid "You need to specify the name of your organization."
 msgstr "Heu d'especificar el nom de l'organització."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:373
-#: metabrainz/supporter/forms.py:30
+#: frontend/js/src/forms/SignupCommercial.tsx:378
+#: metabrainz/supporter/forms.py:32
 msgid "Organization description"
 msgstr "Descripció de l'organització"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:116
-#: metabrainz/supporter/forms.py:31
+#: frontend/js/src/forms/SignupCommercial.tsx:118
+#: metabrainz/supporter/forms.py:33
 msgid "You need to provide description of your organization."
 msgstr "Heu de proporcionar una descripció de la vostra organització."
 
 #: frontend/js/src/Profile.tsx:278
-#: frontend/js/src/forms/SignupCommercial.tsx:396
-#: metabrainz/supporter/forms.py:34
+#: frontend/js/src/forms/SignupCommercial.tsx:401
+#: metabrainz/supporter/forms.py:36
 msgid "Website URL"
 msgstr "URL del lloc web"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:119
-#: metabrainz/supporter/forms.py:35
-msgid "You need to specify website of the organization."
-msgstr "Heu d'especificar el lloc web de l'organització."
+#: frontend/js/src/forms/SignupCommercial.tsx:121
+#: frontend/js/src/forms/SignupCommercial.tsx:123
+#: metabrainz/supporter/forms.py:38 metabrainz/supporter/forms.py:42
+msgid "Website URL must be a valid URL."
+msgstr ""
 
-#: metabrainz/supporter/forms.py:37
+#: metabrainz/supporter/forms.py:45
 msgid "Logo image URL"
 msgstr "URL de la imatge del logotip"
 
 #: frontend/js/src/Profile.tsx:284
-#: frontend/js/src/forms/SignupCommercial.tsx:418
-#: metabrainz/supporter/forms.py:38
+#: frontend/js/src/forms/SignupCommercial.tsx:422
+#: metabrainz/supporter/forms.py:46
 msgid "API URL"
 msgstr "URL de l'API"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:457
-#: metabrainz/supporter/forms.py:40
+#: frontend/js/src/forms/SignupCommercial.tsx:461
+#: metabrainz/supporter/forms.py:48
 msgid "Street"
 msgstr "Carrer"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:123
-#: metabrainz/supporter/forms.py:41
+#: frontend/js/src/forms/SignupCommercial.tsx:128
+#: metabrainz/supporter/forms.py:49
 msgid "You need to specify street."
 msgstr "Heu d'especificar el carrer."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:465
-#: metabrainz/supporter/forms.py:43
+#: frontend/js/src/forms/SignupCommercial.tsx:469
+#: metabrainz/supporter/forms.py:51
 msgid "City"
 msgstr "Ciutat"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:124
-#: metabrainz/supporter/forms.py:44
+#: frontend/js/src/forms/SignupCommercial.tsx:129
+#: metabrainz/supporter/forms.py:52
 msgid "You need to specify city."
 msgstr "Heu d'especificar la ciutat."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:473
-#: metabrainz/supporter/forms.py:46
+#: frontend/js/src/forms/SignupCommercial.tsx:477
+#: metabrainz/supporter/forms.py:54
 msgid "State / Province"
 msgstr "Estat/província"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:126
-#: metabrainz/supporter/forms.py:47
+#: frontend/js/src/forms/SignupCommercial.tsx:131
+#: metabrainz/supporter/forms.py:55
 msgid "You need to specify state/province."
 msgstr "Heu d'especificar l'estat/província."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:481
-#: metabrainz/supporter/forms.py:49
+#: frontend/js/src/forms/SignupCommercial.tsx:485
+#: metabrainz/supporter/forms.py:57
 msgid "Postcode"
 msgstr "Codi postal"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:128
-#: metabrainz/supporter/forms.py:50
+#: frontend/js/src/forms/SignupCommercial.tsx:133
+#: metabrainz/supporter/forms.py:58
 msgid "You need to specify postcode."
 msgstr "Heu d'especificar el codi postal."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:489
-#: metabrainz/supporter/forms.py:52
+#: frontend/js/src/forms/SignupCommercial.tsx:493
+#: metabrainz/supporter/forms.py:60
 msgid "Country"
 msgstr "País"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:129
-#: metabrainz/supporter/forms.py:53
+#: frontend/js/src/forms/SignupCommercial.tsx:134
+#: metabrainz/supporter/forms.py:61
 msgid "You need to specify country."
 msgstr "Heu d'especificar el país."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:132
-#: metabrainz/supporter/forms.py:64
+#: frontend/js/src/forms/SignupCommercial.tsx:137
+#: metabrainz/supporter/forms.py:72
 msgid ""
 "Custom amount must be more than threshold amount for selected tier or "
 "equal to it!"
@@ -369,24 +454,30 @@ msgstr ""
 "L'import personalitzat ha de ser igual o superior a l'import límit per al"
 " nivell seleccionat!"
 
-#: metabrainz/supporter/views.py:46 metabrainz/supporter/views.py:119
-#: metabrainz/supporter/views.py:220
+#: metabrainz/supporter/views.py:54
+msgid ""
+"The verification email could not be sent. Please request a new one from "
+"your profile."
+msgstr ""
+
+#: metabrainz/supporter/views.py:85 metabrainz/supporter/views.py:158
+#: metabrainz/supporter/views.py:260
 msgid "You are already a supporter."
 msgstr "Ja ens doneu suport."
 
-#: metabrainz/supporter/views.py:61
+#: metabrainz/supporter/views.py:100
 msgid "Can't find tier with a specified ID."
 msgstr "No s'ha trobat el nivell amb l'ID especificat."
 
-#: metabrainz/supporter/views.py:127
+#: metabrainz/supporter/views.py:166
 msgid "You need to choose support tier before signing up!"
 msgstr "Heu de triar un nivell de suport abans de registrar-vos!"
 
-#: metabrainz/supporter/views.py:137
+#: metabrainz/supporter/views.py:176
 msgid "You need to choose existing tier before signing up!"
 msgstr "Heu de triar un nivell existent abans de registrar-vos!"
 
-#: metabrainz/supporter/views.py:164
+#: metabrainz/supporter/views.py:204
 msgid ""
 "Thanks for becoming a supporter! Your application will be reviewed soon. "
 "We will send you updates via email."
@@ -394,7 +485,7 @@ msgstr ""
 "Gràcies per començar a donar-nos suport! La vostra sol·licitud es "
 "revisarà aviat. Us enviarem actualitzacions per correu electrònic."
 
-#: metabrainz/supporter/views.py:187
+#: metabrainz/supporter/views.py:228
 msgid ""
 "Thanks for signing up! Your application will be reviewed soon. We will "
 "send you updates via email."
@@ -402,17 +493,17 @@ msgstr ""
 "Gràcies per registrar-vos! La vostra sol·licitud es revisarà aviat. Us "
 "enviarem actualitzacions per correu electrònic."
 
-#: metabrainz/supporter/views.py:248
+#: metabrainz/supporter/views.py:288
 msgid "Thanks for becoming a supporter!"
 msgstr "Gràcies per començar a donar-nos suport!"
 
-#: metabrainz/supporter/views.py:274
+#: metabrainz/supporter/views.py:312
 msgid "Thanks for signing up! Please check your inbox to complete verification."
 msgstr ""
 "Gràcies per registrar-vos! Comproveu la safata d'entrada del vostre "
 "correu electrònic per a completar la verificació."
 
-#: metabrainz/supporter/views.py:302
+#: metabrainz/supporter/views.py:340
 msgid "Can't generate new token unless account is active."
 msgstr "No es pot generar un testimoni nou si el compte no és actiu."
 
@@ -446,7 +537,7 @@ msgstr "Botiga"
 msgid "Policies"
 msgstr "Polítiques"
 
-#: metabrainz/templates/base.html:55 metabrainz/templates/index/gdpr.html:178
+#: metabrainz/templates/base.html:55
 #: metabrainz/templates/index/social-contract.html:3
 #: metabrainz/templates/index/social-contract.html:6
 #: metabrainz/templates/navbar.html:34
@@ -456,14 +547,15 @@ msgstr "Contracte social"
 #: metabrainz/templates/base.html:56
 #: metabrainz/templates/index/code-of-conduct.html:3
 #: metabrainz/templates/index/code-of-conduct.html:16
-#: metabrainz/templates/index/gdpr.html:181 metabrainz/templates/navbar.html:35
+#: metabrainz/templates/navbar.html:35
 msgid "Code of Conduct"
 msgstr "Codi de conducta"
 
+#: frontend/js/src/PrivacySummary.tsx:11
 #: frontend/js/src/forms/ConditionsModal.tsx:21
-#: metabrainz/templates/base.html:57 metabrainz/templates/index/gdpr.html:184
-#: metabrainz/templates/index/privacy.html:6
+#: metabrainz/templates/base.html:57 metabrainz/templates/index/privacy.html:6
 #: metabrainz/templates/navbar.html:36
+#: metabrainz/templates/users/privacy-summary.html:3
 msgid "Privacy Policy"
 msgstr "Política de privadesa"
 
@@ -496,10 +588,7 @@ msgstr "Patrocinadors"
 msgid "Supporters"
 msgstr "Suport"
 
-#: frontend/js/src/forms/LoginUser.tsx:103
-#: frontend/js/src/forms/SignupCommercial.tsx:574
-#: frontend/js/src/forms/SignupNonCommercial.tsx:339
-#: frontend/js/src/forms/SignupUser.tsx:232 metabrainz/templates/base.html:73
+#: frontend/js/src/forms/LoginUser.tsx:103 metabrainz/templates/base.html:73
 #: metabrainz/templates/navbar.html:66 metabrainz/templates/users/login.html:3
 msgid "Sign in"
 msgstr "Inicia la sessió"
@@ -521,26 +610,26 @@ msgid "Contact us"
 msgstr "Contacte"
 
 #: metabrainz/templates/base.html:85
-#: metabrainz/templates/index/contact.html:105
+#: metabrainz/templates/index/contact.html:106
 msgid "Blog"
 msgstr "Blog"
 
-#: metabrainz/templates/base.html:86 metabrainz/templates/index/contact.html:90
+#: metabrainz/templates/base.html:86 metabrainz/templates/index/contact.html:91
 msgid "Chat"
 msgstr "Xat"
 
 #: metabrainz/templates/base.html:87
-#: metabrainz/templates/index/contact.html:106
+#: metabrainz/templates/index/contact.html:107
 msgid "Mastodon"
 msgstr "Mastodon"
 
 #: metabrainz/templates/base.html:88
-#: metabrainz/templates/index/contact.html:107
+#: metabrainz/templates/index/contact.html:108
 msgid "Bluesky"
 msgstr "Bluesky"
 
 #: metabrainz/templates/base.html:89
-#: metabrainz/templates/index/contact.html:108
+#: metabrainz/templates/index/contact.html:109
 msgid "Instagram"
 msgstr "Instagram"
 
@@ -596,15 +685,14 @@ msgstr "Informes financers"
 msgid "Donate"
 msgstr "Fes una donació"
 
-#: frontend/js/src/forms/LoginUser.tsx:110
-#: frontend/js/src/forms/SignupCommercial.tsx:175
-#: frontend/js/src/forms/SignupCommercial.tsx:555
+#: frontend/js/src/forms/SignupCommercial.tsx:180
+#: frontend/js/src/forms/SignupCommercial.tsx:559
 #: frontend/js/src/forms/SignupNonCommercial.tsx:106
 #: frontend/js/src/forms/SignupNonCommercial.tsx:319
 #: metabrainz/templates/navbar.html:65
-#: metabrainz/templates/supporters/account-type.html:51
-#: metabrainz/templates/supporters/account-type.html:93
-#: metabrainz/templates/supporters/account-type.html:144
+#: metabrainz/templates/supporters/account-type.html:47
+#: metabrainz/templates/supporters/account-type.html:84
+#: metabrainz/templates/supporters/account-type.html:130
 #: metabrainz/templates/users/signup.html:3
 msgid "Sign up"
 msgstr ""
@@ -928,8 +1016,430 @@ msgstr ""
 msgid "Introduction"
 msgstr ""
 
-#: metabrainz/templates/index/conflict-policy.html:55
+#: metabrainz/templates/index/conflict-policy.html:17
+msgid ""
+"Conflicts between people arise in open source projects constantly and the"
+" projects by the \n"
+"    MetaBrainz Foundation are no different. This policy aims to establish"
+" a clear and unambiguous \n"
+"    policy for reporting and addressing conflicts in our community. In "
+"this policy we aim to \n"
+"    establish a fair practice that balances the need for confidentiality "
+"and our desire for \n"
+"    transparency in our operations."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:25
+#, python-format
+msgid ""
+"Before you continue to read this policy, we encourage you to review our "
+"existing community policies \n"
+"    including our <a href=\"%(social_contract_url)s\">Social "
+"Contract</a>, \n"
+"    <a href=\"%(code_of_conduct_url)s\">the Code of Conduct</a>, \n"
+"    and our <a href=\"%(privacy_policy_url)s\">Privacy Policy</a>. These "
+"policies establish the norms and rules for \n"
+"    participation in our projects; these policies apply equally to the "
+"contractors of the MetaBrainz \n"
+"    Foundation and any participants in our projects."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:37
+msgid ""
+"This policy divides conflicts into two categories: Private and public. "
+"Private conflicts are conflicts \n"
+"    that involve *confidential* information regarding contributors, "
+"contractors or supporters. Otherwise, any conflicts \n"
+"    that do not involve confidential information are considered to be "
+"public conflicts. For instance, a \n"
+"    conflict between a contractor and the Executive Director (aka BDFL) "
+"that involves contractor pay is \n"
+"    considered a private conflict because pay rates are confidential "
+"information. A public conflict in edit \n"
+"    notes between two editors in our community does not involve "
+"confidential information and therefore should \n"
+"    be considered a public conflict."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:47
+msgid ""
+"When conflicts arise we aim to disclose as much information as possible "
+"about the conflict in a timely \n"
+"    fashion. When conflicts contain confidential matters we will aim to "
+"disclose as much information as \n"
+"    possible, while fully respecting the confidentiality of the people "
+"involved in the conflict. With any \n"
+"    private conflict we will aim to extract the relevant lessons for the "
+"team and community in an effort to \n"
+"    evolve our policies to prevent future conflicts. Should the involved "
+"parties disagree whether a conflict \n"
+"    is private or public, the question about the nature of the conflict "
+"will be presented for the next higher \n"
+"    level in the chain of command to decide. (e.g. if a community member "
+"and the community manager disagree on \n"
+"    a conflict being public or private, the Executive Director shall "
+"decide if the conflict is public or private)."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:58
 msgid "Reporting and Response"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:61
+msgid ""
+"We aim to not have conflict in our community, but we recognize that in "
+"reality conflicts will arise and we \n"
+"    must be prepared to address them in a fair manner. When conflicts "
+"arise, we prefer to have community or team \n"
+"    members resolve the conflicts among themselves, using our existing "
+"policies as guidelines for resolving the \n"
+"    conflict."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:69
+msgid ""
+"If you do not feel comfortable resolving a conflict on your own, you "
+"should feel free to report the conflict to \n"
+"    us. How you address the conflict depends on who is involved in the "
+"conflict and your comfort level. Please see \n"
+"    the detailed sections below on how and with whom to address your "
+"conflict. We aim to address conflicts as soon \n"
+"    as possible in an effort to prevent them from escalating "
+"unnecessarily."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:75
+msgid "Direct conflict resolution"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:78
+msgid ""
+"In direct conflict resolution, the involved parties will attempt to "
+"resolve the conflict themselves without \n"
+"   involving any MetaBrainz Foundation team member. You should aim to use"
+" direct resolution when the conflict does \n"
+"   not involve the violation of one of our policies or if the conflict is"
+" minor."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:84
+#, python-format
+msgid ""
+"For instance, if a user uses a rude tone, is disruptive or flagrantly "
+"ignores our project guidelines, we suggest \n"
+"    that you use direct conflict resolution to resolve the conflict. Some"
+" resources that might give you some suggestions \n"
+"    on how to go about resolving the conflict might be this <a "
+"href=\"%(conflict_resolution_primer_url)s\">\n"
+"    conflict resolution primer</a> and <a "
+"href=\"%(difficult_conversations_url)s\">how to\n"
+"    have difficult conversations at work</a>."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:93
+msgid "Informal reporting"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:96
+msgid ""
+"You may use informal reporting of a conflict if you aim to communicate a "
+"concern or incident without \n"
+"    seeking a corrective outcome. Informal reporting may also be an "
+"option if you have not been personally \n"
+"    victimized, but you’ve witnessed a violation of our policies or where"
+" you wish to maintain confidentiality \n"
+"    throughout the entire reporting process."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:103
+msgid ""
+"For editing in MusicBrainz you may informally report a user using the "
+"“Report this user for bad behavior” \n"
+"    link from the user’s profile. For reporting bad user behavior in "
+"other of our projects, please report them to our \n"
+"    community manager by mailing <span class=\"backemail\">gro.zniarbatem"
+"@reganam-ytinummoc</span> . For conflicts \n"
+"    that involve the community manager, report them by mailing <span "
+"class=\"backemail\">gro.zniarbatem@de</span> ."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:110
+msgid ""
+"Depending the the severity of the issue, repeated informal complaints may"
+" eventually require a formal response \n"
+"    from the MetaBrainz team. If an involved party requires anonymity, "
+"the conflict becomes a private conflict. If at \n"
+"    all possible minor issues should be resolved in a public forum in "
+"order for all people to witness and learn from \n"
+"    the issue at hand."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:116
+msgid "Formal complaint process"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:119
+msgid ""
+"All complaints about conflicts should be submitted via email. To whom a "
+"complaint should be mailed and who will \n"
+"    carry out the investigation will be described in the next section."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:124
+msgid "All complaint submissions to the Foundation should include the following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:128
+msgid ""
+"Contact info, if it is different than the email used to submit the "
+"conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:129
+msgid "Who was involved in the conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:130
+msgid "Where and when the incident happened"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:131
+msgid ""
+"A description of what happened -- ideally with links (e.g. chatlogs, edit"
+" notes) that outlines what \n"
+"         happened so that the persons evaluating the conflict may "
+"understand the issue at hand"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:133
+msgid ""
+"Any related pieces of information that provide more context on the "
+"conflict (e.g. links, screenshots)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:134
+msgid "An indication if this conflict is ongoing or not"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:139
+msgid "The investigation that follows aims to determine:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:143
+msgid "The nature and severity of the incident"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:144
+msgid ""
+"Whether or not the incident is considered a violation of MetaBrainz’ "
+"conduct policies or core values"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:145
+msgid ""
+"The amount of harm experienced by the person who submitted the complaint "
+"and the broader MetaBrainz community \n"
+"         as a result of the incident"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:147
+msgid ""
+"Whether there have been prior complaints against the individual or "
+"individuals reported"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:148
+msgid "Whether the incident is ongoing"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:152
+msgid ""
+"The following potential forms of resolution may apply to any team members"
+" involved in the conflict:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:155
+#: metabrainz/templates/index/conflict-policy.html:168
+msgid "Nothing (if it has been found no violation occurred)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:156
+msgid "Creating a plan to improve the performance"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:157
+msgid "Creating a negative performance evaluation"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:158
+msgid "Mediation, an intervention by a third party to resolve the conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:159
+msgid "Suspension or forced leave"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:160
+msgid "Termination of contract"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:164
+msgid ""
+"The following potential forms of resolution may apply to non team members"
+" involved in the conflict:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:169
+msgid "A reprimand, either public or private"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:170
+msgid "Suspension of the users’ account"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:171
+msgid "Deletion of the users’ account"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:172
+msgid ""
+"Removal of user privileges (e.g. if an auto editor commits a serious "
+"offence, they may lose their auto editor status)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:175
+msgid "Filing a complaint"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:178
+msgid ""
+"NOTE: For complaints not about MetaBrainz staff, please see the "
+"<em>Informal reporting</em> section above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:182
+msgid ""
+"If the complaint does not involve the Executive Director (ED), do the "
+"following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:186
+msgid ""
+"If team member has directly violated conduct policies or engaged in "
+"otherwise harmful behavior, a formal complaint should be filed."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:187
+msgid ""
+"Mail <span class=\"backemail\">gro.zniarbatem@de</span> and include the "
+"complaint information outlined above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:188
+msgid ""
+"You should expect a response within a working day acknowledging the "
+"complaint."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:189
+msgid ""
+"The complaint will be investigated by the ED, member(s) of the board of "
+"directors or a neutral third party."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:190
+msgid ""
+"Once the investigation has been completed, the ED, with the support of "
+"others involved in the investigation will respond. The \n"
+"        ED will respond to incidents no later than 7 working days after a"
+" complaint has been filed with either a resolution or an \n"
+"        explanation of why the process must be extended."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:196
+msgid "If a complaint involves the Executive Director, do the following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:200
+msgid ""
+"If the Executive Director has directly violated conduct policies or "
+"engaged in otherwise harmful behavior, \n"
+"        a formal complaint should be filed with the board of directors."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:202
+msgid ""
+"Mail <span class=\"backemail\">gro.zniarbatem@noituloser-tcilfnoc</span> "
+"and include the complaint information outlined above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:203
+msgid ""
+"You should get a response within 5 working days acknowledging the "
+"complaint."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:204
+msgid ""
+"The complaint will be investigated by the member(s) of the board of "
+"directors, the community manager, a neutral \n"
+"        third party or a combination thereof."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:206
+msgid ""
+"Once the investigation has been completed, the board, with the support of"
+" others involved in the investigation \n"
+"        will respond. The board will aim to respond to incidents no later"
+" than 15 working days after a complaint has been filed \n"
+"        with either a resolution or an explanation of why the process "
+"must be extended."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:211
+msgid "Confidentiality"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:214
+msgid ""
+"Confidentiality is an important aspect of conflict resolution and all of "
+"the conflicts brought to the attention of the foundation \n"
+"    will be evaluated with confidentiality in mind and acted upon "
+"accordingly."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:219
+msgid ""
+"We work hard to make all of the actions of the foundation as transparent "
+"and open as possible. In cases where we cannot \n"
+"    disclose all aspects of a conflict we will disclose that a conflict "
+"is or has occurred and we will attempt to disclose the \n"
+"    appropriate amount of information about the conflict while balancing "
+"the need for confidentiality and our desire to learn \n"
+"    from conflicts so that we as a foundation and community can learn "
+"from these conflicts and improve our policies to avoid the \n"
+"    conflicts in the future."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:227
+msgid ""
+"Any breaches of confidentiality will be treated as severe breaches of our"
+" conduct policies."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:230
+msgid "Retaliation"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:233
+msgid ""
+"We will not allow retaliation for any contractor or volunteer that files "
+"a complaint or is involved in an investigation. If you \n"
+"    believe that you are being treated negatively because of your "
+"involvement in a complaint please report this complaint directly \n"
+"    to the ED at <span class=\"backemail\">gro.zniarbatem@de</span> or "
+"the board at \n"
+"    <span class=\"backemail\">gro.zniarbatem@noituloser-tcilfnoc</span>."
 msgstr ""
 
 #: metabrainz/templates/index/contact.html:3
@@ -1010,7 +1520,7 @@ msgstr ""
 msgid ""
 "We are currently evaluating our overall online advertising strategy. We "
 "are evaluating advertising, traffic optimization,\n"
-"    search engine optimization and software monitization technologies. If"
+"    search engine optimization and software monetization technologies. If"
 " you provide these professional services, please provide a detailed\n"
 "    deck of your comprehensive services to the following email address. "
 "<em>Please respect our other non-media teams and do not contact us \n"
@@ -1085,11 +1595,11 @@ msgstr ""
 #, python-format
 msgid ""
 "Please come ask your questions at our <a "
-"href=\"%(forums_url)s\">forums</a>! We would love to\n"
-"    answer any questions you may have."
+"href=\"%(forums_url)s\">forums</a>!\n"
+"    The community and the team will be more than happy to help you."
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:92
+#: metabrainz/templates/index/contact.html:93
 #, python-format
 msgid ""
 "The MetaBrainz/MusicBrainz/ListenBrainz team and community hang out\n"
@@ -1099,15 +1609,15 @@ msgid ""
 "    <a href=\"%(chatlogs_url)s\">chat log archives</a>."
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:101
+#: metabrainz/templates/index/contact.html:102
 msgid "Social media"
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:103
+#: metabrainz/templates/index/contact.html:104
 msgid "You can follow us on these social channels:"
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:112
+#: metabrainz/templates/index/contact.html:113
 msgid "Mailing address"
 msgstr ""
 
@@ -1120,33 +1630,349 @@ msgstr ""
 msgid "GDPR Compliance Statement"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:37
+#: metabrainz/templates/index/gdpr.html:10
+msgid ""
+"The General Data Protection Regulation is a complex EU regulation that "
+"stipulates many points for protecting private data of\n"
+"    users on the Internet. Even though this is an EU regulation, it has a"
+" worldwide impact due to the nature of the Internet.\n"
+"    The MetaBrainz Foundation with its collection of projects is also "
+"affected by this regulation. We’ve been learning and adapting\n"
+"    our sites to be compliant with the GDPR – sadly this regulation isn’t"
+" entirely black and white and there is an incredible\n"
+"    amount of room left for interpretation of these rules."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:17
+msgid ""
+"The good news is that this regulation is roughly in line with our "
+"established practices: We’ve always held private information\n"
+"    in a high regard and applied the sort of rules to ourselves as we "
+"wish to have our own private data treated. Luckily, this\n"
+"    makes our compliance effort considerably easier. We’ve made two "
+"significant changes to how we treat your data and also adopted\n"
+"    terminology as used in the GDPR in order to use the same languages "
+"that many other sites are now adopting. Please keep reading\n"
+"    to find out the exact details of what we are doing to comply."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:24
+#, python-format
+msgid ""
+"However, we do ask for your compassion and help in our process of "
+"complying with the GDPR. As we already mentioned, the GDPR is\n"
+"    a complex set of rules that are not fully clarified yet. We’ve taken "
+"action on the steps that are clear to us and we’re following\n"
+"    ongoing conversations on points that are in gray zones or unclear to "
+"us. We’ve made our best initial effort on compliance and\n"
+"    promise to keep working on it as the picture becomes more clear. If "
+"you believe that we could improve our compliance, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a> and let us know what we "
+"can do to improve. It would also help us if you\n"
+"    could provide concrete discussion or examples to help us understand "
+"and take action on your suggestion."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:33
+msgid ""
+"Finally, below are the key sections of the GDPR as we understand them and"
+" how they affect your data in our ecosystem. Where\n"
+"    possible, we provide links for deeper understanding, links for you to"
+" examine our relevant code and links to tickets to follow\n"
+"    the process of improving our compliance."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:38
 msgid "Right to be forgotten"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:77
+#: metabrainz/templates/index/gdpr.html:41
+msgid ""
+"Summary: <i>Provide the user with the ability to remove their private "
+"data from our services</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:44
+msgid ""
+"The most important aspect of the right to be forgotten is the ability to "
+"delete your account. Once you request for us to delete\n"
+"    your account, we will remove any personally identifying information "
+"you may have provided us from your account (name, email\n"
+"    address, gender, biography, URL, etc.). The visible name on your "
+"account will be changed to “Deleted User #####” and effectively\n"
+"    the account will no longer be identifiable as your account."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:50
+msgid ""
+"However, given the nature of our projects where we work on collaborative "
+"databases, your contributions that are not personally\n"
+"    identifying are valuable assets to our database and these "
+"contributions will not be removed from our databases. But we will\n"
+"    ensure that these contributions no longer contain personally "
+"identifying data."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:55
+#, python-format
+msgid ""
+"Our process of automatically deleting your accounts across the MetaBrainz"
+" ecosystem is not complete yet (see below for a set of\n"
+"    tickets where you can track our progress). If you would like to "
+"delete your accounts in the MetaBrainz ecosystem or mark a\n"
+"    donation that is currently public as a private donation, please <a "
+"href=\"%(contact_url)s\">contact us</a>\n"
+"    and we will address your request as soon as possible."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:62
+#: metabrainz/templates/index/gdpr.html:182
+msgid "Links:"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:66
+#, python-format
+msgid ""
+"<a href=\"%(editor_deletion_doc_url)s\">How we delete accounts\n"
+"       in MusicBrainz</a> (warning, geek content ahead!)"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:70
+msgid ""
+"Implement sitewide user account deletion in\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/MBS-9680\">MusicBrainz</a>,"
+"\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/AB-337\">AcousticBrainz</a>,"
+"\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/BB-260\">BookBrainz</a>,\n"
+"         <a href=\"https://tickets.metabrainz.org/browse/MEB-103\">the "
+"MetaBrainz Site</a>,\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/LB-354\">ListenBrainz</a>, "
+"and\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/CB-307\">CritiqueBrainz</a>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:80
 msgid "Restriction of processing"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:110
+#: metabrainz/templates/index/gdpr.html:83
+msgid ""
+"Summary: <i>To allow the user to control how their personally identifying"
+" data is being used.</i>"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:86
+msgid ""
+"Except for the ListenBrainz and AcousticBrainz projects, we do not "
+"process personally identifying data. Any personally\n"
+"    identifying data that our projects store is for the purpose of being "
+"able to contact you about your contributions to our database\n"
+"    (email address) or for voluntarily showing information about you to "
+"other users (biography, homepage, location, etc)."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:91
+#, python-format
+msgid ""
+"The ListenBrainz project differs in that the Listens (metadata about what"
+" music you have listened to) are stored on our servers\n"
+"    and <a href=\"%(listenbrainz_data_url)s\">made available to the "
+"public</a>. We believe Listens to be personally identifying\n"
+"    data and furthermore, we have goals of creating open source "
+"recommendation engines with this data, which involves processing the\n"
+"    user’s data. These two points are fundamental goals of the "
+"ListenBrainz project and we do not see a reasonable way to reach another"
+"\n"
+"    compromise position."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:99
+msgid ""
+"Because of this, we are going to require users to either acknowledge that"
+" we may process their Listen data or alternatively to\n"
+"    delete their account, including all of their Listens. Please note "
+"that if you decide to delete your ListenBrainz account, it may\n"
+"    take up to two weeks for all of your listens to no longer be included"
+" in our efforts to build a recommendation engine."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:104
+msgid ""
+"We have always made it clear that the data in ListenBrainz was to be "
+"public and that we plan to build new tools with your data, so\n"
+"    this should not come as a surprise to our users."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:108
+msgid ""
+"The AcousticBrainz project does not track who submits data to the "
+"database. If you create an account and use our data creation\n"
+"    tools (e.g. create a dataset or participate in a challenge) then we "
+"link your participation and the things that you create to\n"
+"    your account. If you choose to delete your account then we keep the "
+"non personally identifying data that you create, but anonymize\n"
+"    it so that it cannot be linked back to you."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:114
 msgid "Right to data portability / exporting your data"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:150
+#: metabrainz/templates/index/gdpr.html:117
+msgid ""
+"Summary: <i>You have the right to access/download the data we store about"
+" you</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:120
+msgid ""
+"Except for the ListenBrainz and AcousticBrainz projects, we do not store "
+"personally identifying data beyond the\n"
+"    information that is available in your public profile on each of our "
+"projects. Since this data is plainly available in your\n"
+"    profile we do not provide a means for you to export this data."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:125
+msgid "There are the following exceptions to this:"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:129
+msgid ""
+"<b>IP addresses</b>: If you visit one of our sites the IP address of your"
+" computer is stored in our web logs for 7 days\n"
+"        before our servers automatically delete them. This data is almost"
+" never used by anyone: the only time we look at the\n"
+"        IP addresses is if our sites are adversely impacted by the "
+"actions of some unknown users. In that case, we may investigate\n"
+"        the logs to identify the IP address that needs to be blocked in "
+"order to restore the stability of our service.\n"
+"        This data is not available to anyone but the contractors of the "
+"MetaBrainz Foundation and is not available to download\n"
+"        to anyone at all."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:137
+#, python-format
+msgid ""
+"<b>ListenBrainz Listen data</b>: Users may <a "
+"href=\"%(listenbrainz_export_url)s\">export their ListenBrainz Listen\n"
+"        data</a> directly from the site. The user Listen data is also "
+"included in the <a href=\"%(listenbrainz_data_url)s\">ListenBrainz\n"
+"        data dumps</a> that are available for public download."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:146
+msgid ""
+"All of the non personally identifying data, such as your metadata "
+"contributions, are publicly visible, available for download\n"
+"    and available via the project APIs. For details about this data, "
+"downloads and APIs please check the documentation for the\n"
+"    respective projects you are interested in."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:151
+#, python-format
+msgid ""
+"Anyone wishing to get a list of financial donations they have made to the"
+" MetaBrainz Foundation, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a> and provide your "
+"MusicBrainz editor name so that we can look up\n"
+"    your donations."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:157
 msgid "Right to rectification"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:165
+#: metabrainz/templates/index/gdpr.html:160
+msgid "Summary: <i>You have the right to correct your data</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:163
+msgid ""
+"All of our projects allow their users to update their personally "
+"identifying information in their profiles. Furthermore, most\n"
+"    of our projects allow the editing of their own metadata "
+"contributions. If you find that some of your data is incorrect, please\n"
+"    feel free to edit the data since we provide the tools to do so."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:168
+#, python-format
+msgid ""
+"If anyone who has made a financial donation to the MetaBrainz Foundation "
+"would like to make their donation private, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:173
 msgid "Right to be informed"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:188
+#: metabrainz/templates/index/gdpr.html:175
+msgid ""
+"Summary: <i>You have the right to be informed about how we use your data "
+"in plain English</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:178
+msgid ""
+"Our privacy policy, as well as other policies, have always been written "
+"by humans for human consumption. We abhor legalese and\n"
+"    not speaking in direct terms."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:186
+msgid "Social contract"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:189
+msgid "Code of conduct"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:192
+msgid "Privacy policy"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:196
 msgid "Right to access"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:198
-#: metabrainz/templates/index/privacy.html:166
+#: metabrainz/templates/index/gdpr.html:199
+msgid ""
+"Summary: <i>You have the right to access the data that we collect about "
+"you</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:202
+msgid ""
+"All of our projects make all of the data we collect on your behalf, "
+"privately identifying or not, available to you. The\n"
+"    only exception to this are the IP addresses we store for 7 days – see"
+" above for details."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:206
+#: metabrainz/templates/index/privacy.html:168
 msgid "Privacy/GDPR Representative"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:209
+#, python-format
+msgid ""
+"If you have any questions about our privacy policy, please <a "
+"href=\"%(contact_url)s\">contact us</a>. To report\n"
+"   any privacy problems, violations or leaks, our GDPR representative is "
+"our Interim Executive Director Nicolás Tamargo and for\n"
+"   privacy issues contact him at <strong><a "
+"href=\"mailto:gdpr@metabrainz.org\">gdpr@metabrainz.org</a></strong>."
 msgstr ""
 
 #: metabrainz/templates/index/index.html:6
@@ -1251,13 +2077,51 @@ msgid ""
 "      <a href=\"%(about_url)s\">about</a> page."
 msgstr ""
 
-#: frontend/js/src/forms/ConditionsModal.tsx:43
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:32
 #: metabrainz/templates/index/privacy.html:3
 msgid "Privacy"
 msgstr ""
 
 #: metabrainz/templates/index/privacy.html:8
 msgid "Summary"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:12
+msgid ""
+"You do not have to provide any personal data to be able to browse the "
+"contents of the databases published by MetaBrainz."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:15
+msgid ""
+"You do not have to provide any personally-identifying information if you "
+"choose not to."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:18
+msgid ""
+"We will never reveal your email address on MetaBrainz controlled web "
+"sites."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:22
+msgid ""
+"In order to get maximum value out of the MetaBrainz projects, you may "
+"want to create an account and log in. \n"
+"    Doing so grants you the ability to: edit the databases, contribute "
+"your own data, communicate with other users, and keep track \n"
+"    of recently released music from artists in your MusicBrainz "
+"collection. If you choose to create an account then the minimum we \n"
+"    ask is that you: choose a unique username and password, use a web "
+"browser that accepts \"session\" cookies, and provide a verified \n"
+"    email address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:29
+msgid ""
+"If you do not create an account (or are not logged in) you will not have "
+"access to the above listed features, however, you will \n"
+"    still have full access to browse and examine the databases."
 msgstr ""
 
 #: metabrainz/templates/index/privacy.html:33
@@ -1268,39 +2132,197 @@ msgstr ""
 msgid "Cookies"
 msgstr ""
 
+#: metabrainz/templates/index/privacy.html:37
+msgid "We use two cookies that contain sensitive information:"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:42
+msgid ""
+"<b>remember_login</b>: If you choose the \"Log in permanently\" option "
+"when logging in to one of our sites; the cookie will be used to \n"
+"      remember your login details."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:46
+msgid ""
+"<b>musicbrainz_server_session, session, or connect.sid</b>: If you are "
+"logged into one of our sites, your current session ID is stored in this "
+"cookie."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:51
+msgid ""
+"We may store dynamic preference information in other cookies, but these "
+"do not contain any sensitive information."
+msgstr ""
+
 #: metabrainz/templates/index/privacy.html:54
 msgid "Web and FTP access logs"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:57
+msgid ""
+"In a practice similar to other web sites (and APIs) we keep logs of all "
+"web requests made against our servers. These logs include: your IP\n"
+"    address, your browser's (or API client's) \"User-Agent\" string, and "
+"which page (or API endpoint) you requested with which parameters. "
+"Aggregate information about web and FTP traffic is\n"
+"    made available to the public via our site usage pages."
 msgstr ""
 
 #: metabrainz/templates/index/privacy.html:62
 msgid "Third-Party content"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:92
+#: metabrainz/templates/index/privacy.html:64
+msgid ""
+"Our projects' web pages may load some third-party content. Some, but "
+"possibly not all sites are listed below:"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:69
+#, python-format
+msgid ""
+"Cover art and other images: These are provided by the various cover art "
+"sites that have given MusicBrainz permission to do so and our own \n"
+"      <a href=\"%(caa_url)s\">Cover Art Archive</a>. This means that the "
+"relevant site will know (if they want to) your IP \n"
+"      address, User-Agent string, etc., and which MusicBrainz web page "
+"you were visiting (the one which included the cover art image)."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:75
+msgid ""
+"AcoustID: Our fingerprints tab loads fingerprint information from "
+"acoustid.org."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:78
+msgid ""
+"MTCaptcha: Our account creation page loads third party content in order "
+"to prevent spammers from creating accounts."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:83
+msgid ""
+"<i>The above information assumes that you are using \"normal\" web "
+"browser settings, whereby images are always loaded and HTTP referrer \n"
+"    information is always sent.</i>"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:88
+msgid ""
+"It is impractical to constantly modify this privacy policy when "
+"MetaBrainz projects change which third party content they utilize. We "
+"will \n"
+"    aim to use common sense, respect to our community and community "
+"review when adding more content from third party sites. We will also \n"
+"    periodically review our policy to ensure that it remains current."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:93
 msgid "Applicable to account holders"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:94
+#: metabrainz/templates/index/privacy.html:95
 msgid "Account creation"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:108
+#: metabrainz/templates/index/privacy.html:97
+msgid ""
+"When creating an account with a MetaBrainz project you need to pick a "
+"unique username and choose a password, the username you pick is the \n"
+"    only name associated with your account and will be what other "
+"MetaBrainz users know you as. You may optionally also tell us other \n"
+"    information about yourself that will be displayed to other MetaBrainz"
+" users and the public."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:103
+msgid ""
+"Additionally, in order to edit the databases you will need to provide a "
+"confirmed email address. This email address will be held in \n"
+"    confidence, the only method of revealing your email address to "
+"another user is if you choose to send a message to another \n"
+"    user and enable the option to \"reveal my email address\". Changing "
+"the email address stored with your account will require you to \n"
+"    verify the new address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:109
 msgid "Edits and Notes"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:114
+#: metabrainz/templates/index/privacy.html:111
+msgid ""
+"If you make any changes to a MetaBrainz project database, such as adding "
+"any data, the details of those changes will be visible to \n"
+"    other logged-in users and the change will be associated with your "
+"username."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:115
 msgid "Subscriptions on MusicBrainz"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:131
+#: metabrainz/templates/index/privacy.html:117
+msgid ""
+"As a logged-in user you can subscribe to one or more artists, labels, "
+"collections or other editors. The act of subscribing causes \n"
+"    any edits made to (or by in the case of another editor) those "
+"entities to be emailed to you. By default, other users can see your \n"
+"    list of subscriptions, however, you can opt out of this by editing "
+"the appropriate preference."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:123
+msgid ""
+"This does not provide \"perfect\" privacy though, in some cases it will "
+"be possible to infer information about the contents of your \n"
+"    subscription list even though you have disallowed others from viewing"
+" that list directly. This imperfection arises because various \n"
+"    parts of the system behave differently depending on whether or not an"
+" entity has any subscribers; also, the number of users \n"
+"    subscribed to each artist is available via the artist pages. In the "
+"most extreme (possibly contrived) example, imagine that all \n"
+"    users have their subscriptions set to \"public\", except for exactly "
+"one user whose list is \"private\". In that case, any discrepancy \n"
+"    for a given artist between the shown list of subscribers and the "
+"total number of subscribers must be down to that one user. Thus, \n"
+"    you can infer what artists are on that user's list."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:132
 msgid "Third-party sites"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:145
-msgid "MetaBrainz donors"
+#: metabrainz/templates/index/privacy.html:134
+#, python-format
+msgid ""
+"Our code reviews are done on GitHub, which is not under the control of "
+"MetaBrainz. Participating in code reviews or other\n"
+"    tasks carried out on GitHub are subject to <a "
+"href=\"%(github_url)s\">GitHub's privacy policy</a>."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:140
+#, python-format
+msgid ""
+"Our translations platform is provided and hosted by Weblate, which has a "
+"data processing agreement with MetaBrainz.\n"
+"    Participating in translations is subject to <a "
+"href=\"%(weblate_url)s\">dedicated legal terms</a>.\n"
+"    Any translations you make will be submitted to our Git repositories "
+"and publicly associated with your username;\n"
+"    if you so choose, you can also publicly associate them with your own "
+"verified email address."
 msgstr ""
 
 #: metabrainz/templates/index/privacy.html:147
+msgid "MetaBrainz donors"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:149
 msgid ""
 "When you make a donation to the MetaBrainz Foundation, we are legally\n"
 "    required to collect your personal information and keep it in our "
@@ -1310,7 +2332,7 @@ msgid ""
 "    information to anyone else, ever."
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:153
+#: metabrainz/templates/index/privacy.html:155
 msgid ""
 "We believe in transparent finances, which means that we list all "
 "donations\n"
@@ -1320,11 +2342,34 @@ msgid ""
 "process."
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:158
+#: metabrainz/templates/index/privacy.html:160
 msgid "Exceptions"
 msgstr "Excepcions"
 
-#: frontend/js/src/Profile.tsx:598
+#: metabrainz/templates/index/privacy.html:162
+msgid ""
+"<i><b>Please note</b>: Reasonable exceptions may apply to the above "
+"policy, for example to comply with applicable laws.\n"
+"    Also, members of the MetaBrainz team and other personnel contracted "
+"to provide services to MetaBrainz may have access to\n"
+"    our infrastructure and could therefore view any information contained"
+" therein. However all personnel are contractually bound\n"
+"    by non-disclosure clauses which prevent them from making any such "
+"information available to others."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:171
+#, python-format
+msgid ""
+"If you have any questions about our GDPR statement, please <a "
+"href=\"%(contact_url)s\">contact us</a>. To report\n"
+"   any privacy problems, violations or leaks, our GDPR representative is "
+"our Interim Executive Director Nicolás Tamargo and for\n"
+"   privacy issues contact him at <strong><a "
+"href=\"mailto:gdpr@metabrainz.org\">gdpr@metabrainz.org</a></strong>."
+msgstr ""
+
+#: frontend/js/src/Profile.tsx:603
 #: frontend/js/src/forms/ProfileChangePassword.tsx:22
 #: frontend/js/src/forms/ProfileChangePassword.tsx:111
 #: metabrainz/templates/index/profile-change-password.html:3
@@ -1355,9 +2400,10 @@ msgid ""
 "source music encyclopedia that\n"
 "            collects music metadata and makes it available to the public."
 msgstr ""
-"<a href=\"%(mb_url)s\">MusicBrainz</a> és una enciclopèdia musical lliure "
-"mantinguda per la comunitat que\n"
-"            recopila metadades musicals i les posa a disposició del públic."
+"<a href=\"%(mb_url)s\">MusicBrainz</a> és una enciclopèdia musical lliure"
+" mantinguda per la comunitat que\n"
+"            recopila metadades musicals i les posa a disposició del "
+"públic."
 
 #: metabrainz/templates/index/projects.html:32
 msgid "MusicBrainz Picard"
@@ -1404,8 +2450,8 @@ msgid ""
 "            providing a platform created for the sole purpose of Creative"
 " Commons licensed reviews."
 msgstr ""
-"<a href=\"%(cb_url)s\">CritiqueBrainz</a> omple el buit entre els crítics de "
-"música i llibres i les dades sense processar\n"
+"<a href=\"%(cb_url)s\">CritiqueBrainz</a> omple el buit entre els crítics"
+" de música i llibres i les dades sense processar\n"
 "            proporcionant una plataforma creada únicament per a les "
 "ressenyes amb llicència Creative Commons."
 
@@ -1421,8 +2467,8 @@ msgid ""
 "            literature. Its aim is to collect and store data about every "
 "publication ever written."
 msgstr ""
-"<a href=\"%(bb_url)s\">BookBrainz</a> és una enciclopèdia en línia que conté "
-"informació sobre la literatura\n"
+"<a href=\"%(bb_url)s\">BookBrainz</a> és una enciclopèdia en línia que "
+"conté informació sobre la literatura\n"
 "            publicada. Té com a objectiu recopilar i emmagatzemar dades "
 "sobre totes les publicacions escrites."
 
@@ -1438,10 +2484,11 @@ msgid ""
 "            their listen history. One of the goals is for this data to be"
 " used for building open music recommendation systems."
 msgstr ""
-"<a href=\"%(lb_url)s\">ListenBrainz</a> és un lloc web musical lliure que "
-"permet als usuaris importar\n"
+"<a href=\"%(lb_url)s\">ListenBrainz</a> és un lloc web musical lliure que"
+" permet als usuaris importar\n"
 "            el seu historial de reproduccions. Un dels objectius és fer "
-"servir aquestes dades per a crear sistemes de recomanació musical lliures."
+"servir aquestes dades per a crear sistemes de recomanació musical "
+"lliures."
 
 #: metabrainz/templates/index/projects.html:104
 msgid "Past Projects"
@@ -1464,10 +2511,10 @@ msgid ""
 msgstr ""
 "<a href=\"%(ab_url)s\">AcousticBrainz</a> va recopilar col·lectivament "
 "informació acústica de tota\n"
-"            la músicadel món i la va posar a disposició del públic. Va ser "
-"un projecte conjunt amb el\n"
-"            <a href=\"%(mtg_url)s\">Grup de Tecnologia Musical</a> de la <a "
-"href=\"%(upf_url)s\">Universitat Pompeu Fabra</a>\n"
+"            la músicadel món i la va posar a disposició del públic. Va "
+"ser un projecte conjunt amb el\n"
+"            <a href=\"%(mtg_url)s\">Grup de Tecnologia Musical</a> de la "
+"<a href=\"%(upf_url)s\">Universitat Pompeu Fabra</a>\n"
 "            de Barcelona."
 
 #: metabrainz/templates/index/projects.html:132
@@ -1483,8 +2530,8 @@ msgid ""
 "used for AcousticBrainz and is still being\n"
 "            used in ListenBrainz."
 msgstr ""
-"<a href=\"%(messybrainz_url)s\">MessyBrainz</a> identifica metadades sense "
-"netejar i, quan és possible,\n"
+"<a href=\"%(messybrainz_url)s\">MessyBrainz</a> identifica metadades "
+"sense netejar i, quan és possible,\n"
 "            les enllaça amb identificadors de MusicBrainz estables. "
 "MessyBrainz es feia servir per a AcousticBrainz\n"
 "            i encara es fa servir a ListenBrainz."
@@ -1571,8 +2618,8 @@ msgid ""
 "Thanks to everyone who has helped make the MetaBrainz Foundation what it "
 "is today!"
 msgstr ""
-"Gràcies a tothom qui ha ajudat a fer que MetaBrainz Foundation sigui el que "
-"és avui!"
+"Gràcies a tothom qui ha ajudat a fer que MetaBrainz Foundation sigui el "
+"que és avui!"
 
 #: metabrainz/templates/index/team.html:6
 msgid "The MetaBrainz Team"
@@ -1609,13 +2656,18 @@ msgstr ""
 msgid "He lives on in our hearts and in open source."
 msgstr "Viu en els nostres cors i en el codi lliure."
 
+#: metabrainz/templates/index/team.html:29
+#: metabrainz/templates/index/team.html:315
+msgid "you’re welcome to try"
+msgstr ""
+
 #: metabrainz/templates/index/team.html:39
 msgid ""
 "<span class=\"name\">Michael Wiencek</span> &mdash; Senior Software "
 "Engineer"
 msgstr ""
-"<span class=\"name\">Michael Wiencek</span> &mdash; Enginyer de programari "
-"sènior"
+"<span class=\"name\">Michael Wiencek</span> &mdash; Enginyer de "
+"programari sènior"
 
 #: metabrainz/templates/index/team.html:41
 msgid ""
@@ -1634,8 +2686,8 @@ msgid ""
 "<span class=\"name\">Nicolás Tamargo</span> &mdash; Style Leader/Customer"
 " Support/Community Manager/Software Engineer"
 msgstr ""
-"<span class=\"name\">Nicolás Tamargo</span> &mdash; Líder d'estil, atenció "
-"al client, gestor de la comunitat i enginyer de programari"
+"<span class=\"name\">Nicolás Tamargo</span> &mdash; Líder d'estil, "
+"atenció al client, gestor de la comunitat i enginyer de programari"
 
 #: metabrainz/templates/index/team.html:59
 #, python-format
@@ -1662,7 +2714,8 @@ msgstr "Originari d'Espanya, ara viu a Tartu, Estònia."
 #: metabrainz/templates/index/team.html:81
 msgid "<span class=\"name\">Laurent Monin</span> &mdash; System Administrator"
 msgstr ""
-"<span class=\"name\">Laurent Monin</span> &mdash; Administrador de sistemes"
+"<span class=\"name\">Laurent Monin</span> &mdash; Administrador de "
+"sistemes"
 
 #: metabrainz/templates/index/team.html:83
 msgid ""
@@ -1690,8 +2743,7 @@ msgstr ""
 
 #: metabrainz/templates/index/team.html:105
 msgid "<span class=\"name\">Yvan Rivierre</span> &mdash; Software Engineer"
-msgstr ""
-"<span class=\"name\">Yvan Rivierre</span> &mdash; Enginyer de programari"
+msgstr "<span class=\"name\">Yvan Rivierre</span> &mdash; Enginyer de programari"
 
 #: metabrainz/templates/index/team.html:107
 msgid ""
@@ -1708,8 +2760,8 @@ msgid ""
 "<span class=\"name\">Nicolas Pelletier</span> &mdash; BookBrainz Lead,  "
 "Software Engineer & Graphic Designer"
 msgstr ""
-"<span class=\"name\">Nicolas Pelletier</span> &mdash; Líder de BookBrainz, "
-"enginyer de programari i dissenyador gràfic"
+"<span class=\"name\">Nicolas Pelletier</span> &mdash; Líder de "
+"BookBrainz, enginyer de programari i dissenyador gràfic"
 
 #: metabrainz/templates/index/team.html:122
 msgid ""
@@ -1731,8 +2783,7 @@ msgstr ""
 msgid ""
 "Born in Canada and raised in France, Nicolas now lives in Barcelona, "
 "Spain."
-msgstr ""
-"Nascut al Canadà i criat a França, Nicolas ara viu a Barcelona, Espanya."
+msgstr "Nascut al Canadà i criat a França, Nicolas ara viu a Barcelona, Espanya."
 
 #: metabrainz/templates/index/team.html:146
 msgid ""
@@ -1755,8 +2806,7 @@ msgstr ""
 
 #: metabrainz/templates/index/team.html:166
 msgid "<span class=\"name\">Adam James</span> &mdash; System Administrator"
-msgstr ""
-"<span class=\"name\">Adam James</span> &mdash; Administrador de sistemes"
+msgstr "<span class=\"name\">Adam James</span> &mdash; Administrador de sistemes"
 
 #: metabrainz/templates/index/team.html:168
 msgid ""
@@ -1773,7 +2823,8 @@ msgstr ""
 #: metabrainz/templates/index/team.html:189
 msgid "<span class=\"name\">Julian Anderson</span> &mdash; System Administrator"
 msgstr ""
-"<span class=\"name\">Julian Anderson</span> &mdash; Administrador de sistemes"
+"<span class=\"name\">Julian Anderson</span> &mdash; Administrador de "
+"sistemes"
 
 #: metabrainz/templates/index/team.html:191
 msgid ""
@@ -1812,7 +2863,8 @@ msgstr ""
 #: metabrainz/templates/index/team.html:236
 msgid "<span class=\"name\">Ansh Goyal</span> &mdash; Junior Software Engineer"
 msgstr ""
-"<span class=\"name\">Ansh Goyal</span> &mdash; Enginyer de programari júnior"
+"<span class=\"name\">Ansh Goyal</span> &mdash; Enginyer de programari "
+"júnior"
 
 #: metabrainz/templates/index/team.html:238
 msgid ""
@@ -1855,8 +2907,8 @@ msgid ""
 "<span class=\"name\">Param Singh</span> &mdash; Former ListenBrainz team "
 "leader"
 msgstr ""
-"<span class=\"name\">Param Singh</span> &mdash; Antic líder de l'equip de "
-"ListenBrainz"
+"<span class=\"name\">Param Singh</span> &mdash; Antic líder de l'equip de"
+" ListenBrainz"
 
 #: metabrainz/templates/index/team.html:280
 msgid ""
@@ -1896,8 +2948,7 @@ msgstr ""
 
 #: metabrainz/templates/index/team.html:328
 msgid "<span class=\"name\">Akira Holm</span> &mdash; MusicBrainz Instruments"
-msgstr ""
-"<span class=\"name\">Akira Holm</span> &mdash; Instruments de MusicBrainz"
+msgstr "<span class=\"name\">Akira Holm</span> &mdash; Instruments de MusicBrainz"
 
 #: metabrainz/templates/index/team.html:330
 msgid ""
@@ -2050,7 +3101,8 @@ msgstr "Nom d'usuari de MusicBrainz"
 #: metabrainz/templates/payments/donate.html:82
 msgid "Email me about future fundraising events"
 msgstr ""
-"Envia'm correus electrònics sobre futurs esdeveniments de recollida de fons"
+"Envia'm correus electrònics sobre futurs esdeveniments de recollida de "
+"fons"
 
 #: metabrainz/templates/payments/donate.html:83
 msgid "This will be very seldom"
@@ -2126,8 +3178,10 @@ msgstr "Xec dels EUA"
 
 #: metabrainz/templates/payments/donate.html:146
 msgid ""
-"Due to the increased unreliability of the US Postal Service we have "
-"stopped accepting paper checks. Sorry!"
+"Due to the increased unreliability of the US Postal Service and the "
+"relatively large fees involved, we ask you to only send a paper check if "
+"it is the only possible option. Due to the fees, we will not cash checks "
+"for less than $25."
 msgstr ""
 
 #: metabrainz/templates/payments/donate.html:241
@@ -3011,8 +4065,8 @@ msgid "Monthly balance sheets"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:520
-#: frontend/js/src/forms/SignupCommercial.tsx:175
-#: frontend/js/src/forms/SignupCommercial.tsx:554
+#: frontend/js/src/forms/SignupCommercial.tsx:180
+#: frontend/js/src/forms/SignupCommercial.tsx:558
 #: frontend/js/src/forms/SignupNonCommercial.tsx:106
 #: frontend/js/src/forms/SignupNonCommercial.tsx:318
 #: metabrainz/templates/supporters/account-type.html:3
@@ -3033,6 +4087,7 @@ msgid "Non-commercial / Personal"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:235
+#: frontend/js/src/forms/SignupNonCommercial.tsx:107
 #: frontend/js/src/forms/SignupNonCommercial.tsx:151
 #: metabrainz/templates/supporters/account-type.html:42
 msgid "Non-commercial"
@@ -3046,55 +4101,45 @@ msgstr ""
 msgid "Personal or university assignment user."
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:48
-#: metabrainz/templates/supporters/account-type.html:90
-#: metabrainz/templates/supporters/account-type.html:141
-msgid "Upgrade"
-msgstr ""
-
 #: frontend/js/src/Profile.tsx:235
-#: frontend/js/src/forms/SignupCommercial.tsx:176
-#: frontend/js/src/forms/SignupCommercial.tsx:228
-#: metabrainz/templates/supporters/account-type.html:61
+#: frontend/js/src/forms/SignupCommercial.tsx:181
+#: frontend/js/src/forms/SignupCommercial.tsx:233
+#: metabrainz/templates/supporters/account-type.html:56
 msgid "Commercial"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:83
-#: metabrainz/templates/supporters/account-type.html:135
+#: metabrainz/templates/supporters/account-type.html:78
+#: metabrainz/templates/supporters/account-type.html:125
 #, python-format
 msgid "$%(tier_price)s/month and up"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:87
-#: metabrainz/templates/supporters/account-type.html:138
+#: metabrainz/templates/supporters/account-type.html:82
+#: metabrainz/templates/supporters/account-type.html:128
 msgid "More info"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:104
+#: metabrainz/templates/supporters/account-type.html:94
 msgid "View all tiers"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:112
+#: metabrainz/templates/supporters/account-type.html:102
 msgid "Some of our Unicorn members"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:123
+#: metabrainz/templates/supporters/account-type.html:113
 msgid "See all our supporters"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:151
+#: metabrainz/templates/supporters/account-type.html:136
 msgid "View featured tiers"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:158
+#: metabrainz/templates/supporters/account-type.html:143
 #, python-format
 msgid ""
 "If you are not sure which tier to pick, please\n"
 "      <a href=\"%(contact_url)s\">contact us</a>."
-msgstr ""
-
-#: metabrainz/templates/supporters/account-type.html:166
-msgid "Back to Profile"
 msgstr ""
 
 #: metabrainz/templates/supporters/bad-standing.html:3
@@ -3156,9 +4201,9 @@ msgid "Forgot your username"
 msgstr ""
 
 #: frontend/js/src/forms/ResetPassword.tsx:79
-#: frontend/js/src/forms/SignupCommercial.tsx:320
+#: frontend/js/src/forms/SignupCommercial.tsx:325
 #: frontend/js/src/forms/SignupNonCommercial.tsx:227
-#: frontend/js/src/forms/SignupUser.tsx:169
+#: frontend/js/src/forms/SignupUser.tsx:175
 #: metabrainz/templates/users/reauthenticate.html:3
 #: metabrainz/templates/users/reauthenticate.html:6
 msgid "Confirm Password"
@@ -3168,17 +4213,22 @@ msgstr ""
 msgid "Please re-enter your password to continue."
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:108
+#: frontend/js/src/ProfileDelete.tsx:110
 #: frontend/js/src/forms/DeleteApplication.tsx:53
 #: frontend/js/src/forms/OAuthPrompt.tsx:54
 #: frontend/js/src/forms/ProfileChangePassword.tsx:104
 #: frontend/js/src/forms/ProfileEdit.tsx:105
-#: metabrainz/templates/users/reauthenticate.html:23
+#: metabrainz/templates/users/reauthenticate.html:28
 msgid "Cancel"
 msgstr ""
 
-#: metabrainz/templates/users/reauthenticate.html:24
+#: metabrainz/templates/users/reauthenticate.html:29
 msgid "Continue"
+msgstr ""
+
+#: frontend/js/src/forms/utils.tsx:202
+#: metabrainz/templates/users/reauthenticate.html:40
+msgid "Password must not exceed 72 bytes."
 msgstr ""
 
 #: frontend/js/src/forms/ResetPassword.tsx:27
@@ -3186,38 +4236,38 @@ msgstr ""
 msgid "Reset your password"
 msgstr ""
 
-#: frontend/js/src/hooks/useEmailValidation.ts:41 metabrainz/user/forms.py:15
+#: frontend/js/src/hooks/useEmailValidation.ts:41 metabrainz/user/forms.py:16
 msgid "Registration from this email domain is not allowed."
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:50
 #: frontend/js/src/forms/LostPassword.tsx:45
-#: frontend/js/src/forms/SignupCommercial.tsx:270
+#: frontend/js/src/forms/SignupCommercial.tsx:275
 #: frontend/js/src/forms/SignupNonCommercial.tsx:175
-#: frontend/js/src/forms/SignupUser.tsx:114 metabrainz/user/forms.py:20
-#: metabrainz/user/forms.py:45 metabrainz/user/forms.py:62
+#: frontend/js/src/forms/SignupUser.tsx:120 metabrainz/user/forms.py:22
+#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:75
 msgid "Username"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:42
 #: frontend/js/src/forms/LostPassword.tsx:37
-#: frontend/js/src/forms/SignupCommercial.tsx:153
+#: frontend/js/src/forms/SignupCommercial.tsx:158
 #: frontend/js/src/forms/SignupNonCommercial.tsx:84
-#: frontend/js/src/forms/SignupUser.tsx:67 metabrainz/user/forms.py:21
-#: metabrainz/user/forms.py:45 metabrainz/user/forms.py:62
+#: frontend/js/src/forms/SignupUser.tsx:73 metabrainz/user/forms.py:26
+#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:75
 msgid "Username is required!"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:63
 #: frontend/js/src/forms/ResetPassword.tsx:72
-#: frontend/js/src/forms/SignupCommercial.tsx:308
+#: frontend/js/src/forms/SignupCommercial.tsx:313
 #: frontend/js/src/forms/SignupNonCommercial.tsx:214
-#: frontend/js/src/forms/SignupUser.tsx:157 metabrainz/user/forms.py:46
-#: metabrainz/user/forms.py:52
+#: frontend/js/src/forms/SignupUser.tsx:163 metabrainz/user/forms.py:53
+#: metabrainz/user/forms.py:62
 msgid "Password"
 msgstr ""
 
-#: frontend/js/src/forms/LoginUser.tsx:76 metabrainz/user/forms.py:47
+#: frontend/js/src/forms/LoginUser.tsx:76 metabrainz/user/forms.py:57
 msgid "Remember me"
 msgstr ""
 
@@ -3229,11 +4279,11 @@ msgstr ""
 msgid "Username contains invalid or invisible characters."
 msgstr ""
 
-#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:181
+#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:220
 msgid "Hide password"
 msgstr ""
 
-#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:181
+#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:220
 msgid "Show password"
 msgstr ""
 
@@ -3290,11 +4340,11 @@ msgstr ""
 msgid "Revoke access"
 msgstr ""
 
-#: frontend/js/src/OAuthError.tsx:17
+#: frontend/js/src/OAuthError.tsx:18
 msgid "OAuth2 Error"
 msgstr ""
 
-#: frontend/js/src/OAuthError.tsx:18
+#: frontend/js/src/OAuthError.tsx:19
 msgid "An error occurred during OAuth authentication process."
 msgstr ""
 
@@ -3324,8 +4374,8 @@ msgstr ""
 
 #: frontend/js/src/Profile.tsx:109
 msgid ""
-"Are you sure you want to generate new access token? Current token will be"
-" revoked!"
+"Are you sure you want to generate a new access token? The current token "
+"will be revoked!"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:118
@@ -3440,8 +4490,8 @@ msgid "Contact Information"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:310 frontend/js/src/forms/ProfileEdit.tsx:70
-#: frontend/js/src/forms/SignupCommercial.tsx:284
-#: frontend/js/src/forms/SignupCommercial.tsx:333
+#: frontend/js/src/forms/SignupCommercial.tsx:289
+#: frontend/js/src/forms/SignupCommercial.tsx:338
 #: frontend/js/src/forms/SignupNonCommercial.tsx:189
 #: frontend/js/src/forms/SignupNonCommercial.tsx:241
 msgid "Contact name"
@@ -3556,7 +4606,7 @@ msgstr ""
 msgid "Once you delete your account, there is no going back. Please be certain."
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:550 frontend/js/src/ProfileDelete.tsx:105
+#: frontend/js/src/Profile.tsx:550 frontend/js/src/ProfileDelete.tsx:107
 msgid "Delete My Account"
 msgstr ""
 
@@ -3568,39 +4618,39 @@ msgstr ""
 msgid "Need to delete your account?"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:574
+#: frontend/js/src/Profile.tsx:575
 msgid ""
 "Deletion of supporter accounts requires manual review. Please contact us "
-"at"
+"at <email />."
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:594
+#: frontend/js/src/Profile.tsx:599
 msgid "Security"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:626
+#: frontend/js/src/Profile.tsx:631
 msgid "MetaBrainz Applications"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:630
+#: frontend/js/src/Profile.tsx:635
 msgid ""
 "With your MetaBrainz account, you can access every project in the "
 "MetaBrainz family:"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:643
+#: frontend/js/src/Profile.tsx:648
 msgid "The open-source music encyclopedia"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:655
+#: frontend/js/src/Profile.tsx:660
 msgid "Track, visualise and share the music you listen to"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:667
+#: frontend/js/src/Profile.tsx:672
 msgid "The open-source book database"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:679
+#: frontend/js/src/Profile.tsx:684
 msgid "Creative Commons licensed reviews"
 msgstr ""
 
@@ -3623,7 +4673,7 @@ msgid "Permanently remove all your account information"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:64
-msgid "Revoke all your API tokens and access"
+msgid "Revoke all your tokens and access to the replication API"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:65
@@ -3635,14 +4685,16 @@ msgid "Log you out of all MetaBrainz services"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:70
-msgid "Your username will be reserved and cannot be reused."
+msgid ""
+"Your username will be reserved and cannot be reused without the "
+"intervention of an administrator."
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:82
+#: frontend/js/src/ProfileDelete.tsx:84
 msgid "To confirm, type your username '<username />' below:"
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:105
+#: frontend/js/src/ProfileDelete.tsx:107
 msgid "Deleting..."
 msgstr ""
 
@@ -3654,64 +4706,7 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: frontend/js/src/forms/ConditionsModal.tsx:23
-msgid "Licensing"
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:25
-msgid ""
-"Any contributions you make to any MetaBrainz service will be released "
-"into the Public Domain and/or licensed under a Creative Commons by-nc-sa "
-"license. Furthermore, you give the MetaBrainz Foundation the right to "
-"license this data for commercial use."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:30
-msgid "Please read our <licenseLink>license page</licenseLink> for more details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:45
-msgid ""
-"MetaBrainz strongly believes in the privacy of its users. Any personal "
-"information you choose to provide will not be sold or shared with anyone "
-"else."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:50
-msgid ""
-"Please read our <privacyLink>privacy policy</privacyLink> for more "
-"details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:59
-msgid "GDPR compliance"
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:61
-msgid ""
-"You may remove your personal information from our services anytime by "
-"deleting your account."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:66
-msgid ""
-"Please read our <gdprLink>GDPR compliance statement</gdprLink> for more "
-"details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:78
-msgid ""
-"Creating an account on MetaBrainz will give you access to all of our "
-"projects, such as MusicBrainz, ListenBrainz, BookBrainz, and more."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:82
-msgid ""
-"We create a placeholder account for all the MetaBrainz projects when you "
-"sign up, and you are one log-in away from activating them."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:91
+#: frontend/js/src/forms/ConditionsModal.tsx:29
 msgid "Sounds good"
 msgstr ""
 
@@ -3799,8 +4794,8 @@ msgstr ""
 msgid "Forgot your password?"
 msgstr ""
 
-#: frontend/js/src/forms/LoginUser.tsx:109
-msgid "Don't have an account?"
+#: frontend/js/src/forms/LoginUser.tsx:110
+msgid "Don't have an account? <signupLink>Sign up</signupLink>"
 msgstr ""
 
 #: frontend/js/src/forms/LostPassword.tsx:38
@@ -3829,15 +4824,72 @@ msgstr ""
 msgid "Allow access"
 msgstr ""
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:71
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:10
+msgid "Licensing"
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:12
+msgid ""
+"Any contributions you make to any MetaBrainz service will be released "
+"into the Public Domain and/or licensed under a Creative Commons by-nc-sa "
+"license. Furthermore, you give the MetaBrainz Foundation the right to "
+"license this data for commercial use."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:17
+msgid "Please read our <licenseLink>license page</licenseLink> for more details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:34
+msgid ""
+"MetaBrainz strongly believes in the privacy of its users. Any personal "
+"information you choose to provide will not be sold or shared with anyone "
+"else."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:39
+msgid ""
+"Please read our <privacyLink>privacy policy</privacyLink> for more "
+"details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:50
+msgid "GDPR compliance"
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:52
+msgid ""
+"You may remove your personal information from our services anytime by "
+"deleting your account."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:57
+msgid ""
+"Please read our <gdprLink>GDPR compliance statement</gdprLink> for more "
+"details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:71
+msgid ""
+"Creating an account on MetaBrainz will give you access to all of our "
+"projects, such as MusicBrainz, ListenBrainz, BookBrainz, and more."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:75
+msgid ""
+"We create a placeholder account for all the MetaBrainz projects when you "
+"sign up, and you are one log-in away from activating them."
+msgstr ""
+
+#: frontend/js/src/forms/ProfileChangePassword.tsx:70
 msgid "Current Password"
 msgstr ""
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:80
+#: frontend/js/src/forms/ProfileChangePassword.tsx:79
 msgid "New Password"
 msgstr ""
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:89
+#: frontend/js/src/forms/ProfileChangePassword.tsx:88
 msgid "Confirm New Password"
 msgstr ""
 
@@ -3849,190 +4901,180 @@ msgstr ""
 msgid "Reset Password"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:38
-msgid "If you would like to support us with more than $"
+#: frontend/js/src/forms/SignupCommercial.tsx:40
+msgid ""
+"If you would like to support us with more than ${{minPledge}}, please "
+"enter the actual amount here:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:39
-msgid ", please enter the actual amount here:"
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:144
+#: frontend/js/src/forms/SignupCommercial.tsx:149
 #: frontend/js/src/forms/SignupNonCommercial.tsx:75
-#: frontend/js/src/forms/SignupUser.tsx:87
+#: frontend/js/src/forms/SignupUser.tsx:93
 msgid "Captcha is required!"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:179
+#: frontend/js/src/forms/SignupCommercial.tsx:184
 #: frontend/js/src/forms/SignupNonCommercial.tsx:110
 #: frontend/js/src/forms/SignupUser.tsx:46
 msgid "Access all MetaBrainz projects"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:182
+#: frontend/js/src/forms/SignupCommercial.tsx:187
 msgid "Note:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:184
+#: frontend/js/src/forms/SignupCommercial.tsx:189
 msgid ""
 "Signing up for any tier other than the <italic>Stealth startup</italic> "
 "tier will publicly list your company on this web site. However, we will "
 "not publish any of your private details."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:221
+#: frontend/js/src/forms/SignupCommercial.tsx:226
 #: frontend/js/src/forms/SignupNonCommercial.tsx:145
 msgid "Account type"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:234
+#: frontend/js/src/forms/SignupCommercial.tsx:239
 msgid "Selected tier"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:242
-msgid "month and up"
+#: frontend/js/src/forms/SignupCommercial.tsx:247
+msgid "${{tierPrice}}/month and up"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:250
+#: frontend/js/src/forms/SignupCommercial.tsx:255
 msgid "Change account type or tier"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:261
+#: frontend/js/src/forms/SignupCommercial.tsx:266
 #: frontend/js/src/forms/SignupNonCommercial.tsx:166
 msgid "Your account:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:271
+#: frontend/js/src/forms/SignupCommercial.tsx:276
 #: frontend/js/src/forms/SignupNonCommercial.tsx:176
-#: frontend/js/src/forms/SignupUser.tsx:114
+#: frontend/js/src/forms/SignupUser.tsx:120
 msgid "(public)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:291
+#: frontend/js/src/forms/SignupCommercial.tsx:296
 #: frontend/js/src/forms/SignupNonCommercial.tsx:196
-#: frontend/js/src/forms/SignupUser.tsx:127
+#: frontend/js/src/forms/SignupUser.tsx:133
 msgid "E-mail address"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:295
+#: frontend/js/src/forms/SignupCommercial.tsx:300
 #: frontend/js/src/forms/SignupNonCommercial.tsx:200
-#: frontend/js/src/forms/SignupUser.tsx:131
+#: frontend/js/src/forms/SignupUser.tsx:137
 msgid "(checking...)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:314
+#: frontend/js/src/forms/SignupCommercial.tsx:319
 #: frontend/js/src/forms/SignupNonCommercial.tsx:220
-#: frontend/js/src/forms/SignupUser.tsx:163
+#: frontend/js/src/forms/SignupUser.tsx:169
 msgid "Must be at least 8 characters"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:348
+#: frontend/js/src/forms/SignupCommercial.tsx:353
 msgid ""
 "If you don't have an organization name, you probably want to become a "
 "supporter as a <nonCommercialLink>Non-commercial / "
 "Personal</nonCommercialLink> supporter."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:358
+#: frontend/js/src/forms/SignupCommercial.tsx:363
 msgid ""
 "If you don't have an organization name, you probably want to sign up as a"
 " <nonCommercialLink>Non-commercial / Personal</nonCommercialLink> user."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:378
+#: frontend/js/src/forms/SignupCommercial.tsx:383
 msgid ""
 "Please tell us a little about your company and whether you plan to use "
 "our <apiLink>API</apiLink> or to <hostLink>host your own copy</hostLink> "
 "of the data."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:404
+#: frontend/js/src/forms/SignupCommercial.tsx:408
 msgid "Logo URL"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:405
+#: frontend/js/src/forms/SignupCommercial.tsx:409
 msgid "(preferably in SVG format)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:408
+#: frontend/js/src/forms/SignupCommercial.tsx:412
 msgid ""
 "Image should be about 250 pixels wide on a white or transparent "
 "background. We will host it on our site."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:421
+#: frontend/js/src/forms/SignupCommercial.tsx:425
 msgid ""
 "URL to where developers can use your APIs using MusicBrainz IDs, if "
-"available.."
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:430
-msgid "Your project"
+"available."
 msgstr ""
 
 #: frontend/js/src/forms/SignupCommercial.tsx:434
+msgid "Your project"
+msgstr ""
+
+#: frontend/js/src/forms/SignupCommercial.tsx:438
 #: frontend/js/src/forms/SignupNonCommercial.tsx:261
 msgid "(max 150 characters)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:451
+#: frontend/js/src/forms/SignupCommercial.tsx:455
 msgid "Billing address"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:502
+#: frontend/js/src/forms/SignupCommercial.tsx:506
 msgid ""
 "I agree to support the MetaBrainz Foundation when my organization is able"
 " to do so."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:507
+#: frontend/js/src/forms/SignupCommercial.tsx:511
+#: frontend/js/src/forms/SignupNonCommercial.tsx:284
 msgid ""
-"I also agree that if I generate a Live Data Feed access token, that I "
-"treat my access token as a secret and will not share this token publicly "
-"or commit it to a source code repository."
+"I also agree that if I generate a Live Data Feed access token, then I "
+"will treat my access token as a secret and will not share this token "
+"publicly or commit it to a source code repository."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:515
+#: frontend/js/src/forms/SignupCommercial.tsx:519
 msgid ""
 "The following information will be shown publicly: organization name, "
 "logo, website and API URLs, data usage description."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:520
+#: frontend/js/src/forms/SignupCommercial.tsx:524
 msgid ""
 "We'll send you more details about payment process once your application "
 "is approved."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:552
+#: frontend/js/src/forms/SignupCommercial.tsx:556
 #: frontend/js/src/forms/SignupNonCommercial.tsx:316
-#: frontend/js/src/forms/SignupUser.tsx:224
+#: frontend/js/src/forms/SignupUser.tsx:230
 msgid "Validating..."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:564
+#: frontend/js/src/forms/SignupCommercial.tsx:568
 #: frontend/js/src/forms/SignupNonCommercial.tsx:329
 msgid "Back to profile"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:569
-#: frontend/js/src/forms/SignupNonCommercial.tsx:334
-msgid "Not a supporter?"
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:570
+#: frontend/js/src/forms/SignupCommercial.tsx:574
 #: frontend/js/src/forms/SignupNonCommercial.tsx:335
-msgid "Create a user account"
+msgid "Not a supporter? <signupLink>Create a user account</signupLink>"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:573
-#: frontend/js/src/forms/SignupNonCommercial.tsx:338
-#: frontend/js/src/forms/SignupUser.tsx:231
-msgid "Already have an account?"
-msgstr ""
-
-#: frontend/js/src/forms/SignupNonCommercial.tsx:107
-msgid "non-commercial"
+#: frontend/js/src/forms/SignupCommercial.tsx:583
+#: frontend/js/src/forms/SignupNonCommercial.tsx:344
+#: frontend/js/src/forms/SignupUser.tsx:238
+msgid "Already have an account? <loginLink>Sign in</loginLink>"
 msgstr ""
 
 #: frontend/js/src/forms/SignupNonCommercial.tsx:113
@@ -4060,46 +5102,40 @@ msgid ""
 "income per year) or personal uses only."
 msgstr ""
 
-#: frontend/js/src/forms/SignupNonCommercial.tsx:284
-msgid ""
-"I also agree that if I generate a Live Data Feed access token, then I "
-"will treat my access token as a secret and will not share this token "
-"publicly or commit it to a source code repository."
-msgstr ""
-
 #: frontend/js/src/forms/SignupUser.tsx:43
 msgid "Create your account"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:50
-msgid "Registration started by"
+#: frontend/js/src/forms/SignupUser.tsx:51
+msgid "Registration started by <client />"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:69
+#: frontend/js/src/forms/SignupUser.tsx:75
+#: frontend/js/src/hooks/useEmailValidation.ts:82
 msgid "Invalid email address."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:150
+#: frontend/js/src/forms/SignupUser.tsx:156
 msgid ""
 "This username and email were provided by the app that started "
 "registration. You can change them later from MetaBrainz settings."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:182
+#: frontend/js/src/forms/SignupUser.tsx:188
 msgid ""
 "I accept that my contributions will be released into the public domain or"
 " licensed for use."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:191
+#: frontend/js/src/forms/SignupUser.tsx:197
 msgid "We will never share your personal information."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:200
+#: frontend/js/src/forms/SignupUser.tsx:206
 msgid "Click here to read more"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:224
+#: frontend/js/src/forms/SignupUser.tsx:230
 msgid "Create account"
 msgstr ""
 
@@ -4109,10 +5145,6 @@ msgstr ""
 
 #: frontend/js/src/hooks/useEmailValidation.ts:47
 msgid "Email validation failed"
-msgstr ""
-
-#: frontend/js/src/hooks/useEmailValidation.ts:82
-msgid "Invalid email address"
 msgstr ""
 
 #~ msgid "About "
@@ -4399,3 +5431,108 @@ msgstr ""
 
 #~ msgid "Edit contact information"
 #~ msgstr ""
+
+#~ msgid "You need to specify website of the organization."
+#~ msgstr "Heu d'especificar el lloc web de l'organització."
+
+#~ msgid ""
+#~ "We are currently evaluating our overall"
+#~ " online advertising strategy. We are "
+#~ "evaluating advertising, traffic optimization,\n"
+#~ ""
+#~ "    search engine optimization and "
+#~ "software monitization technologies. If you "
+#~ "provide these professional services, please"
+#~ " provide a detailed\n"
+#~ "    deck of your comprehensive services"
+#~ " to the following email address. "
+#~ "<em>Please respect our other non-media"
+#~ " teams and do not contact us \n"
+#~ "    regarding these services on any "
+#~ "other of our email addresses. We "
+#~ "will disregard the entirety of your "
+#~ "submissions if you contact us any "
+#~ "other way!</em>"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Please come ask your questions at "
+#~ "our <a href=\"%(forums_url)s\">forums</a>! We "
+#~ "would love to\n"
+#~ "    answer any questions you may have."
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Due to the increased unreliability of"
+#~ " the US Postal Service we have "
+#~ "stopped accepting paper checks. Sorry!"
+#~ msgstr ""
+
+#~ msgid "Upgrade"
+#~ msgstr ""
+
+#~ msgid "Back to Profile"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Are you sure you want to generate"
+#~ " new access token? Current token will"
+#~ " be revoked!"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Deletion of supporter accounts requires "
+#~ "manual review. Please contact us at"
+#~ msgstr ""
+
+#~ msgid "Revoke all your API tokens and access"
+#~ msgstr ""
+
+#~ msgid "Your username will be reserved and cannot be reused."
+#~ msgstr ""
+
+#~ msgid "Don't have an account?"
+#~ msgstr ""
+
+#~ msgid "If you would like to support us with more than $"
+#~ msgstr ""
+
+#~ msgid ", please enter the actual amount here:"
+#~ msgstr ""
+
+#~ msgid "month and up"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "URL to where developers can use "
+#~ "your APIs using MusicBrainz IDs, if "
+#~ "available.."
+#~ msgstr ""
+
+#~ msgid ""
+#~ "I also agree that if I generate"
+#~ " a Live Data Feed access token, "
+#~ "that I treat my access token as"
+#~ " a secret and will not share "
+#~ "this token publicly or commit it "
+#~ "to a source code repository."
+#~ msgstr ""
+
+#~ msgid "Not a supporter?"
+#~ msgstr ""
+
+#~ msgid "Create a user account"
+#~ msgstr ""
+
+#~ msgid "Already have an account?"
+#~ msgstr ""
+
+#~ msgid "non-commercial"
+#~ msgstr ""
+
+#~ msgid "Registration started by"
+#~ msgstr ""
+
+#~ msgid "Invalid email address"
+#~ msgstr ""
+

--- a/metabrainz/translations/cs/LC_MESSAGES/messages.po
+++ b/metabrainz/translations/cs/LC_MESSAGES/messages.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-07-25 16:21+0200\n"
+"POT-Creation-Date: 2026-09-08 11:18+0200\n"
 "PO-Revision-Date: 2026-06-12 00:51+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: cs\n"
@@ -22,162 +22,247 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.18.0\n"
 
-#: metabrainz/index/forms.py:46
+#: metabrainz/errors.py:24
+msgid "Authorization was declined."
+msgstr ""
+
+#: metabrainz/errors.py:25
+msgid "The authorization request was invalid."
+msgstr ""
+
+#: metabrainz/errors.py:26
+msgid "The application could not be authenticated."
+msgstr ""
+
+#: metabrainz/errors.py:27
+msgid "This application is not allowed to request authorization."
+msgstr ""
+
+#: metabrainz/errors.py:28
+msgid "The application asked for a response type this server does not support."
+msgstr ""
+
+#: metabrainz/errors.py:29
+msgid "The permissions requested by the application are invalid."
+msgstr ""
+
+#: metabrainz/errors.py:30
+msgid "You need to sign in to continue."
+msgstr ""
+
+#: metabrainz/errors.py:31
+msgid "Your consent is required to continue."
+msgstr ""
+
+#: metabrainz/password.py:12
+#, python-format
+msgid "Password must not exceed %(max_bytes)s bytes."
+msgstr ""
+
+#: metabrainz/index/forms.py:48
 #, python-format
 msgid "'%(value)s' is not a valid choice for this field"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileEdit.tsx:27
-#: frontend/js/src/forms/SignupCommercial.tsx:154
+#: frontend/js/src/forms/SignupCommercial.tsx:159
 #: frontend/js/src/forms/SignupNonCommercial.tsx:85
-#: frontend/js/src/forms/SignupUser.tsx:70
-#: frontend/js/src/hooks/useEmailValidation.ts:78 metabrainz/index/forms.py:57
-#: metabrainz/user/forms.py:25 metabrainz/user/forms.py:57
-#: metabrainz/user/forms.py:63
+#: frontend/js/src/forms/SignupUser.tsx:76
+#: frontend/js/src/hooks/useEmailValidation.ts:78 metabrainz/index/forms.py:59
+#: metabrainz/user/forms.py:31 metabrainz/user/forms.py:70
+#: metabrainz/user/forms.py:76
 msgid "Email address is required!"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:34
-#: metabrainz/index/forms.py:63
+#: metabrainz/index/forms.py:65
 msgid "Current password is required!"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:43
 #: frontend/js/src/forms/ProfileChangePassword.tsx:37
 #: frontend/js/src/forms/ResetPassword.tsx:39
-#: frontend/js/src/forms/SignupCommercial.tsx:156
+#: frontend/js/src/forms/SignupCommercial.tsx:161
 #: frontend/js/src/forms/SignupNonCommercial.tsx:87
-#: frontend/js/src/forms/SignupUser.tsx:72 metabrainz/index/forms.py:66
-#: metabrainz/user/forms.py:29 metabrainz/user/forms.py:46
-#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:69
+#: frontend/js/src/forms/SignupUser.tsx:78 metabrainz/index/forms.py:69
+#: metabrainz/user/forms.py:35 metabrainz/user/forms.py:54
+#: metabrainz/user/forms.py:63 metabrainz/user/forms.py:82
 msgid "Password is required!"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:41
-#: frontend/js/src/forms/SignupCommercial.tsx:160
+#: frontend/js/src/forms/SignupCommercial.tsx:165
 #: frontend/js/src/forms/SignupNonCommercial.tsx:91
-#: frontend/js/src/forms/SignupUser.tsx:76 metabrainz/index/forms.py:70
-#: metabrainz/user/forms.py:33 metabrainz/user/forms.py:73
+#: frontend/js/src/forms/SignupUser.tsx:82 metabrainz/index/forms.py:74
+#: metabrainz/user/forms.py:40 metabrainz/user/forms.py:87
 msgid "Confirm Password is required!"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:46
 #: frontend/js/src/forms/ResetPassword.tsx:48
-#: frontend/js/src/forms/SignupCommercial.tsx:165
+#: frontend/js/src/forms/SignupCommercial.tsx:170
 #: frontend/js/src/forms/SignupNonCommercial.tsx:96
-#: frontend/js/src/forms/SignupUser.tsx:81 metabrainz/index/forms.py:72
-#: metabrainz/user/forms.py:35 metabrainz/user/forms.py:75
+#: frontend/js/src/forms/SignupUser.tsx:87 metabrainz/index/forms.py:76
+#: metabrainz/user/forms.py:42 metabrainz/user/forms.py:89
 msgid "Confirm Password should match password!"
 msgstr ""
 
 #: frontend/js/src/Applications.tsx:56 frontend/js/src/Applications.tsx:86
 #: frontend/js/src/Profile.tsx:272 frontend/js/src/Profile.tsx:482
-#: metabrainz/index/forms.py:78
+#: metabrainz/index/forms.py:82
 msgid "Name"
 msgstr ""
 
-#: metabrainz/index/forms.py:79
+#: metabrainz/index/forms.py:83
 msgid "Contact name field is empty."
 msgstr ""
 
-#: metabrainz/index/views.py:234
+#: metabrainz/index/views.py:251
 msgid "Profile updated successfully."
 msgstr ""
 
-#: metabrainz/index/views.py:261
+#: metabrainz/index/views.py:278
 msgid "Current password is incorrect."
 msgstr ""
 
-#: metabrainz/index/views.py:266
+#: metabrainz/index/views.py:283
 msgid "Password changed successfully."
 msgstr ""
 
-#: metabrainz/index/views.py:372
+#: metabrainz/index/views.py:389
 msgid "You have updated an application!"
 msgstr ""
 
-#: metabrainz/index/views.py:424
+#: metabrainz/index/views.py:441
 msgid "You have deleted an application."
 msgstr ""
 
-#: metabrainz/index/views.py:426
+#: metabrainz/index/views.py:443
 msgid "Failed to delete an application."
 msgstr ""
 
-#: metabrainz/index/views.py:449
+#: metabrainz/index/views.py:466
 msgid "Revoked tokens successfully!"
 msgstr ""
 
-#: metabrainz/index/views.py:478
+#: metabrainz/index/views.py:495
 msgid "Your account has been deleted."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:106 metabrainz/oauth/forms.py:58
+#: frontend/js/src/forms/CreateApplication.tsx:106 metabrainz/oauth/forms.py:57
 msgid "Application Name"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:59
+#: metabrainz/oauth/forms.py:58
 msgid "Application name field is empty."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:60 metabrainz/oauth/forms.py:60
+#: frontend/js/src/forms/CreateApplication.tsx:60 metabrainz/oauth/forms.py:59
 msgid "Application name needs to be at least 3 characters long."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:64 metabrainz/oauth/forms.py:61
+#: frontend/js/src/forms/CreateApplication.tsx:64 metabrainz/oauth/forms.py:60
 msgid "Application name needs to be at most 64 characters long."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:114 metabrainz/oauth/forms.py:63
+#: frontend/js/src/forms/CreateApplication.tsx:114 metabrainz/oauth/forms.py:62
 msgid "Description"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:64
+#: metabrainz/oauth/forms.py:63
 msgid "Client description field is empty."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:65
+#: metabrainz/oauth/forms.py:64
 msgid "Client description needs to be at least 3 characters long."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:66
+#: metabrainz/oauth/forms.py:65
 msgid "Client description needs to be at most 512 characters long."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:122 metabrainz/oauth/forms.py:68
+#: frontend/js/src/forms/CreateApplication.tsx:122 metabrainz/oauth/forms.py:67
 msgid "Homepage"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:69
+#: metabrainz/oauth/forms.py:68
 msgid "Homepage field is empty."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:70
+#: metabrainz/oauth/forms.py:69
 msgid "Homepage is not a valid URI."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:71
+#: metabrainz/oauth/forms.py:70
 msgid "Homepage URL must use http or https"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:73
+#: metabrainz/oauth/forms.py:72
 msgid "Authorization callback URL"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:74
+#: metabrainz/oauth/forms.py:73
 msgid "Authorization callback URL field is empty."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:75
+#: metabrainz/oauth/forms.py:74
 msgid "Authorization callback URL is invalid."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:76
+#: metabrainz/oauth/forms.py:75
 msgid "Authorization callback URL must use http or https."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:81 metabrainz/oauth/forms.py:85
+#: metabrainz/oauth/forms.py:80 metabrainz/oauth/forms.py:84
 msgid "Confirm"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:15
+msgid "View your public account information"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:16
+msgid "View your email address"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:17
+msgid "View and modify your private tags"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:18
+msgid "View and modify your private ratings"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:19
+msgid "View and modify your private collections"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:20
+msgid "Submit new ISRCs to the database"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:21
+msgid "Submit new barcodes to the database"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:22
+msgid "Sign you in and view your unique user id"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:23
+msgid "Submit listens to ListenBrainz."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:24
+msgid "Create and modify CritiqueBrainz reviews."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:25
+msgid "Submit and delete votes on CritiqueBrainz reviews."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:26
+msgid "Modify profile info and delete profile on CritiqueBrainz."
 msgstr ""
 
 #: metabrainz/payments/views.py:164
@@ -231,158 +316,165 @@ msgid "Requested annual report was not found."
 msgstr "Požadovaný roční výpis nebyl nalezen."
 
 #: frontend/js/src/forms/ProfileEdit.tsx:30
-#: frontend/js/src/forms/SignupCommercial.tsx:139
+#: frontend/js/src/forms/SignupCommercial.tsx:144
 #: frontend/js/src/forms/SignupNonCommercial.tsx:70
-#: metabrainz/supporter/forms.py:13
+#: metabrainz/supporter/forms.py:15
 msgid "Contact name is required!"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:437
+#: frontend/js/src/forms/SignupCommercial.tsx:441
 #: frontend/js/src/forms/SignupNonCommercial.tsx:264
-#: metabrainz/supporter/forms.py:15
+#: metabrainz/supporter/forms.py:17
 msgid ""
 "Can you please tell us more about the project in which you'd like to use "
 "our data? Do you plan to self host the data or use our APIs?"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:137
+#: frontend/js/src/forms/SignupCommercial.tsx:142
 #: frontend/js/src/forms/SignupNonCommercial.tsx:68
-#: metabrainz/supporter/forms.py:17
+#: metabrainz/supporter/forms.py:19
 msgid "Please, tell us how you (will) use our data."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:138
+#: frontend/js/src/forms/SignupCommercial.tsx:143
 #: frontend/js/src/forms/SignupNonCommercial.tsx:69
-#: metabrainz/supporter/forms.py:18
+#: metabrainz/supporter/forms.py:20
 msgid "Please, limit usage description to 500 characters."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:141
-#: frontend/js/src/forms/SignupCommercial.tsx:142
+#: frontend/js/src/forms/SignupCommercial.tsx:146
+#: frontend/js/src/forms/SignupCommercial.tsx:147
 #: frontend/js/src/forms/SignupNonCommercial.tsx:72
 #: frontend/js/src/forms/SignupNonCommercial.tsx:73
-#: frontend/js/src/forms/SignupUser.tsx:84
-#: frontend/js/src/forms/SignupUser.tsx:85 metabrainz/supporter/forms.py:21
-#: metabrainz/user/forms.py:38
+#: frontend/js/src/forms/SignupUser.tsx:90
+#: frontend/js/src/forms/SignupUser.tsx:91 metabrainz/supporter/forms.py:23
+#: metabrainz/user/forms.py:45
 msgid "You need to accept the agreement!"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:342
-#: metabrainz/supporter/forms.py:27
+#: frontend/js/src/forms/SignupCommercial.tsx:347
+#: metabrainz/supporter/forms.py:29
 msgid "Organization name"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:113
-#: metabrainz/supporter/forms.py:28
+#: frontend/js/src/forms/SignupCommercial.tsx:115
+#: metabrainz/supporter/forms.py:30
 msgid "You need to specify the name of your organization."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:373
-#: metabrainz/supporter/forms.py:30
+#: frontend/js/src/forms/SignupCommercial.tsx:378
+#: metabrainz/supporter/forms.py:32
 msgid "Organization description"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:116
-#: metabrainz/supporter/forms.py:31
+#: frontend/js/src/forms/SignupCommercial.tsx:118
+#: metabrainz/supporter/forms.py:33
 msgid "You need to provide description of your organization."
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:278
-#: frontend/js/src/forms/SignupCommercial.tsx:396
-#: metabrainz/supporter/forms.py:34
+#: frontend/js/src/forms/SignupCommercial.tsx:401
+#: metabrainz/supporter/forms.py:36
 msgid "Website URL"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:119
-#: metabrainz/supporter/forms.py:35
-msgid "You need to specify website of the organization."
+#: frontend/js/src/forms/SignupCommercial.tsx:121
+#: frontend/js/src/forms/SignupCommercial.tsx:123
+#: metabrainz/supporter/forms.py:38 metabrainz/supporter/forms.py:42
+msgid "Website URL must be a valid URL."
 msgstr ""
 
-#: metabrainz/supporter/forms.py:37
+#: metabrainz/supporter/forms.py:45
 msgid "Logo image URL"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:284
-#: frontend/js/src/forms/SignupCommercial.tsx:418
-#: metabrainz/supporter/forms.py:38
+#: frontend/js/src/forms/SignupCommercial.tsx:422
+#: metabrainz/supporter/forms.py:46
 msgid "API URL"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:457
-#: metabrainz/supporter/forms.py:40
+#: frontend/js/src/forms/SignupCommercial.tsx:461
+#: metabrainz/supporter/forms.py:48
 msgid "Street"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:123
-#: metabrainz/supporter/forms.py:41
+#: frontend/js/src/forms/SignupCommercial.tsx:128
+#: metabrainz/supporter/forms.py:49
 msgid "You need to specify street."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:465
-#: metabrainz/supporter/forms.py:43
+#: frontend/js/src/forms/SignupCommercial.tsx:469
+#: metabrainz/supporter/forms.py:51
 msgid "City"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:124
-#: metabrainz/supporter/forms.py:44
+#: frontend/js/src/forms/SignupCommercial.tsx:129
+#: metabrainz/supporter/forms.py:52
 msgid "You need to specify city."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:473
-#: metabrainz/supporter/forms.py:46
+#: frontend/js/src/forms/SignupCommercial.tsx:477
+#: metabrainz/supporter/forms.py:54
 msgid "State / Province"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:126
-#: metabrainz/supporter/forms.py:47
+#: frontend/js/src/forms/SignupCommercial.tsx:131
+#: metabrainz/supporter/forms.py:55
 msgid "You need to specify state/province."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:481
-#: metabrainz/supporter/forms.py:49
+#: frontend/js/src/forms/SignupCommercial.tsx:485
+#: metabrainz/supporter/forms.py:57
 msgid "Postcode"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:128
-#: metabrainz/supporter/forms.py:50
+#: frontend/js/src/forms/SignupCommercial.tsx:133
+#: metabrainz/supporter/forms.py:58
 msgid "You need to specify postcode."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:489
-#: metabrainz/supporter/forms.py:52
+#: frontend/js/src/forms/SignupCommercial.tsx:493
+#: metabrainz/supporter/forms.py:60
 msgid "Country"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:129
-#: metabrainz/supporter/forms.py:53
+#: frontend/js/src/forms/SignupCommercial.tsx:134
+#: metabrainz/supporter/forms.py:61
 msgid "You need to specify country."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:132
-#: metabrainz/supporter/forms.py:64
+#: frontend/js/src/forms/SignupCommercial.tsx:137
+#: metabrainz/supporter/forms.py:72
 msgid ""
 "Custom amount must be more than threshold amount for selected tier or "
 "equal to it!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:46 metabrainz/supporter/views.py:119
-#: metabrainz/supporter/views.py:220
+#: metabrainz/supporter/views.py:54
+msgid ""
+"The verification email could not be sent. Please request a new one from "
+"your profile."
+msgstr ""
+
+#: metabrainz/supporter/views.py:85 metabrainz/supporter/views.py:158
+#: metabrainz/supporter/views.py:260
 msgid "You are already a supporter."
 msgstr ""
 
-#: metabrainz/supporter/views.py:61
+#: metabrainz/supporter/views.py:100
 msgid "Can't find tier with a specified ID."
 msgstr ""
 
-#: metabrainz/supporter/views.py:127
+#: metabrainz/supporter/views.py:166
 msgid "You need to choose support tier before signing up!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:137
+#: metabrainz/supporter/views.py:176
 msgid "You need to choose existing tier before signing up!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:164
+#: metabrainz/supporter/views.py:204
 #, fuzzy
 msgid ""
 "Thanks for becoming a supporter! Your application will be reviewed soon. "
@@ -391,7 +483,7 @@ msgstr ""
 "Děkujeme Vám za přihlášení! Vaše aplikace bude brzy zkontrolována. "
 "Aktualizace Vám zašleme e-mailem."
 
-#: metabrainz/supporter/views.py:187
+#: metabrainz/supporter/views.py:228
 msgid ""
 "Thanks for signing up! Your application will be reviewed soon. We will "
 "send you updates via email."
@@ -399,15 +491,15 @@ msgstr ""
 "Děkujeme Vám za přihlášení! Vaše aplikace bude brzy zkontrolována. "
 "Aktualizace Vám zašleme e-mailem."
 
-#: metabrainz/supporter/views.py:248
+#: metabrainz/supporter/views.py:288
 msgid "Thanks for becoming a supporter!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:274
+#: metabrainz/supporter/views.py:312
 msgid "Thanks for signing up! Please check your inbox to complete verification."
 msgstr ""
 
-#: metabrainz/supporter/views.py:302
+#: metabrainz/supporter/views.py:340
 msgid "Can't generate new token unless account is active."
 msgstr ""
 
@@ -441,7 +533,7 @@ msgstr ""
 msgid "Policies"
 msgstr ""
 
-#: metabrainz/templates/base.html:55 metabrainz/templates/index/gdpr.html:178
+#: metabrainz/templates/base.html:55
 #: metabrainz/templates/index/social-contract.html:3
 #: metabrainz/templates/index/social-contract.html:6
 #: metabrainz/templates/navbar.html:34
@@ -451,14 +543,15 @@ msgstr ""
 #: metabrainz/templates/base.html:56
 #: metabrainz/templates/index/code-of-conduct.html:3
 #: metabrainz/templates/index/code-of-conduct.html:16
-#: metabrainz/templates/index/gdpr.html:181 metabrainz/templates/navbar.html:35
+#: metabrainz/templates/navbar.html:35
 msgid "Code of Conduct"
 msgstr ""
 
+#: frontend/js/src/PrivacySummary.tsx:11
 #: frontend/js/src/forms/ConditionsModal.tsx:21
-#: metabrainz/templates/base.html:57 metabrainz/templates/index/gdpr.html:184
-#: metabrainz/templates/index/privacy.html:6
+#: metabrainz/templates/base.html:57 metabrainz/templates/index/privacy.html:6
 #: metabrainz/templates/navbar.html:36
+#: metabrainz/templates/users/privacy-summary.html:3
 msgid "Privacy Policy"
 msgstr "Zásady ochrany osobních údajů"
 
@@ -492,10 +585,7 @@ msgstr "Sponzoři"
 msgid "Supporters"
 msgstr "Podporovatelé"
 
-#: frontend/js/src/forms/LoginUser.tsx:103
-#: frontend/js/src/forms/SignupCommercial.tsx:574
-#: frontend/js/src/forms/SignupNonCommercial.tsx:339
-#: frontend/js/src/forms/SignupUser.tsx:232 metabrainz/templates/base.html:73
+#: frontend/js/src/forms/LoginUser.tsx:103 metabrainz/templates/base.html:73
 #: metabrainz/templates/navbar.html:66 metabrainz/templates/users/login.html:3
 msgid "Sign in"
 msgstr "Přihlásit se"
@@ -517,26 +607,26 @@ msgid "Contact us"
 msgstr "Napište nám"
 
 #: metabrainz/templates/base.html:85
-#: metabrainz/templates/index/contact.html:105
+#: metabrainz/templates/index/contact.html:106
 msgid "Blog"
 msgstr "Blog"
 
-#: metabrainz/templates/base.html:86 metabrainz/templates/index/contact.html:90
+#: metabrainz/templates/base.html:86 metabrainz/templates/index/contact.html:91
 msgid "Chat"
 msgstr ""
 
 #: metabrainz/templates/base.html:87
-#: metabrainz/templates/index/contact.html:106
+#: metabrainz/templates/index/contact.html:107
 msgid "Mastodon"
 msgstr ""
 
 #: metabrainz/templates/base.html:88
-#: metabrainz/templates/index/contact.html:107
+#: metabrainz/templates/index/contact.html:108
 msgid "Bluesky"
 msgstr ""
 
 #: metabrainz/templates/base.html:89
-#: metabrainz/templates/index/contact.html:108
+#: metabrainz/templates/index/contact.html:109
 msgid "Instagram"
 msgstr ""
 
@@ -595,15 +685,14 @@ msgstr "Finanční výkazy"
 msgid "Donate"
 msgstr "Přispět"
 
-#: frontend/js/src/forms/LoginUser.tsx:110
-#: frontend/js/src/forms/SignupCommercial.tsx:175
-#: frontend/js/src/forms/SignupCommercial.tsx:555
+#: frontend/js/src/forms/SignupCommercial.tsx:180
+#: frontend/js/src/forms/SignupCommercial.tsx:559
 #: frontend/js/src/forms/SignupNonCommercial.tsx:106
 #: frontend/js/src/forms/SignupNonCommercial.tsx:319
 #: metabrainz/templates/navbar.html:65
-#: metabrainz/templates/supporters/account-type.html:51
-#: metabrainz/templates/supporters/account-type.html:93
-#: metabrainz/templates/supporters/account-type.html:144
+#: metabrainz/templates/supporters/account-type.html:47
+#: metabrainz/templates/supporters/account-type.html:84
+#: metabrainz/templates/supporters/account-type.html:130
 #: metabrainz/templates/users/signup.html:3
 msgid "Sign up"
 msgstr "Registrace"
@@ -950,8 +1039,430 @@ msgstr ""
 msgid "Introduction"
 msgstr ""
 
-#: metabrainz/templates/index/conflict-policy.html:55
+#: metabrainz/templates/index/conflict-policy.html:17
+msgid ""
+"Conflicts between people arise in open source projects constantly and the"
+" projects by the \n"
+"    MetaBrainz Foundation are no different. This policy aims to establish"
+" a clear and unambiguous \n"
+"    policy for reporting and addressing conflicts in our community. In "
+"this policy we aim to \n"
+"    establish a fair practice that balances the need for confidentiality "
+"and our desire for \n"
+"    transparency in our operations."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:25
+#, python-format
+msgid ""
+"Before you continue to read this policy, we encourage you to review our "
+"existing community policies \n"
+"    including our <a href=\"%(social_contract_url)s\">Social "
+"Contract</a>, \n"
+"    <a href=\"%(code_of_conduct_url)s\">the Code of Conduct</a>, \n"
+"    and our <a href=\"%(privacy_policy_url)s\">Privacy Policy</a>. These "
+"policies establish the norms and rules for \n"
+"    participation in our projects; these policies apply equally to the "
+"contractors of the MetaBrainz \n"
+"    Foundation and any participants in our projects."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:37
+msgid ""
+"This policy divides conflicts into two categories: Private and public. "
+"Private conflicts are conflicts \n"
+"    that involve *confidential* information regarding contributors, "
+"contractors or supporters. Otherwise, any conflicts \n"
+"    that do not involve confidential information are considered to be "
+"public conflicts. For instance, a \n"
+"    conflict between a contractor and the Executive Director (aka BDFL) "
+"that involves contractor pay is \n"
+"    considered a private conflict because pay rates are confidential "
+"information. A public conflict in edit \n"
+"    notes between two editors in our community does not involve "
+"confidential information and therefore should \n"
+"    be considered a public conflict."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:47
+msgid ""
+"When conflicts arise we aim to disclose as much information as possible "
+"about the conflict in a timely \n"
+"    fashion. When conflicts contain confidential matters we will aim to "
+"disclose as much information as \n"
+"    possible, while fully respecting the confidentiality of the people "
+"involved in the conflict. With any \n"
+"    private conflict we will aim to extract the relevant lessons for the "
+"team and community in an effort to \n"
+"    evolve our policies to prevent future conflicts. Should the involved "
+"parties disagree whether a conflict \n"
+"    is private or public, the question about the nature of the conflict "
+"will be presented for the next higher \n"
+"    level in the chain of command to decide. (e.g. if a community member "
+"and the community manager disagree on \n"
+"    a conflict being public or private, the Executive Director shall "
+"decide if the conflict is public or private)."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:58
 msgid "Reporting and Response"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:61
+msgid ""
+"We aim to not have conflict in our community, but we recognize that in "
+"reality conflicts will arise and we \n"
+"    must be prepared to address them in a fair manner. When conflicts "
+"arise, we prefer to have community or team \n"
+"    members resolve the conflicts among themselves, using our existing "
+"policies as guidelines for resolving the \n"
+"    conflict."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:69
+msgid ""
+"If you do not feel comfortable resolving a conflict on your own, you "
+"should feel free to report the conflict to \n"
+"    us. How you address the conflict depends on who is involved in the "
+"conflict and your comfort level. Please see \n"
+"    the detailed sections below on how and with whom to address your "
+"conflict. We aim to address conflicts as soon \n"
+"    as possible in an effort to prevent them from escalating "
+"unnecessarily."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:75
+msgid "Direct conflict resolution"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:78
+msgid ""
+"In direct conflict resolution, the involved parties will attempt to "
+"resolve the conflict themselves without \n"
+"   involving any MetaBrainz Foundation team member. You should aim to use"
+" direct resolution when the conflict does \n"
+"   not involve the violation of one of our policies or if the conflict is"
+" minor."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:84
+#, python-format
+msgid ""
+"For instance, if a user uses a rude tone, is disruptive or flagrantly "
+"ignores our project guidelines, we suggest \n"
+"    that you use direct conflict resolution to resolve the conflict. Some"
+" resources that might give you some suggestions \n"
+"    on how to go about resolving the conflict might be this <a "
+"href=\"%(conflict_resolution_primer_url)s\">\n"
+"    conflict resolution primer</a> and <a "
+"href=\"%(difficult_conversations_url)s\">how to\n"
+"    have difficult conversations at work</a>."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:93
+msgid "Informal reporting"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:96
+msgid ""
+"You may use informal reporting of a conflict if you aim to communicate a "
+"concern or incident without \n"
+"    seeking a corrective outcome. Informal reporting may also be an "
+"option if you have not been personally \n"
+"    victimized, but you’ve witnessed a violation of our policies or where"
+" you wish to maintain confidentiality \n"
+"    throughout the entire reporting process."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:103
+msgid ""
+"For editing in MusicBrainz you may informally report a user using the "
+"“Report this user for bad behavior” \n"
+"    link from the user’s profile. For reporting bad user behavior in "
+"other of our projects, please report them to our \n"
+"    community manager by mailing <span class=\"backemail\">gro.zniarbatem"
+"@reganam-ytinummoc</span> . For conflicts \n"
+"    that involve the community manager, report them by mailing <span "
+"class=\"backemail\">gro.zniarbatem@de</span> ."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:110
+msgid ""
+"Depending the the severity of the issue, repeated informal complaints may"
+" eventually require a formal response \n"
+"    from the MetaBrainz team. If an involved party requires anonymity, "
+"the conflict becomes a private conflict. If at \n"
+"    all possible minor issues should be resolved in a public forum in "
+"order for all people to witness and learn from \n"
+"    the issue at hand."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:116
+msgid "Formal complaint process"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:119
+msgid ""
+"All complaints about conflicts should be submitted via email. To whom a "
+"complaint should be mailed and who will \n"
+"    carry out the investigation will be described in the next section."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:124
+msgid "All complaint submissions to the Foundation should include the following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:128
+msgid ""
+"Contact info, if it is different than the email used to submit the "
+"conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:129
+msgid "Who was involved in the conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:130
+msgid "Where and when the incident happened"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:131
+msgid ""
+"A description of what happened -- ideally with links (e.g. chatlogs, edit"
+" notes) that outlines what \n"
+"         happened so that the persons evaluating the conflict may "
+"understand the issue at hand"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:133
+msgid ""
+"Any related pieces of information that provide more context on the "
+"conflict (e.g. links, screenshots)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:134
+msgid "An indication if this conflict is ongoing or not"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:139
+msgid "The investigation that follows aims to determine:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:143
+msgid "The nature and severity of the incident"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:144
+msgid ""
+"Whether or not the incident is considered a violation of MetaBrainz’ "
+"conduct policies or core values"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:145
+msgid ""
+"The amount of harm experienced by the person who submitted the complaint "
+"and the broader MetaBrainz community \n"
+"         as a result of the incident"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:147
+msgid ""
+"Whether there have been prior complaints against the individual or "
+"individuals reported"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:148
+msgid "Whether the incident is ongoing"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:152
+msgid ""
+"The following potential forms of resolution may apply to any team members"
+" involved in the conflict:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:155
+#: metabrainz/templates/index/conflict-policy.html:168
+msgid "Nothing (if it has been found no violation occurred)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:156
+msgid "Creating a plan to improve the performance"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:157
+msgid "Creating a negative performance evaluation"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:158
+msgid "Mediation, an intervention by a third party to resolve the conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:159
+msgid "Suspension or forced leave"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:160
+msgid "Termination of contract"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:164
+msgid ""
+"The following potential forms of resolution may apply to non team members"
+" involved in the conflict:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:169
+msgid "A reprimand, either public or private"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:170
+msgid "Suspension of the users’ account"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:171
+msgid "Deletion of the users’ account"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:172
+msgid ""
+"Removal of user privileges (e.g. if an auto editor commits a serious "
+"offence, they may lose their auto editor status)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:175
+msgid "Filing a complaint"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:178
+msgid ""
+"NOTE: For complaints not about MetaBrainz staff, please see the "
+"<em>Informal reporting</em> section above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:182
+msgid ""
+"If the complaint does not involve the Executive Director (ED), do the "
+"following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:186
+msgid ""
+"If team member has directly violated conduct policies or engaged in "
+"otherwise harmful behavior, a formal complaint should be filed."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:187
+msgid ""
+"Mail <span class=\"backemail\">gro.zniarbatem@de</span> and include the "
+"complaint information outlined above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:188
+msgid ""
+"You should expect a response within a working day acknowledging the "
+"complaint."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:189
+msgid ""
+"The complaint will be investigated by the ED, member(s) of the board of "
+"directors or a neutral third party."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:190
+msgid ""
+"Once the investigation has been completed, the ED, with the support of "
+"others involved in the investigation will respond. The \n"
+"        ED will respond to incidents no later than 7 working days after a"
+" complaint has been filed with either a resolution or an \n"
+"        explanation of why the process must be extended."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:196
+msgid "If a complaint involves the Executive Director, do the following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:200
+msgid ""
+"If the Executive Director has directly violated conduct policies or "
+"engaged in otherwise harmful behavior, \n"
+"        a formal complaint should be filed with the board of directors."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:202
+msgid ""
+"Mail <span class=\"backemail\">gro.zniarbatem@noituloser-tcilfnoc</span> "
+"and include the complaint information outlined above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:203
+msgid ""
+"You should get a response within 5 working days acknowledging the "
+"complaint."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:204
+msgid ""
+"The complaint will be investigated by the member(s) of the board of "
+"directors, the community manager, a neutral \n"
+"        third party or a combination thereof."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:206
+msgid ""
+"Once the investigation has been completed, the board, with the support of"
+" others involved in the investigation \n"
+"        will respond. The board will aim to respond to incidents no later"
+" than 15 working days after a complaint has been filed \n"
+"        with either a resolution or an explanation of why the process "
+"must be extended."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:211
+msgid "Confidentiality"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:214
+msgid ""
+"Confidentiality is an important aspect of conflict resolution and all of "
+"the conflicts brought to the attention of the foundation \n"
+"    will be evaluated with confidentiality in mind and acted upon "
+"accordingly."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:219
+msgid ""
+"We work hard to make all of the actions of the foundation as transparent "
+"and open as possible. In cases where we cannot \n"
+"    disclose all aspects of a conflict we will disclose that a conflict "
+"is or has occurred and we will attempt to disclose the \n"
+"    appropriate amount of information about the conflict while balancing "
+"the need for confidentiality and our desire to learn \n"
+"    from conflicts so that we as a foundation and community can learn "
+"from these conflicts and improve our policies to avoid the \n"
+"    conflicts in the future."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:227
+msgid ""
+"Any breaches of confidentiality will be treated as severe breaches of our"
+" conduct policies."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:230
+msgid "Retaliation"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:233
+msgid ""
+"We will not allow retaliation for any contractor or volunteer that files "
+"a complaint or is involved in an investigation. If you \n"
+"    believe that you are being treated negatively because of your "
+"involvement in a complaint please report this complaint directly \n"
+"    to the ED at <span class=\"backemail\">gro.zniarbatem@de</span> or "
+"the board at \n"
+"    <span class=\"backemail\">gro.zniarbatem@noituloser-tcilfnoc</span>."
 msgstr ""
 
 #: metabrainz/templates/index/contact.html:3
@@ -1050,7 +1561,7 @@ msgstr ""
 msgid ""
 "We are currently evaluating our overall online advertising strategy. We "
 "are evaluating advertising, traffic optimization,\n"
-"    search engine optimization and software monitization technologies. If"
+"    search engine optimization and software monetization technologies. If"
 " you provide these professional services, please provide a detailed\n"
 "    deck of your comprehensive services to the following email address. "
 "<em>Please respect our other non-media teams and do not contact us \n"
@@ -1125,11 +1636,11 @@ msgstr "Fóra"
 #, python-format
 msgid ""
 "Please come ask your questions at our <a "
-"href=\"%(forums_url)s\">forums</a>! We would love to\n"
-"    answer any questions you may have."
+"href=\"%(forums_url)s\">forums</a>!\n"
+"    The community and the team will be more than happy to help you."
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:92
+#: metabrainz/templates/index/contact.html:93
 #, python-format
 msgid ""
 "The MetaBrainz/MusicBrainz/ListenBrainz team and community hang out\n"
@@ -1139,15 +1650,15 @@ msgid ""
 "    <a href=\"%(chatlogs_url)s\">chat log archives</a>."
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:101
+#: metabrainz/templates/index/contact.html:102
 msgid "Social media"
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:103
+#: metabrainz/templates/index/contact.html:104
 msgid "You can follow us on these social channels:"
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:112
+#: metabrainz/templates/index/contact.html:113
 msgid "Mailing address"
 msgstr "Poštovní adresa"
 
@@ -1160,33 +1671,349 @@ msgstr ""
 msgid "GDPR Compliance Statement"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:37
+#: metabrainz/templates/index/gdpr.html:10
+msgid ""
+"The General Data Protection Regulation is a complex EU regulation that "
+"stipulates many points for protecting private data of\n"
+"    users on the Internet. Even though this is an EU regulation, it has a"
+" worldwide impact due to the nature of the Internet.\n"
+"    The MetaBrainz Foundation with its collection of projects is also "
+"affected by this regulation. We’ve been learning and adapting\n"
+"    our sites to be compliant with the GDPR – sadly this regulation isn’t"
+" entirely black and white and there is an incredible\n"
+"    amount of room left for interpretation of these rules."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:17
+msgid ""
+"The good news is that this regulation is roughly in line with our "
+"established practices: We’ve always held private information\n"
+"    in a high regard and applied the sort of rules to ourselves as we "
+"wish to have our own private data treated. Luckily, this\n"
+"    makes our compliance effort considerably easier. We’ve made two "
+"significant changes to how we treat your data and also adopted\n"
+"    terminology as used in the GDPR in order to use the same languages "
+"that many other sites are now adopting. Please keep reading\n"
+"    to find out the exact details of what we are doing to comply."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:24
+#, python-format
+msgid ""
+"However, we do ask for your compassion and help in our process of "
+"complying with the GDPR. As we already mentioned, the GDPR is\n"
+"    a complex set of rules that are not fully clarified yet. We’ve taken "
+"action on the steps that are clear to us and we’re following\n"
+"    ongoing conversations on points that are in gray zones or unclear to "
+"us. We’ve made our best initial effort on compliance and\n"
+"    promise to keep working on it as the picture becomes more clear. If "
+"you believe that we could improve our compliance, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a> and let us know what we "
+"can do to improve. It would also help us if you\n"
+"    could provide concrete discussion or examples to help us understand "
+"and take action on your suggestion."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:33
+msgid ""
+"Finally, below are the key sections of the GDPR as we understand them and"
+" how they affect your data in our ecosystem. Where\n"
+"    possible, we provide links for deeper understanding, links for you to"
+" examine our relevant code and links to tickets to follow\n"
+"    the process of improving our compliance."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:38
 msgid "Right to be forgotten"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:77
+#: metabrainz/templates/index/gdpr.html:41
+msgid ""
+"Summary: <i>Provide the user with the ability to remove their private "
+"data from our services</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:44
+msgid ""
+"The most important aspect of the right to be forgotten is the ability to "
+"delete your account. Once you request for us to delete\n"
+"    your account, we will remove any personally identifying information "
+"you may have provided us from your account (name, email\n"
+"    address, gender, biography, URL, etc.). The visible name on your "
+"account will be changed to “Deleted User #####” and effectively\n"
+"    the account will no longer be identifiable as your account."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:50
+msgid ""
+"However, given the nature of our projects where we work on collaborative "
+"databases, your contributions that are not personally\n"
+"    identifying are valuable assets to our database and these "
+"contributions will not be removed from our databases. But we will\n"
+"    ensure that these contributions no longer contain personally "
+"identifying data."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:55
+#, python-format
+msgid ""
+"Our process of automatically deleting your accounts across the MetaBrainz"
+" ecosystem is not complete yet (see below for a set of\n"
+"    tickets where you can track our progress). If you would like to "
+"delete your accounts in the MetaBrainz ecosystem or mark a\n"
+"    donation that is currently public as a private donation, please <a "
+"href=\"%(contact_url)s\">contact us</a>\n"
+"    and we will address your request as soon as possible."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:62
+#: metabrainz/templates/index/gdpr.html:182
+msgid "Links:"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:66
+#, python-format
+msgid ""
+"<a href=\"%(editor_deletion_doc_url)s\">How we delete accounts\n"
+"       in MusicBrainz</a> (warning, geek content ahead!)"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:70
+msgid ""
+"Implement sitewide user account deletion in\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/MBS-9680\">MusicBrainz</a>,"
+"\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/AB-337\">AcousticBrainz</a>,"
+"\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/BB-260\">BookBrainz</a>,\n"
+"         <a href=\"https://tickets.metabrainz.org/browse/MEB-103\">the "
+"MetaBrainz Site</a>,\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/LB-354\">ListenBrainz</a>, "
+"and\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/CB-307\">CritiqueBrainz</a>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:80
 msgid "Restriction of processing"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:110
+#: metabrainz/templates/index/gdpr.html:83
+msgid ""
+"Summary: <i>To allow the user to control how their personally identifying"
+" data is being used.</i>"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:86
+msgid ""
+"Except for the ListenBrainz and AcousticBrainz projects, we do not "
+"process personally identifying data. Any personally\n"
+"    identifying data that our projects store is for the purpose of being "
+"able to contact you about your contributions to our database\n"
+"    (email address) or for voluntarily showing information about you to "
+"other users (biography, homepage, location, etc)."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:91
+#, python-format
+msgid ""
+"The ListenBrainz project differs in that the Listens (metadata about what"
+" music you have listened to) are stored on our servers\n"
+"    and <a href=\"%(listenbrainz_data_url)s\">made available to the "
+"public</a>. We believe Listens to be personally identifying\n"
+"    data and furthermore, we have goals of creating open source "
+"recommendation engines with this data, which involves processing the\n"
+"    user’s data. These two points are fundamental goals of the "
+"ListenBrainz project and we do not see a reasonable way to reach another"
+"\n"
+"    compromise position."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:99
+msgid ""
+"Because of this, we are going to require users to either acknowledge that"
+" we may process their Listen data or alternatively to\n"
+"    delete their account, including all of their Listens. Please note "
+"that if you decide to delete your ListenBrainz account, it may\n"
+"    take up to two weeks for all of your listens to no longer be included"
+" in our efforts to build a recommendation engine."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:104
+msgid ""
+"We have always made it clear that the data in ListenBrainz was to be "
+"public and that we plan to build new tools with your data, so\n"
+"    this should not come as a surprise to our users."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:108
+msgid ""
+"The AcousticBrainz project does not track who submits data to the "
+"database. If you create an account and use our data creation\n"
+"    tools (e.g. create a dataset or participate in a challenge) then we "
+"link your participation and the things that you create to\n"
+"    your account. If you choose to delete your account then we keep the "
+"non personally identifying data that you create, but anonymize\n"
+"    it so that it cannot be linked back to you."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:114
 msgid "Right to data portability / exporting your data"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:150
+#: metabrainz/templates/index/gdpr.html:117
+msgid ""
+"Summary: <i>You have the right to access/download the data we store about"
+" you</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:120
+msgid ""
+"Except for the ListenBrainz and AcousticBrainz projects, we do not store "
+"personally identifying data beyond the\n"
+"    information that is available in your public profile on each of our "
+"projects. Since this data is plainly available in your\n"
+"    profile we do not provide a means for you to export this data."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:125
+msgid "There are the following exceptions to this:"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:129
+msgid ""
+"<b>IP addresses</b>: If you visit one of our sites the IP address of your"
+" computer is stored in our web logs for 7 days\n"
+"        before our servers automatically delete them. This data is almost"
+" never used by anyone: the only time we look at the\n"
+"        IP addresses is if our sites are adversely impacted by the "
+"actions of some unknown users. In that case, we may investigate\n"
+"        the logs to identify the IP address that needs to be blocked in "
+"order to restore the stability of our service.\n"
+"        This data is not available to anyone but the contractors of the "
+"MetaBrainz Foundation and is not available to download\n"
+"        to anyone at all."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:137
+#, python-format
+msgid ""
+"<b>ListenBrainz Listen data</b>: Users may <a "
+"href=\"%(listenbrainz_export_url)s\">export their ListenBrainz Listen\n"
+"        data</a> directly from the site. The user Listen data is also "
+"included in the <a href=\"%(listenbrainz_data_url)s\">ListenBrainz\n"
+"        data dumps</a> that are available for public download."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:146
+msgid ""
+"All of the non personally identifying data, such as your metadata "
+"contributions, are publicly visible, available for download\n"
+"    and available via the project APIs. For details about this data, "
+"downloads and APIs please check the documentation for the\n"
+"    respective projects you are interested in."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:151
+#, python-format
+msgid ""
+"Anyone wishing to get a list of financial donations they have made to the"
+" MetaBrainz Foundation, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a> and provide your "
+"MusicBrainz editor name so that we can look up\n"
+"    your donations."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:157
 msgid "Right to rectification"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:165
+#: metabrainz/templates/index/gdpr.html:160
+msgid "Summary: <i>You have the right to correct your data</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:163
+msgid ""
+"All of our projects allow their users to update their personally "
+"identifying information in their profiles. Furthermore, most\n"
+"    of our projects allow the editing of their own metadata "
+"contributions. If you find that some of your data is incorrect, please\n"
+"    feel free to edit the data since we provide the tools to do so."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:168
+#, python-format
+msgid ""
+"If anyone who has made a financial donation to the MetaBrainz Foundation "
+"would like to make their donation private, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:173
 msgid "Right to be informed"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:188
+#: metabrainz/templates/index/gdpr.html:175
+msgid ""
+"Summary: <i>You have the right to be informed about how we use your data "
+"in plain English</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:178
+msgid ""
+"Our privacy policy, as well as other policies, have always been written "
+"by humans for human consumption. We abhor legalese and\n"
+"    not speaking in direct terms."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:186
+msgid "Social contract"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:189
+msgid "Code of conduct"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:192
+msgid "Privacy policy"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:196
 msgid "Right to access"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:198
-#: metabrainz/templates/index/privacy.html:166
+#: metabrainz/templates/index/gdpr.html:199
+msgid ""
+"Summary: <i>You have the right to access the data that we collect about "
+"you</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:202
+msgid ""
+"All of our projects make all of the data we collect on your behalf, "
+"privately identifying or not, available to you. The\n"
+"    only exception to this are the IP addresses we store for 7 days – see"
+" above for details."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:206
+#: metabrainz/templates/index/privacy.html:168
 msgid "Privacy/GDPR Representative"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:209
+#, python-format
+msgid ""
+"If you have any questions about our privacy policy, please <a "
+"href=\"%(contact_url)s\">contact us</a>. To report\n"
+"   any privacy problems, violations or leaks, our GDPR representative is "
+"our Interim Executive Director Nicolás Tamargo and for\n"
+"   privacy issues contact him at <strong><a "
+"href=\"mailto:gdpr@metabrainz.org\">gdpr@metabrainz.org</a></strong>."
 msgstr ""
 
 #: metabrainz/templates/index/index.html:6
@@ -1305,7 +2132,7 @@ msgid ""
 "      <a href=\"%(about_url)s\">about</a> page."
 msgstr ""
 
-#: frontend/js/src/forms/ConditionsModal.tsx:43
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:32
 #: metabrainz/templates/index/privacy.html:3
 msgid "Privacy"
 msgstr "Soukromí"
@@ -1313,6 +2140,44 @@ msgstr "Soukromí"
 #: metabrainz/templates/index/privacy.html:8
 msgid "Summary"
 msgstr "Souhrn"
+
+#: metabrainz/templates/index/privacy.html:12
+msgid ""
+"You do not have to provide any personal data to be able to browse the "
+"contents of the databases published by MetaBrainz."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:15
+msgid ""
+"You do not have to provide any personally-identifying information if you "
+"choose not to."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:18
+msgid ""
+"We will never reveal your email address on MetaBrainz controlled web "
+"sites."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:22
+msgid ""
+"In order to get maximum value out of the MetaBrainz projects, you may "
+"want to create an account and log in. \n"
+"    Doing so grants you the ability to: edit the databases, contribute "
+"your own data, communicate with other users, and keep track \n"
+"    of recently released music from artists in your MusicBrainz "
+"collection. If you choose to create an account then the minimum we \n"
+"    ask is that you: choose a unique username and password, use a web "
+"browser that accepts \"session\" cookies, and provide a verified \n"
+"    email address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:29
+msgid ""
+"If you do not create an account (or are not logged in) you will not have "
+"access to the above listed features, however, you will \n"
+"    still have full access to browse and examine the databases."
+msgstr ""
 
 #: metabrainz/templates/index/privacy.html:33
 msgid "Applicable to all users"
@@ -1322,40 +2187,198 @@ msgstr ""
 msgid "Cookies"
 msgstr ""
 
+#: metabrainz/templates/index/privacy.html:37
+msgid "We use two cookies that contain sensitive information:"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:42
+msgid ""
+"<b>remember_login</b>: If you choose the \"Log in permanently\" option "
+"when logging in to one of our sites; the cookie will be used to \n"
+"      remember your login details."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:46
+msgid ""
+"<b>musicbrainz_server_session, session, or connect.sid</b>: If you are "
+"logged into one of our sites, your current session ID is stored in this "
+"cookie."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:51
+msgid ""
+"We may store dynamic preference information in other cookies, but these "
+"do not contain any sensitive information."
+msgstr ""
+
 #: metabrainz/templates/index/privacy.html:54
 #, fuzzy
 msgid "Web and FTP access logs"
 msgstr "Web a FTP protokoly přístupů (všichni uživatelé)"
 
+#: metabrainz/templates/index/privacy.html:57
+msgid ""
+"In a practice similar to other web sites (and APIs) we keep logs of all "
+"web requests made against our servers. These logs include: your IP\n"
+"    address, your browser's (or API client's) \"User-Agent\" string, and "
+"which page (or API endpoint) you requested with which parameters. "
+"Aggregate information about web and FTP traffic is\n"
+"    made available to the public via our site usage pages."
+msgstr ""
+
 #: metabrainz/templates/index/privacy.html:62
 msgid "Third-Party content"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:92
+#: metabrainz/templates/index/privacy.html:64
+msgid ""
+"Our projects' web pages may load some third-party content. Some, but "
+"possibly not all sites are listed below:"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:69
+#, python-format
+msgid ""
+"Cover art and other images: These are provided by the various cover art "
+"sites that have given MusicBrainz permission to do so and our own \n"
+"      <a href=\"%(caa_url)s\">Cover Art Archive</a>. This means that the "
+"relevant site will know (if they want to) your IP \n"
+"      address, User-Agent string, etc., and which MusicBrainz web page "
+"you were visiting (the one which included the cover art image)."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:75
+msgid ""
+"AcoustID: Our fingerprints tab loads fingerprint information from "
+"acoustid.org."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:78
+msgid ""
+"MTCaptcha: Our account creation page loads third party content in order "
+"to prevent spammers from creating accounts."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:83
+msgid ""
+"<i>The above information assumes that you are using \"normal\" web "
+"browser settings, whereby images are always loaded and HTTP referrer \n"
+"    information is always sent.</i>"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:88
+msgid ""
+"It is impractical to constantly modify this privacy policy when "
+"MetaBrainz projects change which third party content they utilize. We "
+"will \n"
+"    aim to use common sense, respect to our community and community "
+"review when adding more content from third party sites. We will also \n"
+"    periodically review our policy to ensure that it remains current."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:93
 msgid "Applicable to account holders"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:94
+#: metabrainz/templates/index/privacy.html:95
 msgid "Account creation"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:108
+#: metabrainz/templates/index/privacy.html:97
+msgid ""
+"When creating an account with a MetaBrainz project you need to pick a "
+"unique username and choose a password, the username you pick is the \n"
+"    only name associated with your account and will be what other "
+"MetaBrainz users know you as. You may optionally also tell us other \n"
+"    information about yourself that will be displayed to other MetaBrainz"
+" users and the public."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:103
+msgid ""
+"Additionally, in order to edit the databases you will need to provide a "
+"confirmed email address. This email address will be held in \n"
+"    confidence, the only method of revealing your email address to "
+"another user is if you choose to send a message to another \n"
+"    user and enable the option to \"reveal my email address\". Changing "
+"the email address stored with your account will require you to \n"
+"    verify the new address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:109
 msgid "Edits and Notes"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:114
+#: metabrainz/templates/index/privacy.html:111
+msgid ""
+"If you make any changes to a MetaBrainz project database, such as adding "
+"any data, the details of those changes will be visible to \n"
+"    other logged-in users and the change will be associated with your "
+"username."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:115
 msgid "Subscriptions on MusicBrainz"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:131
+#: metabrainz/templates/index/privacy.html:117
+msgid ""
+"As a logged-in user you can subscribe to one or more artists, labels, "
+"collections or other editors. The act of subscribing causes \n"
+"    any edits made to (or by in the case of another editor) those "
+"entities to be emailed to you. By default, other users can see your \n"
+"    list of subscriptions, however, you can opt out of this by editing "
+"the appropriate preference."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:123
+msgid ""
+"This does not provide \"perfect\" privacy though, in some cases it will "
+"be possible to infer information about the contents of your \n"
+"    subscription list even though you have disallowed others from viewing"
+" that list directly. This imperfection arises because various \n"
+"    parts of the system behave differently depending on whether or not an"
+" entity has any subscribers; also, the number of users \n"
+"    subscribed to each artist is available via the artist pages. In the "
+"most extreme (possibly contrived) example, imagine that all \n"
+"    users have their subscriptions set to \"public\", except for exactly "
+"one user whose list is \"private\". In that case, any discrepancy \n"
+"    for a given artist between the shown list of subscribers and the "
+"total number of subscribers must be down to that one user. Thus, \n"
+"    you can infer what artists are on that user's list."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:132
 msgid "Third-party sites"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:145
+#: metabrainz/templates/index/privacy.html:134
+#, python-format
+msgid ""
+"Our code reviews are done on GitHub, which is not under the control of "
+"MetaBrainz. Participating in code reviews or other\n"
+"    tasks carried out on GitHub are subject to <a "
+"href=\"%(github_url)s\">GitHub's privacy policy</a>."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:140
+#, python-format
+msgid ""
+"Our translations platform is provided and hosted by Weblate, which has a "
+"data processing agreement with MetaBrainz.\n"
+"    Participating in translations is subject to <a "
+"href=\"%(weblate_url)s\">dedicated legal terms</a>.\n"
+"    Any translations you make will be submitted to our Git repositories "
+"and publicly associated with your username;\n"
+"    if you so choose, you can also publicly associate them with your own "
+"verified email address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:147
 msgid "MetaBrainz donors"
 msgstr "MetaBrainz dárci"
 
-#: metabrainz/templates/index/privacy.html:147
+#: metabrainz/templates/index/privacy.html:149
 msgid ""
 "When you make a donation to the MetaBrainz Foundation, we are legally\n"
 "    required to collect your personal information and keep it in our "
@@ -1365,7 +2388,7 @@ msgid ""
 "    information to anyone else, ever."
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:153
+#: metabrainz/templates/index/privacy.html:155
 msgid ""
 "We believe in transparent finances, which means that we list all "
 "donations\n"
@@ -1375,11 +2398,34 @@ msgid ""
 "process."
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:158
+#: metabrainz/templates/index/privacy.html:160
 msgid "Exceptions"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:598
+#: metabrainz/templates/index/privacy.html:162
+msgid ""
+"<i><b>Please note</b>: Reasonable exceptions may apply to the above "
+"policy, for example to comply with applicable laws.\n"
+"    Also, members of the MetaBrainz team and other personnel contracted "
+"to provide services to MetaBrainz may have access to\n"
+"    our infrastructure and could therefore view any information contained"
+" therein. However all personnel are contractually bound\n"
+"    by non-disclosure clauses which prevent them from making any such "
+"information available to others."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:171
+#, python-format
+msgid ""
+"If you have any questions about our GDPR statement, please <a "
+"href=\"%(contact_url)s\">contact us</a>. To report\n"
+"   any privacy problems, violations or leaks, our GDPR representative is "
+"our Interim Executive Director Nicolás Tamargo and for\n"
+"   privacy issues contact him at <strong><a "
+"href=\"mailto:gdpr@metabrainz.org\">gdpr@metabrainz.org</a></strong>."
+msgstr ""
+
+#: frontend/js/src/Profile.tsx:603
 #: frontend/js/src/forms/ProfileChangePassword.tsx:22
 #: frontend/js/src/forms/ProfileChangePassword.tsx:111
 #: metabrainz/templates/index/profile-change-password.html:3
@@ -1627,6 +2673,11 @@ msgstr ""
 
 #: metabrainz/templates/index/team.html:26
 msgid "He lives on in our hearts and in open source."
+msgstr ""
+
+#: metabrainz/templates/index/team.html:29
+#: metabrainz/templates/index/team.html:315
+msgid "you’re welcome to try"
 msgstr ""
 
 #: metabrainz/templates/index/team.html:39
@@ -2125,8 +3176,10 @@ msgstr ""
 
 #: metabrainz/templates/payments/donate.html:146
 msgid ""
-"Due to the increased unreliability of the US Postal Service we have "
-"stopped accepting paper checks. Sorry!"
+"Due to the increased unreliability of the US Postal Service and the "
+"relatively large fees involved, we ask you to only send a paper check if "
+"it is the only possible option. Due to the fees, we will not cash checks "
+"for less than $25."
 msgstr ""
 
 #: metabrainz/templates/payments/donate.html:241
@@ -3010,8 +4063,8 @@ msgid "Monthly balance sheets"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:520
-#: frontend/js/src/forms/SignupCommercial.tsx:175
-#: frontend/js/src/forms/SignupCommercial.tsx:554
+#: frontend/js/src/forms/SignupCommercial.tsx:180
+#: frontend/js/src/forms/SignupCommercial.tsx:558
 #: frontend/js/src/forms/SignupNonCommercial.tsx:106
 #: frontend/js/src/forms/SignupNonCommercial.tsx:318
 #: metabrainz/templates/supporters/account-type.html:3
@@ -3033,6 +4086,7 @@ msgid "Non-commercial / Personal"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:235
+#: frontend/js/src/forms/SignupNonCommercial.tsx:107
 #: frontend/js/src/forms/SignupNonCommercial.tsx:151
 #: metabrainz/templates/supporters/account-type.html:42
 msgid "Non-commercial"
@@ -3046,57 +4100,46 @@ msgstr ""
 msgid "Personal or university assignment user."
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:48
-#: metabrainz/templates/supporters/account-type.html:90
-#: metabrainz/templates/supporters/account-type.html:141
-msgid "Upgrade"
-msgstr ""
-
 #: frontend/js/src/Profile.tsx:235
-#: frontend/js/src/forms/SignupCommercial.tsx:176
-#: frontend/js/src/forms/SignupCommercial.tsx:228
-#: metabrainz/templates/supporters/account-type.html:61
+#: frontend/js/src/forms/SignupCommercial.tsx:181
+#: frontend/js/src/forms/SignupCommercial.tsx:233
+#: metabrainz/templates/supporters/account-type.html:56
 msgid "Commercial"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:83
-#: metabrainz/templates/supporters/account-type.html:135
+#: metabrainz/templates/supporters/account-type.html:78
+#: metabrainz/templates/supporters/account-type.html:125
 #, python-format
 msgid "$%(tier_price)s/month and up"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:87
-#: metabrainz/templates/supporters/account-type.html:138
+#: metabrainz/templates/supporters/account-type.html:82
+#: metabrainz/templates/supporters/account-type.html:128
 msgid "More info"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:104
+#: metabrainz/templates/supporters/account-type.html:94
 msgid "View all tiers"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:112
+#: metabrainz/templates/supporters/account-type.html:102
 msgid "Some of our Unicorn members"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:123
+#: metabrainz/templates/supporters/account-type.html:113
 msgid "See all our supporters"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:151
+#: metabrainz/templates/supporters/account-type.html:136
 msgid "View featured tiers"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:158
+#: metabrainz/templates/supporters/account-type.html:143
 #, python-format
 msgid ""
 "If you are not sure which tier to pick, please\n"
 "      <a href=\"%(contact_url)s\">contact us</a>."
 msgstr ""
-
-#: metabrainz/templates/supporters/account-type.html:166
-#, fuzzy
-msgid "Back to Profile"
-msgstr "Váš profil"
 
 #: metabrainz/templates/supporters/bad-standing.html:3
 #: metabrainz/templates/supporters/bad-standing.html:6
@@ -3157,9 +4200,9 @@ msgid "Forgot your username"
 msgstr ""
 
 #: frontend/js/src/forms/ResetPassword.tsx:79
-#: frontend/js/src/forms/SignupCommercial.tsx:320
+#: frontend/js/src/forms/SignupCommercial.tsx:325
 #: frontend/js/src/forms/SignupNonCommercial.tsx:227
-#: frontend/js/src/forms/SignupUser.tsx:169
+#: frontend/js/src/forms/SignupUser.tsx:175
 #: metabrainz/templates/users/reauthenticate.html:3
 #: metabrainz/templates/users/reauthenticate.html:6
 msgid "Confirm Password"
@@ -3169,17 +4212,22 @@ msgstr ""
 msgid "Please re-enter your password to continue."
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:108
+#: frontend/js/src/ProfileDelete.tsx:110
 #: frontend/js/src/forms/DeleteApplication.tsx:53
 #: frontend/js/src/forms/OAuthPrompt.tsx:54
 #: frontend/js/src/forms/ProfileChangePassword.tsx:104
 #: frontend/js/src/forms/ProfileEdit.tsx:105
-#: metabrainz/templates/users/reauthenticate.html:23
+#: metabrainz/templates/users/reauthenticate.html:28
 msgid "Cancel"
 msgstr ""
 
-#: metabrainz/templates/users/reauthenticate.html:24
+#: metabrainz/templates/users/reauthenticate.html:29
 msgid "Continue"
+msgstr ""
+
+#: frontend/js/src/forms/utils.tsx:202
+#: metabrainz/templates/users/reauthenticate.html:40
+msgid "Password must not exceed 72 bytes."
 msgstr ""
 
 #: frontend/js/src/forms/ResetPassword.tsx:27
@@ -3187,38 +4235,38 @@ msgstr ""
 msgid "Reset your password"
 msgstr ""
 
-#: frontend/js/src/hooks/useEmailValidation.ts:41 metabrainz/user/forms.py:15
+#: frontend/js/src/hooks/useEmailValidation.ts:41 metabrainz/user/forms.py:16
 msgid "Registration from this email domain is not allowed."
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:50
 #: frontend/js/src/forms/LostPassword.tsx:45
-#: frontend/js/src/forms/SignupCommercial.tsx:270
+#: frontend/js/src/forms/SignupCommercial.tsx:275
 #: frontend/js/src/forms/SignupNonCommercial.tsx:175
-#: frontend/js/src/forms/SignupUser.tsx:114 metabrainz/user/forms.py:20
-#: metabrainz/user/forms.py:45 metabrainz/user/forms.py:62
+#: frontend/js/src/forms/SignupUser.tsx:120 metabrainz/user/forms.py:22
+#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:75
 msgid "Username"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:42
 #: frontend/js/src/forms/LostPassword.tsx:37
-#: frontend/js/src/forms/SignupCommercial.tsx:153
+#: frontend/js/src/forms/SignupCommercial.tsx:158
 #: frontend/js/src/forms/SignupNonCommercial.tsx:84
-#: frontend/js/src/forms/SignupUser.tsx:67 metabrainz/user/forms.py:21
-#: metabrainz/user/forms.py:45 metabrainz/user/forms.py:62
+#: frontend/js/src/forms/SignupUser.tsx:73 metabrainz/user/forms.py:26
+#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:75
 msgid "Username is required!"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:63
 #: frontend/js/src/forms/ResetPassword.tsx:72
-#: frontend/js/src/forms/SignupCommercial.tsx:308
+#: frontend/js/src/forms/SignupCommercial.tsx:313
 #: frontend/js/src/forms/SignupNonCommercial.tsx:214
-#: frontend/js/src/forms/SignupUser.tsx:157 metabrainz/user/forms.py:46
-#: metabrainz/user/forms.py:52
+#: frontend/js/src/forms/SignupUser.tsx:163 metabrainz/user/forms.py:53
+#: metabrainz/user/forms.py:62
 msgid "Password"
 msgstr ""
 
-#: frontend/js/src/forms/LoginUser.tsx:76 metabrainz/user/forms.py:47
+#: frontend/js/src/forms/LoginUser.tsx:76 metabrainz/user/forms.py:57
 msgid "Remember me"
 msgstr ""
 
@@ -3230,11 +4278,11 @@ msgstr ""
 msgid "Username contains invalid or invisible characters."
 msgstr ""
 
-#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:181
+#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:220
 msgid "Hide password"
 msgstr ""
 
-#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:181
+#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:220
 msgid "Show password"
 msgstr ""
 
@@ -3291,11 +4339,11 @@ msgstr ""
 msgid "Revoke access"
 msgstr ""
 
-#: frontend/js/src/OAuthError.tsx:17
+#: frontend/js/src/OAuthError.tsx:18
 msgid "OAuth2 Error"
 msgstr ""
 
-#: frontend/js/src/OAuthError.tsx:18
+#: frontend/js/src/OAuthError.tsx:19
 msgid "An error occurred during OAuth authentication process."
 msgstr ""
 
@@ -3325,8 +4373,8 @@ msgstr ""
 
 #: frontend/js/src/Profile.tsx:109
 msgid ""
-"Are you sure you want to generate new access token? Current token will be"
-" revoked!"
+"Are you sure you want to generate a new access token? The current token "
+"will be revoked!"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:118
@@ -3441,8 +4489,8 @@ msgid "Contact Information"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:310 frontend/js/src/forms/ProfileEdit.tsx:70
-#: frontend/js/src/forms/SignupCommercial.tsx:284
-#: frontend/js/src/forms/SignupCommercial.tsx:333
+#: frontend/js/src/forms/SignupCommercial.tsx:289
+#: frontend/js/src/forms/SignupCommercial.tsx:338
 #: frontend/js/src/forms/SignupNonCommercial.tsx:189
 #: frontend/js/src/forms/SignupNonCommercial.tsx:241
 msgid "Contact name"
@@ -3557,7 +4605,7 @@ msgstr ""
 msgid "Once you delete your account, there is no going back. Please be certain."
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:550 frontend/js/src/ProfileDelete.tsx:105
+#: frontend/js/src/Profile.tsx:550 frontend/js/src/ProfileDelete.tsx:107
 msgid "Delete My Account"
 msgstr ""
 
@@ -3569,39 +4617,39 @@ msgstr ""
 msgid "Need to delete your account?"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:574
+#: frontend/js/src/Profile.tsx:575
 msgid ""
 "Deletion of supporter accounts requires manual review. Please contact us "
-"at"
+"at <email />."
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:594
+#: frontend/js/src/Profile.tsx:599
 msgid "Security"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:626
+#: frontend/js/src/Profile.tsx:631
 msgid "MetaBrainz Applications"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:630
+#: frontend/js/src/Profile.tsx:635
 msgid ""
 "With your MetaBrainz account, you can access every project in the "
 "MetaBrainz family:"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:643
+#: frontend/js/src/Profile.tsx:648
 msgid "The open-source music encyclopedia"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:655
+#: frontend/js/src/Profile.tsx:660
 msgid "Track, visualise and share the music you listen to"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:667
+#: frontend/js/src/Profile.tsx:672
 msgid "The open-source book database"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:679
+#: frontend/js/src/Profile.tsx:684
 msgid "Creative Commons licensed reviews"
 msgstr ""
 
@@ -3624,7 +4672,7 @@ msgid "Permanently remove all your account information"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:64
-msgid "Revoke all your API tokens and access"
+msgid "Revoke all your tokens and access to the replication API"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:65
@@ -3636,14 +4684,16 @@ msgid "Log you out of all MetaBrainz services"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:70
-msgid "Your username will be reserved and cannot be reused."
+msgid ""
+"Your username will be reserved and cannot be reused without the "
+"intervention of an administrator."
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:82
+#: frontend/js/src/ProfileDelete.tsx:84
 msgid "To confirm, type your username '<username />' below:"
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:105
+#: frontend/js/src/ProfileDelete.tsx:107
 msgid "Deleting..."
 msgstr ""
 
@@ -3656,64 +4706,7 @@ msgstr "Váš profil"
 msgid "Close"
 msgstr ""
 
-#: frontend/js/src/forms/ConditionsModal.tsx:23
-msgid "Licensing"
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:25
-msgid ""
-"Any contributions you make to any MetaBrainz service will be released "
-"into the Public Domain and/or licensed under a Creative Commons by-nc-sa "
-"license. Furthermore, you give the MetaBrainz Foundation the right to "
-"license this data for commercial use."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:30
-msgid "Please read our <licenseLink>license page</licenseLink> for more details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:45
-msgid ""
-"MetaBrainz strongly believes in the privacy of its users. Any personal "
-"information you choose to provide will not be sold or shared with anyone "
-"else."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:50
-msgid ""
-"Please read our <privacyLink>privacy policy</privacyLink> for more "
-"details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:59
-msgid "GDPR compliance"
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:61
-msgid ""
-"You may remove your personal information from our services anytime by "
-"deleting your account."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:66
-msgid ""
-"Please read our <gdprLink>GDPR compliance statement</gdprLink> for more "
-"details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:78
-msgid ""
-"Creating an account on MetaBrainz will give you access to all of our "
-"projects, such as MusicBrainz, ListenBrainz, BookBrainz, and more."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:82
-msgid ""
-"We create a placeholder account for all the MetaBrainz projects when you "
-"sign up, and you are one log-in away from activating them."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:91
+#: frontend/js/src/forms/ConditionsModal.tsx:29
 msgid "Sounds good"
 msgstr ""
 
@@ -3799,8 +4792,8 @@ msgstr ""
 msgid "Forgot your password?"
 msgstr ""
 
-#: frontend/js/src/forms/LoginUser.tsx:109
-msgid "Don't have an account?"
+#: frontend/js/src/forms/LoginUser.tsx:110
+msgid "Don't have an account? <signupLink>Sign up</signupLink>"
 msgstr ""
 
 #: frontend/js/src/forms/LostPassword.tsx:38
@@ -3829,15 +4822,72 @@ msgstr ""
 msgid "Allow access"
 msgstr ""
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:71
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:10
+msgid "Licensing"
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:12
+msgid ""
+"Any contributions you make to any MetaBrainz service will be released "
+"into the Public Domain and/or licensed under a Creative Commons by-nc-sa "
+"license. Furthermore, you give the MetaBrainz Foundation the right to "
+"license this data for commercial use."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:17
+msgid "Please read our <licenseLink>license page</licenseLink> for more details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:34
+msgid ""
+"MetaBrainz strongly believes in the privacy of its users. Any personal "
+"information you choose to provide will not be sold or shared with anyone "
+"else."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:39
+msgid ""
+"Please read our <privacyLink>privacy policy</privacyLink> for more "
+"details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:50
+msgid "GDPR compliance"
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:52
+msgid ""
+"You may remove your personal information from our services anytime by "
+"deleting your account."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:57
+msgid ""
+"Please read our <gdprLink>GDPR compliance statement</gdprLink> for more "
+"details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:71
+msgid ""
+"Creating an account on MetaBrainz will give you access to all of our "
+"projects, such as MusicBrainz, ListenBrainz, BookBrainz, and more."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:75
+msgid ""
+"We create a placeholder account for all the MetaBrainz projects when you "
+"sign up, and you are one log-in away from activating them."
+msgstr ""
+
+#: frontend/js/src/forms/ProfileChangePassword.tsx:70
 msgid "Current Password"
 msgstr ""
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:80
+#: frontend/js/src/forms/ProfileChangePassword.tsx:79
 msgid "New Password"
 msgstr ""
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:89
+#: frontend/js/src/forms/ProfileChangePassword.tsx:88
 msgid "Confirm New Password"
 msgstr ""
 
@@ -3849,192 +4899,182 @@ msgstr ""
 msgid "Reset Password"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:38
-msgid "If you would like to support us with more than $"
+#: frontend/js/src/forms/SignupCommercial.tsx:40
+msgid ""
+"If you would like to support us with more than ${{minPledge}}, please "
+"enter the actual amount here:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:39
-msgid ", please enter the actual amount here:"
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:144
+#: frontend/js/src/forms/SignupCommercial.tsx:149
 #: frontend/js/src/forms/SignupNonCommercial.tsx:75
-#: frontend/js/src/forms/SignupUser.tsx:87
+#: frontend/js/src/forms/SignupUser.tsx:93
 msgid "Captcha is required!"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:179
+#: frontend/js/src/forms/SignupCommercial.tsx:184
 #: frontend/js/src/forms/SignupNonCommercial.tsx:110
 #: frontend/js/src/forms/SignupUser.tsx:46
 #, fuzzy
 msgid "Access all MetaBrainz projects"
 msgstr "Projekty MetaBrainz"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:182
+#: frontend/js/src/forms/SignupCommercial.tsx:187
 msgid "Note:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:184
+#: frontend/js/src/forms/SignupCommercial.tsx:189
 msgid ""
 "Signing up for any tier other than the <italic>Stealth startup</italic> "
 "tier will publicly list your company on this web site. However, we will "
 "not publish any of your private details."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:221
+#: frontend/js/src/forms/SignupCommercial.tsx:226
 #: frontend/js/src/forms/SignupNonCommercial.tsx:145
 msgid "Account type"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:234
+#: frontend/js/src/forms/SignupCommercial.tsx:239
 msgid "Selected tier"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:242
-msgid "month and up"
+#: frontend/js/src/forms/SignupCommercial.tsx:247
+msgid "${{tierPrice}}/month and up"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:250
+#: frontend/js/src/forms/SignupCommercial.tsx:255
 msgid "Change account type or tier"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:261
+#: frontend/js/src/forms/SignupCommercial.tsx:266
 #: frontend/js/src/forms/SignupNonCommercial.tsx:166
 msgid "Your account:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:271
+#: frontend/js/src/forms/SignupCommercial.tsx:276
 #: frontend/js/src/forms/SignupNonCommercial.tsx:176
-#: frontend/js/src/forms/SignupUser.tsx:114
+#: frontend/js/src/forms/SignupUser.tsx:120
 msgid "(public)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:291
+#: frontend/js/src/forms/SignupCommercial.tsx:296
 #: frontend/js/src/forms/SignupNonCommercial.tsx:196
-#: frontend/js/src/forms/SignupUser.tsx:127
+#: frontend/js/src/forms/SignupUser.tsx:133
 msgid "E-mail address"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:295
+#: frontend/js/src/forms/SignupCommercial.tsx:300
 #: frontend/js/src/forms/SignupNonCommercial.tsx:200
-#: frontend/js/src/forms/SignupUser.tsx:131
+#: frontend/js/src/forms/SignupUser.tsx:137
 msgid "(checking...)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:314
+#: frontend/js/src/forms/SignupCommercial.tsx:319
 #: frontend/js/src/forms/SignupNonCommercial.tsx:220
-#: frontend/js/src/forms/SignupUser.tsx:163
+#: frontend/js/src/forms/SignupUser.tsx:169
 msgid "Must be at least 8 characters"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:348
+#: frontend/js/src/forms/SignupCommercial.tsx:353
 msgid ""
 "If you don't have an organization name, you probably want to become a "
 "supporter as a <nonCommercialLink>Non-commercial / "
 "Personal</nonCommercialLink> supporter."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:358
+#: frontend/js/src/forms/SignupCommercial.tsx:363
 msgid ""
 "If you don't have an organization name, you probably want to sign up as a"
 " <nonCommercialLink>Non-commercial / Personal</nonCommercialLink> user."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:378
+#: frontend/js/src/forms/SignupCommercial.tsx:383
 msgid ""
 "Please tell us a little about your company and whether you plan to use "
 "our <apiLink>API</apiLink> or to <hostLink>host your own copy</hostLink> "
 "of the data."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:404
+#: frontend/js/src/forms/SignupCommercial.tsx:408
 msgid "Logo URL"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:405
+#: frontend/js/src/forms/SignupCommercial.tsx:409
 msgid "(preferably in SVG format)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:408
+#: frontend/js/src/forms/SignupCommercial.tsx:412
 msgid ""
 "Image should be about 250 pixels wide on a white or transparent "
 "background. We will host it on our site."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:421
+#: frontend/js/src/forms/SignupCommercial.tsx:425
 msgid ""
 "URL to where developers can use your APIs using MusicBrainz IDs, if "
-"available.."
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:430
-msgid "Your project"
+"available."
 msgstr ""
 
 #: frontend/js/src/forms/SignupCommercial.tsx:434
+msgid "Your project"
+msgstr ""
+
+#: frontend/js/src/forms/SignupCommercial.tsx:438
 #: frontend/js/src/forms/SignupNonCommercial.tsx:261
 msgid "(max 150 characters)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:451
+#: frontend/js/src/forms/SignupCommercial.tsx:455
 msgid "Billing address"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:502
+#: frontend/js/src/forms/SignupCommercial.tsx:506
 msgid ""
 "I agree to support the MetaBrainz Foundation when my organization is able"
 " to do so."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:507
+#: frontend/js/src/forms/SignupCommercial.tsx:511
+#: frontend/js/src/forms/SignupNonCommercial.tsx:284
 msgid ""
-"I also agree that if I generate a Live Data Feed access token, that I "
-"treat my access token as a secret and will not share this token publicly "
-"or commit it to a source code repository."
+"I also agree that if I generate a Live Data Feed access token, then I "
+"will treat my access token as a secret and will not share this token "
+"publicly or commit it to a source code repository."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:515
+#: frontend/js/src/forms/SignupCommercial.tsx:519
 msgid ""
 "The following information will be shown publicly: organization name, "
 "logo, website and API URLs, data usage description."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:520
+#: frontend/js/src/forms/SignupCommercial.tsx:524
 msgid ""
 "We'll send you more details about payment process once your application "
 "is approved."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:552
+#: frontend/js/src/forms/SignupCommercial.tsx:556
 #: frontend/js/src/forms/SignupNonCommercial.tsx:316
-#: frontend/js/src/forms/SignupUser.tsx:224
+#: frontend/js/src/forms/SignupUser.tsx:230
 msgid "Validating..."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:564
+#: frontend/js/src/forms/SignupCommercial.tsx:568
 #: frontend/js/src/forms/SignupNonCommercial.tsx:329
 #, fuzzy
 msgid "Back to profile"
 msgstr "Váš profil"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:569
-#: frontend/js/src/forms/SignupNonCommercial.tsx:334
-msgid "Not a supporter?"
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:570
+#: frontend/js/src/forms/SignupCommercial.tsx:574
 #: frontend/js/src/forms/SignupNonCommercial.tsx:335
-msgid "Create a user account"
+msgid "Not a supporter? <signupLink>Create a user account</signupLink>"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:573
-#: frontend/js/src/forms/SignupNonCommercial.tsx:338
-#: frontend/js/src/forms/SignupUser.tsx:231
-msgid "Already have an account?"
-msgstr ""
-
-#: frontend/js/src/forms/SignupNonCommercial.tsx:107
-msgid "non-commercial"
+#: frontend/js/src/forms/SignupCommercial.tsx:583
+#: frontend/js/src/forms/SignupNonCommercial.tsx:344
+#: frontend/js/src/forms/SignupUser.tsx:238
+msgid "Already have an account? <loginLink>Sign in</loginLink>"
 msgstr ""
 
 #: frontend/js/src/forms/SignupNonCommercial.tsx:113
@@ -4062,46 +5102,40 @@ msgid ""
 "income per year) or personal uses only."
 msgstr ""
 
-#: frontend/js/src/forms/SignupNonCommercial.tsx:284
-msgid ""
-"I also agree that if I generate a Live Data Feed access token, then I "
-"will treat my access token as a secret and will not share this token "
-"publicly or commit it to a source code repository."
-msgstr ""
-
 #: frontend/js/src/forms/SignupUser.tsx:43
 msgid "Create your account"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:50
-msgid "Registration started by"
+#: frontend/js/src/forms/SignupUser.tsx:51
+msgid "Registration started by <client />"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:69
+#: frontend/js/src/forms/SignupUser.tsx:75
+#: frontend/js/src/hooks/useEmailValidation.ts:82
 msgid "Invalid email address."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:150
+#: frontend/js/src/forms/SignupUser.tsx:156
 msgid ""
 "This username and email were provided by the app that started "
 "registration. You can change them later from MetaBrainz settings."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:182
+#: frontend/js/src/forms/SignupUser.tsx:188
 msgid ""
 "I accept that my contributions will be released into the public domain or"
 " licensed for use."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:191
+#: frontend/js/src/forms/SignupUser.tsx:197
 msgid "We will never share your personal information."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:200
+#: frontend/js/src/forms/SignupUser.tsx:206
 msgid "Click here to read more"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:224
+#: frontend/js/src/forms/SignupUser.tsx:230
 msgid "Create account"
 msgstr ""
 
@@ -4111,10 +5145,6 @@ msgstr ""
 
 #: frontend/js/src/hooks/useEmailValidation.ts:47
 msgid "Email validation failed"
-msgstr ""
-
-#: frontend/js/src/hooks/useEmailValidation.ts:82
-msgid "Invalid email address"
 msgstr ""
 
 #~ msgid "You need to specify amount!"
@@ -5329,4 +6359,96 @@ msgstr ""
 
 #~ msgid "Privacy policy"
 #~ msgstr "Zásady ochrany osobních údajů"
+
+#~ msgid "You need to specify website of the organization."
+#~ msgstr ""
+
+#~ msgid ""
+#~ "We are currently evaluating our overall"
+#~ " online advertising strategy. We are "
+#~ "evaluating advertising, traffic optimization,\n"
+#~ ""
+#~ "    search engine optimization and "
+#~ "software monitization technologies. If you "
+#~ "provide these professional services, please"
+#~ " provide a detailed\n"
+#~ "    deck of your comprehensive services"
+#~ " to the following email address. "
+#~ "<em>Please respect our other non-media"
+#~ " teams and do not contact us \n"
+#~ "    regarding these services on any "
+#~ "other of our email addresses. We "
+#~ "will disregard the entirety of your "
+#~ "submissions if you contact us any "
+#~ "other way!</em>"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Please come ask your questions at "
+#~ "our <a href=\"%(forums_url)s\">forums</a>! We "
+#~ "would love to\n"
+#~ "    answer any questions you may have."
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Due to the increased unreliability of"
+#~ " the US Postal Service we have "
+#~ "stopped accepting paper checks. Sorry!"
+#~ msgstr ""
+
+#~ msgid "Upgrade"
+#~ msgstr ""
+
+#~ msgid "Back to Profile"
+#~ msgstr "Váš profil"
+
+#~ msgid ""
+#~ "Deletion of supporter accounts requires "
+#~ "manual review. Please contact us at"
+#~ msgstr ""
+
+#~ msgid "Revoke all your API tokens and access"
+#~ msgstr ""
+
+#~ msgid "Your username will be reserved and cannot be reused."
+#~ msgstr ""
+
+#~ msgid "Don't have an account?"
+#~ msgstr ""
+
+#~ msgid "If you would like to support us with more than $"
+#~ msgstr ""
+
+#~ msgid ", please enter the actual amount here:"
+#~ msgstr ""
+
+#~ msgid "month and up"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "I also agree that if I generate"
+#~ " a Live Data Feed access token, "
+#~ "that I treat my access token as"
+#~ " a secret and will not share "
+#~ "this token publicly or commit it "
+#~ "to a source code repository."
+#~ msgstr ""
+
+#~ msgid "Not a supporter?"
+#~ msgstr ""
+
+#~ msgid "Create a user account"
+#~ msgstr ""
+
+#~ msgid "Already have an account?"
+#~ msgstr ""
+
+#~ msgid "non-commercial"
+#~ msgstr ""
+
+#~ msgid "Registration started by"
+#~ msgstr ""
+
+#~ msgid "Invalid email address"
+#~ msgstr ""
 

--- a/metabrainz/translations/de/LC_MESSAGES/messages.po
+++ b/metabrainz/translations/de/LC_MESSAGES/messages.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-07-25 16:21+0200\n"
+"POT-Creation-Date: 2026-09-08 11:18+0200\n"
 "PO-Revision-Date: 2026-06-12 00:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: de\n"
@@ -22,162 +22,247 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.18.0\n"
 
-#: metabrainz/index/forms.py:46
+#: metabrainz/errors.py:24
+msgid "Authorization was declined."
+msgstr ""
+
+#: metabrainz/errors.py:25
+msgid "The authorization request was invalid."
+msgstr ""
+
+#: metabrainz/errors.py:26
+msgid "The application could not be authenticated."
+msgstr ""
+
+#: metabrainz/errors.py:27
+msgid "This application is not allowed to request authorization."
+msgstr ""
+
+#: metabrainz/errors.py:28
+msgid "The application asked for a response type this server does not support."
+msgstr ""
+
+#: metabrainz/errors.py:29
+msgid "The permissions requested by the application are invalid."
+msgstr ""
+
+#: metabrainz/errors.py:30
+msgid "You need to sign in to continue."
+msgstr ""
+
+#: metabrainz/errors.py:31
+msgid "Your consent is required to continue."
+msgstr ""
+
+#: metabrainz/password.py:12
+#, python-format
+msgid "Password must not exceed %(max_bytes)s bytes."
+msgstr ""
+
+#: metabrainz/index/forms.py:48
 #, python-format
 msgid "'%(value)s' is not a valid choice for this field"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileEdit.tsx:27
-#: frontend/js/src/forms/SignupCommercial.tsx:154
+#: frontend/js/src/forms/SignupCommercial.tsx:159
 #: frontend/js/src/forms/SignupNonCommercial.tsx:85
-#: frontend/js/src/forms/SignupUser.tsx:70
-#: frontend/js/src/hooks/useEmailValidation.ts:78 metabrainz/index/forms.py:57
-#: metabrainz/user/forms.py:25 metabrainz/user/forms.py:57
-#: metabrainz/user/forms.py:63
+#: frontend/js/src/forms/SignupUser.tsx:76
+#: frontend/js/src/hooks/useEmailValidation.ts:78 metabrainz/index/forms.py:59
+#: metabrainz/user/forms.py:31 metabrainz/user/forms.py:70
+#: metabrainz/user/forms.py:76
 msgid "Email address is required!"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:34
-#: metabrainz/index/forms.py:63
+#: metabrainz/index/forms.py:65
 msgid "Current password is required!"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:43
 #: frontend/js/src/forms/ProfileChangePassword.tsx:37
 #: frontend/js/src/forms/ResetPassword.tsx:39
-#: frontend/js/src/forms/SignupCommercial.tsx:156
+#: frontend/js/src/forms/SignupCommercial.tsx:161
 #: frontend/js/src/forms/SignupNonCommercial.tsx:87
-#: frontend/js/src/forms/SignupUser.tsx:72 metabrainz/index/forms.py:66
-#: metabrainz/user/forms.py:29 metabrainz/user/forms.py:46
-#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:69
+#: frontend/js/src/forms/SignupUser.tsx:78 metabrainz/index/forms.py:69
+#: metabrainz/user/forms.py:35 metabrainz/user/forms.py:54
+#: metabrainz/user/forms.py:63 metabrainz/user/forms.py:82
 msgid "Password is required!"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:41
-#: frontend/js/src/forms/SignupCommercial.tsx:160
+#: frontend/js/src/forms/SignupCommercial.tsx:165
 #: frontend/js/src/forms/SignupNonCommercial.tsx:91
-#: frontend/js/src/forms/SignupUser.tsx:76 metabrainz/index/forms.py:70
-#: metabrainz/user/forms.py:33 metabrainz/user/forms.py:73
+#: frontend/js/src/forms/SignupUser.tsx:82 metabrainz/index/forms.py:74
+#: metabrainz/user/forms.py:40 metabrainz/user/forms.py:87
 msgid "Confirm Password is required!"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:46
 #: frontend/js/src/forms/ResetPassword.tsx:48
-#: frontend/js/src/forms/SignupCommercial.tsx:165
+#: frontend/js/src/forms/SignupCommercial.tsx:170
 #: frontend/js/src/forms/SignupNonCommercial.tsx:96
-#: frontend/js/src/forms/SignupUser.tsx:81 metabrainz/index/forms.py:72
-#: metabrainz/user/forms.py:35 metabrainz/user/forms.py:75
+#: frontend/js/src/forms/SignupUser.tsx:87 metabrainz/index/forms.py:76
+#: metabrainz/user/forms.py:42 metabrainz/user/forms.py:89
 msgid "Confirm Password should match password!"
 msgstr ""
 
 #: frontend/js/src/Applications.tsx:56 frontend/js/src/Applications.tsx:86
 #: frontend/js/src/Profile.tsx:272 frontend/js/src/Profile.tsx:482
-#: metabrainz/index/forms.py:78
+#: metabrainz/index/forms.py:82
 msgid "Name"
 msgstr "Name"
 
-#: metabrainz/index/forms.py:79
+#: metabrainz/index/forms.py:83
 msgid "Contact name field is empty."
 msgstr ""
 
-#: metabrainz/index/views.py:234
+#: metabrainz/index/views.py:251
 msgid "Profile updated successfully."
 msgstr ""
 
-#: metabrainz/index/views.py:261
+#: metabrainz/index/views.py:278
 msgid "Current password is incorrect."
 msgstr ""
 
-#: metabrainz/index/views.py:266
+#: metabrainz/index/views.py:283
 msgid "Password changed successfully."
 msgstr ""
 
-#: metabrainz/index/views.py:372
+#: metabrainz/index/views.py:389
 msgid "You have updated an application!"
 msgstr ""
 
-#: metabrainz/index/views.py:424
+#: metabrainz/index/views.py:441
 msgid "You have deleted an application."
 msgstr ""
 
-#: metabrainz/index/views.py:426
+#: metabrainz/index/views.py:443
 msgid "Failed to delete an application."
 msgstr ""
 
-#: metabrainz/index/views.py:449
+#: metabrainz/index/views.py:466
 msgid "Revoked tokens successfully!"
 msgstr ""
 
-#: metabrainz/index/views.py:478
+#: metabrainz/index/views.py:495
 msgid "Your account has been deleted."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:106 metabrainz/oauth/forms.py:58
+#: frontend/js/src/forms/CreateApplication.tsx:106 metabrainz/oauth/forms.py:57
 msgid "Application Name"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:59
+#: metabrainz/oauth/forms.py:58
 msgid "Application name field is empty."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:60 metabrainz/oauth/forms.py:60
+#: frontend/js/src/forms/CreateApplication.tsx:60 metabrainz/oauth/forms.py:59
 msgid "Application name needs to be at least 3 characters long."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:64 metabrainz/oauth/forms.py:61
+#: frontend/js/src/forms/CreateApplication.tsx:64 metabrainz/oauth/forms.py:60
 msgid "Application name needs to be at most 64 characters long."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:114 metabrainz/oauth/forms.py:63
+#: frontend/js/src/forms/CreateApplication.tsx:114 metabrainz/oauth/forms.py:62
 msgid "Description"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:64
+#: metabrainz/oauth/forms.py:63
 msgid "Client description field is empty."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:65
+#: metabrainz/oauth/forms.py:64
 msgid "Client description needs to be at least 3 characters long."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:66
+#: metabrainz/oauth/forms.py:65
 msgid "Client description needs to be at most 512 characters long."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:122 metabrainz/oauth/forms.py:68
+#: frontend/js/src/forms/CreateApplication.tsx:122 metabrainz/oauth/forms.py:67
 msgid "Homepage"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:69
+#: metabrainz/oauth/forms.py:68
 msgid "Homepage field is empty."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:70
+#: metabrainz/oauth/forms.py:69
 msgid "Homepage is not a valid URI."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:71
+#: metabrainz/oauth/forms.py:70
 msgid "Homepage URL must use http or https"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:73
+#: metabrainz/oauth/forms.py:72
 msgid "Authorization callback URL"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:74
+#: metabrainz/oauth/forms.py:73
 msgid "Authorization callback URL field is empty."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:75
+#: metabrainz/oauth/forms.py:74
 msgid "Authorization callback URL is invalid."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:76
+#: metabrainz/oauth/forms.py:75
 msgid "Authorization callback URL must use http or https."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:81 metabrainz/oauth/forms.py:85
+#: metabrainz/oauth/forms.py:80 metabrainz/oauth/forms.py:84
 msgid "Confirm"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:15
+msgid "View your public account information"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:16
+msgid "View your email address"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:17
+msgid "View and modify your private tags"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:18
+msgid "View and modify your private ratings"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:19
+msgid "View and modify your private collections"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:20
+msgid "Submit new ISRCs to the database"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:21
+msgid "Submit new barcodes to the database"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:22
+msgid "Sign you in and view your unique user id"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:23
+msgid "Submit listens to ListenBrainz."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:24
+msgid "Create and modify CritiqueBrainz reviews."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:25
+msgid "Submit and delete votes on CritiqueBrainz reviews."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:26
+msgid "Modify profile info and delete profile on CritiqueBrainz."
 msgstr ""
 
 #: metabrainz/payments/views.py:164
@@ -226,178 +311,185 @@ msgid "Requested annual report was not found."
 msgstr "Der angeforderte Jahresbericht wurde nicht gefunden."
 
 #: frontend/js/src/forms/ProfileEdit.tsx:30
-#: frontend/js/src/forms/SignupCommercial.tsx:139
+#: frontend/js/src/forms/SignupCommercial.tsx:144
 #: frontend/js/src/forms/SignupNonCommercial.tsx:70
-#: metabrainz/supporter/forms.py:13
+#: metabrainz/supporter/forms.py:15
 msgid "Contact name is required!"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:437
+#: frontend/js/src/forms/SignupCommercial.tsx:441
 #: frontend/js/src/forms/SignupNonCommercial.tsx:264
-#: metabrainz/supporter/forms.py:15
+#: metabrainz/supporter/forms.py:17
 msgid ""
 "Can you please tell us more about the project in which you'd like to use "
 "our data? Do you plan to self host the data or use our APIs?"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:137
+#: frontend/js/src/forms/SignupCommercial.tsx:142
 #: frontend/js/src/forms/SignupNonCommercial.tsx:68
-#: metabrainz/supporter/forms.py:17
+#: metabrainz/supporter/forms.py:19
 msgid "Please, tell us how you (will) use our data."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:138
+#: frontend/js/src/forms/SignupCommercial.tsx:143
 #: frontend/js/src/forms/SignupNonCommercial.tsx:69
-#: metabrainz/supporter/forms.py:18
+#: metabrainz/supporter/forms.py:20
 msgid "Please, limit usage description to 500 characters."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:141
-#: frontend/js/src/forms/SignupCommercial.tsx:142
+#: frontend/js/src/forms/SignupCommercial.tsx:146
+#: frontend/js/src/forms/SignupCommercial.tsx:147
 #: frontend/js/src/forms/SignupNonCommercial.tsx:72
 #: frontend/js/src/forms/SignupNonCommercial.tsx:73
-#: frontend/js/src/forms/SignupUser.tsx:84
-#: frontend/js/src/forms/SignupUser.tsx:85 metabrainz/supporter/forms.py:21
-#: metabrainz/user/forms.py:38
+#: frontend/js/src/forms/SignupUser.tsx:90
+#: frontend/js/src/forms/SignupUser.tsx:91 metabrainz/supporter/forms.py:23
+#: metabrainz/user/forms.py:45
 msgid "You need to accept the agreement!"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:342
-#: metabrainz/supporter/forms.py:27
+#: frontend/js/src/forms/SignupCommercial.tsx:347
+#: metabrainz/supporter/forms.py:29
 msgid "Organization name"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:113
-#: metabrainz/supporter/forms.py:28
+#: frontend/js/src/forms/SignupCommercial.tsx:115
+#: metabrainz/supporter/forms.py:30
 msgid "You need to specify the name of your organization."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:373
-#: metabrainz/supporter/forms.py:30
+#: frontend/js/src/forms/SignupCommercial.tsx:378
+#: metabrainz/supporter/forms.py:32
 msgid "Organization description"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:116
-#: metabrainz/supporter/forms.py:31
+#: frontend/js/src/forms/SignupCommercial.tsx:118
+#: metabrainz/supporter/forms.py:33
 msgid "You need to provide description of your organization."
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:278
-#: frontend/js/src/forms/SignupCommercial.tsx:396
-#: metabrainz/supporter/forms.py:34
+#: frontend/js/src/forms/SignupCommercial.tsx:401
+#: metabrainz/supporter/forms.py:36
 msgid "Website URL"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:119
-#: metabrainz/supporter/forms.py:35
-msgid "You need to specify website of the organization."
+#: frontend/js/src/forms/SignupCommercial.tsx:121
+#: frontend/js/src/forms/SignupCommercial.tsx:123
+#: metabrainz/supporter/forms.py:38 metabrainz/supporter/forms.py:42
+msgid "Website URL must be a valid URL."
 msgstr ""
 
-#: metabrainz/supporter/forms.py:37
+#: metabrainz/supporter/forms.py:45
 msgid "Logo image URL"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:284
-#: frontend/js/src/forms/SignupCommercial.tsx:418
-#: metabrainz/supporter/forms.py:38
+#: frontend/js/src/forms/SignupCommercial.tsx:422
+#: metabrainz/supporter/forms.py:46
 msgid "API URL"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:457
-#: metabrainz/supporter/forms.py:40
+#: frontend/js/src/forms/SignupCommercial.tsx:461
+#: metabrainz/supporter/forms.py:48
 msgid "Street"
 msgstr "Straße"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:123
-#: metabrainz/supporter/forms.py:41
+#: frontend/js/src/forms/SignupCommercial.tsx:128
+#: metabrainz/supporter/forms.py:49
 msgid "You need to specify street."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:465
-#: metabrainz/supporter/forms.py:43
+#: frontend/js/src/forms/SignupCommercial.tsx:469
+#: metabrainz/supporter/forms.py:51
 msgid "City"
 msgstr "Stadt"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:124
-#: metabrainz/supporter/forms.py:44
+#: frontend/js/src/forms/SignupCommercial.tsx:129
+#: metabrainz/supporter/forms.py:52
 msgid "You need to specify city."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:473
-#: metabrainz/supporter/forms.py:46
+#: frontend/js/src/forms/SignupCommercial.tsx:477
+#: metabrainz/supporter/forms.py:54
 msgid "State / Province"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:126
-#: metabrainz/supporter/forms.py:47
+#: frontend/js/src/forms/SignupCommercial.tsx:131
+#: metabrainz/supporter/forms.py:55
 msgid "You need to specify state/province."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:481
-#: metabrainz/supporter/forms.py:49
+#: frontend/js/src/forms/SignupCommercial.tsx:485
+#: metabrainz/supporter/forms.py:57
 msgid "Postcode"
 msgstr "Postleitzahl"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:128
-#: metabrainz/supporter/forms.py:50
+#: frontend/js/src/forms/SignupCommercial.tsx:133
+#: metabrainz/supporter/forms.py:58
 msgid "You need to specify postcode."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:489
-#: metabrainz/supporter/forms.py:52
+#: frontend/js/src/forms/SignupCommercial.tsx:493
+#: metabrainz/supporter/forms.py:60
 msgid "Country"
 msgstr "Land"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:129
-#: metabrainz/supporter/forms.py:53
+#: frontend/js/src/forms/SignupCommercial.tsx:134
+#: metabrainz/supporter/forms.py:61
 msgid "You need to specify country."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:132
-#: metabrainz/supporter/forms.py:64
+#: frontend/js/src/forms/SignupCommercial.tsx:137
+#: metabrainz/supporter/forms.py:72
 msgid ""
 "Custom amount must be more than threshold amount for selected tier or "
 "equal to it!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:46 metabrainz/supporter/views.py:119
-#: metabrainz/supporter/views.py:220
+#: metabrainz/supporter/views.py:54
+msgid ""
+"The verification email could not be sent. Please request a new one from "
+"your profile."
+msgstr ""
+
+#: metabrainz/supporter/views.py:85 metabrainz/supporter/views.py:158
+#: metabrainz/supporter/views.py:260
 msgid "You are already a supporter."
 msgstr ""
 
-#: metabrainz/supporter/views.py:61
+#: metabrainz/supporter/views.py:100
 msgid "Can't find tier with a specified ID."
 msgstr ""
 
-#: metabrainz/supporter/views.py:127
+#: metabrainz/supporter/views.py:166
 msgid "You need to choose support tier before signing up!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:137
+#: metabrainz/supporter/views.py:176
 msgid "You need to choose existing tier before signing up!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:164
+#: metabrainz/supporter/views.py:204
 msgid ""
 "Thanks for becoming a supporter! Your application will be reviewed soon. "
 "We will send you updates via email."
 msgstr ""
 
-#: metabrainz/supporter/views.py:187
+#: metabrainz/supporter/views.py:228
 msgid ""
 "Thanks for signing up! Your application will be reviewed soon. We will "
 "send you updates via email."
 msgstr ""
 
-#: metabrainz/supporter/views.py:248
+#: metabrainz/supporter/views.py:288
 msgid "Thanks for becoming a supporter!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:274
+#: metabrainz/supporter/views.py:312
 msgid "Thanks for signing up! Please check your inbox to complete verification."
 msgstr ""
 
-#: metabrainz/supporter/views.py:302
+#: metabrainz/supporter/views.py:340
 msgid "Can't generate new token unless account is active."
 msgstr ""
 
@@ -431,7 +523,7 @@ msgstr ""
 msgid "Policies"
 msgstr ""
 
-#: metabrainz/templates/base.html:55 metabrainz/templates/index/gdpr.html:178
+#: metabrainz/templates/base.html:55
 #: metabrainz/templates/index/social-contract.html:3
 #: metabrainz/templates/index/social-contract.html:6
 #: metabrainz/templates/navbar.html:34
@@ -441,14 +533,15 @@ msgstr ""
 #: metabrainz/templates/base.html:56
 #: metabrainz/templates/index/code-of-conduct.html:3
 #: metabrainz/templates/index/code-of-conduct.html:16
-#: metabrainz/templates/index/gdpr.html:181 metabrainz/templates/navbar.html:35
+#: metabrainz/templates/navbar.html:35
 msgid "Code of Conduct"
 msgstr ""
 
+#: frontend/js/src/PrivacySummary.tsx:11
 #: frontend/js/src/forms/ConditionsModal.tsx:21
-#: metabrainz/templates/base.html:57 metabrainz/templates/index/gdpr.html:184
-#: metabrainz/templates/index/privacy.html:6
+#: metabrainz/templates/base.html:57 metabrainz/templates/index/privacy.html:6
 #: metabrainz/templates/navbar.html:36
+#: metabrainz/templates/users/privacy-summary.html:3
 msgid "Privacy Policy"
 msgstr "Datenschutzerklärung"
 
@@ -482,10 +575,7 @@ msgstr "Sponsoren"
 msgid "Supporters"
 msgstr "Unterstützer"
 
-#: frontend/js/src/forms/LoginUser.tsx:103
-#: frontend/js/src/forms/SignupCommercial.tsx:574
-#: frontend/js/src/forms/SignupNonCommercial.tsx:339
-#: frontend/js/src/forms/SignupUser.tsx:232 metabrainz/templates/base.html:73
+#: frontend/js/src/forms/LoginUser.tsx:103 metabrainz/templates/base.html:73
 #: metabrainz/templates/navbar.html:66 metabrainz/templates/users/login.html:3
 msgid "Sign in"
 msgstr "Einloggen"
@@ -507,26 +597,26 @@ msgid "Contact us"
 msgstr "Kontaktiere uns"
 
 #: metabrainz/templates/base.html:85
-#: metabrainz/templates/index/contact.html:105
+#: metabrainz/templates/index/contact.html:106
 msgid "Blog"
 msgstr "Blog"
 
-#: metabrainz/templates/base.html:86 metabrainz/templates/index/contact.html:90
+#: metabrainz/templates/base.html:86 metabrainz/templates/index/contact.html:91
 msgid "Chat"
 msgstr ""
 
 #: metabrainz/templates/base.html:87
-#: metabrainz/templates/index/contact.html:106
+#: metabrainz/templates/index/contact.html:107
 msgid "Mastodon"
 msgstr ""
 
 #: metabrainz/templates/base.html:88
-#: metabrainz/templates/index/contact.html:107
+#: metabrainz/templates/index/contact.html:108
 msgid "Bluesky"
 msgstr ""
 
 #: metabrainz/templates/base.html:89
-#: metabrainz/templates/index/contact.html:108
+#: metabrainz/templates/index/contact.html:109
 msgid "Instagram"
 msgstr ""
 
@@ -585,15 +675,14 @@ msgstr "Finanzberichte"
 msgid "Donate"
 msgstr "Spenden"
 
-#: frontend/js/src/forms/LoginUser.tsx:110
-#: frontend/js/src/forms/SignupCommercial.tsx:175
-#: frontend/js/src/forms/SignupCommercial.tsx:555
+#: frontend/js/src/forms/SignupCommercial.tsx:180
+#: frontend/js/src/forms/SignupCommercial.tsx:559
 #: frontend/js/src/forms/SignupNonCommercial.tsx:106
 #: frontend/js/src/forms/SignupNonCommercial.tsx:319
 #: metabrainz/templates/navbar.html:65
-#: metabrainz/templates/supporters/account-type.html:51
-#: metabrainz/templates/supporters/account-type.html:93
-#: metabrainz/templates/supporters/account-type.html:144
+#: metabrainz/templates/supporters/account-type.html:47
+#: metabrainz/templates/supporters/account-type.html:84
+#: metabrainz/templates/supporters/account-type.html:130
 #: metabrainz/templates/users/signup.html:3
 msgid "Sign up"
 msgstr "Registrieren"
@@ -907,8 +996,430 @@ msgstr ""
 msgid "Introduction"
 msgstr ""
 
-#: metabrainz/templates/index/conflict-policy.html:55
+#: metabrainz/templates/index/conflict-policy.html:17
+msgid ""
+"Conflicts between people arise in open source projects constantly and the"
+" projects by the \n"
+"    MetaBrainz Foundation are no different. This policy aims to establish"
+" a clear and unambiguous \n"
+"    policy for reporting and addressing conflicts in our community. In "
+"this policy we aim to \n"
+"    establish a fair practice that balances the need for confidentiality "
+"and our desire for \n"
+"    transparency in our operations."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:25
+#, python-format
+msgid ""
+"Before you continue to read this policy, we encourage you to review our "
+"existing community policies \n"
+"    including our <a href=\"%(social_contract_url)s\">Social "
+"Contract</a>, \n"
+"    <a href=\"%(code_of_conduct_url)s\">the Code of Conduct</a>, \n"
+"    and our <a href=\"%(privacy_policy_url)s\">Privacy Policy</a>. These "
+"policies establish the norms and rules for \n"
+"    participation in our projects; these policies apply equally to the "
+"contractors of the MetaBrainz \n"
+"    Foundation and any participants in our projects."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:37
+msgid ""
+"This policy divides conflicts into two categories: Private and public. "
+"Private conflicts are conflicts \n"
+"    that involve *confidential* information regarding contributors, "
+"contractors or supporters. Otherwise, any conflicts \n"
+"    that do not involve confidential information are considered to be "
+"public conflicts. For instance, a \n"
+"    conflict between a contractor and the Executive Director (aka BDFL) "
+"that involves contractor pay is \n"
+"    considered a private conflict because pay rates are confidential "
+"information. A public conflict in edit \n"
+"    notes between two editors in our community does not involve "
+"confidential information and therefore should \n"
+"    be considered a public conflict."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:47
+msgid ""
+"When conflicts arise we aim to disclose as much information as possible "
+"about the conflict in a timely \n"
+"    fashion. When conflicts contain confidential matters we will aim to "
+"disclose as much information as \n"
+"    possible, while fully respecting the confidentiality of the people "
+"involved in the conflict. With any \n"
+"    private conflict we will aim to extract the relevant lessons for the "
+"team and community in an effort to \n"
+"    evolve our policies to prevent future conflicts. Should the involved "
+"parties disagree whether a conflict \n"
+"    is private or public, the question about the nature of the conflict "
+"will be presented for the next higher \n"
+"    level in the chain of command to decide. (e.g. if a community member "
+"and the community manager disagree on \n"
+"    a conflict being public or private, the Executive Director shall "
+"decide if the conflict is public or private)."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:58
 msgid "Reporting and Response"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:61
+msgid ""
+"We aim to not have conflict in our community, but we recognize that in "
+"reality conflicts will arise and we \n"
+"    must be prepared to address them in a fair manner. When conflicts "
+"arise, we prefer to have community or team \n"
+"    members resolve the conflicts among themselves, using our existing "
+"policies as guidelines for resolving the \n"
+"    conflict."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:69
+msgid ""
+"If you do not feel comfortable resolving a conflict on your own, you "
+"should feel free to report the conflict to \n"
+"    us. How you address the conflict depends on who is involved in the "
+"conflict and your comfort level. Please see \n"
+"    the detailed sections below on how and with whom to address your "
+"conflict. We aim to address conflicts as soon \n"
+"    as possible in an effort to prevent them from escalating "
+"unnecessarily."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:75
+msgid "Direct conflict resolution"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:78
+msgid ""
+"In direct conflict resolution, the involved parties will attempt to "
+"resolve the conflict themselves without \n"
+"   involving any MetaBrainz Foundation team member. You should aim to use"
+" direct resolution when the conflict does \n"
+"   not involve the violation of one of our policies or if the conflict is"
+" minor."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:84
+#, python-format
+msgid ""
+"For instance, if a user uses a rude tone, is disruptive or flagrantly "
+"ignores our project guidelines, we suggest \n"
+"    that you use direct conflict resolution to resolve the conflict. Some"
+" resources that might give you some suggestions \n"
+"    on how to go about resolving the conflict might be this <a "
+"href=\"%(conflict_resolution_primer_url)s\">\n"
+"    conflict resolution primer</a> and <a "
+"href=\"%(difficult_conversations_url)s\">how to\n"
+"    have difficult conversations at work</a>."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:93
+msgid "Informal reporting"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:96
+msgid ""
+"You may use informal reporting of a conflict if you aim to communicate a "
+"concern or incident without \n"
+"    seeking a corrective outcome. Informal reporting may also be an "
+"option if you have not been personally \n"
+"    victimized, but you’ve witnessed a violation of our policies or where"
+" you wish to maintain confidentiality \n"
+"    throughout the entire reporting process."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:103
+msgid ""
+"For editing in MusicBrainz you may informally report a user using the "
+"“Report this user for bad behavior” \n"
+"    link from the user’s profile. For reporting bad user behavior in "
+"other of our projects, please report them to our \n"
+"    community manager by mailing <span class=\"backemail\">gro.zniarbatem"
+"@reganam-ytinummoc</span> . For conflicts \n"
+"    that involve the community manager, report them by mailing <span "
+"class=\"backemail\">gro.zniarbatem@de</span> ."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:110
+msgid ""
+"Depending the the severity of the issue, repeated informal complaints may"
+" eventually require a formal response \n"
+"    from the MetaBrainz team. If an involved party requires anonymity, "
+"the conflict becomes a private conflict. If at \n"
+"    all possible minor issues should be resolved in a public forum in "
+"order for all people to witness and learn from \n"
+"    the issue at hand."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:116
+msgid "Formal complaint process"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:119
+msgid ""
+"All complaints about conflicts should be submitted via email. To whom a "
+"complaint should be mailed and who will \n"
+"    carry out the investigation will be described in the next section."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:124
+msgid "All complaint submissions to the Foundation should include the following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:128
+msgid ""
+"Contact info, if it is different than the email used to submit the "
+"conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:129
+msgid "Who was involved in the conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:130
+msgid "Where and when the incident happened"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:131
+msgid ""
+"A description of what happened -- ideally with links (e.g. chatlogs, edit"
+" notes) that outlines what \n"
+"         happened so that the persons evaluating the conflict may "
+"understand the issue at hand"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:133
+msgid ""
+"Any related pieces of information that provide more context on the "
+"conflict (e.g. links, screenshots)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:134
+msgid "An indication if this conflict is ongoing or not"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:139
+msgid "The investigation that follows aims to determine:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:143
+msgid "The nature and severity of the incident"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:144
+msgid ""
+"Whether or not the incident is considered a violation of MetaBrainz’ "
+"conduct policies or core values"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:145
+msgid ""
+"The amount of harm experienced by the person who submitted the complaint "
+"and the broader MetaBrainz community \n"
+"         as a result of the incident"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:147
+msgid ""
+"Whether there have been prior complaints against the individual or "
+"individuals reported"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:148
+msgid "Whether the incident is ongoing"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:152
+msgid ""
+"The following potential forms of resolution may apply to any team members"
+" involved in the conflict:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:155
+#: metabrainz/templates/index/conflict-policy.html:168
+msgid "Nothing (if it has been found no violation occurred)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:156
+msgid "Creating a plan to improve the performance"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:157
+msgid "Creating a negative performance evaluation"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:158
+msgid "Mediation, an intervention by a third party to resolve the conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:159
+msgid "Suspension or forced leave"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:160
+msgid "Termination of contract"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:164
+msgid ""
+"The following potential forms of resolution may apply to non team members"
+" involved in the conflict:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:169
+msgid "A reprimand, either public or private"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:170
+msgid "Suspension of the users’ account"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:171
+msgid "Deletion of the users’ account"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:172
+msgid ""
+"Removal of user privileges (e.g. if an auto editor commits a serious "
+"offence, they may lose their auto editor status)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:175
+msgid "Filing a complaint"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:178
+msgid ""
+"NOTE: For complaints not about MetaBrainz staff, please see the "
+"<em>Informal reporting</em> section above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:182
+msgid ""
+"If the complaint does not involve the Executive Director (ED), do the "
+"following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:186
+msgid ""
+"If team member has directly violated conduct policies or engaged in "
+"otherwise harmful behavior, a formal complaint should be filed."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:187
+msgid ""
+"Mail <span class=\"backemail\">gro.zniarbatem@de</span> and include the "
+"complaint information outlined above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:188
+msgid ""
+"You should expect a response within a working day acknowledging the "
+"complaint."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:189
+msgid ""
+"The complaint will be investigated by the ED, member(s) of the board of "
+"directors or a neutral third party."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:190
+msgid ""
+"Once the investigation has been completed, the ED, with the support of "
+"others involved in the investigation will respond. The \n"
+"        ED will respond to incidents no later than 7 working days after a"
+" complaint has been filed with either a resolution or an \n"
+"        explanation of why the process must be extended."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:196
+msgid "If a complaint involves the Executive Director, do the following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:200
+msgid ""
+"If the Executive Director has directly violated conduct policies or "
+"engaged in otherwise harmful behavior, \n"
+"        a formal complaint should be filed with the board of directors."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:202
+msgid ""
+"Mail <span class=\"backemail\">gro.zniarbatem@noituloser-tcilfnoc</span> "
+"and include the complaint information outlined above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:203
+msgid ""
+"You should get a response within 5 working days acknowledging the "
+"complaint."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:204
+msgid ""
+"The complaint will be investigated by the member(s) of the board of "
+"directors, the community manager, a neutral \n"
+"        third party or a combination thereof."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:206
+msgid ""
+"Once the investigation has been completed, the board, with the support of"
+" others involved in the investigation \n"
+"        will respond. The board will aim to respond to incidents no later"
+" than 15 working days after a complaint has been filed \n"
+"        with either a resolution or an explanation of why the process "
+"must be extended."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:211
+msgid "Confidentiality"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:214
+msgid ""
+"Confidentiality is an important aspect of conflict resolution and all of "
+"the conflicts brought to the attention of the foundation \n"
+"    will be evaluated with confidentiality in mind and acted upon "
+"accordingly."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:219
+msgid ""
+"We work hard to make all of the actions of the foundation as transparent "
+"and open as possible. In cases where we cannot \n"
+"    disclose all aspects of a conflict we will disclose that a conflict "
+"is or has occurred and we will attempt to disclose the \n"
+"    appropriate amount of information about the conflict while balancing "
+"the need for confidentiality and our desire to learn \n"
+"    from conflicts so that we as a foundation and community can learn "
+"from these conflicts and improve our policies to avoid the \n"
+"    conflicts in the future."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:227
+msgid ""
+"Any breaches of confidentiality will be treated as severe breaches of our"
+" conduct policies."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:230
+msgid "Retaliation"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:233
+msgid ""
+"We will not allow retaliation for any contractor or volunteer that files "
+"a complaint or is involved in an investigation. If you \n"
+"    believe that you are being treated negatively because of your "
+"involvement in a complaint please report this complaint directly \n"
+"    to the ED at <span class=\"backemail\">gro.zniarbatem@de</span> or "
+"the board at \n"
+"    <span class=\"backemail\">gro.zniarbatem@noituloser-tcilfnoc</span>."
 msgstr ""
 
 #: metabrainz/templates/index/contact.html:3
@@ -989,7 +1500,7 @@ msgstr ""
 msgid ""
 "We are currently evaluating our overall online advertising strategy. We "
 "are evaluating advertising, traffic optimization,\n"
-"    search engine optimization and software monitization technologies. If"
+"    search engine optimization and software monetization technologies. If"
 " you provide these professional services, please provide a detailed\n"
 "    deck of your comprehensive services to the following email address. "
 "<em>Please respect our other non-media teams and do not contact us \n"
@@ -1064,11 +1575,11 @@ msgstr "Foren"
 #, python-format
 msgid ""
 "Please come ask your questions at our <a "
-"href=\"%(forums_url)s\">forums</a>! We would love to\n"
-"    answer any questions you may have."
+"href=\"%(forums_url)s\">forums</a>!\n"
+"    The community and the team will be more than happy to help you."
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:92
+#: metabrainz/templates/index/contact.html:93
 #, python-format
 msgid ""
 "The MetaBrainz/MusicBrainz/ListenBrainz team and community hang out\n"
@@ -1078,15 +1589,15 @@ msgid ""
 "    <a href=\"%(chatlogs_url)s\">chat log archives</a>."
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:101
+#: metabrainz/templates/index/contact.html:102
 msgid "Social media"
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:103
+#: metabrainz/templates/index/contact.html:104
 msgid "You can follow us on these social channels:"
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:112
+#: metabrainz/templates/index/contact.html:113
 msgid "Mailing address"
 msgstr "Mail-Adresse"
 
@@ -1099,33 +1610,349 @@ msgstr ""
 msgid "GDPR Compliance Statement"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:37
+#: metabrainz/templates/index/gdpr.html:10
+msgid ""
+"The General Data Protection Regulation is a complex EU regulation that "
+"stipulates many points for protecting private data of\n"
+"    users on the Internet. Even though this is an EU regulation, it has a"
+" worldwide impact due to the nature of the Internet.\n"
+"    The MetaBrainz Foundation with its collection of projects is also "
+"affected by this regulation. We’ve been learning and adapting\n"
+"    our sites to be compliant with the GDPR – sadly this regulation isn’t"
+" entirely black and white and there is an incredible\n"
+"    amount of room left for interpretation of these rules."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:17
+msgid ""
+"The good news is that this regulation is roughly in line with our "
+"established practices: We’ve always held private information\n"
+"    in a high regard and applied the sort of rules to ourselves as we "
+"wish to have our own private data treated. Luckily, this\n"
+"    makes our compliance effort considerably easier. We’ve made two "
+"significant changes to how we treat your data and also adopted\n"
+"    terminology as used in the GDPR in order to use the same languages "
+"that many other sites are now adopting. Please keep reading\n"
+"    to find out the exact details of what we are doing to comply."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:24
+#, python-format
+msgid ""
+"However, we do ask for your compassion and help in our process of "
+"complying with the GDPR. As we already mentioned, the GDPR is\n"
+"    a complex set of rules that are not fully clarified yet. We’ve taken "
+"action on the steps that are clear to us and we’re following\n"
+"    ongoing conversations on points that are in gray zones or unclear to "
+"us. We’ve made our best initial effort on compliance and\n"
+"    promise to keep working on it as the picture becomes more clear. If "
+"you believe that we could improve our compliance, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a> and let us know what we "
+"can do to improve. It would also help us if you\n"
+"    could provide concrete discussion or examples to help us understand "
+"and take action on your suggestion."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:33
+msgid ""
+"Finally, below are the key sections of the GDPR as we understand them and"
+" how they affect your data in our ecosystem. Where\n"
+"    possible, we provide links for deeper understanding, links for you to"
+" examine our relevant code and links to tickets to follow\n"
+"    the process of improving our compliance."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:38
 msgid "Right to be forgotten"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:77
+#: metabrainz/templates/index/gdpr.html:41
+msgid ""
+"Summary: <i>Provide the user with the ability to remove their private "
+"data from our services</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:44
+msgid ""
+"The most important aspect of the right to be forgotten is the ability to "
+"delete your account. Once you request for us to delete\n"
+"    your account, we will remove any personally identifying information "
+"you may have provided us from your account (name, email\n"
+"    address, gender, biography, URL, etc.). The visible name on your "
+"account will be changed to “Deleted User #####” and effectively\n"
+"    the account will no longer be identifiable as your account."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:50
+msgid ""
+"However, given the nature of our projects where we work on collaborative "
+"databases, your contributions that are not personally\n"
+"    identifying are valuable assets to our database and these "
+"contributions will not be removed from our databases. But we will\n"
+"    ensure that these contributions no longer contain personally "
+"identifying data."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:55
+#, python-format
+msgid ""
+"Our process of automatically deleting your accounts across the MetaBrainz"
+" ecosystem is not complete yet (see below for a set of\n"
+"    tickets where you can track our progress). If you would like to "
+"delete your accounts in the MetaBrainz ecosystem or mark a\n"
+"    donation that is currently public as a private donation, please <a "
+"href=\"%(contact_url)s\">contact us</a>\n"
+"    and we will address your request as soon as possible."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:62
+#: metabrainz/templates/index/gdpr.html:182
+msgid "Links:"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:66
+#, python-format
+msgid ""
+"<a href=\"%(editor_deletion_doc_url)s\">How we delete accounts\n"
+"       in MusicBrainz</a> (warning, geek content ahead!)"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:70
+msgid ""
+"Implement sitewide user account deletion in\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/MBS-9680\">MusicBrainz</a>,"
+"\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/AB-337\">AcousticBrainz</a>,"
+"\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/BB-260\">BookBrainz</a>,\n"
+"         <a href=\"https://tickets.metabrainz.org/browse/MEB-103\">the "
+"MetaBrainz Site</a>,\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/LB-354\">ListenBrainz</a>, "
+"and\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/CB-307\">CritiqueBrainz</a>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:80
 msgid "Restriction of processing"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:110
+#: metabrainz/templates/index/gdpr.html:83
+msgid ""
+"Summary: <i>To allow the user to control how their personally identifying"
+" data is being used.</i>"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:86
+msgid ""
+"Except for the ListenBrainz and AcousticBrainz projects, we do not "
+"process personally identifying data. Any personally\n"
+"    identifying data that our projects store is for the purpose of being "
+"able to contact you about your contributions to our database\n"
+"    (email address) or for voluntarily showing information about you to "
+"other users (biography, homepage, location, etc)."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:91
+#, python-format
+msgid ""
+"The ListenBrainz project differs in that the Listens (metadata about what"
+" music you have listened to) are stored on our servers\n"
+"    and <a href=\"%(listenbrainz_data_url)s\">made available to the "
+"public</a>. We believe Listens to be personally identifying\n"
+"    data and furthermore, we have goals of creating open source "
+"recommendation engines with this data, which involves processing the\n"
+"    user’s data. These two points are fundamental goals of the "
+"ListenBrainz project and we do not see a reasonable way to reach another"
+"\n"
+"    compromise position."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:99
+msgid ""
+"Because of this, we are going to require users to either acknowledge that"
+" we may process their Listen data or alternatively to\n"
+"    delete their account, including all of their Listens. Please note "
+"that if you decide to delete your ListenBrainz account, it may\n"
+"    take up to two weeks for all of your listens to no longer be included"
+" in our efforts to build a recommendation engine."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:104
+msgid ""
+"We have always made it clear that the data in ListenBrainz was to be "
+"public and that we plan to build new tools with your data, so\n"
+"    this should not come as a surprise to our users."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:108
+msgid ""
+"The AcousticBrainz project does not track who submits data to the "
+"database. If you create an account and use our data creation\n"
+"    tools (e.g. create a dataset or participate in a challenge) then we "
+"link your participation and the things that you create to\n"
+"    your account. If you choose to delete your account then we keep the "
+"non personally identifying data that you create, but anonymize\n"
+"    it so that it cannot be linked back to you."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:114
 msgid "Right to data portability / exporting your data"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:150
+#: metabrainz/templates/index/gdpr.html:117
+msgid ""
+"Summary: <i>You have the right to access/download the data we store about"
+" you</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:120
+msgid ""
+"Except for the ListenBrainz and AcousticBrainz projects, we do not store "
+"personally identifying data beyond the\n"
+"    information that is available in your public profile on each of our "
+"projects. Since this data is plainly available in your\n"
+"    profile we do not provide a means for you to export this data."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:125
+msgid "There are the following exceptions to this:"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:129
+msgid ""
+"<b>IP addresses</b>: If you visit one of our sites the IP address of your"
+" computer is stored in our web logs for 7 days\n"
+"        before our servers automatically delete them. This data is almost"
+" never used by anyone: the only time we look at the\n"
+"        IP addresses is if our sites are adversely impacted by the "
+"actions of some unknown users. In that case, we may investigate\n"
+"        the logs to identify the IP address that needs to be blocked in "
+"order to restore the stability of our service.\n"
+"        This data is not available to anyone but the contractors of the "
+"MetaBrainz Foundation and is not available to download\n"
+"        to anyone at all."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:137
+#, python-format
+msgid ""
+"<b>ListenBrainz Listen data</b>: Users may <a "
+"href=\"%(listenbrainz_export_url)s\">export their ListenBrainz Listen\n"
+"        data</a> directly from the site. The user Listen data is also "
+"included in the <a href=\"%(listenbrainz_data_url)s\">ListenBrainz\n"
+"        data dumps</a> that are available for public download."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:146
+msgid ""
+"All of the non personally identifying data, such as your metadata "
+"contributions, are publicly visible, available for download\n"
+"    and available via the project APIs. For details about this data, "
+"downloads and APIs please check the documentation for the\n"
+"    respective projects you are interested in."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:151
+#, python-format
+msgid ""
+"Anyone wishing to get a list of financial donations they have made to the"
+" MetaBrainz Foundation, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a> and provide your "
+"MusicBrainz editor name so that we can look up\n"
+"    your donations."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:157
 msgid "Right to rectification"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:165
+#: metabrainz/templates/index/gdpr.html:160
+msgid "Summary: <i>You have the right to correct your data</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:163
+msgid ""
+"All of our projects allow their users to update their personally "
+"identifying information in their profiles. Furthermore, most\n"
+"    of our projects allow the editing of their own metadata "
+"contributions. If you find that some of your data is incorrect, please\n"
+"    feel free to edit the data since we provide the tools to do so."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:168
+#, python-format
+msgid ""
+"If anyone who has made a financial donation to the MetaBrainz Foundation "
+"would like to make their donation private, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:173
 msgid "Right to be informed"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:188
+#: metabrainz/templates/index/gdpr.html:175
+msgid ""
+"Summary: <i>You have the right to be informed about how we use your data "
+"in plain English</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:178
+msgid ""
+"Our privacy policy, as well as other policies, have always been written "
+"by humans for human consumption. We abhor legalese and\n"
+"    not speaking in direct terms."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:186
+msgid "Social contract"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:189
+msgid "Code of conduct"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:192
+msgid "Privacy policy"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:196
 msgid "Right to access"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:198
-#: metabrainz/templates/index/privacy.html:166
+#: metabrainz/templates/index/gdpr.html:199
+msgid ""
+"Summary: <i>You have the right to access the data that we collect about "
+"you</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:202
+msgid ""
+"All of our projects make all of the data we collect on your behalf, "
+"privately identifying or not, available to you. The\n"
+"    only exception to this are the IP addresses we store for 7 days – see"
+" above for details."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:206
+#: metabrainz/templates/index/privacy.html:168
 msgid "Privacy/GDPR Representative"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:209
+#, python-format
+msgid ""
+"If you have any questions about our privacy policy, please <a "
+"href=\"%(contact_url)s\">contact us</a>. To report\n"
+"   any privacy problems, violations or leaks, our GDPR representative is "
+"our Interim Executive Director Nicolás Tamargo and for\n"
+"   privacy issues contact him at <strong><a "
+"href=\"mailto:gdpr@metabrainz.org\">gdpr@metabrainz.org</a></strong>."
 msgstr ""
 
 #: metabrainz/templates/index/index.html:6
@@ -1234,7 +2061,7 @@ msgid ""
 "      <a href=\"%(about_url)s\">about</a> page."
 msgstr ""
 
-#: frontend/js/src/forms/ConditionsModal.tsx:43
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:32
 #: metabrainz/templates/index/privacy.html:3
 msgid "Privacy"
 msgstr "Privatsphäre"
@@ -1242,6 +2069,44 @@ msgstr "Privatsphäre"
 #: metabrainz/templates/index/privacy.html:8
 msgid "Summary"
 msgstr "Zusammenfassung"
+
+#: metabrainz/templates/index/privacy.html:12
+msgid ""
+"You do not have to provide any personal data to be able to browse the "
+"contents of the databases published by MetaBrainz."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:15
+msgid ""
+"You do not have to provide any personally-identifying information if you "
+"choose not to."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:18
+msgid ""
+"We will never reveal your email address on MetaBrainz controlled web "
+"sites."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:22
+msgid ""
+"In order to get maximum value out of the MetaBrainz projects, you may "
+"want to create an account and log in. \n"
+"    Doing so grants you the ability to: edit the databases, contribute "
+"your own data, communicate with other users, and keep track \n"
+"    of recently released music from artists in your MusicBrainz "
+"collection. If you choose to create an account then the minimum we \n"
+"    ask is that you: choose a unique username and password, use a web "
+"browser that accepts \"session\" cookies, and provide a verified \n"
+"    email address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:29
+msgid ""
+"If you do not create an account (or are not logged in) you will not have "
+"access to the above listed features, however, you will \n"
+"    still have full access to browse and examine the databases."
+msgstr ""
 
 #: metabrainz/templates/index/privacy.html:33
 msgid "Applicable to all users"
@@ -1251,39 +2116,197 @@ msgstr ""
 msgid "Cookies"
 msgstr ""
 
+#: metabrainz/templates/index/privacy.html:37
+msgid "We use two cookies that contain sensitive information:"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:42
+msgid ""
+"<b>remember_login</b>: If you choose the \"Log in permanently\" option "
+"when logging in to one of our sites; the cookie will be used to \n"
+"      remember your login details."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:46
+msgid ""
+"<b>musicbrainz_server_session, session, or connect.sid</b>: If you are "
+"logged into one of our sites, your current session ID is stored in this "
+"cookie."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:51
+msgid ""
+"We may store dynamic preference information in other cookies, but these "
+"do not contain any sensitive information."
+msgstr ""
+
 #: metabrainz/templates/index/privacy.html:54
 msgid "Web and FTP access logs"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:57
+msgid ""
+"In a practice similar to other web sites (and APIs) we keep logs of all "
+"web requests made against our servers. These logs include: your IP\n"
+"    address, your browser's (or API client's) \"User-Agent\" string, and "
+"which page (or API endpoint) you requested with which parameters. "
+"Aggregate information about web and FTP traffic is\n"
+"    made available to the public via our site usage pages."
 msgstr ""
 
 #: metabrainz/templates/index/privacy.html:62
 msgid "Third-Party content"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:92
+#: metabrainz/templates/index/privacy.html:64
+msgid ""
+"Our projects' web pages may load some third-party content. Some, but "
+"possibly not all sites are listed below:"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:69
+#, python-format
+msgid ""
+"Cover art and other images: These are provided by the various cover art "
+"sites that have given MusicBrainz permission to do so and our own \n"
+"      <a href=\"%(caa_url)s\">Cover Art Archive</a>. This means that the "
+"relevant site will know (if they want to) your IP \n"
+"      address, User-Agent string, etc., and which MusicBrainz web page "
+"you were visiting (the one which included the cover art image)."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:75
+msgid ""
+"AcoustID: Our fingerprints tab loads fingerprint information from "
+"acoustid.org."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:78
+msgid ""
+"MTCaptcha: Our account creation page loads third party content in order "
+"to prevent spammers from creating accounts."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:83
+msgid ""
+"<i>The above information assumes that you are using \"normal\" web "
+"browser settings, whereby images are always loaded and HTTP referrer \n"
+"    information is always sent.</i>"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:88
+msgid ""
+"It is impractical to constantly modify this privacy policy when "
+"MetaBrainz projects change which third party content they utilize. We "
+"will \n"
+"    aim to use common sense, respect to our community and community "
+"review when adding more content from third party sites. We will also \n"
+"    periodically review our policy to ensure that it remains current."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:93
 msgid "Applicable to account holders"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:94
+#: metabrainz/templates/index/privacy.html:95
 msgid "Account creation"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:108
+#: metabrainz/templates/index/privacy.html:97
+msgid ""
+"When creating an account with a MetaBrainz project you need to pick a "
+"unique username and choose a password, the username you pick is the \n"
+"    only name associated with your account and will be what other "
+"MetaBrainz users know you as. You may optionally also tell us other \n"
+"    information about yourself that will be displayed to other MetaBrainz"
+" users and the public."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:103
+msgid ""
+"Additionally, in order to edit the databases you will need to provide a "
+"confirmed email address. This email address will be held in \n"
+"    confidence, the only method of revealing your email address to "
+"another user is if you choose to send a message to another \n"
+"    user and enable the option to \"reveal my email address\". Changing "
+"the email address stored with your account will require you to \n"
+"    verify the new address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:109
 msgid "Edits and Notes"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:114
+#: metabrainz/templates/index/privacy.html:111
+msgid ""
+"If you make any changes to a MetaBrainz project database, such as adding "
+"any data, the details of those changes will be visible to \n"
+"    other logged-in users and the change will be associated with your "
+"username."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:115
 msgid "Subscriptions on MusicBrainz"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:131
+#: metabrainz/templates/index/privacy.html:117
+msgid ""
+"As a logged-in user you can subscribe to one or more artists, labels, "
+"collections or other editors. The act of subscribing causes \n"
+"    any edits made to (or by in the case of another editor) those "
+"entities to be emailed to you. By default, other users can see your \n"
+"    list of subscriptions, however, you can opt out of this by editing "
+"the appropriate preference."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:123
+msgid ""
+"This does not provide \"perfect\" privacy though, in some cases it will "
+"be possible to infer information about the contents of your \n"
+"    subscription list even though you have disallowed others from viewing"
+" that list directly. This imperfection arises because various \n"
+"    parts of the system behave differently depending on whether or not an"
+" entity has any subscribers; also, the number of users \n"
+"    subscribed to each artist is available via the artist pages. In the "
+"most extreme (possibly contrived) example, imagine that all \n"
+"    users have their subscriptions set to \"public\", except for exactly "
+"one user whose list is \"private\". In that case, any discrepancy \n"
+"    for a given artist between the shown list of subscribers and the "
+"total number of subscribers must be down to that one user. Thus, \n"
+"    you can infer what artists are on that user's list."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:132
 msgid "Third-party sites"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:145
+#: metabrainz/templates/index/privacy.html:134
+#, python-format
+msgid ""
+"Our code reviews are done on GitHub, which is not under the control of "
+"MetaBrainz. Participating in code reviews or other\n"
+"    tasks carried out on GitHub are subject to <a "
+"href=\"%(github_url)s\">GitHub's privacy policy</a>."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:140
+#, python-format
+msgid ""
+"Our translations platform is provided and hosted by Weblate, which has a "
+"data processing agreement with MetaBrainz.\n"
+"    Participating in translations is subject to <a "
+"href=\"%(weblate_url)s\">dedicated legal terms</a>.\n"
+"    Any translations you make will be submitted to our Git repositories "
+"and publicly associated with your username;\n"
+"    if you so choose, you can also publicly associate them with your own "
+"verified email address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:147
 msgid "MetaBrainz donors"
 msgstr "MetaBrainz Spender"
 
-#: metabrainz/templates/index/privacy.html:147
+#: metabrainz/templates/index/privacy.html:149
 msgid ""
 "When you make a donation to the MetaBrainz Foundation, we are legally\n"
 "    required to collect your personal information and keep it in our "
@@ -1293,7 +2316,7 @@ msgid ""
 "    information to anyone else, ever."
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:153
+#: metabrainz/templates/index/privacy.html:155
 msgid ""
 "We believe in transparent finances, which means that we list all "
 "donations\n"
@@ -1303,11 +2326,34 @@ msgid ""
 "process."
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:158
+#: metabrainz/templates/index/privacy.html:160
 msgid "Exceptions"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:598
+#: metabrainz/templates/index/privacy.html:162
+msgid ""
+"<i><b>Please note</b>: Reasonable exceptions may apply to the above "
+"policy, for example to comply with applicable laws.\n"
+"    Also, members of the MetaBrainz team and other personnel contracted "
+"to provide services to MetaBrainz may have access to\n"
+"    our infrastructure and could therefore view any information contained"
+" therein. However all personnel are contractually bound\n"
+"    by non-disclosure clauses which prevent them from making any such "
+"information available to others."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:171
+#, python-format
+msgid ""
+"If you have any questions about our GDPR statement, please <a "
+"href=\"%(contact_url)s\">contact us</a>. To report\n"
+"   any privacy problems, violations or leaks, our GDPR representative is "
+"our Interim Executive Director Nicolás Tamargo and for\n"
+"   privacy issues contact him at <strong><a "
+"href=\"mailto:gdpr@metabrainz.org\">gdpr@metabrainz.org</a></strong>."
+msgstr ""
+
+#: frontend/js/src/Profile.tsx:603
 #: frontend/js/src/forms/ProfileChangePassword.tsx:22
 #: frontend/js/src/forms/ProfileChangePassword.tsx:111
 #: metabrainz/templates/index/profile-change-password.html:3
@@ -1552,6 +2598,11 @@ msgstr ""
 
 #: metabrainz/templates/index/team.html:26
 msgid "He lives on in our hearts and in open source."
+msgstr ""
+
+#: metabrainz/templates/index/team.html:29
+#: metabrainz/templates/index/team.html:315
+msgid "you’re welcome to try"
 msgstr ""
 
 #: metabrainz/templates/index/team.html:39
@@ -2052,8 +3103,10 @@ msgstr ""
 
 #: metabrainz/templates/payments/donate.html:146
 msgid ""
-"Due to the increased unreliability of the US Postal Service we have "
-"stopped accepting paper checks. Sorry!"
+"Due to the increased unreliability of the US Postal Service and the "
+"relatively large fees involved, we ask you to only send a paper check if "
+"it is the only possible option. Due to the fees, we will not cash checks "
+"for less than $25."
 msgstr ""
 
 #: metabrainz/templates/payments/donate.html:241
@@ -2937,8 +3990,8 @@ msgid "Monthly balance sheets"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:520
-#: frontend/js/src/forms/SignupCommercial.tsx:175
-#: frontend/js/src/forms/SignupCommercial.tsx:554
+#: frontend/js/src/forms/SignupCommercial.tsx:180
+#: frontend/js/src/forms/SignupCommercial.tsx:558
 #: frontend/js/src/forms/SignupNonCommercial.tsx:106
 #: frontend/js/src/forms/SignupNonCommercial.tsx:318
 #: metabrainz/templates/supporters/account-type.html:3
@@ -2960,6 +4013,7 @@ msgid "Non-commercial / Personal"
 msgstr "Nicht-kommerziell / Privat"
 
 #: frontend/js/src/Profile.tsx:235
+#: frontend/js/src/forms/SignupNonCommercial.tsx:107
 #: frontend/js/src/forms/SignupNonCommercial.tsx:151
 #: metabrainz/templates/supporters/account-type.html:42
 msgid "Non-commercial"
@@ -2973,57 +4027,46 @@ msgstr ""
 msgid "Personal or university assignment user."
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:48
-#: metabrainz/templates/supporters/account-type.html:90
-#: metabrainz/templates/supporters/account-type.html:141
-msgid "Upgrade"
-msgstr ""
-
 #: frontend/js/src/Profile.tsx:235
-#: frontend/js/src/forms/SignupCommercial.tsx:176
-#: frontend/js/src/forms/SignupCommercial.tsx:228
-#: metabrainz/templates/supporters/account-type.html:61
+#: frontend/js/src/forms/SignupCommercial.tsx:181
+#: frontend/js/src/forms/SignupCommercial.tsx:233
+#: metabrainz/templates/supporters/account-type.html:56
 msgid "Commercial"
 msgstr "Kommerziell"
 
-#: metabrainz/templates/supporters/account-type.html:83
-#: metabrainz/templates/supporters/account-type.html:135
+#: metabrainz/templates/supporters/account-type.html:78
+#: metabrainz/templates/supporters/account-type.html:125
 #, python-format
 msgid "$%(tier_price)s/month and up"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:87
-#: metabrainz/templates/supporters/account-type.html:138
+#: metabrainz/templates/supporters/account-type.html:82
+#: metabrainz/templates/supporters/account-type.html:128
 msgid "More info"
 msgstr "Mehr Informationen"
 
-#: metabrainz/templates/supporters/account-type.html:104
+#: metabrainz/templates/supporters/account-type.html:94
 msgid "View all tiers"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:112
+#: metabrainz/templates/supporters/account-type.html:102
 msgid "Some of our Unicorn members"
 msgstr "Einige unserer \"Unicorn\" Mitglieder"
 
-#: metabrainz/templates/supporters/account-type.html:123
+#: metabrainz/templates/supporters/account-type.html:113
 msgid "See all our supporters"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:151
+#: metabrainz/templates/supporters/account-type.html:136
 msgid "View featured tiers"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:158
+#: metabrainz/templates/supporters/account-type.html:143
 #, python-format
 msgid ""
 "If you are not sure which tier to pick, please\n"
 "      <a href=\"%(contact_url)s\">contact us</a>."
 msgstr ""
-
-#: metabrainz/templates/supporters/account-type.html:166
-#, fuzzy
-msgid "Back to Profile"
-msgstr "Dein Profil"
 
 #: metabrainz/templates/supporters/bad-standing.html:3
 #: metabrainz/templates/supporters/bad-standing.html:6
@@ -3084,9 +4127,9 @@ msgid "Forgot your username"
 msgstr ""
 
 #: frontend/js/src/forms/ResetPassword.tsx:79
-#: frontend/js/src/forms/SignupCommercial.tsx:320
+#: frontend/js/src/forms/SignupCommercial.tsx:325
 #: frontend/js/src/forms/SignupNonCommercial.tsx:227
-#: frontend/js/src/forms/SignupUser.tsx:169
+#: frontend/js/src/forms/SignupUser.tsx:175
 #: metabrainz/templates/users/reauthenticate.html:3
 #: metabrainz/templates/users/reauthenticate.html:6
 msgid "Confirm Password"
@@ -3096,17 +4139,22 @@ msgstr ""
 msgid "Please re-enter your password to continue."
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:108
+#: frontend/js/src/ProfileDelete.tsx:110
 #: frontend/js/src/forms/DeleteApplication.tsx:53
 #: frontend/js/src/forms/OAuthPrompt.tsx:54
 #: frontend/js/src/forms/ProfileChangePassword.tsx:104
 #: frontend/js/src/forms/ProfileEdit.tsx:105
-#: metabrainz/templates/users/reauthenticate.html:23
+#: metabrainz/templates/users/reauthenticate.html:28
 msgid "Cancel"
 msgstr ""
 
-#: metabrainz/templates/users/reauthenticate.html:24
+#: metabrainz/templates/users/reauthenticate.html:29
 msgid "Continue"
+msgstr ""
+
+#: frontend/js/src/forms/utils.tsx:202
+#: metabrainz/templates/users/reauthenticate.html:40
+msgid "Password must not exceed 72 bytes."
 msgstr ""
 
 #: frontend/js/src/forms/ResetPassword.tsx:27
@@ -3114,38 +4162,38 @@ msgstr ""
 msgid "Reset your password"
 msgstr ""
 
-#: frontend/js/src/hooks/useEmailValidation.ts:41 metabrainz/user/forms.py:15
+#: frontend/js/src/hooks/useEmailValidation.ts:41 metabrainz/user/forms.py:16
 msgid "Registration from this email domain is not allowed."
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:50
 #: frontend/js/src/forms/LostPassword.tsx:45
-#: frontend/js/src/forms/SignupCommercial.tsx:270
+#: frontend/js/src/forms/SignupCommercial.tsx:275
 #: frontend/js/src/forms/SignupNonCommercial.tsx:175
-#: frontend/js/src/forms/SignupUser.tsx:114 metabrainz/user/forms.py:20
-#: metabrainz/user/forms.py:45 metabrainz/user/forms.py:62
+#: frontend/js/src/forms/SignupUser.tsx:120 metabrainz/user/forms.py:22
+#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:75
 msgid "Username"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:42
 #: frontend/js/src/forms/LostPassword.tsx:37
-#: frontend/js/src/forms/SignupCommercial.tsx:153
+#: frontend/js/src/forms/SignupCommercial.tsx:158
 #: frontend/js/src/forms/SignupNonCommercial.tsx:84
-#: frontend/js/src/forms/SignupUser.tsx:67 metabrainz/user/forms.py:21
-#: metabrainz/user/forms.py:45 metabrainz/user/forms.py:62
+#: frontend/js/src/forms/SignupUser.tsx:73 metabrainz/user/forms.py:26
+#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:75
 msgid "Username is required!"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:63
 #: frontend/js/src/forms/ResetPassword.tsx:72
-#: frontend/js/src/forms/SignupCommercial.tsx:308
+#: frontend/js/src/forms/SignupCommercial.tsx:313
 #: frontend/js/src/forms/SignupNonCommercial.tsx:214
-#: frontend/js/src/forms/SignupUser.tsx:157 metabrainz/user/forms.py:46
-#: metabrainz/user/forms.py:52
+#: frontend/js/src/forms/SignupUser.tsx:163 metabrainz/user/forms.py:53
+#: metabrainz/user/forms.py:62
 msgid "Password"
 msgstr ""
 
-#: frontend/js/src/forms/LoginUser.tsx:76 metabrainz/user/forms.py:47
+#: frontend/js/src/forms/LoginUser.tsx:76 metabrainz/user/forms.py:57
 msgid "Remember me"
 msgstr ""
 
@@ -3157,11 +4205,11 @@ msgstr ""
 msgid "Username contains invalid or invisible characters."
 msgstr ""
 
-#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:181
+#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:220
 msgid "Hide password"
 msgstr ""
 
-#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:181
+#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:220
 msgid "Show password"
 msgstr ""
 
@@ -3218,11 +4266,11 @@ msgstr ""
 msgid "Revoke access"
 msgstr ""
 
-#: frontend/js/src/OAuthError.tsx:17
+#: frontend/js/src/OAuthError.tsx:18
 msgid "OAuth2 Error"
 msgstr ""
 
-#: frontend/js/src/OAuthError.tsx:18
+#: frontend/js/src/OAuthError.tsx:19
 msgid "An error occurred during OAuth authentication process."
 msgstr ""
 
@@ -3252,8 +4300,8 @@ msgstr ""
 
 #: frontend/js/src/Profile.tsx:109
 msgid ""
-"Are you sure you want to generate new access token? Current token will be"
-" revoked!"
+"Are you sure you want to generate a new access token? The current token "
+"will be revoked!"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:118
@@ -3368,8 +4416,8 @@ msgid "Contact Information"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:310 frontend/js/src/forms/ProfileEdit.tsx:70
-#: frontend/js/src/forms/SignupCommercial.tsx:284
-#: frontend/js/src/forms/SignupCommercial.tsx:333
+#: frontend/js/src/forms/SignupCommercial.tsx:289
+#: frontend/js/src/forms/SignupCommercial.tsx:338
 #: frontend/js/src/forms/SignupNonCommercial.tsx:189
 #: frontend/js/src/forms/SignupNonCommercial.tsx:241
 msgid "Contact name"
@@ -3484,7 +4532,7 @@ msgstr ""
 msgid "Once you delete your account, there is no going back. Please be certain."
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:550 frontend/js/src/ProfileDelete.tsx:105
+#: frontend/js/src/Profile.tsx:550 frontend/js/src/ProfileDelete.tsx:107
 msgid "Delete My Account"
 msgstr ""
 
@@ -3496,39 +4544,39 @@ msgstr ""
 msgid "Need to delete your account?"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:574
+#: frontend/js/src/Profile.tsx:575
 msgid ""
 "Deletion of supporter accounts requires manual review. Please contact us "
-"at"
+"at <email />."
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:594
+#: frontend/js/src/Profile.tsx:599
 msgid "Security"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:626
+#: frontend/js/src/Profile.tsx:631
 msgid "MetaBrainz Applications"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:630
+#: frontend/js/src/Profile.tsx:635
 msgid ""
 "With your MetaBrainz account, you can access every project in the "
 "MetaBrainz family:"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:643
+#: frontend/js/src/Profile.tsx:648
 msgid "The open-source music encyclopedia"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:655
+#: frontend/js/src/Profile.tsx:660
 msgid "Track, visualise and share the music you listen to"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:667
+#: frontend/js/src/Profile.tsx:672
 msgid "The open-source book database"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:679
+#: frontend/js/src/Profile.tsx:684
 msgid "Creative Commons licensed reviews"
 msgstr ""
 
@@ -3551,7 +4599,7 @@ msgid "Permanently remove all your account information"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:64
-msgid "Revoke all your API tokens and access"
+msgid "Revoke all your tokens and access to the replication API"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:65
@@ -3563,14 +4611,16 @@ msgid "Log you out of all MetaBrainz services"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:70
-msgid "Your username will be reserved and cannot be reused."
+msgid ""
+"Your username will be reserved and cannot be reused without the "
+"intervention of an administrator."
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:82
+#: frontend/js/src/ProfileDelete.tsx:84
 msgid "To confirm, type your username '<username />' below:"
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:105
+#: frontend/js/src/ProfileDelete.tsx:107
 msgid "Deleting..."
 msgstr ""
 
@@ -3583,64 +4633,7 @@ msgstr "Dein Profil"
 msgid "Close"
 msgstr ""
 
-#: frontend/js/src/forms/ConditionsModal.tsx:23
-msgid "Licensing"
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:25
-msgid ""
-"Any contributions you make to any MetaBrainz service will be released "
-"into the Public Domain and/or licensed under a Creative Commons by-nc-sa "
-"license. Furthermore, you give the MetaBrainz Foundation the right to "
-"license this data for commercial use."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:30
-msgid "Please read our <licenseLink>license page</licenseLink> for more details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:45
-msgid ""
-"MetaBrainz strongly believes in the privacy of its users. Any personal "
-"information you choose to provide will not be sold or shared with anyone "
-"else."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:50
-msgid ""
-"Please read our <privacyLink>privacy policy</privacyLink> for more "
-"details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:59
-msgid "GDPR compliance"
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:61
-msgid ""
-"You may remove your personal information from our services anytime by "
-"deleting your account."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:66
-msgid ""
-"Please read our <gdprLink>GDPR compliance statement</gdprLink> for more "
-"details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:78
-msgid ""
-"Creating an account on MetaBrainz will give you access to all of our "
-"projects, such as MusicBrainz, ListenBrainz, BookBrainz, and more."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:82
-msgid ""
-"We create a placeholder account for all the MetaBrainz projects when you "
-"sign up, and you are one log-in away from activating them."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:91
+#: frontend/js/src/forms/ConditionsModal.tsx:29
 msgid "Sounds good"
 msgstr ""
 
@@ -3727,8 +4720,8 @@ msgstr ""
 msgid "Forgot your password?"
 msgstr ""
 
-#: frontend/js/src/forms/LoginUser.tsx:109
-msgid "Don't have an account?"
+#: frontend/js/src/forms/LoginUser.tsx:110
+msgid "Don't have an account? <signupLink>Sign up</signupLink>"
 msgstr ""
 
 #: frontend/js/src/forms/LostPassword.tsx:38
@@ -3757,15 +4750,72 @@ msgstr ""
 msgid "Allow access"
 msgstr ""
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:71
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:10
+msgid "Licensing"
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:12
+msgid ""
+"Any contributions you make to any MetaBrainz service will be released "
+"into the Public Domain and/or licensed under a Creative Commons by-nc-sa "
+"license. Furthermore, you give the MetaBrainz Foundation the right to "
+"license this data for commercial use."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:17
+msgid "Please read our <licenseLink>license page</licenseLink> for more details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:34
+msgid ""
+"MetaBrainz strongly believes in the privacy of its users. Any personal "
+"information you choose to provide will not be sold or shared with anyone "
+"else."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:39
+msgid ""
+"Please read our <privacyLink>privacy policy</privacyLink> for more "
+"details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:50
+msgid "GDPR compliance"
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:52
+msgid ""
+"You may remove your personal information from our services anytime by "
+"deleting your account."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:57
+msgid ""
+"Please read our <gdprLink>GDPR compliance statement</gdprLink> for more "
+"details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:71
+msgid ""
+"Creating an account on MetaBrainz will give you access to all of our "
+"projects, such as MusicBrainz, ListenBrainz, BookBrainz, and more."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:75
+msgid ""
+"We create a placeholder account for all the MetaBrainz projects when you "
+"sign up, and you are one log-in away from activating them."
+msgstr ""
+
+#: frontend/js/src/forms/ProfileChangePassword.tsx:70
 msgid "Current Password"
 msgstr ""
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:80
+#: frontend/js/src/forms/ProfileChangePassword.tsx:79
 msgid "New Password"
 msgstr ""
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:89
+#: frontend/js/src/forms/ProfileChangePassword.tsx:88
 msgid "Confirm New Password"
 msgstr ""
 
@@ -3777,194 +4827,183 @@ msgstr ""
 msgid "Reset Password"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:38
-msgid "If you would like to support us with more than $"
+#: frontend/js/src/forms/SignupCommercial.tsx:40
+msgid ""
+"If you would like to support us with more than ${{minPledge}}, please "
+"enter the actual amount here:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:39
-msgid ", please enter the actual amount here:"
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:144
+#: frontend/js/src/forms/SignupCommercial.tsx:149
 #: frontend/js/src/forms/SignupNonCommercial.tsx:75
-#: frontend/js/src/forms/SignupUser.tsx:87
+#: frontend/js/src/forms/SignupUser.tsx:93
 msgid "Captcha is required!"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:179
+#: frontend/js/src/forms/SignupCommercial.tsx:184
 #: frontend/js/src/forms/SignupNonCommercial.tsx:110
 #: frontend/js/src/forms/SignupUser.tsx:46
 #, fuzzy
 msgid "Access all MetaBrainz projects"
 msgstr "MetaBrainz Projekte"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:182
+#: frontend/js/src/forms/SignupCommercial.tsx:187
 msgid "Note:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:184
+#: frontend/js/src/forms/SignupCommercial.tsx:189
 msgid ""
 "Signing up for any tier other than the <italic>Stealth startup</italic> "
 "tier will publicly list your company on this web site. However, we will "
 "not publish any of your private details."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:221
+#: frontend/js/src/forms/SignupCommercial.tsx:226
 #: frontend/js/src/forms/SignupNonCommercial.tsx:145
 msgid "Account type"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:234
+#: frontend/js/src/forms/SignupCommercial.tsx:239
 msgid "Selected tier"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:242
-msgid "month and up"
+#: frontend/js/src/forms/SignupCommercial.tsx:247
+msgid "${{tierPrice}}/month and up"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:250
+#: frontend/js/src/forms/SignupCommercial.tsx:255
 msgid "Change account type or tier"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:261
+#: frontend/js/src/forms/SignupCommercial.tsx:266
 #: frontend/js/src/forms/SignupNonCommercial.tsx:166
 msgid "Your account:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:271
+#: frontend/js/src/forms/SignupCommercial.tsx:276
 #: frontend/js/src/forms/SignupNonCommercial.tsx:176
-#: frontend/js/src/forms/SignupUser.tsx:114
+#: frontend/js/src/forms/SignupUser.tsx:120
 msgid "(public)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:291
+#: frontend/js/src/forms/SignupCommercial.tsx:296
 #: frontend/js/src/forms/SignupNonCommercial.tsx:196
-#: frontend/js/src/forms/SignupUser.tsx:127
+#: frontend/js/src/forms/SignupUser.tsx:133
 msgid "E-mail address"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:295
+#: frontend/js/src/forms/SignupCommercial.tsx:300
 #: frontend/js/src/forms/SignupNonCommercial.tsx:200
-#: frontend/js/src/forms/SignupUser.tsx:131
+#: frontend/js/src/forms/SignupUser.tsx:137
 msgid "(checking...)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:314
+#: frontend/js/src/forms/SignupCommercial.tsx:319
 #: frontend/js/src/forms/SignupNonCommercial.tsx:220
-#: frontend/js/src/forms/SignupUser.tsx:163
+#: frontend/js/src/forms/SignupUser.tsx:169
 msgid "Must be at least 8 characters"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:348
+#: frontend/js/src/forms/SignupCommercial.tsx:353
 msgid ""
 "If you don't have an organization name, you probably want to become a "
 "supporter as a <nonCommercialLink>Non-commercial / "
 "Personal</nonCommercialLink> supporter."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:358
+#: frontend/js/src/forms/SignupCommercial.tsx:363
 msgid ""
 "If you don't have an organization name, you probably want to sign up as a"
 " <nonCommercialLink>Non-commercial / Personal</nonCommercialLink> user."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:378
+#: frontend/js/src/forms/SignupCommercial.tsx:383
 msgid ""
 "Please tell us a little about your company and whether you plan to use "
 "our <apiLink>API</apiLink> or to <hostLink>host your own copy</hostLink> "
 "of the data."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:404
+#: frontend/js/src/forms/SignupCommercial.tsx:408
 msgid "Logo URL"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:405
+#: frontend/js/src/forms/SignupCommercial.tsx:409
 msgid "(preferably in SVG format)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:408
+#: frontend/js/src/forms/SignupCommercial.tsx:412
 msgid ""
 "Image should be about 250 pixels wide on a white or transparent "
 "background. We will host it on our site."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:421
+#: frontend/js/src/forms/SignupCommercial.tsx:425
 msgid ""
 "URL to where developers can use your APIs using MusicBrainz IDs, if "
-"available.."
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:430
-msgid "Your project"
+"available."
 msgstr ""
 
 #: frontend/js/src/forms/SignupCommercial.tsx:434
+msgid "Your project"
+msgstr ""
+
+#: frontend/js/src/forms/SignupCommercial.tsx:438
 #: frontend/js/src/forms/SignupNonCommercial.tsx:261
 msgid "(max 150 characters)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:451
+#: frontend/js/src/forms/SignupCommercial.tsx:455
 msgid "Billing address"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:502
+#: frontend/js/src/forms/SignupCommercial.tsx:506
 msgid ""
 "I agree to support the MetaBrainz Foundation when my organization is able"
 " to do so."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:507
+#: frontend/js/src/forms/SignupCommercial.tsx:511
+#: frontend/js/src/forms/SignupNonCommercial.tsx:284
 msgid ""
-"I also agree that if I generate a Live Data Feed access token, that I "
-"treat my access token as a secret and will not share this token publicly "
-"or commit it to a source code repository."
+"I also agree that if I generate a Live Data Feed access token, then I "
+"will treat my access token as a secret and will not share this token "
+"publicly or commit it to a source code repository."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:515
+#: frontend/js/src/forms/SignupCommercial.tsx:519
 msgid ""
 "The following information will be shown publicly: organization name, "
 "logo, website and API URLs, data usage description."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:520
+#: frontend/js/src/forms/SignupCommercial.tsx:524
 msgid ""
 "We'll send you more details about payment process once your application "
 "is approved."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:552
+#: frontend/js/src/forms/SignupCommercial.tsx:556
 #: frontend/js/src/forms/SignupNonCommercial.tsx:316
-#: frontend/js/src/forms/SignupUser.tsx:224
+#: frontend/js/src/forms/SignupUser.tsx:230
 msgid "Validating..."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:564
+#: frontend/js/src/forms/SignupCommercial.tsx:568
 #: frontend/js/src/forms/SignupNonCommercial.tsx:329
 #, fuzzy
 msgid "Back to profile"
 msgstr "Dein Profil"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:569
-#: frontend/js/src/forms/SignupNonCommercial.tsx:334
-msgid "Not a supporter?"
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:570
+#: frontend/js/src/forms/SignupCommercial.tsx:574
 #: frontend/js/src/forms/SignupNonCommercial.tsx:335
-msgid "Create a user account"
+msgid "Not a supporter? <signupLink>Create a user account</signupLink>"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:573
-#: frontend/js/src/forms/SignupNonCommercial.tsx:338
-#: frontend/js/src/forms/SignupUser.tsx:231
-msgid "Already have an account?"
+#: frontend/js/src/forms/SignupCommercial.tsx:583
+#: frontend/js/src/forms/SignupNonCommercial.tsx:344
+#: frontend/js/src/forms/SignupUser.tsx:238
+msgid "Already have an account? <loginLink>Sign in</loginLink>"
 msgstr ""
-
-#: frontend/js/src/forms/SignupNonCommercial.tsx:107
-#, fuzzy
-msgid "non-commercial"
-msgstr "Nicht-kommerziell"
 
 #: frontend/js/src/forms/SignupNonCommercial.tsx:113
 msgid ""
@@ -3991,46 +5030,40 @@ msgid ""
 "income per year) or personal uses only."
 msgstr ""
 
-#: frontend/js/src/forms/SignupNonCommercial.tsx:284
-msgid ""
-"I also agree that if I generate a Live Data Feed access token, then I "
-"will treat my access token as a secret and will not share this token "
-"publicly or commit it to a source code repository."
-msgstr ""
-
 #: frontend/js/src/forms/SignupUser.tsx:43
 msgid "Create your account"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:50
-msgid "Registration started by"
+#: frontend/js/src/forms/SignupUser.tsx:51
+msgid "Registration started by <client />"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:69
+#: frontend/js/src/forms/SignupUser.tsx:75
+#: frontend/js/src/hooks/useEmailValidation.ts:82
 msgid "Invalid email address."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:150
+#: frontend/js/src/forms/SignupUser.tsx:156
 msgid ""
 "This username and email were provided by the app that started "
 "registration. You can change them later from MetaBrainz settings."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:182
+#: frontend/js/src/forms/SignupUser.tsx:188
 msgid ""
 "I accept that my contributions will be released into the public domain or"
 " licensed for use."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:191
+#: frontend/js/src/forms/SignupUser.tsx:197
 msgid "We will never share your personal information."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:200
+#: frontend/js/src/forms/SignupUser.tsx:206
 msgid "Click here to read more"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:224
+#: frontend/js/src/forms/SignupUser.tsx:230
 msgid "Create account"
 msgstr ""
 
@@ -4040,10 +5073,6 @@ msgstr ""
 
 #: frontend/js/src/hooks/useEmailValidation.ts:47
 msgid "Email validation failed"
-msgstr ""
-
-#: frontend/js/src/hooks/useEmailValidation.ts:82
-msgid "Invalid email address"
 msgstr ""
 
 #~ msgid "You need to specify amount!"
@@ -5319,4 +6348,96 @@ msgstr ""
 
 #~ msgid "Privacy policy"
 #~ msgstr "Datenschutzerklärung"
+
+#~ msgid "You need to specify website of the organization."
+#~ msgstr ""
+
+#~ msgid ""
+#~ "We are currently evaluating our overall"
+#~ " online advertising strategy. We are "
+#~ "evaluating advertising, traffic optimization,\n"
+#~ ""
+#~ "    search engine optimization and "
+#~ "software monitization technologies. If you "
+#~ "provide these professional services, please"
+#~ " provide a detailed\n"
+#~ "    deck of your comprehensive services"
+#~ " to the following email address. "
+#~ "<em>Please respect our other non-media"
+#~ " teams and do not contact us \n"
+#~ "    regarding these services on any "
+#~ "other of our email addresses. We "
+#~ "will disregard the entirety of your "
+#~ "submissions if you contact us any "
+#~ "other way!</em>"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Please come ask your questions at "
+#~ "our <a href=\"%(forums_url)s\">forums</a>! We "
+#~ "would love to\n"
+#~ "    answer any questions you may have."
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Due to the increased unreliability of"
+#~ " the US Postal Service we have "
+#~ "stopped accepting paper checks. Sorry!"
+#~ msgstr ""
+
+#~ msgid "Upgrade"
+#~ msgstr ""
+
+#~ msgid "Back to Profile"
+#~ msgstr "Dein Profil"
+
+#~ msgid ""
+#~ "Deletion of supporter accounts requires "
+#~ "manual review. Please contact us at"
+#~ msgstr ""
+
+#~ msgid "Revoke all your API tokens and access"
+#~ msgstr ""
+
+#~ msgid "Your username will be reserved and cannot be reused."
+#~ msgstr ""
+
+#~ msgid "Don't have an account?"
+#~ msgstr ""
+
+#~ msgid "If you would like to support us with more than $"
+#~ msgstr ""
+
+#~ msgid ", please enter the actual amount here:"
+#~ msgstr ""
+
+#~ msgid "month and up"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "I also agree that if I generate"
+#~ " a Live Data Feed access token, "
+#~ "that I treat my access token as"
+#~ " a secret and will not share "
+#~ "this token publicly or commit it "
+#~ "to a source code repository."
+#~ msgstr ""
+
+#~ msgid "Not a supporter?"
+#~ msgstr ""
+
+#~ msgid "Create a user account"
+#~ msgstr ""
+
+#~ msgid "Already have an account?"
+#~ msgstr ""
+
+#~ msgid "non-commercial"
+#~ msgstr "Nicht-kommerziell"
+
+#~ msgid "Registration started by"
+#~ msgstr ""
+
+#~ msgid "Invalid email address"
+#~ msgstr ""
 

--- a/metabrainz/translations/el/LC_MESSAGES/messages.po
+++ b/metabrainz/translations/el/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-07-25 16:21+0200\n"
+"POT-Creation-Date: 2026-09-08 11:18+0200\n"
 "PO-Revision-Date: 2026-06-12 00:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: el\n"
@@ -20,162 +20,247 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.18.0\n"
 
-#: metabrainz/index/forms.py:46
+#: metabrainz/errors.py:24
+msgid "Authorization was declined."
+msgstr ""
+
+#: metabrainz/errors.py:25
+msgid "The authorization request was invalid."
+msgstr ""
+
+#: metabrainz/errors.py:26
+msgid "The application could not be authenticated."
+msgstr ""
+
+#: metabrainz/errors.py:27
+msgid "This application is not allowed to request authorization."
+msgstr ""
+
+#: metabrainz/errors.py:28
+msgid "The application asked for a response type this server does not support."
+msgstr ""
+
+#: metabrainz/errors.py:29
+msgid "The permissions requested by the application are invalid."
+msgstr ""
+
+#: metabrainz/errors.py:30
+msgid "You need to sign in to continue."
+msgstr ""
+
+#: metabrainz/errors.py:31
+msgid "Your consent is required to continue."
+msgstr ""
+
+#: metabrainz/password.py:12
+#, python-format
+msgid "Password must not exceed %(max_bytes)s bytes."
+msgstr ""
+
+#: metabrainz/index/forms.py:48
 #, python-format
 msgid "'%(value)s' is not a valid choice for this field"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileEdit.tsx:27
-#: frontend/js/src/forms/SignupCommercial.tsx:154
+#: frontend/js/src/forms/SignupCommercial.tsx:159
 #: frontend/js/src/forms/SignupNonCommercial.tsx:85
-#: frontend/js/src/forms/SignupUser.tsx:70
-#: frontend/js/src/hooks/useEmailValidation.ts:78 metabrainz/index/forms.py:57
-#: metabrainz/user/forms.py:25 metabrainz/user/forms.py:57
-#: metabrainz/user/forms.py:63
+#: frontend/js/src/forms/SignupUser.tsx:76
+#: frontend/js/src/hooks/useEmailValidation.ts:78 metabrainz/index/forms.py:59
+#: metabrainz/user/forms.py:31 metabrainz/user/forms.py:70
+#: metabrainz/user/forms.py:76
 msgid "Email address is required!"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:34
-#: metabrainz/index/forms.py:63
+#: metabrainz/index/forms.py:65
 msgid "Current password is required!"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:43
 #: frontend/js/src/forms/ProfileChangePassword.tsx:37
 #: frontend/js/src/forms/ResetPassword.tsx:39
-#: frontend/js/src/forms/SignupCommercial.tsx:156
+#: frontend/js/src/forms/SignupCommercial.tsx:161
 #: frontend/js/src/forms/SignupNonCommercial.tsx:87
-#: frontend/js/src/forms/SignupUser.tsx:72 metabrainz/index/forms.py:66
-#: metabrainz/user/forms.py:29 metabrainz/user/forms.py:46
-#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:69
+#: frontend/js/src/forms/SignupUser.tsx:78 metabrainz/index/forms.py:69
+#: metabrainz/user/forms.py:35 metabrainz/user/forms.py:54
+#: metabrainz/user/forms.py:63 metabrainz/user/forms.py:82
 msgid "Password is required!"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:41
-#: frontend/js/src/forms/SignupCommercial.tsx:160
+#: frontend/js/src/forms/SignupCommercial.tsx:165
 #: frontend/js/src/forms/SignupNonCommercial.tsx:91
-#: frontend/js/src/forms/SignupUser.tsx:76 metabrainz/index/forms.py:70
-#: metabrainz/user/forms.py:33 metabrainz/user/forms.py:73
+#: frontend/js/src/forms/SignupUser.tsx:82 metabrainz/index/forms.py:74
+#: metabrainz/user/forms.py:40 metabrainz/user/forms.py:87
 msgid "Confirm Password is required!"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:46
 #: frontend/js/src/forms/ResetPassword.tsx:48
-#: frontend/js/src/forms/SignupCommercial.tsx:165
+#: frontend/js/src/forms/SignupCommercial.tsx:170
 #: frontend/js/src/forms/SignupNonCommercial.tsx:96
-#: frontend/js/src/forms/SignupUser.tsx:81 metabrainz/index/forms.py:72
-#: metabrainz/user/forms.py:35 metabrainz/user/forms.py:75
+#: frontend/js/src/forms/SignupUser.tsx:87 metabrainz/index/forms.py:76
+#: metabrainz/user/forms.py:42 metabrainz/user/forms.py:89
 msgid "Confirm Password should match password!"
 msgstr ""
 
 #: frontend/js/src/Applications.tsx:56 frontend/js/src/Applications.tsx:86
 #: frontend/js/src/Profile.tsx:272 frontend/js/src/Profile.tsx:482
-#: metabrainz/index/forms.py:78
+#: metabrainz/index/forms.py:82
 msgid "Name"
 msgstr ""
 
-#: metabrainz/index/forms.py:79
+#: metabrainz/index/forms.py:83
 msgid "Contact name field is empty."
 msgstr ""
 
-#: metabrainz/index/views.py:234
+#: metabrainz/index/views.py:251
 msgid "Profile updated successfully."
 msgstr ""
 
-#: metabrainz/index/views.py:261
+#: metabrainz/index/views.py:278
 msgid "Current password is incorrect."
 msgstr ""
 
-#: metabrainz/index/views.py:266
+#: metabrainz/index/views.py:283
 msgid "Password changed successfully."
 msgstr ""
 
-#: metabrainz/index/views.py:372
+#: metabrainz/index/views.py:389
 msgid "You have updated an application!"
 msgstr ""
 
-#: metabrainz/index/views.py:424
+#: metabrainz/index/views.py:441
 msgid "You have deleted an application."
 msgstr ""
 
-#: metabrainz/index/views.py:426
+#: metabrainz/index/views.py:443
 msgid "Failed to delete an application."
 msgstr ""
 
-#: metabrainz/index/views.py:449
+#: metabrainz/index/views.py:466
 msgid "Revoked tokens successfully!"
 msgstr ""
 
-#: metabrainz/index/views.py:478
+#: metabrainz/index/views.py:495
 msgid "Your account has been deleted."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:106 metabrainz/oauth/forms.py:58
+#: frontend/js/src/forms/CreateApplication.tsx:106 metabrainz/oauth/forms.py:57
 msgid "Application Name"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:59
+#: metabrainz/oauth/forms.py:58
 msgid "Application name field is empty."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:60 metabrainz/oauth/forms.py:60
+#: frontend/js/src/forms/CreateApplication.tsx:60 metabrainz/oauth/forms.py:59
 msgid "Application name needs to be at least 3 characters long."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:64 metabrainz/oauth/forms.py:61
+#: frontend/js/src/forms/CreateApplication.tsx:64 metabrainz/oauth/forms.py:60
 msgid "Application name needs to be at most 64 characters long."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:114 metabrainz/oauth/forms.py:63
+#: frontend/js/src/forms/CreateApplication.tsx:114 metabrainz/oauth/forms.py:62
 msgid "Description"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:64
+#: metabrainz/oauth/forms.py:63
 msgid "Client description field is empty."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:65
+#: metabrainz/oauth/forms.py:64
 msgid "Client description needs to be at least 3 characters long."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:66
+#: metabrainz/oauth/forms.py:65
 msgid "Client description needs to be at most 512 characters long."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:122 metabrainz/oauth/forms.py:68
+#: frontend/js/src/forms/CreateApplication.tsx:122 metabrainz/oauth/forms.py:67
 msgid "Homepage"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:69
+#: metabrainz/oauth/forms.py:68
 msgid "Homepage field is empty."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:70
+#: metabrainz/oauth/forms.py:69
 msgid "Homepage is not a valid URI."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:71
+#: metabrainz/oauth/forms.py:70
 msgid "Homepage URL must use http or https"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:73
+#: metabrainz/oauth/forms.py:72
 msgid "Authorization callback URL"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:74
+#: metabrainz/oauth/forms.py:73
 msgid "Authorization callback URL field is empty."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:75
+#: metabrainz/oauth/forms.py:74
 msgid "Authorization callback URL is invalid."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:76
+#: metabrainz/oauth/forms.py:75
 msgid "Authorization callback URL must use http or https."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:81 metabrainz/oauth/forms.py:85
+#: metabrainz/oauth/forms.py:80 metabrainz/oauth/forms.py:84
 msgid "Confirm"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:15
+msgid "View your public account information"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:16
+msgid "View your email address"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:17
+msgid "View and modify your private tags"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:18
+msgid "View and modify your private ratings"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:19
+msgid "View and modify your private collections"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:20
+msgid "Submit new ISRCs to the database"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:21
+msgid "Submit new barcodes to the database"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:22
+msgid "Sign you in and view your unique user id"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:23
+msgid "Submit listens to ListenBrainz."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:24
+msgid "Create and modify CritiqueBrainz reviews."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:25
+msgid "Submit and delete votes on CritiqueBrainz reviews."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:26
+msgid "Modify profile info and delete profile on CritiqueBrainz."
 msgstr ""
 
 #: metabrainz/payments/views.py:164
@@ -220,178 +305,185 @@ msgid "Requested annual report was not found."
 msgstr ""
 
 #: frontend/js/src/forms/ProfileEdit.tsx:30
-#: frontend/js/src/forms/SignupCommercial.tsx:139
+#: frontend/js/src/forms/SignupCommercial.tsx:144
 #: frontend/js/src/forms/SignupNonCommercial.tsx:70
-#: metabrainz/supporter/forms.py:13
+#: metabrainz/supporter/forms.py:15
 msgid "Contact name is required!"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:437
+#: frontend/js/src/forms/SignupCommercial.tsx:441
 #: frontend/js/src/forms/SignupNonCommercial.tsx:264
-#: metabrainz/supporter/forms.py:15
+#: metabrainz/supporter/forms.py:17
 msgid ""
 "Can you please tell us more about the project in which you'd like to use "
 "our data? Do you plan to self host the data or use our APIs?"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:137
+#: frontend/js/src/forms/SignupCommercial.tsx:142
 #: frontend/js/src/forms/SignupNonCommercial.tsx:68
-#: metabrainz/supporter/forms.py:17
+#: metabrainz/supporter/forms.py:19
 msgid "Please, tell us how you (will) use our data."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:138
+#: frontend/js/src/forms/SignupCommercial.tsx:143
 #: frontend/js/src/forms/SignupNonCommercial.tsx:69
-#: metabrainz/supporter/forms.py:18
+#: metabrainz/supporter/forms.py:20
 msgid "Please, limit usage description to 500 characters."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:141
-#: frontend/js/src/forms/SignupCommercial.tsx:142
+#: frontend/js/src/forms/SignupCommercial.tsx:146
+#: frontend/js/src/forms/SignupCommercial.tsx:147
 #: frontend/js/src/forms/SignupNonCommercial.tsx:72
 #: frontend/js/src/forms/SignupNonCommercial.tsx:73
-#: frontend/js/src/forms/SignupUser.tsx:84
-#: frontend/js/src/forms/SignupUser.tsx:85 metabrainz/supporter/forms.py:21
-#: metabrainz/user/forms.py:38
+#: frontend/js/src/forms/SignupUser.tsx:90
+#: frontend/js/src/forms/SignupUser.tsx:91 metabrainz/supporter/forms.py:23
+#: metabrainz/user/forms.py:45
 msgid "You need to accept the agreement!"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:342
-#: metabrainz/supporter/forms.py:27
+#: frontend/js/src/forms/SignupCommercial.tsx:347
+#: metabrainz/supporter/forms.py:29
 msgid "Organization name"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:113
-#: metabrainz/supporter/forms.py:28
+#: frontend/js/src/forms/SignupCommercial.tsx:115
+#: metabrainz/supporter/forms.py:30
 msgid "You need to specify the name of your organization."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:373
-#: metabrainz/supporter/forms.py:30
+#: frontend/js/src/forms/SignupCommercial.tsx:378
+#: metabrainz/supporter/forms.py:32
 msgid "Organization description"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:116
-#: metabrainz/supporter/forms.py:31
+#: frontend/js/src/forms/SignupCommercial.tsx:118
+#: metabrainz/supporter/forms.py:33
 msgid "You need to provide description of your organization."
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:278
-#: frontend/js/src/forms/SignupCommercial.tsx:396
-#: metabrainz/supporter/forms.py:34
+#: frontend/js/src/forms/SignupCommercial.tsx:401
+#: metabrainz/supporter/forms.py:36
 msgid "Website URL"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:119
-#: metabrainz/supporter/forms.py:35
-msgid "You need to specify website of the organization."
+#: frontend/js/src/forms/SignupCommercial.tsx:121
+#: frontend/js/src/forms/SignupCommercial.tsx:123
+#: metabrainz/supporter/forms.py:38 metabrainz/supporter/forms.py:42
+msgid "Website URL must be a valid URL."
 msgstr ""
 
-#: metabrainz/supporter/forms.py:37
+#: metabrainz/supporter/forms.py:45
 msgid "Logo image URL"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:284
-#: frontend/js/src/forms/SignupCommercial.tsx:418
-#: metabrainz/supporter/forms.py:38
+#: frontend/js/src/forms/SignupCommercial.tsx:422
+#: metabrainz/supporter/forms.py:46
 msgid "API URL"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:457
-#: metabrainz/supporter/forms.py:40
+#: frontend/js/src/forms/SignupCommercial.tsx:461
+#: metabrainz/supporter/forms.py:48
 msgid "Street"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:123
-#: metabrainz/supporter/forms.py:41
+#: frontend/js/src/forms/SignupCommercial.tsx:128
+#: metabrainz/supporter/forms.py:49
 msgid "You need to specify street."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:465
-#: metabrainz/supporter/forms.py:43
+#: frontend/js/src/forms/SignupCommercial.tsx:469
+#: metabrainz/supporter/forms.py:51
 msgid "City"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:124
-#: metabrainz/supporter/forms.py:44
+#: frontend/js/src/forms/SignupCommercial.tsx:129
+#: metabrainz/supporter/forms.py:52
 msgid "You need to specify city."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:473
-#: metabrainz/supporter/forms.py:46
+#: frontend/js/src/forms/SignupCommercial.tsx:477
+#: metabrainz/supporter/forms.py:54
 msgid "State / Province"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:126
-#: metabrainz/supporter/forms.py:47
+#: frontend/js/src/forms/SignupCommercial.tsx:131
+#: metabrainz/supporter/forms.py:55
 msgid "You need to specify state/province."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:481
-#: metabrainz/supporter/forms.py:49
+#: frontend/js/src/forms/SignupCommercial.tsx:485
+#: metabrainz/supporter/forms.py:57
 msgid "Postcode"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:128
-#: metabrainz/supporter/forms.py:50
+#: frontend/js/src/forms/SignupCommercial.tsx:133
+#: metabrainz/supporter/forms.py:58
 msgid "You need to specify postcode."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:489
-#: metabrainz/supporter/forms.py:52
+#: frontend/js/src/forms/SignupCommercial.tsx:493
+#: metabrainz/supporter/forms.py:60
 msgid "Country"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:129
-#: metabrainz/supporter/forms.py:53
+#: frontend/js/src/forms/SignupCommercial.tsx:134
+#: metabrainz/supporter/forms.py:61
 msgid "You need to specify country."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:132
-#: metabrainz/supporter/forms.py:64
+#: frontend/js/src/forms/SignupCommercial.tsx:137
+#: metabrainz/supporter/forms.py:72
 msgid ""
 "Custom amount must be more than threshold amount for selected tier or "
 "equal to it!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:46 metabrainz/supporter/views.py:119
-#: metabrainz/supporter/views.py:220
+#: metabrainz/supporter/views.py:54
+msgid ""
+"The verification email could not be sent. Please request a new one from "
+"your profile."
+msgstr ""
+
+#: metabrainz/supporter/views.py:85 metabrainz/supporter/views.py:158
+#: metabrainz/supporter/views.py:260
 msgid "You are already a supporter."
 msgstr ""
 
-#: metabrainz/supporter/views.py:61
+#: metabrainz/supporter/views.py:100
 msgid "Can't find tier with a specified ID."
 msgstr ""
 
-#: metabrainz/supporter/views.py:127
+#: metabrainz/supporter/views.py:166
 msgid "You need to choose support tier before signing up!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:137
+#: metabrainz/supporter/views.py:176
 msgid "You need to choose existing tier before signing up!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:164
+#: metabrainz/supporter/views.py:204
 msgid ""
 "Thanks for becoming a supporter! Your application will be reviewed soon. "
 "We will send you updates via email."
 msgstr ""
 
-#: metabrainz/supporter/views.py:187
+#: metabrainz/supporter/views.py:228
 msgid ""
 "Thanks for signing up! Your application will be reviewed soon. We will "
 "send you updates via email."
 msgstr ""
 
-#: metabrainz/supporter/views.py:248
+#: metabrainz/supporter/views.py:288
 msgid "Thanks for becoming a supporter!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:274
+#: metabrainz/supporter/views.py:312
 msgid "Thanks for signing up! Please check your inbox to complete verification."
 msgstr ""
 
-#: metabrainz/supporter/views.py:302
+#: metabrainz/supporter/views.py:340
 msgid "Can't generate new token unless account is active."
 msgstr ""
 
@@ -425,7 +517,7 @@ msgstr ""
 msgid "Policies"
 msgstr ""
 
-#: metabrainz/templates/base.html:55 metabrainz/templates/index/gdpr.html:178
+#: metabrainz/templates/base.html:55
 #: metabrainz/templates/index/social-contract.html:3
 #: metabrainz/templates/index/social-contract.html:6
 #: metabrainz/templates/navbar.html:34
@@ -435,14 +527,15 @@ msgstr ""
 #: metabrainz/templates/base.html:56
 #: metabrainz/templates/index/code-of-conduct.html:3
 #: metabrainz/templates/index/code-of-conduct.html:16
-#: metabrainz/templates/index/gdpr.html:181 metabrainz/templates/navbar.html:35
+#: metabrainz/templates/navbar.html:35
 msgid "Code of Conduct"
 msgstr ""
 
+#: frontend/js/src/PrivacySummary.tsx:11
 #: frontend/js/src/forms/ConditionsModal.tsx:21
-#: metabrainz/templates/base.html:57 metabrainz/templates/index/gdpr.html:184
-#: metabrainz/templates/index/privacy.html:6
+#: metabrainz/templates/base.html:57 metabrainz/templates/index/privacy.html:6
 #: metabrainz/templates/navbar.html:36
+#: metabrainz/templates/users/privacy-summary.html:3
 msgid "Privacy Policy"
 msgstr ""
 
@@ -475,10 +568,7 @@ msgstr ""
 msgid "Supporters"
 msgstr ""
 
-#: frontend/js/src/forms/LoginUser.tsx:103
-#: frontend/js/src/forms/SignupCommercial.tsx:574
-#: frontend/js/src/forms/SignupNonCommercial.tsx:339
-#: frontend/js/src/forms/SignupUser.tsx:232 metabrainz/templates/base.html:73
+#: frontend/js/src/forms/LoginUser.tsx:103 metabrainz/templates/base.html:73
 #: metabrainz/templates/navbar.html:66 metabrainz/templates/users/login.html:3
 msgid "Sign in"
 msgstr ""
@@ -500,26 +590,26 @@ msgid "Contact us"
 msgstr ""
 
 #: metabrainz/templates/base.html:85
-#: metabrainz/templates/index/contact.html:105
+#: metabrainz/templates/index/contact.html:106
 msgid "Blog"
 msgstr ""
 
-#: metabrainz/templates/base.html:86 metabrainz/templates/index/contact.html:90
+#: metabrainz/templates/base.html:86 metabrainz/templates/index/contact.html:91
 msgid "Chat"
 msgstr ""
 
 #: metabrainz/templates/base.html:87
-#: metabrainz/templates/index/contact.html:106
+#: metabrainz/templates/index/contact.html:107
 msgid "Mastodon"
 msgstr ""
 
 #: metabrainz/templates/base.html:88
-#: metabrainz/templates/index/contact.html:107
+#: metabrainz/templates/index/contact.html:108
 msgid "Bluesky"
 msgstr ""
 
 #: metabrainz/templates/base.html:89
-#: metabrainz/templates/index/contact.html:108
+#: metabrainz/templates/index/contact.html:109
 msgid "Instagram"
 msgstr ""
 
@@ -575,15 +665,14 @@ msgstr ""
 msgid "Donate"
 msgstr ""
 
-#: frontend/js/src/forms/LoginUser.tsx:110
-#: frontend/js/src/forms/SignupCommercial.tsx:175
-#: frontend/js/src/forms/SignupCommercial.tsx:555
+#: frontend/js/src/forms/SignupCommercial.tsx:180
+#: frontend/js/src/forms/SignupCommercial.tsx:559
 #: frontend/js/src/forms/SignupNonCommercial.tsx:106
 #: frontend/js/src/forms/SignupNonCommercial.tsx:319
 #: metabrainz/templates/navbar.html:65
-#: metabrainz/templates/supporters/account-type.html:51
-#: metabrainz/templates/supporters/account-type.html:93
-#: metabrainz/templates/supporters/account-type.html:144
+#: metabrainz/templates/supporters/account-type.html:47
+#: metabrainz/templates/supporters/account-type.html:84
+#: metabrainz/templates/supporters/account-type.html:130
 #: metabrainz/templates/users/signup.html:3
 msgid "Sign up"
 msgstr ""
@@ -890,8 +979,430 @@ msgstr ""
 msgid "Introduction"
 msgstr ""
 
-#: metabrainz/templates/index/conflict-policy.html:55
+#: metabrainz/templates/index/conflict-policy.html:17
+msgid ""
+"Conflicts between people arise in open source projects constantly and the"
+" projects by the \n"
+"    MetaBrainz Foundation are no different. This policy aims to establish"
+" a clear and unambiguous \n"
+"    policy for reporting and addressing conflicts in our community. In "
+"this policy we aim to \n"
+"    establish a fair practice that balances the need for confidentiality "
+"and our desire for \n"
+"    transparency in our operations."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:25
+#, python-format
+msgid ""
+"Before you continue to read this policy, we encourage you to review our "
+"existing community policies \n"
+"    including our <a href=\"%(social_contract_url)s\">Social "
+"Contract</a>, \n"
+"    <a href=\"%(code_of_conduct_url)s\">the Code of Conduct</a>, \n"
+"    and our <a href=\"%(privacy_policy_url)s\">Privacy Policy</a>. These "
+"policies establish the norms and rules for \n"
+"    participation in our projects; these policies apply equally to the "
+"contractors of the MetaBrainz \n"
+"    Foundation and any participants in our projects."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:37
+msgid ""
+"This policy divides conflicts into two categories: Private and public. "
+"Private conflicts are conflicts \n"
+"    that involve *confidential* information regarding contributors, "
+"contractors or supporters. Otherwise, any conflicts \n"
+"    that do not involve confidential information are considered to be "
+"public conflicts. For instance, a \n"
+"    conflict between a contractor and the Executive Director (aka BDFL) "
+"that involves contractor pay is \n"
+"    considered a private conflict because pay rates are confidential "
+"information. A public conflict in edit \n"
+"    notes between two editors in our community does not involve "
+"confidential information and therefore should \n"
+"    be considered a public conflict."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:47
+msgid ""
+"When conflicts arise we aim to disclose as much information as possible "
+"about the conflict in a timely \n"
+"    fashion. When conflicts contain confidential matters we will aim to "
+"disclose as much information as \n"
+"    possible, while fully respecting the confidentiality of the people "
+"involved in the conflict. With any \n"
+"    private conflict we will aim to extract the relevant lessons for the "
+"team and community in an effort to \n"
+"    evolve our policies to prevent future conflicts. Should the involved "
+"parties disagree whether a conflict \n"
+"    is private or public, the question about the nature of the conflict "
+"will be presented for the next higher \n"
+"    level in the chain of command to decide. (e.g. if a community member "
+"and the community manager disagree on \n"
+"    a conflict being public or private, the Executive Director shall "
+"decide if the conflict is public or private)."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:58
 msgid "Reporting and Response"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:61
+msgid ""
+"We aim to not have conflict in our community, but we recognize that in "
+"reality conflicts will arise and we \n"
+"    must be prepared to address them in a fair manner. When conflicts "
+"arise, we prefer to have community or team \n"
+"    members resolve the conflicts among themselves, using our existing "
+"policies as guidelines for resolving the \n"
+"    conflict."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:69
+msgid ""
+"If you do not feel comfortable resolving a conflict on your own, you "
+"should feel free to report the conflict to \n"
+"    us. How you address the conflict depends on who is involved in the "
+"conflict and your comfort level. Please see \n"
+"    the detailed sections below on how and with whom to address your "
+"conflict. We aim to address conflicts as soon \n"
+"    as possible in an effort to prevent them from escalating "
+"unnecessarily."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:75
+msgid "Direct conflict resolution"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:78
+msgid ""
+"In direct conflict resolution, the involved parties will attempt to "
+"resolve the conflict themselves without \n"
+"   involving any MetaBrainz Foundation team member. You should aim to use"
+" direct resolution when the conflict does \n"
+"   not involve the violation of one of our policies or if the conflict is"
+" minor."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:84
+#, python-format
+msgid ""
+"For instance, if a user uses a rude tone, is disruptive or flagrantly "
+"ignores our project guidelines, we suggest \n"
+"    that you use direct conflict resolution to resolve the conflict. Some"
+" resources that might give you some suggestions \n"
+"    on how to go about resolving the conflict might be this <a "
+"href=\"%(conflict_resolution_primer_url)s\">\n"
+"    conflict resolution primer</a> and <a "
+"href=\"%(difficult_conversations_url)s\">how to\n"
+"    have difficult conversations at work</a>."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:93
+msgid "Informal reporting"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:96
+msgid ""
+"You may use informal reporting of a conflict if you aim to communicate a "
+"concern or incident without \n"
+"    seeking a corrective outcome. Informal reporting may also be an "
+"option if you have not been personally \n"
+"    victimized, but you’ve witnessed a violation of our policies or where"
+" you wish to maintain confidentiality \n"
+"    throughout the entire reporting process."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:103
+msgid ""
+"For editing in MusicBrainz you may informally report a user using the "
+"“Report this user for bad behavior” \n"
+"    link from the user’s profile. For reporting bad user behavior in "
+"other of our projects, please report them to our \n"
+"    community manager by mailing <span class=\"backemail\">gro.zniarbatem"
+"@reganam-ytinummoc</span> . For conflicts \n"
+"    that involve the community manager, report them by mailing <span "
+"class=\"backemail\">gro.zniarbatem@de</span> ."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:110
+msgid ""
+"Depending the the severity of the issue, repeated informal complaints may"
+" eventually require a formal response \n"
+"    from the MetaBrainz team. If an involved party requires anonymity, "
+"the conflict becomes a private conflict. If at \n"
+"    all possible minor issues should be resolved in a public forum in "
+"order for all people to witness and learn from \n"
+"    the issue at hand."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:116
+msgid "Formal complaint process"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:119
+msgid ""
+"All complaints about conflicts should be submitted via email. To whom a "
+"complaint should be mailed and who will \n"
+"    carry out the investigation will be described in the next section."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:124
+msgid "All complaint submissions to the Foundation should include the following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:128
+msgid ""
+"Contact info, if it is different than the email used to submit the "
+"conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:129
+msgid "Who was involved in the conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:130
+msgid "Where and when the incident happened"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:131
+msgid ""
+"A description of what happened -- ideally with links (e.g. chatlogs, edit"
+" notes) that outlines what \n"
+"         happened so that the persons evaluating the conflict may "
+"understand the issue at hand"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:133
+msgid ""
+"Any related pieces of information that provide more context on the "
+"conflict (e.g. links, screenshots)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:134
+msgid "An indication if this conflict is ongoing or not"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:139
+msgid "The investigation that follows aims to determine:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:143
+msgid "The nature and severity of the incident"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:144
+msgid ""
+"Whether or not the incident is considered a violation of MetaBrainz’ "
+"conduct policies or core values"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:145
+msgid ""
+"The amount of harm experienced by the person who submitted the complaint "
+"and the broader MetaBrainz community \n"
+"         as a result of the incident"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:147
+msgid ""
+"Whether there have been prior complaints against the individual or "
+"individuals reported"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:148
+msgid "Whether the incident is ongoing"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:152
+msgid ""
+"The following potential forms of resolution may apply to any team members"
+" involved in the conflict:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:155
+#: metabrainz/templates/index/conflict-policy.html:168
+msgid "Nothing (if it has been found no violation occurred)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:156
+msgid "Creating a plan to improve the performance"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:157
+msgid "Creating a negative performance evaluation"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:158
+msgid "Mediation, an intervention by a third party to resolve the conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:159
+msgid "Suspension or forced leave"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:160
+msgid "Termination of contract"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:164
+msgid ""
+"The following potential forms of resolution may apply to non team members"
+" involved in the conflict:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:169
+msgid "A reprimand, either public or private"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:170
+msgid "Suspension of the users’ account"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:171
+msgid "Deletion of the users’ account"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:172
+msgid ""
+"Removal of user privileges (e.g. if an auto editor commits a serious "
+"offence, they may lose their auto editor status)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:175
+msgid "Filing a complaint"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:178
+msgid ""
+"NOTE: For complaints not about MetaBrainz staff, please see the "
+"<em>Informal reporting</em> section above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:182
+msgid ""
+"If the complaint does not involve the Executive Director (ED), do the "
+"following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:186
+msgid ""
+"If team member has directly violated conduct policies or engaged in "
+"otherwise harmful behavior, a formal complaint should be filed."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:187
+msgid ""
+"Mail <span class=\"backemail\">gro.zniarbatem@de</span> and include the "
+"complaint information outlined above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:188
+msgid ""
+"You should expect a response within a working day acknowledging the "
+"complaint."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:189
+msgid ""
+"The complaint will be investigated by the ED, member(s) of the board of "
+"directors or a neutral third party."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:190
+msgid ""
+"Once the investigation has been completed, the ED, with the support of "
+"others involved in the investigation will respond. The \n"
+"        ED will respond to incidents no later than 7 working days after a"
+" complaint has been filed with either a resolution or an \n"
+"        explanation of why the process must be extended."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:196
+msgid "If a complaint involves the Executive Director, do the following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:200
+msgid ""
+"If the Executive Director has directly violated conduct policies or "
+"engaged in otherwise harmful behavior, \n"
+"        a formal complaint should be filed with the board of directors."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:202
+msgid ""
+"Mail <span class=\"backemail\">gro.zniarbatem@noituloser-tcilfnoc</span> "
+"and include the complaint information outlined above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:203
+msgid ""
+"You should get a response within 5 working days acknowledging the "
+"complaint."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:204
+msgid ""
+"The complaint will be investigated by the member(s) of the board of "
+"directors, the community manager, a neutral \n"
+"        third party or a combination thereof."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:206
+msgid ""
+"Once the investigation has been completed, the board, with the support of"
+" others involved in the investigation \n"
+"        will respond. The board will aim to respond to incidents no later"
+" than 15 working days after a complaint has been filed \n"
+"        with either a resolution or an explanation of why the process "
+"must be extended."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:211
+msgid "Confidentiality"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:214
+msgid ""
+"Confidentiality is an important aspect of conflict resolution and all of "
+"the conflicts brought to the attention of the foundation \n"
+"    will be evaluated with confidentiality in mind and acted upon "
+"accordingly."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:219
+msgid ""
+"We work hard to make all of the actions of the foundation as transparent "
+"and open as possible. In cases where we cannot \n"
+"    disclose all aspects of a conflict we will disclose that a conflict "
+"is or has occurred and we will attempt to disclose the \n"
+"    appropriate amount of information about the conflict while balancing "
+"the need for confidentiality and our desire to learn \n"
+"    from conflicts so that we as a foundation and community can learn "
+"from these conflicts and improve our policies to avoid the \n"
+"    conflicts in the future."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:227
+msgid ""
+"Any breaches of confidentiality will be treated as severe breaches of our"
+" conduct policies."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:230
+msgid "Retaliation"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:233
+msgid ""
+"We will not allow retaliation for any contractor or volunteer that files "
+"a complaint or is involved in an investigation. If you \n"
+"    believe that you are being treated negatively because of your "
+"involvement in a complaint please report this complaint directly \n"
+"    to the ED at <span class=\"backemail\">gro.zniarbatem@de</span> or "
+"the board at \n"
+"    <span class=\"backemail\">gro.zniarbatem@noituloser-tcilfnoc</span>."
 msgstr ""
 
 #: metabrainz/templates/index/contact.html:3
@@ -972,7 +1483,7 @@ msgstr ""
 msgid ""
 "We are currently evaluating our overall online advertising strategy. We "
 "are evaluating advertising, traffic optimization,\n"
-"    search engine optimization and software monitization technologies. If"
+"    search engine optimization and software monetization technologies. If"
 " you provide these professional services, please provide a detailed\n"
 "    deck of your comprehensive services to the following email address. "
 "<em>Please respect our other non-media teams and do not contact us \n"
@@ -1047,11 +1558,11 @@ msgstr ""
 #, python-format
 msgid ""
 "Please come ask your questions at our <a "
-"href=\"%(forums_url)s\">forums</a>! We would love to\n"
-"    answer any questions you may have."
+"href=\"%(forums_url)s\">forums</a>!\n"
+"    The community and the team will be more than happy to help you."
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:92
+#: metabrainz/templates/index/contact.html:93
 #, python-format
 msgid ""
 "The MetaBrainz/MusicBrainz/ListenBrainz team and community hang out\n"
@@ -1061,15 +1572,15 @@ msgid ""
 "    <a href=\"%(chatlogs_url)s\">chat log archives</a>."
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:101
+#: metabrainz/templates/index/contact.html:102
 msgid "Social media"
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:103
+#: metabrainz/templates/index/contact.html:104
 msgid "You can follow us on these social channels:"
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:112
+#: metabrainz/templates/index/contact.html:113
 msgid "Mailing address"
 msgstr ""
 
@@ -1082,33 +1593,349 @@ msgstr ""
 msgid "GDPR Compliance Statement"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:37
+#: metabrainz/templates/index/gdpr.html:10
+msgid ""
+"The General Data Protection Regulation is a complex EU regulation that "
+"stipulates many points for protecting private data of\n"
+"    users on the Internet. Even though this is an EU regulation, it has a"
+" worldwide impact due to the nature of the Internet.\n"
+"    The MetaBrainz Foundation with its collection of projects is also "
+"affected by this regulation. We’ve been learning and adapting\n"
+"    our sites to be compliant with the GDPR – sadly this regulation isn’t"
+" entirely black and white and there is an incredible\n"
+"    amount of room left for interpretation of these rules."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:17
+msgid ""
+"The good news is that this regulation is roughly in line with our "
+"established practices: We’ve always held private information\n"
+"    in a high regard and applied the sort of rules to ourselves as we "
+"wish to have our own private data treated. Luckily, this\n"
+"    makes our compliance effort considerably easier. We’ve made two "
+"significant changes to how we treat your data and also adopted\n"
+"    terminology as used in the GDPR in order to use the same languages "
+"that many other sites are now adopting. Please keep reading\n"
+"    to find out the exact details of what we are doing to comply."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:24
+#, python-format
+msgid ""
+"However, we do ask for your compassion and help in our process of "
+"complying with the GDPR. As we already mentioned, the GDPR is\n"
+"    a complex set of rules that are not fully clarified yet. We’ve taken "
+"action on the steps that are clear to us and we’re following\n"
+"    ongoing conversations on points that are in gray zones or unclear to "
+"us. We’ve made our best initial effort on compliance and\n"
+"    promise to keep working on it as the picture becomes more clear. If "
+"you believe that we could improve our compliance, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a> and let us know what we "
+"can do to improve. It would also help us if you\n"
+"    could provide concrete discussion or examples to help us understand "
+"and take action on your suggestion."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:33
+msgid ""
+"Finally, below are the key sections of the GDPR as we understand them and"
+" how they affect your data in our ecosystem. Where\n"
+"    possible, we provide links for deeper understanding, links for you to"
+" examine our relevant code and links to tickets to follow\n"
+"    the process of improving our compliance."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:38
 msgid "Right to be forgotten"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:77
+#: metabrainz/templates/index/gdpr.html:41
+msgid ""
+"Summary: <i>Provide the user with the ability to remove their private "
+"data from our services</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:44
+msgid ""
+"The most important aspect of the right to be forgotten is the ability to "
+"delete your account. Once you request for us to delete\n"
+"    your account, we will remove any personally identifying information "
+"you may have provided us from your account (name, email\n"
+"    address, gender, biography, URL, etc.). The visible name on your "
+"account will be changed to “Deleted User #####” and effectively\n"
+"    the account will no longer be identifiable as your account."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:50
+msgid ""
+"However, given the nature of our projects where we work on collaborative "
+"databases, your contributions that are not personally\n"
+"    identifying are valuable assets to our database and these "
+"contributions will not be removed from our databases. But we will\n"
+"    ensure that these contributions no longer contain personally "
+"identifying data."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:55
+#, python-format
+msgid ""
+"Our process of automatically deleting your accounts across the MetaBrainz"
+" ecosystem is not complete yet (see below for a set of\n"
+"    tickets where you can track our progress). If you would like to "
+"delete your accounts in the MetaBrainz ecosystem or mark a\n"
+"    donation that is currently public as a private donation, please <a "
+"href=\"%(contact_url)s\">contact us</a>\n"
+"    and we will address your request as soon as possible."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:62
+#: metabrainz/templates/index/gdpr.html:182
+msgid "Links:"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:66
+#, python-format
+msgid ""
+"<a href=\"%(editor_deletion_doc_url)s\">How we delete accounts\n"
+"       in MusicBrainz</a> (warning, geek content ahead!)"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:70
+msgid ""
+"Implement sitewide user account deletion in\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/MBS-9680\">MusicBrainz</a>,"
+"\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/AB-337\">AcousticBrainz</a>,"
+"\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/BB-260\">BookBrainz</a>,\n"
+"         <a href=\"https://tickets.metabrainz.org/browse/MEB-103\">the "
+"MetaBrainz Site</a>,\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/LB-354\">ListenBrainz</a>, "
+"and\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/CB-307\">CritiqueBrainz</a>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:80
 msgid "Restriction of processing"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:110
+#: metabrainz/templates/index/gdpr.html:83
+msgid ""
+"Summary: <i>To allow the user to control how their personally identifying"
+" data is being used.</i>"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:86
+msgid ""
+"Except for the ListenBrainz and AcousticBrainz projects, we do not "
+"process personally identifying data. Any personally\n"
+"    identifying data that our projects store is for the purpose of being "
+"able to contact you about your contributions to our database\n"
+"    (email address) or for voluntarily showing information about you to "
+"other users (biography, homepage, location, etc)."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:91
+#, python-format
+msgid ""
+"The ListenBrainz project differs in that the Listens (metadata about what"
+" music you have listened to) are stored on our servers\n"
+"    and <a href=\"%(listenbrainz_data_url)s\">made available to the "
+"public</a>. We believe Listens to be personally identifying\n"
+"    data and furthermore, we have goals of creating open source "
+"recommendation engines with this data, which involves processing the\n"
+"    user’s data. These two points are fundamental goals of the "
+"ListenBrainz project and we do not see a reasonable way to reach another"
+"\n"
+"    compromise position."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:99
+msgid ""
+"Because of this, we are going to require users to either acknowledge that"
+" we may process their Listen data or alternatively to\n"
+"    delete their account, including all of their Listens. Please note "
+"that if you decide to delete your ListenBrainz account, it may\n"
+"    take up to two weeks for all of your listens to no longer be included"
+" in our efforts to build a recommendation engine."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:104
+msgid ""
+"We have always made it clear that the data in ListenBrainz was to be "
+"public and that we plan to build new tools with your data, so\n"
+"    this should not come as a surprise to our users."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:108
+msgid ""
+"The AcousticBrainz project does not track who submits data to the "
+"database. If you create an account and use our data creation\n"
+"    tools (e.g. create a dataset or participate in a challenge) then we "
+"link your participation and the things that you create to\n"
+"    your account. If you choose to delete your account then we keep the "
+"non personally identifying data that you create, but anonymize\n"
+"    it so that it cannot be linked back to you."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:114
 msgid "Right to data portability / exporting your data"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:150
+#: metabrainz/templates/index/gdpr.html:117
+msgid ""
+"Summary: <i>You have the right to access/download the data we store about"
+" you</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:120
+msgid ""
+"Except for the ListenBrainz and AcousticBrainz projects, we do not store "
+"personally identifying data beyond the\n"
+"    information that is available in your public profile on each of our "
+"projects. Since this data is plainly available in your\n"
+"    profile we do not provide a means for you to export this data."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:125
+msgid "There are the following exceptions to this:"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:129
+msgid ""
+"<b>IP addresses</b>: If you visit one of our sites the IP address of your"
+" computer is stored in our web logs for 7 days\n"
+"        before our servers automatically delete them. This data is almost"
+" never used by anyone: the only time we look at the\n"
+"        IP addresses is if our sites are adversely impacted by the "
+"actions of some unknown users. In that case, we may investigate\n"
+"        the logs to identify the IP address that needs to be blocked in "
+"order to restore the stability of our service.\n"
+"        This data is not available to anyone but the contractors of the "
+"MetaBrainz Foundation and is not available to download\n"
+"        to anyone at all."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:137
+#, python-format
+msgid ""
+"<b>ListenBrainz Listen data</b>: Users may <a "
+"href=\"%(listenbrainz_export_url)s\">export their ListenBrainz Listen\n"
+"        data</a> directly from the site. The user Listen data is also "
+"included in the <a href=\"%(listenbrainz_data_url)s\">ListenBrainz\n"
+"        data dumps</a> that are available for public download."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:146
+msgid ""
+"All of the non personally identifying data, such as your metadata "
+"contributions, are publicly visible, available for download\n"
+"    and available via the project APIs. For details about this data, "
+"downloads and APIs please check the documentation for the\n"
+"    respective projects you are interested in."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:151
+#, python-format
+msgid ""
+"Anyone wishing to get a list of financial donations they have made to the"
+" MetaBrainz Foundation, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a> and provide your "
+"MusicBrainz editor name so that we can look up\n"
+"    your donations."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:157
 msgid "Right to rectification"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:165
+#: metabrainz/templates/index/gdpr.html:160
+msgid "Summary: <i>You have the right to correct your data</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:163
+msgid ""
+"All of our projects allow their users to update their personally "
+"identifying information in their profiles. Furthermore, most\n"
+"    of our projects allow the editing of their own metadata "
+"contributions. If you find that some of your data is incorrect, please\n"
+"    feel free to edit the data since we provide the tools to do so."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:168
+#, python-format
+msgid ""
+"If anyone who has made a financial donation to the MetaBrainz Foundation "
+"would like to make their donation private, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:173
 msgid "Right to be informed"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:188
+#: metabrainz/templates/index/gdpr.html:175
+msgid ""
+"Summary: <i>You have the right to be informed about how we use your data "
+"in plain English</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:178
+msgid ""
+"Our privacy policy, as well as other policies, have always been written "
+"by humans for human consumption. We abhor legalese and\n"
+"    not speaking in direct terms."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:186
+msgid "Social contract"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:189
+msgid "Code of conduct"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:192
+msgid "Privacy policy"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:196
 msgid "Right to access"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:198
-#: metabrainz/templates/index/privacy.html:166
+#: metabrainz/templates/index/gdpr.html:199
+msgid ""
+"Summary: <i>You have the right to access the data that we collect about "
+"you</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:202
+msgid ""
+"All of our projects make all of the data we collect on your behalf, "
+"privately identifying or not, available to you. The\n"
+"    only exception to this are the IP addresses we store for 7 days – see"
+" above for details."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:206
+#: metabrainz/templates/index/privacy.html:168
 msgid "Privacy/GDPR Representative"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:209
+#, python-format
+msgid ""
+"If you have any questions about our privacy policy, please <a "
+"href=\"%(contact_url)s\">contact us</a>. To report\n"
+"   any privacy problems, violations or leaks, our GDPR representative is "
+"our Interim Executive Director Nicolás Tamargo and for\n"
+"   privacy issues contact him at <strong><a "
+"href=\"mailto:gdpr@metabrainz.org\">gdpr@metabrainz.org</a></strong>."
 msgstr ""
 
 #: metabrainz/templates/index/index.html:6
@@ -1213,13 +2040,51 @@ msgid ""
 "      <a href=\"%(about_url)s\">about</a> page."
 msgstr ""
 
-#: frontend/js/src/forms/ConditionsModal.tsx:43
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:32
 #: metabrainz/templates/index/privacy.html:3
 msgid "Privacy"
 msgstr ""
 
 #: metabrainz/templates/index/privacy.html:8
 msgid "Summary"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:12
+msgid ""
+"You do not have to provide any personal data to be able to browse the "
+"contents of the databases published by MetaBrainz."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:15
+msgid ""
+"You do not have to provide any personally-identifying information if you "
+"choose not to."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:18
+msgid ""
+"We will never reveal your email address on MetaBrainz controlled web "
+"sites."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:22
+msgid ""
+"In order to get maximum value out of the MetaBrainz projects, you may "
+"want to create an account and log in. \n"
+"    Doing so grants you the ability to: edit the databases, contribute "
+"your own data, communicate with other users, and keep track \n"
+"    of recently released music from artists in your MusicBrainz "
+"collection. If you choose to create an account then the minimum we \n"
+"    ask is that you: choose a unique username and password, use a web "
+"browser that accepts \"session\" cookies, and provide a verified \n"
+"    email address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:29
+msgid ""
+"If you do not create an account (or are not logged in) you will not have "
+"access to the above listed features, however, you will \n"
+"    still have full access to browse and examine the databases."
 msgstr ""
 
 #: metabrainz/templates/index/privacy.html:33
@@ -1230,39 +2095,197 @@ msgstr ""
 msgid "Cookies"
 msgstr ""
 
+#: metabrainz/templates/index/privacy.html:37
+msgid "We use two cookies that contain sensitive information:"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:42
+msgid ""
+"<b>remember_login</b>: If you choose the \"Log in permanently\" option "
+"when logging in to one of our sites; the cookie will be used to \n"
+"      remember your login details."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:46
+msgid ""
+"<b>musicbrainz_server_session, session, or connect.sid</b>: If you are "
+"logged into one of our sites, your current session ID is stored in this "
+"cookie."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:51
+msgid ""
+"We may store dynamic preference information in other cookies, but these "
+"do not contain any sensitive information."
+msgstr ""
+
 #: metabrainz/templates/index/privacy.html:54
 msgid "Web and FTP access logs"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:57
+msgid ""
+"In a practice similar to other web sites (and APIs) we keep logs of all "
+"web requests made against our servers. These logs include: your IP\n"
+"    address, your browser's (or API client's) \"User-Agent\" string, and "
+"which page (or API endpoint) you requested with which parameters. "
+"Aggregate information about web and FTP traffic is\n"
+"    made available to the public via our site usage pages."
 msgstr ""
 
 #: metabrainz/templates/index/privacy.html:62
 msgid "Third-Party content"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:92
+#: metabrainz/templates/index/privacy.html:64
+msgid ""
+"Our projects' web pages may load some third-party content. Some, but "
+"possibly not all sites are listed below:"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:69
+#, python-format
+msgid ""
+"Cover art and other images: These are provided by the various cover art "
+"sites that have given MusicBrainz permission to do so and our own \n"
+"      <a href=\"%(caa_url)s\">Cover Art Archive</a>. This means that the "
+"relevant site will know (if they want to) your IP \n"
+"      address, User-Agent string, etc., and which MusicBrainz web page "
+"you were visiting (the one which included the cover art image)."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:75
+msgid ""
+"AcoustID: Our fingerprints tab loads fingerprint information from "
+"acoustid.org."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:78
+msgid ""
+"MTCaptcha: Our account creation page loads third party content in order "
+"to prevent spammers from creating accounts."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:83
+msgid ""
+"<i>The above information assumes that you are using \"normal\" web "
+"browser settings, whereby images are always loaded and HTTP referrer \n"
+"    information is always sent.</i>"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:88
+msgid ""
+"It is impractical to constantly modify this privacy policy when "
+"MetaBrainz projects change which third party content they utilize. We "
+"will \n"
+"    aim to use common sense, respect to our community and community "
+"review when adding more content from third party sites. We will also \n"
+"    periodically review our policy to ensure that it remains current."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:93
 msgid "Applicable to account holders"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:94
+#: metabrainz/templates/index/privacy.html:95
 msgid "Account creation"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:108
+#: metabrainz/templates/index/privacy.html:97
+msgid ""
+"When creating an account with a MetaBrainz project you need to pick a "
+"unique username and choose a password, the username you pick is the \n"
+"    only name associated with your account and will be what other "
+"MetaBrainz users know you as. You may optionally also tell us other \n"
+"    information about yourself that will be displayed to other MetaBrainz"
+" users and the public."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:103
+msgid ""
+"Additionally, in order to edit the databases you will need to provide a "
+"confirmed email address. This email address will be held in \n"
+"    confidence, the only method of revealing your email address to "
+"another user is if you choose to send a message to another \n"
+"    user and enable the option to \"reveal my email address\". Changing "
+"the email address stored with your account will require you to \n"
+"    verify the new address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:109
 msgid "Edits and Notes"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:114
+#: metabrainz/templates/index/privacy.html:111
+msgid ""
+"If you make any changes to a MetaBrainz project database, such as adding "
+"any data, the details of those changes will be visible to \n"
+"    other logged-in users and the change will be associated with your "
+"username."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:115
 msgid "Subscriptions on MusicBrainz"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:131
+#: metabrainz/templates/index/privacy.html:117
+msgid ""
+"As a logged-in user you can subscribe to one or more artists, labels, "
+"collections or other editors. The act of subscribing causes \n"
+"    any edits made to (or by in the case of another editor) those "
+"entities to be emailed to you. By default, other users can see your \n"
+"    list of subscriptions, however, you can opt out of this by editing "
+"the appropriate preference."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:123
+msgid ""
+"This does not provide \"perfect\" privacy though, in some cases it will "
+"be possible to infer information about the contents of your \n"
+"    subscription list even though you have disallowed others from viewing"
+" that list directly. This imperfection arises because various \n"
+"    parts of the system behave differently depending on whether or not an"
+" entity has any subscribers; also, the number of users \n"
+"    subscribed to each artist is available via the artist pages. In the "
+"most extreme (possibly contrived) example, imagine that all \n"
+"    users have their subscriptions set to \"public\", except for exactly "
+"one user whose list is \"private\". In that case, any discrepancy \n"
+"    for a given artist between the shown list of subscribers and the "
+"total number of subscribers must be down to that one user. Thus, \n"
+"    you can infer what artists are on that user's list."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:132
 msgid "Third-party sites"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:145
-msgid "MetaBrainz donors"
+#: metabrainz/templates/index/privacy.html:134
+#, python-format
+msgid ""
+"Our code reviews are done on GitHub, which is not under the control of "
+"MetaBrainz. Participating in code reviews or other\n"
+"    tasks carried out on GitHub are subject to <a "
+"href=\"%(github_url)s\">GitHub's privacy policy</a>."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:140
+#, python-format
+msgid ""
+"Our translations platform is provided and hosted by Weblate, which has a "
+"data processing agreement with MetaBrainz.\n"
+"    Participating in translations is subject to <a "
+"href=\"%(weblate_url)s\">dedicated legal terms</a>.\n"
+"    Any translations you make will be submitted to our Git repositories "
+"and publicly associated with your username;\n"
+"    if you so choose, you can also publicly associate them with your own "
+"verified email address."
 msgstr ""
 
 #: metabrainz/templates/index/privacy.html:147
+msgid "MetaBrainz donors"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:149
 msgid ""
 "When you make a donation to the MetaBrainz Foundation, we are legally\n"
 "    required to collect your personal information and keep it in our "
@@ -1272,7 +2295,7 @@ msgid ""
 "    information to anyone else, ever."
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:153
+#: metabrainz/templates/index/privacy.html:155
 msgid ""
 "We believe in transparent finances, which means that we list all "
 "donations\n"
@@ -1282,11 +2305,34 @@ msgid ""
 "process."
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:158
+#: metabrainz/templates/index/privacy.html:160
 msgid "Exceptions"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:598
+#: metabrainz/templates/index/privacy.html:162
+msgid ""
+"<i><b>Please note</b>: Reasonable exceptions may apply to the above "
+"policy, for example to comply with applicable laws.\n"
+"    Also, members of the MetaBrainz team and other personnel contracted "
+"to provide services to MetaBrainz may have access to\n"
+"    our infrastructure and could therefore view any information contained"
+" therein. However all personnel are contractually bound\n"
+"    by non-disclosure clauses which prevent them from making any such "
+"information available to others."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:171
+#, python-format
+msgid ""
+"If you have any questions about our GDPR statement, please <a "
+"href=\"%(contact_url)s\">contact us</a>. To report\n"
+"   any privacy problems, violations or leaks, our GDPR representative is "
+"our Interim Executive Director Nicolás Tamargo and for\n"
+"   privacy issues contact him at <strong><a "
+"href=\"mailto:gdpr@metabrainz.org\">gdpr@metabrainz.org</a></strong>."
+msgstr ""
+
+#: frontend/js/src/Profile.tsx:603
 #: frontend/js/src/forms/ProfileChangePassword.tsx:22
 #: frontend/js/src/forms/ProfileChangePassword.tsx:111
 #: metabrainz/templates/index/profile-change-password.html:3
@@ -1530,6 +2576,11 @@ msgstr ""
 
 #: metabrainz/templates/index/team.html:26
 msgid "He lives on in our hearts and in open source."
+msgstr ""
+
+#: metabrainz/templates/index/team.html:29
+#: metabrainz/templates/index/team.html:315
+msgid "you’re welcome to try"
 msgstr ""
 
 #: metabrainz/templates/index/team.html:39
@@ -2027,8 +3078,10 @@ msgstr ""
 
 #: metabrainz/templates/payments/donate.html:146
 msgid ""
-"Due to the increased unreliability of the US Postal Service we have "
-"stopped accepting paper checks. Sorry!"
+"Due to the increased unreliability of the US Postal Service and the "
+"relatively large fees involved, we ask you to only send a paper check if "
+"it is the only possible option. Due to the fees, we will not cash checks "
+"for less than $25."
 msgstr ""
 
 #: metabrainz/templates/payments/donate.html:241
@@ -2912,8 +3965,8 @@ msgid "Monthly balance sheets"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:520
-#: frontend/js/src/forms/SignupCommercial.tsx:175
-#: frontend/js/src/forms/SignupCommercial.tsx:554
+#: frontend/js/src/forms/SignupCommercial.tsx:180
+#: frontend/js/src/forms/SignupCommercial.tsx:558
 #: frontend/js/src/forms/SignupNonCommercial.tsx:106
 #: frontend/js/src/forms/SignupNonCommercial.tsx:318
 #: metabrainz/templates/supporters/account-type.html:3
@@ -2934,6 +3987,7 @@ msgid "Non-commercial / Personal"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:235
+#: frontend/js/src/forms/SignupNonCommercial.tsx:107
 #: frontend/js/src/forms/SignupNonCommercial.tsx:151
 #: metabrainz/templates/supporters/account-type.html:42
 msgid "Non-commercial"
@@ -2947,55 +4001,45 @@ msgstr ""
 msgid "Personal or university assignment user."
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:48
-#: metabrainz/templates/supporters/account-type.html:90
-#: metabrainz/templates/supporters/account-type.html:141
-msgid "Upgrade"
-msgstr ""
-
 #: frontend/js/src/Profile.tsx:235
-#: frontend/js/src/forms/SignupCommercial.tsx:176
-#: frontend/js/src/forms/SignupCommercial.tsx:228
-#: metabrainz/templates/supporters/account-type.html:61
+#: frontend/js/src/forms/SignupCommercial.tsx:181
+#: frontend/js/src/forms/SignupCommercial.tsx:233
+#: metabrainz/templates/supporters/account-type.html:56
 msgid "Commercial"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:83
-#: metabrainz/templates/supporters/account-type.html:135
+#: metabrainz/templates/supporters/account-type.html:78
+#: metabrainz/templates/supporters/account-type.html:125
 #, python-format
 msgid "$%(tier_price)s/month and up"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:87
-#: metabrainz/templates/supporters/account-type.html:138
+#: metabrainz/templates/supporters/account-type.html:82
+#: metabrainz/templates/supporters/account-type.html:128
 msgid "More info"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:104
+#: metabrainz/templates/supporters/account-type.html:94
 msgid "View all tiers"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:112
+#: metabrainz/templates/supporters/account-type.html:102
 msgid "Some of our Unicorn members"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:123
+#: metabrainz/templates/supporters/account-type.html:113
 msgid "See all our supporters"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:151
+#: metabrainz/templates/supporters/account-type.html:136
 msgid "View featured tiers"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:158
+#: metabrainz/templates/supporters/account-type.html:143
 #, python-format
 msgid ""
 "If you are not sure which tier to pick, please\n"
 "      <a href=\"%(contact_url)s\">contact us</a>."
-msgstr ""
-
-#: metabrainz/templates/supporters/account-type.html:166
-msgid "Back to Profile"
 msgstr ""
 
 #: metabrainz/templates/supporters/bad-standing.html:3
@@ -3057,9 +4101,9 @@ msgid "Forgot your username"
 msgstr ""
 
 #: frontend/js/src/forms/ResetPassword.tsx:79
-#: frontend/js/src/forms/SignupCommercial.tsx:320
+#: frontend/js/src/forms/SignupCommercial.tsx:325
 #: frontend/js/src/forms/SignupNonCommercial.tsx:227
-#: frontend/js/src/forms/SignupUser.tsx:169
+#: frontend/js/src/forms/SignupUser.tsx:175
 #: metabrainz/templates/users/reauthenticate.html:3
 #: metabrainz/templates/users/reauthenticate.html:6
 msgid "Confirm Password"
@@ -3069,17 +4113,22 @@ msgstr ""
 msgid "Please re-enter your password to continue."
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:108
+#: frontend/js/src/ProfileDelete.tsx:110
 #: frontend/js/src/forms/DeleteApplication.tsx:53
 #: frontend/js/src/forms/OAuthPrompt.tsx:54
 #: frontend/js/src/forms/ProfileChangePassword.tsx:104
 #: frontend/js/src/forms/ProfileEdit.tsx:105
-#: metabrainz/templates/users/reauthenticate.html:23
+#: metabrainz/templates/users/reauthenticate.html:28
 msgid "Cancel"
 msgstr ""
 
-#: metabrainz/templates/users/reauthenticate.html:24
+#: metabrainz/templates/users/reauthenticate.html:29
 msgid "Continue"
+msgstr ""
+
+#: frontend/js/src/forms/utils.tsx:202
+#: metabrainz/templates/users/reauthenticate.html:40
+msgid "Password must not exceed 72 bytes."
 msgstr ""
 
 #: frontend/js/src/forms/ResetPassword.tsx:27
@@ -3087,38 +4136,38 @@ msgstr ""
 msgid "Reset your password"
 msgstr ""
 
-#: frontend/js/src/hooks/useEmailValidation.ts:41 metabrainz/user/forms.py:15
+#: frontend/js/src/hooks/useEmailValidation.ts:41 metabrainz/user/forms.py:16
 msgid "Registration from this email domain is not allowed."
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:50
 #: frontend/js/src/forms/LostPassword.tsx:45
-#: frontend/js/src/forms/SignupCommercial.tsx:270
+#: frontend/js/src/forms/SignupCommercial.tsx:275
 #: frontend/js/src/forms/SignupNonCommercial.tsx:175
-#: frontend/js/src/forms/SignupUser.tsx:114 metabrainz/user/forms.py:20
-#: metabrainz/user/forms.py:45 metabrainz/user/forms.py:62
+#: frontend/js/src/forms/SignupUser.tsx:120 metabrainz/user/forms.py:22
+#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:75
 msgid "Username"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:42
 #: frontend/js/src/forms/LostPassword.tsx:37
-#: frontend/js/src/forms/SignupCommercial.tsx:153
+#: frontend/js/src/forms/SignupCommercial.tsx:158
 #: frontend/js/src/forms/SignupNonCommercial.tsx:84
-#: frontend/js/src/forms/SignupUser.tsx:67 metabrainz/user/forms.py:21
-#: metabrainz/user/forms.py:45 metabrainz/user/forms.py:62
+#: frontend/js/src/forms/SignupUser.tsx:73 metabrainz/user/forms.py:26
+#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:75
 msgid "Username is required!"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:63
 #: frontend/js/src/forms/ResetPassword.tsx:72
-#: frontend/js/src/forms/SignupCommercial.tsx:308
+#: frontend/js/src/forms/SignupCommercial.tsx:313
 #: frontend/js/src/forms/SignupNonCommercial.tsx:214
-#: frontend/js/src/forms/SignupUser.tsx:157 metabrainz/user/forms.py:46
-#: metabrainz/user/forms.py:52
+#: frontend/js/src/forms/SignupUser.tsx:163 metabrainz/user/forms.py:53
+#: metabrainz/user/forms.py:62
 msgid "Password"
 msgstr ""
 
-#: frontend/js/src/forms/LoginUser.tsx:76 metabrainz/user/forms.py:47
+#: frontend/js/src/forms/LoginUser.tsx:76 metabrainz/user/forms.py:57
 msgid "Remember me"
 msgstr ""
 
@@ -3130,11 +4179,11 @@ msgstr ""
 msgid "Username contains invalid or invisible characters."
 msgstr ""
 
-#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:181
+#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:220
 msgid "Hide password"
 msgstr ""
 
-#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:181
+#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:220
 msgid "Show password"
 msgstr ""
 
@@ -3191,11 +4240,11 @@ msgstr ""
 msgid "Revoke access"
 msgstr ""
 
-#: frontend/js/src/OAuthError.tsx:17
+#: frontend/js/src/OAuthError.tsx:18
 msgid "OAuth2 Error"
 msgstr ""
 
-#: frontend/js/src/OAuthError.tsx:18
+#: frontend/js/src/OAuthError.tsx:19
 msgid "An error occurred during OAuth authentication process."
 msgstr ""
 
@@ -3225,8 +4274,8 @@ msgstr ""
 
 #: frontend/js/src/Profile.tsx:109
 msgid ""
-"Are you sure you want to generate new access token? Current token will be"
-" revoked!"
+"Are you sure you want to generate a new access token? The current token "
+"will be revoked!"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:118
@@ -3341,8 +4390,8 @@ msgid "Contact Information"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:310 frontend/js/src/forms/ProfileEdit.tsx:70
-#: frontend/js/src/forms/SignupCommercial.tsx:284
-#: frontend/js/src/forms/SignupCommercial.tsx:333
+#: frontend/js/src/forms/SignupCommercial.tsx:289
+#: frontend/js/src/forms/SignupCommercial.tsx:338
 #: frontend/js/src/forms/SignupNonCommercial.tsx:189
 #: frontend/js/src/forms/SignupNonCommercial.tsx:241
 msgid "Contact name"
@@ -3457,7 +4506,7 @@ msgstr ""
 msgid "Once you delete your account, there is no going back. Please be certain."
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:550 frontend/js/src/ProfileDelete.tsx:105
+#: frontend/js/src/Profile.tsx:550 frontend/js/src/ProfileDelete.tsx:107
 msgid "Delete My Account"
 msgstr ""
 
@@ -3469,39 +4518,39 @@ msgstr ""
 msgid "Need to delete your account?"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:574
+#: frontend/js/src/Profile.tsx:575
 msgid ""
 "Deletion of supporter accounts requires manual review. Please contact us "
-"at"
+"at <email />."
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:594
+#: frontend/js/src/Profile.tsx:599
 msgid "Security"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:626
+#: frontend/js/src/Profile.tsx:631
 msgid "MetaBrainz Applications"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:630
+#: frontend/js/src/Profile.tsx:635
 msgid ""
 "With your MetaBrainz account, you can access every project in the "
 "MetaBrainz family:"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:643
+#: frontend/js/src/Profile.tsx:648
 msgid "The open-source music encyclopedia"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:655
+#: frontend/js/src/Profile.tsx:660
 msgid "Track, visualise and share the music you listen to"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:667
+#: frontend/js/src/Profile.tsx:672
 msgid "The open-source book database"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:679
+#: frontend/js/src/Profile.tsx:684
 msgid "Creative Commons licensed reviews"
 msgstr ""
 
@@ -3524,7 +4573,7 @@ msgid "Permanently remove all your account information"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:64
-msgid "Revoke all your API tokens and access"
+msgid "Revoke all your tokens and access to the replication API"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:65
@@ -3536,14 +4585,16 @@ msgid "Log you out of all MetaBrainz services"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:70
-msgid "Your username will be reserved and cannot be reused."
+msgid ""
+"Your username will be reserved and cannot be reused without the "
+"intervention of an administrator."
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:82
+#: frontend/js/src/ProfileDelete.tsx:84
 msgid "To confirm, type your username '<username />' below:"
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:105
+#: frontend/js/src/ProfileDelete.tsx:107
 msgid "Deleting..."
 msgstr ""
 
@@ -3555,64 +4606,7 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: frontend/js/src/forms/ConditionsModal.tsx:23
-msgid "Licensing"
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:25
-msgid ""
-"Any contributions you make to any MetaBrainz service will be released "
-"into the Public Domain and/or licensed under a Creative Commons by-nc-sa "
-"license. Furthermore, you give the MetaBrainz Foundation the right to "
-"license this data for commercial use."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:30
-msgid "Please read our <licenseLink>license page</licenseLink> for more details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:45
-msgid ""
-"MetaBrainz strongly believes in the privacy of its users. Any personal "
-"information you choose to provide will not be sold or shared with anyone "
-"else."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:50
-msgid ""
-"Please read our <privacyLink>privacy policy</privacyLink> for more "
-"details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:59
-msgid "GDPR compliance"
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:61
-msgid ""
-"You may remove your personal information from our services anytime by "
-"deleting your account."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:66
-msgid ""
-"Please read our <gdprLink>GDPR compliance statement</gdprLink> for more "
-"details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:78
-msgid ""
-"Creating an account on MetaBrainz will give you access to all of our "
-"projects, such as MusicBrainz, ListenBrainz, BookBrainz, and more."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:82
-msgid ""
-"We create a placeholder account for all the MetaBrainz projects when you "
-"sign up, and you are one log-in away from activating them."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:91
+#: frontend/js/src/forms/ConditionsModal.tsx:29
 msgid "Sounds good"
 msgstr ""
 
@@ -3698,8 +4692,8 @@ msgstr ""
 msgid "Forgot your password?"
 msgstr ""
 
-#: frontend/js/src/forms/LoginUser.tsx:109
-msgid "Don't have an account?"
+#: frontend/js/src/forms/LoginUser.tsx:110
+msgid "Don't have an account? <signupLink>Sign up</signupLink>"
 msgstr ""
 
 #: frontend/js/src/forms/LostPassword.tsx:38
@@ -3728,15 +4722,72 @@ msgstr ""
 msgid "Allow access"
 msgstr ""
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:71
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:10
+msgid "Licensing"
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:12
+msgid ""
+"Any contributions you make to any MetaBrainz service will be released "
+"into the Public Domain and/or licensed under a Creative Commons by-nc-sa "
+"license. Furthermore, you give the MetaBrainz Foundation the right to "
+"license this data for commercial use."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:17
+msgid "Please read our <licenseLink>license page</licenseLink> for more details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:34
+msgid ""
+"MetaBrainz strongly believes in the privacy of its users. Any personal "
+"information you choose to provide will not be sold or shared with anyone "
+"else."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:39
+msgid ""
+"Please read our <privacyLink>privacy policy</privacyLink> for more "
+"details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:50
+msgid "GDPR compliance"
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:52
+msgid ""
+"You may remove your personal information from our services anytime by "
+"deleting your account."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:57
+msgid ""
+"Please read our <gdprLink>GDPR compliance statement</gdprLink> for more "
+"details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:71
+msgid ""
+"Creating an account on MetaBrainz will give you access to all of our "
+"projects, such as MusicBrainz, ListenBrainz, BookBrainz, and more."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:75
+msgid ""
+"We create a placeholder account for all the MetaBrainz projects when you "
+"sign up, and you are one log-in away from activating them."
+msgstr ""
+
+#: frontend/js/src/forms/ProfileChangePassword.tsx:70
 msgid "Current Password"
 msgstr ""
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:80
+#: frontend/js/src/forms/ProfileChangePassword.tsx:79
 msgid "New Password"
 msgstr ""
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:89
+#: frontend/js/src/forms/ProfileChangePassword.tsx:88
 msgid "Confirm New Password"
 msgstr ""
 
@@ -3748,190 +4799,180 @@ msgstr ""
 msgid "Reset Password"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:38
-msgid "If you would like to support us with more than $"
+#: frontend/js/src/forms/SignupCommercial.tsx:40
+msgid ""
+"If you would like to support us with more than ${{minPledge}}, please "
+"enter the actual amount here:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:39
-msgid ", please enter the actual amount here:"
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:144
+#: frontend/js/src/forms/SignupCommercial.tsx:149
 #: frontend/js/src/forms/SignupNonCommercial.tsx:75
-#: frontend/js/src/forms/SignupUser.tsx:87
+#: frontend/js/src/forms/SignupUser.tsx:93
 msgid "Captcha is required!"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:179
+#: frontend/js/src/forms/SignupCommercial.tsx:184
 #: frontend/js/src/forms/SignupNonCommercial.tsx:110
 #: frontend/js/src/forms/SignupUser.tsx:46
 msgid "Access all MetaBrainz projects"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:182
+#: frontend/js/src/forms/SignupCommercial.tsx:187
 msgid "Note:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:184
+#: frontend/js/src/forms/SignupCommercial.tsx:189
 msgid ""
 "Signing up for any tier other than the <italic>Stealth startup</italic> "
 "tier will publicly list your company on this web site. However, we will "
 "not publish any of your private details."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:221
+#: frontend/js/src/forms/SignupCommercial.tsx:226
 #: frontend/js/src/forms/SignupNonCommercial.tsx:145
 msgid "Account type"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:234
+#: frontend/js/src/forms/SignupCommercial.tsx:239
 msgid "Selected tier"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:242
-msgid "month and up"
+#: frontend/js/src/forms/SignupCommercial.tsx:247
+msgid "${{tierPrice}}/month and up"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:250
+#: frontend/js/src/forms/SignupCommercial.tsx:255
 msgid "Change account type or tier"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:261
+#: frontend/js/src/forms/SignupCommercial.tsx:266
 #: frontend/js/src/forms/SignupNonCommercial.tsx:166
 msgid "Your account:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:271
+#: frontend/js/src/forms/SignupCommercial.tsx:276
 #: frontend/js/src/forms/SignupNonCommercial.tsx:176
-#: frontend/js/src/forms/SignupUser.tsx:114
+#: frontend/js/src/forms/SignupUser.tsx:120
 msgid "(public)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:291
+#: frontend/js/src/forms/SignupCommercial.tsx:296
 #: frontend/js/src/forms/SignupNonCommercial.tsx:196
-#: frontend/js/src/forms/SignupUser.tsx:127
+#: frontend/js/src/forms/SignupUser.tsx:133
 msgid "E-mail address"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:295
+#: frontend/js/src/forms/SignupCommercial.tsx:300
 #: frontend/js/src/forms/SignupNonCommercial.tsx:200
-#: frontend/js/src/forms/SignupUser.tsx:131
+#: frontend/js/src/forms/SignupUser.tsx:137
 msgid "(checking...)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:314
+#: frontend/js/src/forms/SignupCommercial.tsx:319
 #: frontend/js/src/forms/SignupNonCommercial.tsx:220
-#: frontend/js/src/forms/SignupUser.tsx:163
+#: frontend/js/src/forms/SignupUser.tsx:169
 msgid "Must be at least 8 characters"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:348
+#: frontend/js/src/forms/SignupCommercial.tsx:353
 msgid ""
 "If you don't have an organization name, you probably want to become a "
 "supporter as a <nonCommercialLink>Non-commercial / "
 "Personal</nonCommercialLink> supporter."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:358
+#: frontend/js/src/forms/SignupCommercial.tsx:363
 msgid ""
 "If you don't have an organization name, you probably want to sign up as a"
 " <nonCommercialLink>Non-commercial / Personal</nonCommercialLink> user."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:378
+#: frontend/js/src/forms/SignupCommercial.tsx:383
 msgid ""
 "Please tell us a little about your company and whether you plan to use "
 "our <apiLink>API</apiLink> or to <hostLink>host your own copy</hostLink> "
 "of the data."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:404
+#: frontend/js/src/forms/SignupCommercial.tsx:408
 msgid "Logo URL"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:405
+#: frontend/js/src/forms/SignupCommercial.tsx:409
 msgid "(preferably in SVG format)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:408
+#: frontend/js/src/forms/SignupCommercial.tsx:412
 msgid ""
 "Image should be about 250 pixels wide on a white or transparent "
 "background. We will host it on our site."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:421
+#: frontend/js/src/forms/SignupCommercial.tsx:425
 msgid ""
 "URL to where developers can use your APIs using MusicBrainz IDs, if "
-"available.."
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:430
-msgid "Your project"
+"available."
 msgstr ""
 
 #: frontend/js/src/forms/SignupCommercial.tsx:434
+msgid "Your project"
+msgstr ""
+
+#: frontend/js/src/forms/SignupCommercial.tsx:438
 #: frontend/js/src/forms/SignupNonCommercial.tsx:261
 msgid "(max 150 characters)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:451
+#: frontend/js/src/forms/SignupCommercial.tsx:455
 msgid "Billing address"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:502
+#: frontend/js/src/forms/SignupCommercial.tsx:506
 msgid ""
 "I agree to support the MetaBrainz Foundation when my organization is able"
 " to do so."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:507
+#: frontend/js/src/forms/SignupCommercial.tsx:511
+#: frontend/js/src/forms/SignupNonCommercial.tsx:284
 msgid ""
-"I also agree that if I generate a Live Data Feed access token, that I "
-"treat my access token as a secret and will not share this token publicly "
-"or commit it to a source code repository."
+"I also agree that if I generate a Live Data Feed access token, then I "
+"will treat my access token as a secret and will not share this token "
+"publicly or commit it to a source code repository."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:515
+#: frontend/js/src/forms/SignupCommercial.tsx:519
 msgid ""
 "The following information will be shown publicly: organization name, "
 "logo, website and API URLs, data usage description."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:520
+#: frontend/js/src/forms/SignupCommercial.tsx:524
 msgid ""
 "We'll send you more details about payment process once your application "
 "is approved."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:552
+#: frontend/js/src/forms/SignupCommercial.tsx:556
 #: frontend/js/src/forms/SignupNonCommercial.tsx:316
-#: frontend/js/src/forms/SignupUser.tsx:224
+#: frontend/js/src/forms/SignupUser.tsx:230
 msgid "Validating..."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:564
+#: frontend/js/src/forms/SignupCommercial.tsx:568
 #: frontend/js/src/forms/SignupNonCommercial.tsx:329
 msgid "Back to profile"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:569
-#: frontend/js/src/forms/SignupNonCommercial.tsx:334
-msgid "Not a supporter?"
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:570
+#: frontend/js/src/forms/SignupCommercial.tsx:574
 #: frontend/js/src/forms/SignupNonCommercial.tsx:335
-msgid "Create a user account"
+msgid "Not a supporter? <signupLink>Create a user account</signupLink>"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:573
-#: frontend/js/src/forms/SignupNonCommercial.tsx:338
-#: frontend/js/src/forms/SignupUser.tsx:231
-msgid "Already have an account?"
-msgstr ""
-
-#: frontend/js/src/forms/SignupNonCommercial.tsx:107
-msgid "non-commercial"
+#: frontend/js/src/forms/SignupCommercial.tsx:583
+#: frontend/js/src/forms/SignupNonCommercial.tsx:344
+#: frontend/js/src/forms/SignupUser.tsx:238
+msgid "Already have an account? <loginLink>Sign in</loginLink>"
 msgstr ""
 
 #: frontend/js/src/forms/SignupNonCommercial.tsx:113
@@ -3959,46 +5000,40 @@ msgid ""
 "income per year) or personal uses only."
 msgstr ""
 
-#: frontend/js/src/forms/SignupNonCommercial.tsx:284
-msgid ""
-"I also agree that if I generate a Live Data Feed access token, then I "
-"will treat my access token as a secret and will not share this token "
-"publicly or commit it to a source code repository."
-msgstr ""
-
 #: frontend/js/src/forms/SignupUser.tsx:43
 msgid "Create your account"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:50
-msgid "Registration started by"
+#: frontend/js/src/forms/SignupUser.tsx:51
+msgid "Registration started by <client />"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:69
+#: frontend/js/src/forms/SignupUser.tsx:75
+#: frontend/js/src/hooks/useEmailValidation.ts:82
 msgid "Invalid email address."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:150
+#: frontend/js/src/forms/SignupUser.tsx:156
 msgid ""
 "This username and email were provided by the app that started "
 "registration. You can change them later from MetaBrainz settings."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:182
+#: frontend/js/src/forms/SignupUser.tsx:188
 msgid ""
 "I accept that my contributions will be released into the public domain or"
 " licensed for use."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:191
+#: frontend/js/src/forms/SignupUser.tsx:197
 msgid "We will never share your personal information."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:200
+#: frontend/js/src/forms/SignupUser.tsx:206
 msgid "Click here to read more"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:224
+#: frontend/js/src/forms/SignupUser.tsx:230
 msgid "Create account"
 msgstr ""
 
@@ -4008,10 +5043,6 @@ msgstr ""
 
 #: frontend/js/src/hooks/useEmailValidation.ts:47
 msgid "Email validation failed"
-msgstr ""
-
-#: frontend/js/src/hooks/useEmailValidation.ts:82
-msgid "Invalid email address"
 msgstr ""
 
 #~ msgid "You need to specify amount!"
@@ -5316,5 +6347,97 @@ msgstr ""
 #~ msgstr ""
 
 #~ msgid "Privacy policy"
+#~ msgstr ""
+
+#~ msgid "You need to specify website of the organization."
+#~ msgstr ""
+
+#~ msgid ""
+#~ "We are currently evaluating our overall"
+#~ " online advertising strategy. We are "
+#~ "evaluating advertising, traffic optimization,\n"
+#~ ""
+#~ "    search engine optimization and "
+#~ "software monitization technologies. If you "
+#~ "provide these professional services, please"
+#~ " provide a detailed\n"
+#~ "    deck of your comprehensive services"
+#~ " to the following email address. "
+#~ "<em>Please respect our other non-media"
+#~ " teams and do not contact us \n"
+#~ "    regarding these services on any "
+#~ "other of our email addresses. We "
+#~ "will disregard the entirety of your "
+#~ "submissions if you contact us any "
+#~ "other way!</em>"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Please come ask your questions at "
+#~ "our <a href=\"%(forums_url)s\">forums</a>! We "
+#~ "would love to\n"
+#~ "    answer any questions you may have."
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Due to the increased unreliability of"
+#~ " the US Postal Service we have "
+#~ "stopped accepting paper checks. Sorry!"
+#~ msgstr ""
+
+#~ msgid "Upgrade"
+#~ msgstr ""
+
+#~ msgid "Back to Profile"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Deletion of supporter accounts requires "
+#~ "manual review. Please contact us at"
+#~ msgstr ""
+
+#~ msgid "Revoke all your API tokens and access"
+#~ msgstr ""
+
+#~ msgid "Your username will be reserved and cannot be reused."
+#~ msgstr ""
+
+#~ msgid "Don't have an account?"
+#~ msgstr ""
+
+#~ msgid "If you would like to support us with more than $"
+#~ msgstr ""
+
+#~ msgid ", please enter the actual amount here:"
+#~ msgstr ""
+
+#~ msgid "month and up"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "I also agree that if I generate"
+#~ " a Live Data Feed access token, "
+#~ "that I treat my access token as"
+#~ " a secret and will not share "
+#~ "this token publicly or commit it "
+#~ "to a source code repository."
+#~ msgstr ""
+
+#~ msgid "Not a supporter?"
+#~ msgstr ""
+
+#~ msgid "Create a user account"
+#~ msgstr ""
+
+#~ msgid "Already have an account?"
+#~ msgstr ""
+
+#~ msgid "non-commercial"
+#~ msgstr ""
+
+#~ msgid "Registration started by"
+#~ msgstr ""
+
+#~ msgid "Invalid email address"
 #~ msgstr ""
 

--- a/metabrainz/translations/es/LC_MESSAGES/messages.po
+++ b/metabrainz/translations/es/LC_MESSAGES/messages.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-07-25 16:21+0200\n"
+"POT-Creation-Date: 2026-09-08 11:18+0200\n"
 "PO-Revision-Date: 2026-07-18 11:12+0000\n"
 "Last-Translator: reosarevok "
 "<reosarevok@users.noreply.translations.metabrainz.org>\n"
@@ -25,165 +25,250 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.18.0\n"
 
-#: metabrainz/index/forms.py:46
+#: metabrainz/errors.py:24
+msgid "Authorization was declined."
+msgstr ""
+
+#: metabrainz/errors.py:25
+msgid "The authorization request was invalid."
+msgstr ""
+
+#: metabrainz/errors.py:26
+msgid "The application could not be authenticated."
+msgstr ""
+
+#: metabrainz/errors.py:27
+msgid "This application is not allowed to request authorization."
+msgstr ""
+
+#: metabrainz/errors.py:28
+msgid "The application asked for a response type this server does not support."
+msgstr ""
+
+#: metabrainz/errors.py:29
+msgid "The permissions requested by the application are invalid."
+msgstr ""
+
+#: metabrainz/errors.py:30
+msgid "You need to sign in to continue."
+msgstr ""
+
+#: metabrainz/errors.py:31
+msgid "Your consent is required to continue."
+msgstr ""
+
+#: metabrainz/password.py:12
+#, python-format
+msgid "Password must not exceed %(max_bytes)s bytes."
+msgstr ""
+
+#: metabrainz/index/forms.py:48
 #, python-format
 msgid "'%(value)s' is not a valid choice for this field"
 msgstr "«%(value)s» no es una opción válida para este campo"
 
 #: frontend/js/src/forms/ProfileEdit.tsx:27
-#: frontend/js/src/forms/SignupCommercial.tsx:154
+#: frontend/js/src/forms/SignupCommercial.tsx:159
 #: frontend/js/src/forms/SignupNonCommercial.tsx:85
-#: frontend/js/src/forms/SignupUser.tsx:70
-#: frontend/js/src/hooks/useEmailValidation.ts:78 metabrainz/index/forms.py:57
-#: metabrainz/user/forms.py:25 metabrainz/user/forms.py:57
-#: metabrainz/user/forms.py:63
+#: frontend/js/src/forms/SignupUser.tsx:76
+#: frontend/js/src/hooks/useEmailValidation.ts:78 metabrainz/index/forms.py:59
+#: metabrainz/user/forms.py:31 metabrainz/user/forms.py:70
+#: metabrainz/user/forms.py:76
 msgid "Email address is required!"
 msgstr "Debes indicar una dirección de correo."
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:34
-#: metabrainz/index/forms.py:63
+#: metabrainz/index/forms.py:65
 msgid "Current password is required!"
 msgstr "Debes indicar la contraseña actual."
 
 #: frontend/js/src/forms/LoginUser.tsx:43
 #: frontend/js/src/forms/ProfileChangePassword.tsx:37
 #: frontend/js/src/forms/ResetPassword.tsx:39
-#: frontend/js/src/forms/SignupCommercial.tsx:156
+#: frontend/js/src/forms/SignupCommercial.tsx:161
 #: frontend/js/src/forms/SignupNonCommercial.tsx:87
-#: frontend/js/src/forms/SignupUser.tsx:72 metabrainz/index/forms.py:66
-#: metabrainz/user/forms.py:29 metabrainz/user/forms.py:46
-#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:69
+#: frontend/js/src/forms/SignupUser.tsx:78 metabrainz/index/forms.py:69
+#: metabrainz/user/forms.py:35 metabrainz/user/forms.py:54
+#: metabrainz/user/forms.py:63 metabrainz/user/forms.py:82
 msgid "Password is required!"
 msgstr "Debes indicar una contraseña."
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:41
-#: frontend/js/src/forms/SignupCommercial.tsx:160
+#: frontend/js/src/forms/SignupCommercial.tsx:165
 #: frontend/js/src/forms/SignupNonCommercial.tsx:91
-#: frontend/js/src/forms/SignupUser.tsx:76 metabrainz/index/forms.py:70
-#: metabrainz/user/forms.py:33 metabrainz/user/forms.py:73
+#: frontend/js/src/forms/SignupUser.tsx:82 metabrainz/index/forms.py:74
+#: metabrainz/user/forms.py:40 metabrainz/user/forms.py:87
 msgid "Confirm Password is required!"
 msgstr "Debes confirmar la contraseña."
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:46
 #: frontend/js/src/forms/ResetPassword.tsx:48
-#: frontend/js/src/forms/SignupCommercial.tsx:165
+#: frontend/js/src/forms/SignupCommercial.tsx:170
 #: frontend/js/src/forms/SignupNonCommercial.tsx:96
-#: frontend/js/src/forms/SignupUser.tsx:81 metabrainz/index/forms.py:72
-#: metabrainz/user/forms.py:35 metabrainz/user/forms.py:75
+#: frontend/js/src/forms/SignupUser.tsx:87 metabrainz/index/forms.py:76
+#: metabrainz/user/forms.py:42 metabrainz/user/forms.py:89
 msgid "Confirm Password should match password!"
 msgstr "¡La confirmación de contraseña debe coincidir con la contraseña!"
 
 #: frontend/js/src/Applications.tsx:56 frontend/js/src/Applications.tsx:86
 #: frontend/js/src/Profile.tsx:272 frontend/js/src/Profile.tsx:482
-#: metabrainz/index/forms.py:78
+#: metabrainz/index/forms.py:82
 msgid "Name"
 msgstr "Nombre"
 
-#: metabrainz/index/forms.py:79
+#: metabrainz/index/forms.py:83
 msgid "Contact name field is empty."
 msgstr "El campo «Nombre del contacto» está vacío."
 
-#: metabrainz/index/views.py:234
+#: metabrainz/index/views.py:251
 msgid "Profile updated successfully."
 msgstr "Tu perfil ha sido actualizado."
 
-#: metabrainz/index/views.py:261
+#: metabrainz/index/views.py:278
 msgid "Current password is incorrect."
 msgstr "La contraseña actual no es correcta."
 
-#: metabrainz/index/views.py:266
+#: metabrainz/index/views.py:283
 msgid "Password changed successfully."
 msgstr "Has cambiado la contraseña."
 
-#: metabrainz/index/views.py:372
+#: metabrainz/index/views.py:389
 msgid "You have updated an application!"
 msgstr "Has actualizado una aplicación."
 
-#: metabrainz/index/views.py:424
+#: metabrainz/index/views.py:441
 msgid "You have deleted an application."
 msgstr "Has eliminado una aplicación."
 
-#: metabrainz/index/views.py:426
+#: metabrainz/index/views.py:443
 msgid "Failed to delete an application."
 msgstr "No hemos podido eliminar la aplicación."
 
-#: metabrainz/index/views.py:449
+#: metabrainz/index/views.py:466
 msgid "Revoked tokens successfully!"
 msgstr "Los tokens han sido anulados."
 
-#: metabrainz/index/views.py:478
+#: metabrainz/index/views.py:495
 msgid "Your account has been deleted."
 msgstr "Tu cuenta ha sido eliminada."
 
-#: frontend/js/src/forms/CreateApplication.tsx:106 metabrainz/oauth/forms.py:58
+#: frontend/js/src/forms/CreateApplication.tsx:106 metabrainz/oauth/forms.py:57
 msgid "Application Name"
 msgstr "Nombre de la aplicación"
 
-#: metabrainz/oauth/forms.py:59
+#: metabrainz/oauth/forms.py:58
 msgid "Application name field is empty."
 msgstr "El campo «Nombre de la aplicación» está vacío."
 
-#: frontend/js/src/forms/CreateApplication.tsx:60 metabrainz/oauth/forms.py:60
+#: frontend/js/src/forms/CreateApplication.tsx:60 metabrainz/oauth/forms.py:59
 msgid "Application name needs to be at least 3 characters long."
 msgstr "El nombre de la aplicación debe contener al menos tres caracteres."
 
-#: frontend/js/src/forms/CreateApplication.tsx:64 metabrainz/oauth/forms.py:61
+#: frontend/js/src/forms/CreateApplication.tsx:64 metabrainz/oauth/forms.py:60
 msgid "Application name needs to be at most 64 characters long."
 msgstr "El nombre de la aplicación debe contener un máximo de 64 caracteres."
 
-#: frontend/js/src/forms/CreateApplication.tsx:114 metabrainz/oauth/forms.py:63
+#: frontend/js/src/forms/CreateApplication.tsx:114 metabrainz/oauth/forms.py:62
 msgid "Description"
 msgstr "Descripción"
 
-#: metabrainz/oauth/forms.py:64
+#: metabrainz/oauth/forms.py:63
 msgid "Client description field is empty."
 msgstr "El campo «Descripción» está vacío."
 
-#: metabrainz/oauth/forms.py:65
+#: metabrainz/oauth/forms.py:64
 msgid "Client description needs to be at least 3 characters long."
 msgstr "La descripción debe contener al menos tres caracteres."
 
-#: metabrainz/oauth/forms.py:66
+#: metabrainz/oauth/forms.py:65
 msgid "Client description needs to be at most 512 characters long."
 msgstr "La descripción debe contener un máximo de 512 caracteres."
 
-#: frontend/js/src/forms/CreateApplication.tsx:122 metabrainz/oauth/forms.py:68
+#: frontend/js/src/forms/CreateApplication.tsx:122 metabrainz/oauth/forms.py:67
 msgid "Homepage"
 msgstr "Sitio web"
 
-#: metabrainz/oauth/forms.py:69
+#: metabrainz/oauth/forms.py:68
 msgid "Homepage field is empty."
 msgstr "El campo «Sitio web» está vacío."
 
-#: metabrainz/oauth/forms.py:70
+#: metabrainz/oauth/forms.py:69
 msgid "Homepage is not a valid URI."
 msgstr "El sitio web indicado no es una URI válida."
 
-#: metabrainz/oauth/forms.py:71
+#: metabrainz/oauth/forms.py:70
 msgid "Homepage URL must use http or https"
 msgstr "La URL del sitio web tiene que usar http o https."
 
-#: metabrainz/oauth/forms.py:73
+#: metabrainz/oauth/forms.py:72
 msgid "Authorization callback URL"
 msgstr "URL de devolución de llamada de autorización"
 
-#: metabrainz/oauth/forms.py:74
+#: metabrainz/oauth/forms.py:73
 msgid "Authorization callback URL field is empty."
 msgstr "El campo «URL de devolución de llamada de autorización» está vacío."
 
-#: metabrainz/oauth/forms.py:75
+#: metabrainz/oauth/forms.py:74
 msgid "Authorization callback URL is invalid."
 msgstr "La URL de devolución de llamada de autorización no es válida."
 
-#: metabrainz/oauth/forms.py:76
+#: metabrainz/oauth/forms.py:75
 msgid "Authorization callback URL must use http or https."
 msgstr ""
 "La URL de devolución de llamada de autorización tiene que usar http o "
 "https."
 
-#: metabrainz/oauth/forms.py:81 metabrainz/oauth/forms.py:85
+#: metabrainz/oauth/forms.py:80 metabrainz/oauth/forms.py:84
 msgid "Confirm"
 msgstr "Confirmar"
+
+#: metabrainz/oauth/scopes.py:15
+msgid "View your public account information"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:16
+msgid "View your email address"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:17
+msgid "View and modify your private tags"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:18
+msgid "View and modify your private ratings"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:19
+msgid "View and modify your private collections"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:20
+msgid "Submit new ISRCs to the database"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:21
+msgid "Submit new barcodes to the database"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:22
+msgid "Sign you in and view your unique user id"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:23
+msgid "Submit listens to ListenBrainz."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:24
+msgid "Create and modify CritiqueBrainz reviews."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:25
+msgid "Submit and delete votes on CritiqueBrainz reviews."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:26
+msgid "Modify profile info and delete profile on CritiqueBrainz."
+msgstr ""
 
 #: metabrainz/payments/views.py:164
 msgid ""
@@ -232,15 +317,15 @@ msgid "Requested annual report was not found."
 msgstr "No hemos encontrado el informe anual solicitado."
 
 #: frontend/js/src/forms/ProfileEdit.tsx:30
-#: frontend/js/src/forms/SignupCommercial.tsx:139
+#: frontend/js/src/forms/SignupCommercial.tsx:144
 #: frontend/js/src/forms/SignupNonCommercial.tsx:70
-#: metabrainz/supporter/forms.py:13
+#: metabrainz/supporter/forms.py:15
 msgid "Contact name is required!"
 msgstr "Debes indicar el nombre de una persona de contacto."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:437
+#: frontend/js/src/forms/SignupCommercial.tsx:441
 #: frontend/js/src/forms/SignupNonCommercial.tsx:264
-#: metabrainz/supporter/forms.py:15
+#: metabrainz/supporter/forms.py:17
 msgid ""
 "Can you please tell us more about the project in which you'd like to use "
 "our data? Do you plan to self host the data or use our APIs?"
@@ -249,123 +334,124 @@ msgstr ""
 "nuestros datos? ¿Quieres alojar los datos en tus propios servidores o "
 "usar nuestras APIs?"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:137
+#: frontend/js/src/forms/SignupCommercial.tsx:142
 #: frontend/js/src/forms/SignupNonCommercial.tsx:68
-#: metabrainz/supporter/forms.py:17
+#: metabrainz/supporter/forms.py:19
 msgid "Please, tell us how you (will) use our data."
 msgstr "Por favor, cuéntanos como usas o planeas usar nuestros datos."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:138
+#: frontend/js/src/forms/SignupCommercial.tsx:143
 #: frontend/js/src/forms/SignupNonCommercial.tsx:69
-#: metabrainz/supporter/forms.py:18
+#: metabrainz/supporter/forms.py:20
 msgid "Please, limit usage description to 500 characters."
 msgstr ""
 "Por favor, no uses más de 500 caracteres para describir el uso de los "
 "datos."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:141
-#: frontend/js/src/forms/SignupCommercial.tsx:142
+#: frontend/js/src/forms/SignupCommercial.tsx:146
+#: frontend/js/src/forms/SignupCommercial.tsx:147
 #: frontend/js/src/forms/SignupNonCommercial.tsx:72
 #: frontend/js/src/forms/SignupNonCommercial.tsx:73
-#: frontend/js/src/forms/SignupUser.tsx:84
-#: frontend/js/src/forms/SignupUser.tsx:85 metabrainz/supporter/forms.py:21
-#: metabrainz/user/forms.py:38
+#: frontend/js/src/forms/SignupUser.tsx:90
+#: frontend/js/src/forms/SignupUser.tsx:91 metabrainz/supporter/forms.py:23
+#: metabrainz/user/forms.py:45
 msgid "You need to accept the agreement!"
 msgstr "¡Debes aceptar el acuerdo!"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:342
-#: metabrainz/supporter/forms.py:27
+#: frontend/js/src/forms/SignupCommercial.tsx:347
+#: metabrainz/supporter/forms.py:29
 msgid "Organization name"
 msgstr "Nombre de la organización"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:113
-#: metabrainz/supporter/forms.py:28
+#: frontend/js/src/forms/SignupCommercial.tsx:115
+#: metabrainz/supporter/forms.py:30
 msgid "You need to specify the name of your organization."
 msgstr "Tienes que indicar el nombre de tu organización."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:373
-#: metabrainz/supporter/forms.py:30
+#: frontend/js/src/forms/SignupCommercial.tsx:378
+#: metabrainz/supporter/forms.py:32
 msgid "Organization description"
 msgstr "Descripción de la organización"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:116
-#: metabrainz/supporter/forms.py:31
+#: frontend/js/src/forms/SignupCommercial.tsx:118
+#: metabrainz/supporter/forms.py:33
 msgid "You need to provide description of your organization."
 msgstr "Tienes que suministrar una descripción de tu organización."
 
 #: frontend/js/src/Profile.tsx:278
-#: frontend/js/src/forms/SignupCommercial.tsx:396
-#: metabrainz/supporter/forms.py:34
+#: frontend/js/src/forms/SignupCommercial.tsx:401
+#: metabrainz/supporter/forms.py:36
 msgid "Website URL"
 msgstr "URL del sitio web"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:119
-#: metabrainz/supporter/forms.py:35
-msgid "You need to specify website of the organization."
-msgstr "Tienes que indicar el sitio web de la organización."
+#: frontend/js/src/forms/SignupCommercial.tsx:121
+#: frontend/js/src/forms/SignupCommercial.tsx:123
+#: metabrainz/supporter/forms.py:38 metabrainz/supporter/forms.py:42
+msgid "Website URL must be a valid URL."
+msgstr ""
 
-#: metabrainz/supporter/forms.py:37
+#: metabrainz/supporter/forms.py:45
 msgid "Logo image URL"
 msgstr "URL de la imagen del logo"
 
 #: frontend/js/src/Profile.tsx:284
-#: frontend/js/src/forms/SignupCommercial.tsx:418
-#: metabrainz/supporter/forms.py:38
+#: frontend/js/src/forms/SignupCommercial.tsx:422
+#: metabrainz/supporter/forms.py:46
 msgid "API URL"
 msgstr "URL de la API"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:457
-#: metabrainz/supporter/forms.py:40
+#: frontend/js/src/forms/SignupCommercial.tsx:461
+#: metabrainz/supporter/forms.py:48
 msgid "Street"
 msgstr "Calle"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:123
-#: metabrainz/supporter/forms.py:41
+#: frontend/js/src/forms/SignupCommercial.tsx:128
+#: metabrainz/supporter/forms.py:49
 msgid "You need to specify street."
 msgstr "Tienes que indicar la calle."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:465
-#: metabrainz/supporter/forms.py:43
+#: frontend/js/src/forms/SignupCommercial.tsx:469
+#: metabrainz/supporter/forms.py:51
 msgid "City"
 msgstr "Ciudad"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:124
-#: metabrainz/supporter/forms.py:44
+#: frontend/js/src/forms/SignupCommercial.tsx:129
+#: metabrainz/supporter/forms.py:52
 msgid "You need to specify city."
 msgstr "Tienes que indicar la ciudad."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:473
-#: metabrainz/supporter/forms.py:46
+#: frontend/js/src/forms/SignupCommercial.tsx:477
+#: metabrainz/supporter/forms.py:54
 msgid "State / Province"
 msgstr "Estado / provincia"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:126
-#: metabrainz/supporter/forms.py:47
+#: frontend/js/src/forms/SignupCommercial.tsx:131
+#: metabrainz/supporter/forms.py:55
 msgid "You need to specify state/province."
 msgstr "Tienes que indicar el estado o la provincia."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:481
-#: metabrainz/supporter/forms.py:49
+#: frontend/js/src/forms/SignupCommercial.tsx:485
+#: metabrainz/supporter/forms.py:57
 msgid "Postcode"
 msgstr "Código postal"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:128
-#: metabrainz/supporter/forms.py:50
+#: frontend/js/src/forms/SignupCommercial.tsx:133
+#: metabrainz/supporter/forms.py:58
 msgid "You need to specify postcode."
 msgstr "Tienes que indicar el código postal."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:489
-#: metabrainz/supporter/forms.py:52
+#: frontend/js/src/forms/SignupCommercial.tsx:493
+#: metabrainz/supporter/forms.py:60
 msgid "Country"
 msgstr "País"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:129
-#: metabrainz/supporter/forms.py:53
+#: frontend/js/src/forms/SignupCommercial.tsx:134
+#: metabrainz/supporter/forms.py:61
 msgid "You need to specify country."
 msgstr "Tienes que indicar el país."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:132
-#: metabrainz/supporter/forms.py:64
+#: frontend/js/src/forms/SignupCommercial.tsx:137
+#: metabrainz/supporter/forms.py:72
 msgid ""
 "Custom amount must be more than threshold amount for selected tier or "
 "equal to it!"
@@ -373,26 +459,32 @@ msgstr ""
 "¡El importe indicado debe ser igual o superior al importe mínimo del "
 "nivel seleccionado!"
 
-#: metabrainz/supporter/views.py:46 metabrainz/supporter/views.py:119
-#: metabrainz/supporter/views.py:220
+#: metabrainz/supporter/views.py:54
+msgid ""
+"The verification email could not be sent. Please request a new one from "
+"your profile."
+msgstr ""
+
+#: metabrainz/supporter/views.py:85 metabrainz/supporter/views.py:158
+#: metabrainz/supporter/views.py:260
 msgid "You are already a supporter."
 msgstr "Ya eres un simpatizante."
 
-#: metabrainz/supporter/views.py:61
+#: metabrainz/supporter/views.py:100
 msgid "Can't find tier with a specified ID."
 msgstr "No hemos encontrado un nivel con la ID indicada."
 
-#: metabrainz/supporter/views.py:127
+#: metabrainz/supporter/views.py:166
 msgid "You need to choose support tier before signing up!"
 msgstr "¡Tienes que elegir un nivel de apoyo para poder registrarte!"
 
-#: metabrainz/supporter/views.py:137
+#: metabrainz/supporter/views.py:176
 msgid "You need to choose existing tier before signing up!"
 msgstr ""
 "¡Tienes que elegir uno de los niveles de apoyo disponibles para poder "
 "registrarte!"
 
-#: metabrainz/supporter/views.py:164
+#: metabrainz/supporter/views.py:204
 msgid ""
 "Thanks for becoming a supporter! Your application will be reviewed soon. "
 "We will send you updates via email."
@@ -400,7 +492,7 @@ msgstr ""
 "¡Gracias por convertirte en nuestro simpatizante! Revisaremos tu "
 "aplicación lo antes posible y te contactaremos por correo electrónico."
 
-#: metabrainz/supporter/views.py:187
+#: metabrainz/supporter/views.py:228
 msgid ""
 "Thanks for signing up! Your application will be reviewed soon. We will "
 "send you updates via email."
@@ -408,17 +500,17 @@ msgstr ""
 "¡Gracias por registrarte! Revisaremos tu aplicación lo antes posible y te"
 " contactaremos por correo electrónico."
 
-#: metabrainz/supporter/views.py:248
+#: metabrainz/supporter/views.py:288
 msgid "Thanks for becoming a supporter!"
 msgstr "¡Gracias por convertirte en simpatizante!"
 
-#: metabrainz/supporter/views.py:274
+#: metabrainz/supporter/views.py:312
 msgid "Thanks for signing up! Please check your inbox to complete verification."
 msgstr ""
 "¡Gracias por registrarte! Por favor, comprueba tu bandeja de entrada para"
 " verificar tu dirección de correo electrónico."
 
-#: metabrainz/supporter/views.py:302
+#: metabrainz/supporter/views.py:340
 msgid "Can't generate new token unless account is active."
 msgstr "Solo las cuentas marcadas como «activas» pueden generar un nuevo token."
 
@@ -452,7 +544,7 @@ msgstr "Tienda"
 msgid "Policies"
 msgstr "Políticas"
 
-#: metabrainz/templates/base.html:55 metabrainz/templates/index/gdpr.html:178
+#: metabrainz/templates/base.html:55
 #: metabrainz/templates/index/social-contract.html:3
 #: metabrainz/templates/index/social-contract.html:6
 #: metabrainz/templates/navbar.html:34
@@ -462,14 +554,15 @@ msgstr "Contrato social"
 #: metabrainz/templates/base.html:56
 #: metabrainz/templates/index/code-of-conduct.html:3
 #: metabrainz/templates/index/code-of-conduct.html:16
-#: metabrainz/templates/index/gdpr.html:181 metabrainz/templates/navbar.html:35
+#: metabrainz/templates/navbar.html:35
 msgid "Code of Conduct"
 msgstr "Código de conducta"
 
+#: frontend/js/src/PrivacySummary.tsx:11
 #: frontend/js/src/forms/ConditionsModal.tsx:21
-#: metabrainz/templates/base.html:57 metabrainz/templates/index/gdpr.html:184
-#: metabrainz/templates/index/privacy.html:6
+#: metabrainz/templates/base.html:57 metabrainz/templates/index/privacy.html:6
 #: metabrainz/templates/navbar.html:36
+#: metabrainz/templates/users/privacy-summary.html:3
 msgid "Privacy Policy"
 msgstr "Política de privacidad"
 
@@ -502,10 +595,7 @@ msgstr "Patrocinadores"
 msgid "Supporters"
 msgstr "Simpatizantes"
 
-#: frontend/js/src/forms/LoginUser.tsx:103
-#: frontend/js/src/forms/SignupCommercial.tsx:574
-#: frontend/js/src/forms/SignupNonCommercial.tsx:339
-#: frontend/js/src/forms/SignupUser.tsx:232 metabrainz/templates/base.html:73
+#: frontend/js/src/forms/LoginUser.tsx:103 metabrainz/templates/base.html:73
 #: metabrainz/templates/navbar.html:66 metabrainz/templates/users/login.html:3
 msgid "Sign in"
 msgstr "Iniciar sesión"
@@ -527,26 +617,26 @@ msgid "Contact us"
 msgstr "Contacta con nosotros"
 
 #: metabrainz/templates/base.html:85
-#: metabrainz/templates/index/contact.html:105
+#: metabrainz/templates/index/contact.html:106
 msgid "Blog"
 msgstr "Blog"
 
-#: metabrainz/templates/base.html:86 metabrainz/templates/index/contact.html:90
+#: metabrainz/templates/base.html:86 metabrainz/templates/index/contact.html:91
 msgid "Chat"
 msgstr "Chat"
 
 #: metabrainz/templates/base.html:87
-#: metabrainz/templates/index/contact.html:106
+#: metabrainz/templates/index/contact.html:107
 msgid "Mastodon"
 msgstr "Mastodon"
 
 #: metabrainz/templates/base.html:88
-#: metabrainz/templates/index/contact.html:107
+#: metabrainz/templates/index/contact.html:108
 msgid "Bluesky"
 msgstr "Bluesky"
 
 #: metabrainz/templates/base.html:89
-#: metabrainz/templates/index/contact.html:108
+#: metabrainz/templates/index/contact.html:109
 msgid "Instagram"
 msgstr "Instagram"
 
@@ -602,15 +692,14 @@ msgstr "Informes financieros"
 msgid "Donate"
 msgstr "Haz una donación"
 
-#: frontend/js/src/forms/LoginUser.tsx:110
-#: frontend/js/src/forms/SignupCommercial.tsx:175
-#: frontend/js/src/forms/SignupCommercial.tsx:555
+#: frontend/js/src/forms/SignupCommercial.tsx:180
+#: frontend/js/src/forms/SignupCommercial.tsx:559
 #: frontend/js/src/forms/SignupNonCommercial.tsx:106
 #: frontend/js/src/forms/SignupNonCommercial.tsx:319
 #: metabrainz/templates/navbar.html:65
-#: metabrainz/templates/supporters/account-type.html:51
-#: metabrainz/templates/supporters/account-type.html:93
-#: metabrainz/templates/supporters/account-type.html:144
+#: metabrainz/templates/supporters/account-type.html:47
+#: metabrainz/templates/supporters/account-type.html:84
+#: metabrainz/templates/supporters/account-type.html:130
 #: metabrainz/templates/users/signup.html:3
 msgid "Sign up"
 msgstr "Registrarse"
@@ -1004,9 +1093,431 @@ msgstr ""
 msgid "Introduction"
 msgstr "Introducción"
 
-#: metabrainz/templates/index/conflict-policy.html:55
+#: metabrainz/templates/index/conflict-policy.html:17
+msgid ""
+"Conflicts between people arise in open source projects constantly and the"
+" projects by the \n"
+"    MetaBrainz Foundation are no different. This policy aims to establish"
+" a clear and unambiguous \n"
+"    policy for reporting and addressing conflicts in our community. In "
+"this policy we aim to \n"
+"    establish a fair practice that balances the need for confidentiality "
+"and our desire for \n"
+"    transparency in our operations."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:25
+#, python-format
+msgid ""
+"Before you continue to read this policy, we encourage you to review our "
+"existing community policies \n"
+"    including our <a href=\"%(social_contract_url)s\">Social "
+"Contract</a>, \n"
+"    <a href=\"%(code_of_conduct_url)s\">the Code of Conduct</a>, \n"
+"    and our <a href=\"%(privacy_policy_url)s\">Privacy Policy</a>. These "
+"policies establish the norms and rules for \n"
+"    participation in our projects; these policies apply equally to the "
+"contractors of the MetaBrainz \n"
+"    Foundation and any participants in our projects."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:37
+msgid ""
+"This policy divides conflicts into two categories: Private and public. "
+"Private conflicts are conflicts \n"
+"    that involve *confidential* information regarding contributors, "
+"contractors or supporters. Otherwise, any conflicts \n"
+"    that do not involve confidential information are considered to be "
+"public conflicts. For instance, a \n"
+"    conflict between a contractor and the Executive Director (aka BDFL) "
+"that involves contractor pay is \n"
+"    considered a private conflict because pay rates are confidential "
+"information. A public conflict in edit \n"
+"    notes between two editors in our community does not involve "
+"confidential information and therefore should \n"
+"    be considered a public conflict."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:47
+msgid ""
+"When conflicts arise we aim to disclose as much information as possible "
+"about the conflict in a timely \n"
+"    fashion. When conflicts contain confidential matters we will aim to "
+"disclose as much information as \n"
+"    possible, while fully respecting the confidentiality of the people "
+"involved in the conflict. With any \n"
+"    private conflict we will aim to extract the relevant lessons for the "
+"team and community in an effort to \n"
+"    evolve our policies to prevent future conflicts. Should the involved "
+"parties disagree whether a conflict \n"
+"    is private or public, the question about the nature of the conflict "
+"will be presented for the next higher \n"
+"    level in the chain of command to decide. (e.g. if a community member "
+"and the community manager disagree on \n"
+"    a conflict being public or private, the Executive Director shall "
+"decide if the conflict is public or private)."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:58
 msgid "Reporting and Response"
 msgstr "Denuncias y respuestas"
+
+#: metabrainz/templates/index/conflict-policy.html:61
+msgid ""
+"We aim to not have conflict in our community, but we recognize that in "
+"reality conflicts will arise and we \n"
+"    must be prepared to address them in a fair manner. When conflicts "
+"arise, we prefer to have community or team \n"
+"    members resolve the conflicts among themselves, using our existing "
+"policies as guidelines for resolving the \n"
+"    conflict."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:69
+msgid ""
+"If you do not feel comfortable resolving a conflict on your own, you "
+"should feel free to report the conflict to \n"
+"    us. How you address the conflict depends on who is involved in the "
+"conflict and your comfort level. Please see \n"
+"    the detailed sections below on how and with whom to address your "
+"conflict. We aim to address conflicts as soon \n"
+"    as possible in an effort to prevent them from escalating "
+"unnecessarily."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:75
+msgid "Direct conflict resolution"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:78
+msgid ""
+"In direct conflict resolution, the involved parties will attempt to "
+"resolve the conflict themselves without \n"
+"   involving any MetaBrainz Foundation team member. You should aim to use"
+" direct resolution when the conflict does \n"
+"   not involve the violation of one of our policies or if the conflict is"
+" minor."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:84
+#, python-format
+msgid ""
+"For instance, if a user uses a rude tone, is disruptive or flagrantly "
+"ignores our project guidelines, we suggest \n"
+"    that you use direct conflict resolution to resolve the conflict. Some"
+" resources that might give you some suggestions \n"
+"    on how to go about resolving the conflict might be this <a "
+"href=\"%(conflict_resolution_primer_url)s\">\n"
+"    conflict resolution primer</a> and <a "
+"href=\"%(difficult_conversations_url)s\">how to\n"
+"    have difficult conversations at work</a>."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:93
+msgid "Informal reporting"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:96
+msgid ""
+"You may use informal reporting of a conflict if you aim to communicate a "
+"concern or incident without \n"
+"    seeking a corrective outcome. Informal reporting may also be an "
+"option if you have not been personally \n"
+"    victimized, but you’ve witnessed a violation of our policies or where"
+" you wish to maintain confidentiality \n"
+"    throughout the entire reporting process."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:103
+msgid ""
+"For editing in MusicBrainz you may informally report a user using the "
+"“Report this user for bad behavior” \n"
+"    link from the user’s profile. For reporting bad user behavior in "
+"other of our projects, please report them to our \n"
+"    community manager by mailing <span class=\"backemail\">gro.zniarbatem"
+"@reganam-ytinummoc</span> . For conflicts \n"
+"    that involve the community manager, report them by mailing <span "
+"class=\"backemail\">gro.zniarbatem@de</span> ."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:110
+msgid ""
+"Depending the the severity of the issue, repeated informal complaints may"
+" eventually require a formal response \n"
+"    from the MetaBrainz team. If an involved party requires anonymity, "
+"the conflict becomes a private conflict. If at \n"
+"    all possible minor issues should be resolved in a public forum in "
+"order for all people to witness and learn from \n"
+"    the issue at hand."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:116
+msgid "Formal complaint process"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:119
+msgid ""
+"All complaints about conflicts should be submitted via email. To whom a "
+"complaint should be mailed and who will \n"
+"    carry out the investigation will be described in the next section."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:124
+msgid "All complaint submissions to the Foundation should include the following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:128
+msgid ""
+"Contact info, if it is different than the email used to submit the "
+"conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:129
+msgid "Who was involved in the conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:130
+msgid "Where and when the incident happened"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:131
+msgid ""
+"A description of what happened -- ideally with links (e.g. chatlogs, edit"
+" notes) that outlines what \n"
+"         happened so that the persons evaluating the conflict may "
+"understand the issue at hand"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:133
+msgid ""
+"Any related pieces of information that provide more context on the "
+"conflict (e.g. links, screenshots)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:134
+msgid "An indication if this conflict is ongoing or not"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:139
+msgid "The investigation that follows aims to determine:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:143
+msgid "The nature and severity of the incident"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:144
+msgid ""
+"Whether or not the incident is considered a violation of MetaBrainz’ "
+"conduct policies or core values"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:145
+msgid ""
+"The amount of harm experienced by the person who submitted the complaint "
+"and the broader MetaBrainz community \n"
+"         as a result of the incident"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:147
+msgid ""
+"Whether there have been prior complaints against the individual or "
+"individuals reported"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:148
+msgid "Whether the incident is ongoing"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:152
+msgid ""
+"The following potential forms of resolution may apply to any team members"
+" involved in the conflict:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:155
+#: metabrainz/templates/index/conflict-policy.html:168
+msgid "Nothing (if it has been found no violation occurred)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:156
+msgid "Creating a plan to improve the performance"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:157
+msgid "Creating a negative performance evaluation"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:158
+msgid "Mediation, an intervention by a third party to resolve the conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:159
+msgid "Suspension or forced leave"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:160
+msgid "Termination of contract"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:164
+msgid ""
+"The following potential forms of resolution may apply to non team members"
+" involved in the conflict:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:169
+msgid "A reprimand, either public or private"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:170
+msgid "Suspension of the users’ account"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:171
+msgid "Deletion of the users’ account"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:172
+msgid ""
+"Removal of user privileges (e.g. if an auto editor commits a serious "
+"offence, they may lose their auto editor status)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:175
+msgid "Filing a complaint"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:178
+msgid ""
+"NOTE: For complaints not about MetaBrainz staff, please see the "
+"<em>Informal reporting</em> section above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:182
+msgid ""
+"If the complaint does not involve the Executive Director (ED), do the "
+"following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:186
+msgid ""
+"If team member has directly violated conduct policies or engaged in "
+"otherwise harmful behavior, a formal complaint should be filed."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:187
+msgid ""
+"Mail <span class=\"backemail\">gro.zniarbatem@de</span> and include the "
+"complaint information outlined above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:188
+msgid ""
+"You should expect a response within a working day acknowledging the "
+"complaint."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:189
+msgid ""
+"The complaint will be investigated by the ED, member(s) of the board of "
+"directors or a neutral third party."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:190
+msgid ""
+"Once the investigation has been completed, the ED, with the support of "
+"others involved in the investigation will respond. The \n"
+"        ED will respond to incidents no later than 7 working days after a"
+" complaint has been filed with either a resolution or an \n"
+"        explanation of why the process must be extended."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:196
+msgid "If a complaint involves the Executive Director, do the following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:200
+msgid ""
+"If the Executive Director has directly violated conduct policies or "
+"engaged in otherwise harmful behavior, \n"
+"        a formal complaint should be filed with the board of directors."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:202
+msgid ""
+"Mail <span class=\"backemail\">gro.zniarbatem@noituloser-tcilfnoc</span> "
+"and include the complaint information outlined above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:203
+msgid ""
+"You should get a response within 5 working days acknowledging the "
+"complaint."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:204
+msgid ""
+"The complaint will be investigated by the member(s) of the board of "
+"directors, the community manager, a neutral \n"
+"        third party or a combination thereof."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:206
+msgid ""
+"Once the investigation has been completed, the board, with the support of"
+" others involved in the investigation \n"
+"        will respond. The board will aim to respond to incidents no later"
+" than 15 working days after a complaint has been filed \n"
+"        with either a resolution or an explanation of why the process "
+"must be extended."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:211
+msgid "Confidentiality"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:214
+msgid ""
+"Confidentiality is an important aspect of conflict resolution and all of "
+"the conflicts brought to the attention of the foundation \n"
+"    will be evaluated with confidentiality in mind and acted upon "
+"accordingly."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:219
+msgid ""
+"We work hard to make all of the actions of the foundation as transparent "
+"and open as possible. In cases where we cannot \n"
+"    disclose all aspects of a conflict we will disclose that a conflict "
+"is or has occurred and we will attempt to disclose the \n"
+"    appropriate amount of information about the conflict while balancing "
+"the need for confidentiality and our desire to learn \n"
+"    from conflicts so that we as a foundation and community can learn "
+"from these conflicts and improve our policies to avoid the \n"
+"    conflicts in the future."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:227
+msgid ""
+"Any breaches of confidentiality will be treated as severe breaches of our"
+" conduct policies."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:230
+msgid "Retaliation"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:233
+msgid ""
+"We will not allow retaliation for any contractor or volunteer that files "
+"a complaint or is involved in an investigation. If you \n"
+"    believe that you are being treated negatively because of your "
+"involvement in a complaint please report this complaint directly \n"
+"    to the ED at <span class=\"backemail\">gro.zniarbatem@de</span> or "
+"the board at \n"
+"    <span class=\"backemail\">gro.zniarbatem@noituloser-tcilfnoc</span>."
+msgstr ""
 
 #: metabrainz/templates/index/contact.html:3
 #: metabrainz/templates/index/contact.html:6
@@ -1111,7 +1622,7 @@ msgstr "Propuestas de márketing"
 msgid ""
 "We are currently evaluating our overall online advertising strategy. We "
 "are evaluating advertising, traffic optimization,\n"
-"    search engine optimization and software monitization technologies. If"
+"    search engine optimization and software monetization technologies. If"
 " you provide these professional services, please provide a detailed\n"
 "    deck of your comprehensive services to the following email address. "
 "<em>Please respect our other non-media teams and do not contact us \n"
@@ -1119,14 +1630,6 @@ msgid ""
 " disregard the entirety of your submissions if you contact us any other "
 "way!</em>"
 msgstr ""
-"Estamos reevaluando nuestras estrategias de márketing, incluyendo "
-"anuncios, optimización de tráfico, SEO y monetización de software. Si "
-"quieres ofrecernos estos servicios, envía un correo con toda la "
-"información sobre tu oferta a la dirección de correo indicada. <em>Por "
-"favor, por respeto a los esfuerzos del resto de nuestro equipo que no se "
-"encarga del márketing, no nos escribas sobre estos temas usando nuestras "
-"otras direcciones de correo. ¡No haremos caso a ningún correo sobre este "
-"tema que sea enviado a cualquier otra dirección!</em>"
 
 #: metabrainz/templates/index/contact.html:52
 #, python-format
@@ -1209,14 +1712,11 @@ msgstr "Foro"
 #, python-format
 msgid ""
 "Please come ask your questions at our <a "
-"href=\"%(forums_url)s\">forums</a>! We would love to\n"
-"    answer any questions you may have."
+"href=\"%(forums_url)s\">forums</a>!\n"
+"    The community and the team will be more than happy to help you."
 msgstr ""
-"¡Puedes publicar tus preguntas en nuestro <a "
-"href=\"%(forums_url)s\">foro</a>! Tanto la comunidad como nuestro equipo "
-"estaremos encantados de ayudarte."
 
-#: metabrainz/templates/index/contact.html:92
+#: metabrainz/templates/index/contact.html:93
 #, python-format
 msgid ""
 "The MetaBrainz/MusicBrainz/ListenBrainz team and community hang out\n"
@@ -1231,15 +1731,15 @@ msgstr ""
 "unirte a los chats. También puedes echar un vistazo a <a "
 "href=\"%(chatlogs_url)s\">nuestras conversaciones archivadas</a>."
 
-#: metabrainz/templates/index/contact.html:101
+#: metabrainz/templates/index/contact.html:102
 msgid "Social media"
 msgstr "Redes sociales"
 
-#: metabrainz/templates/index/contact.html:103
+#: metabrainz/templates/index/contact.html:104
 msgid "You can follow us on these social channels:"
 msgstr "Puedes seguirnos en estos canales:"
 
-#: metabrainz/templates/index/contact.html:112
+#: metabrainz/templates/index/contact.html:113
 msgid "Mailing address"
 msgstr "Mailing address"
 
@@ -1252,34 +1752,350 @@ msgstr "Conjuntos de datos de MetaBrainz"
 msgid "GDPR Compliance Statement"
 msgstr "Declaración de cumplimiento del RGPD"
 
-#: metabrainz/templates/index/gdpr.html:37
+#: metabrainz/templates/index/gdpr.html:10
+msgid ""
+"The General Data Protection Regulation is a complex EU regulation that "
+"stipulates many points for protecting private data of\n"
+"    users on the Internet. Even though this is an EU regulation, it has a"
+" worldwide impact due to the nature of the Internet.\n"
+"    The MetaBrainz Foundation with its collection of projects is also "
+"affected by this regulation. We’ve been learning and adapting\n"
+"    our sites to be compliant with the GDPR – sadly this regulation isn’t"
+" entirely black and white and there is an incredible\n"
+"    amount of room left for interpretation of these rules."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:17
+msgid ""
+"The good news is that this regulation is roughly in line with our "
+"established practices: We’ve always held private information\n"
+"    in a high regard and applied the sort of rules to ourselves as we "
+"wish to have our own private data treated. Luckily, this\n"
+"    makes our compliance effort considerably easier. We’ve made two "
+"significant changes to how we treat your data and also adopted\n"
+"    terminology as used in the GDPR in order to use the same languages "
+"that many other sites are now adopting. Please keep reading\n"
+"    to find out the exact details of what we are doing to comply."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:24
+#, python-format
+msgid ""
+"However, we do ask for your compassion and help in our process of "
+"complying with the GDPR. As we already mentioned, the GDPR is\n"
+"    a complex set of rules that are not fully clarified yet. We’ve taken "
+"action on the steps that are clear to us and we’re following\n"
+"    ongoing conversations on points that are in gray zones or unclear to "
+"us. We’ve made our best initial effort on compliance and\n"
+"    promise to keep working on it as the picture becomes more clear. If "
+"you believe that we could improve our compliance, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a> and let us know what we "
+"can do to improve. It would also help us if you\n"
+"    could provide concrete discussion or examples to help us understand "
+"and take action on your suggestion."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:33
+msgid ""
+"Finally, below are the key sections of the GDPR as we understand them and"
+" how they affect your data in our ecosystem. Where\n"
+"    possible, we provide links for deeper understanding, links for you to"
+" examine our relevant code and links to tickets to follow\n"
+"    the process of improving our compliance."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:38
 msgid "Right to be forgotten"
 msgstr "Derecho de supresión"
 
-#: metabrainz/templates/index/gdpr.html:77
+#: metabrainz/templates/index/gdpr.html:41
+msgid ""
+"Summary: <i>Provide the user with the ability to remove their private "
+"data from our services</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:44
+msgid ""
+"The most important aspect of the right to be forgotten is the ability to "
+"delete your account. Once you request for us to delete\n"
+"    your account, we will remove any personally identifying information "
+"you may have provided us from your account (name, email\n"
+"    address, gender, biography, URL, etc.). The visible name on your "
+"account will be changed to “Deleted User #####” and effectively\n"
+"    the account will no longer be identifiable as your account."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:50
+msgid ""
+"However, given the nature of our projects where we work on collaborative "
+"databases, your contributions that are not personally\n"
+"    identifying are valuable assets to our database and these "
+"contributions will not be removed from our databases. But we will\n"
+"    ensure that these contributions no longer contain personally "
+"identifying data."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:55
+#, python-format
+msgid ""
+"Our process of automatically deleting your accounts across the MetaBrainz"
+" ecosystem is not complete yet (see below for a set of\n"
+"    tickets where you can track our progress). If you would like to "
+"delete your accounts in the MetaBrainz ecosystem or mark a\n"
+"    donation that is currently public as a private donation, please <a "
+"href=\"%(contact_url)s\">contact us</a>\n"
+"    and we will address your request as soon as possible."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:62
+#: metabrainz/templates/index/gdpr.html:182
+msgid "Links:"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:66
+#, python-format
+msgid ""
+"<a href=\"%(editor_deletion_doc_url)s\">How we delete accounts\n"
+"       in MusicBrainz</a> (warning, geek content ahead!)"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:70
+msgid ""
+"Implement sitewide user account deletion in\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/MBS-9680\">MusicBrainz</a>,"
+"\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/AB-337\">AcousticBrainz</a>,"
+"\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/BB-260\">BookBrainz</a>,\n"
+"         <a href=\"https://tickets.metabrainz.org/browse/MEB-103\">the "
+"MetaBrainz Site</a>,\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/LB-354\">ListenBrainz</a>, "
+"and\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/CB-307\">CritiqueBrainz</a>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:80
 msgid "Restriction of processing"
 msgstr "Derecho a la limitación del tratamiento"
 
-#: metabrainz/templates/index/gdpr.html:110
+#: metabrainz/templates/index/gdpr.html:83
+msgid ""
+"Summary: <i>To allow the user to control how their personally identifying"
+" data is being used.</i>"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:86
+msgid ""
+"Except for the ListenBrainz and AcousticBrainz projects, we do not "
+"process personally identifying data. Any personally\n"
+"    identifying data that our projects store is for the purpose of being "
+"able to contact you about your contributions to our database\n"
+"    (email address) or for voluntarily showing information about you to "
+"other users (biography, homepage, location, etc)."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:91
+#, python-format
+msgid ""
+"The ListenBrainz project differs in that the Listens (metadata about what"
+" music you have listened to) are stored on our servers\n"
+"    and <a href=\"%(listenbrainz_data_url)s\">made available to the "
+"public</a>. We believe Listens to be personally identifying\n"
+"    data and furthermore, we have goals of creating open source "
+"recommendation engines with this data, which involves processing the\n"
+"    user’s data. These two points are fundamental goals of the "
+"ListenBrainz project and we do not see a reasonable way to reach another"
+"\n"
+"    compromise position."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:99
+msgid ""
+"Because of this, we are going to require users to either acknowledge that"
+" we may process their Listen data or alternatively to\n"
+"    delete their account, including all of their Listens. Please note "
+"that if you decide to delete your ListenBrainz account, it may\n"
+"    take up to two weeks for all of your listens to no longer be included"
+" in our efforts to build a recommendation engine."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:104
+msgid ""
+"We have always made it clear that the data in ListenBrainz was to be "
+"public and that we plan to build new tools with your data, so\n"
+"    this should not come as a surprise to our users."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:108
+msgid ""
+"The AcousticBrainz project does not track who submits data to the "
+"database. If you create an account and use our data creation\n"
+"    tools (e.g. create a dataset or participate in a challenge) then we "
+"link your participation and the things that you create to\n"
+"    your account. If you choose to delete your account then we keep the "
+"non personally identifying data that you create, but anonymize\n"
+"    it so that it cannot be linked back to you."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:114
 msgid "Right to data portability / exporting your data"
 msgstr "Derecho a la portabilidad de los datos"
 
-#: metabrainz/templates/index/gdpr.html:150
+#: metabrainz/templates/index/gdpr.html:117
+msgid ""
+"Summary: <i>You have the right to access/download the data we store about"
+" you</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:120
+msgid ""
+"Except for the ListenBrainz and AcousticBrainz projects, we do not store "
+"personally identifying data beyond the\n"
+"    information that is available in your public profile on each of our "
+"projects. Since this data is plainly available in your\n"
+"    profile we do not provide a means for you to export this data."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:125
+msgid "There are the following exceptions to this:"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:129
+msgid ""
+"<b>IP addresses</b>: If you visit one of our sites the IP address of your"
+" computer is stored in our web logs for 7 days\n"
+"        before our servers automatically delete them. This data is almost"
+" never used by anyone: the only time we look at the\n"
+"        IP addresses is if our sites are adversely impacted by the "
+"actions of some unknown users. In that case, we may investigate\n"
+"        the logs to identify the IP address that needs to be blocked in "
+"order to restore the stability of our service.\n"
+"        This data is not available to anyone but the contractors of the "
+"MetaBrainz Foundation and is not available to download\n"
+"        to anyone at all."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:137
+#, python-format
+msgid ""
+"<b>ListenBrainz Listen data</b>: Users may <a "
+"href=\"%(listenbrainz_export_url)s\">export their ListenBrainz Listen\n"
+"        data</a> directly from the site. The user Listen data is also "
+"included in the <a href=\"%(listenbrainz_data_url)s\">ListenBrainz\n"
+"        data dumps</a> that are available for public download."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:146
+msgid ""
+"All of the non personally identifying data, such as your metadata "
+"contributions, are publicly visible, available for download\n"
+"    and available via the project APIs. For details about this data, "
+"downloads and APIs please check the documentation for the\n"
+"    respective projects you are interested in."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:151
+#, python-format
+msgid ""
+"Anyone wishing to get a list of financial donations they have made to the"
+" MetaBrainz Foundation, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a> and provide your "
+"MusicBrainz editor name so that we can look up\n"
+"    your donations."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:157
 msgid "Right to rectification"
 msgstr "Derecho a la rectificación de datos"
 
-#: metabrainz/templates/index/gdpr.html:165
+#: metabrainz/templates/index/gdpr.html:160
+msgid "Summary: <i>You have the right to correct your data</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:163
+msgid ""
+"All of our projects allow their users to update their personally "
+"identifying information in their profiles. Furthermore, most\n"
+"    of our projects allow the editing of their own metadata "
+"contributions. If you find that some of your data is incorrect, please\n"
+"    feel free to edit the data since we provide the tools to do so."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:168
+#, python-format
+msgid ""
+"If anyone who has made a financial donation to the MetaBrainz Foundation "
+"would like to make their donation private, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:173
 msgid "Right to be informed"
 msgstr "Derecho a la información"
 
-#: metabrainz/templates/index/gdpr.html:188
+#: metabrainz/templates/index/gdpr.html:175
+msgid ""
+"Summary: <i>You have the right to be informed about how we use your data "
+"in plain English</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:178
+msgid ""
+"Our privacy policy, as well as other policies, have always been written "
+"by humans for human consumption. We abhor legalese and\n"
+"    not speaking in direct terms."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:186
+msgid "Social contract"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:189
+msgid "Code of conduct"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:192
+msgid "Privacy policy"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:196
 msgid "Right to access"
 msgstr "Derecho de acceso"
 
-#: metabrainz/templates/index/gdpr.html:198
-#: metabrainz/templates/index/privacy.html:166
+#: metabrainz/templates/index/gdpr.html:199
+msgid ""
+"Summary: <i>You have the right to access the data that we collect about "
+"you</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:202
+msgid ""
+"All of our projects make all of the data we collect on your behalf, "
+"privately identifying or not, available to you. The\n"
+"    only exception to this are the IP addresses we store for 7 days – see"
+" above for details."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:206
+#: metabrainz/templates/index/privacy.html:168
 msgid "Privacy/GDPR Representative"
 msgstr "Representante de privacidad / RGPD"
+
+#: metabrainz/templates/index/gdpr.html:209
+#, python-format
+msgid ""
+"If you have any questions about our privacy policy, please <a "
+"href=\"%(contact_url)s\">contact us</a>. To report\n"
+"   any privacy problems, violations or leaks, our GDPR representative is "
+"our Interim Executive Director Nicolás Tamargo and for\n"
+"   privacy issues contact him at <strong><a "
+"href=\"mailto:gdpr@metabrainz.org\">gdpr@metabrainz.org</a></strong>."
+msgstr ""
 
 #: metabrainz/templates/index/index.html:6
 msgid "Welcome to MetaBrainz!"
@@ -1414,7 +2230,7 @@ msgstr ""
 "Para saber más sobre la fundación, visita nuestra página <a "
 "href=\"%(about_url)s\">sobre nosotros</a>."
 
-#: frontend/js/src/forms/ConditionsModal.tsx:43
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:32
 #: metabrainz/templates/index/privacy.html:3
 msgid "Privacy"
 msgstr "Privacidad"
@@ -1422,6 +2238,44 @@ msgstr "Privacidad"
 #: metabrainz/templates/index/privacy.html:8
 msgid "Summary"
 msgstr "Resumen"
+
+#: metabrainz/templates/index/privacy.html:12
+msgid ""
+"You do not have to provide any personal data to be able to browse the "
+"contents of the databases published by MetaBrainz."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:15
+msgid ""
+"You do not have to provide any personally-identifying information if you "
+"choose not to."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:18
+msgid ""
+"We will never reveal your email address on MetaBrainz controlled web "
+"sites."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:22
+msgid ""
+"In order to get maximum value out of the MetaBrainz projects, you may "
+"want to create an account and log in. \n"
+"    Doing so grants you the ability to: edit the databases, contribute "
+"your own data, communicate with other users, and keep track \n"
+"    of recently released music from artists in your MusicBrainz "
+"collection. If you choose to create an account then the minimum we \n"
+"    ask is that you: choose a unique username and password, use a web "
+"browser that accepts \"session\" cookies, and provide a verified \n"
+"    email address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:29
+msgid ""
+"If you do not create an account (or are not logged in) you will not have "
+"access to the above listed features, however, you will \n"
+"    still have full access to browse and examine the databases."
+msgstr ""
 
 #: metabrainz/templates/index/privacy.html:33
 msgid "Applicable to all users"
@@ -1431,39 +2285,197 @@ msgstr "Para todos nuestros usuarios"
 msgid "Cookies"
 msgstr "Cookies"
 
+#: metabrainz/templates/index/privacy.html:37
+msgid "We use two cookies that contain sensitive information:"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:42
+msgid ""
+"<b>remember_login</b>: If you choose the \"Log in permanently\" option "
+"when logging in to one of our sites; the cookie will be used to \n"
+"      remember your login details."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:46
+msgid ""
+"<b>musicbrainz_server_session, session, or connect.sid</b>: If you are "
+"logged into one of our sites, your current session ID is stored in this "
+"cookie."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:51
+msgid ""
+"We may store dynamic preference information in other cookies, but these "
+"do not contain any sensitive information."
+msgstr ""
+
 #: metabrainz/templates/index/privacy.html:54
 msgid "Web and FTP access logs"
 msgstr "Registros de acceso al sitio web y FTP"
+
+#: metabrainz/templates/index/privacy.html:57
+msgid ""
+"In a practice similar to other web sites (and APIs) we keep logs of all "
+"web requests made against our servers. These logs include: your IP\n"
+"    address, your browser's (or API client's) \"User-Agent\" string, and "
+"which page (or API endpoint) you requested with which parameters. "
+"Aggregate information about web and FTP traffic is\n"
+"    made available to the public via our site usage pages."
+msgstr ""
 
 #: metabrainz/templates/index/privacy.html:62
 msgid "Third-Party content"
 msgstr "Contenido de terceros"
 
-#: metabrainz/templates/index/privacy.html:92
+#: metabrainz/templates/index/privacy.html:64
+msgid ""
+"Our projects' web pages may load some third-party content. Some, but "
+"possibly not all sites are listed below:"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:69
+#, python-format
+msgid ""
+"Cover art and other images: These are provided by the various cover art "
+"sites that have given MusicBrainz permission to do so and our own \n"
+"      <a href=\"%(caa_url)s\">Cover Art Archive</a>. This means that the "
+"relevant site will know (if they want to) your IP \n"
+"      address, User-Agent string, etc., and which MusicBrainz web page "
+"you were visiting (the one which included the cover art image)."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:75
+msgid ""
+"AcoustID: Our fingerprints tab loads fingerprint information from "
+"acoustid.org."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:78
+msgid ""
+"MTCaptcha: Our account creation page loads third party content in order "
+"to prevent spammers from creating accounts."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:83
+msgid ""
+"<i>The above information assumes that you are using \"normal\" web "
+"browser settings, whereby images are always loaded and HTTP referrer \n"
+"    information is always sent.</i>"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:88
+msgid ""
+"It is impractical to constantly modify this privacy policy when "
+"MetaBrainz projects change which third party content they utilize. We "
+"will \n"
+"    aim to use common sense, respect to our community and community "
+"review when adding more content from third party sites. We will also \n"
+"    periodically review our policy to ensure that it remains current."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:93
 msgid "Applicable to account holders"
 msgstr "Para los usuarios con una cuenta"
 
-#: metabrainz/templates/index/privacy.html:94
+#: metabrainz/templates/index/privacy.html:95
 msgid "Account creation"
 msgstr "Creación de cuenta"
 
-#: metabrainz/templates/index/privacy.html:108
+#: metabrainz/templates/index/privacy.html:97
+msgid ""
+"When creating an account with a MetaBrainz project you need to pick a "
+"unique username and choose a password, the username you pick is the \n"
+"    only name associated with your account and will be what other "
+"MetaBrainz users know you as. You may optionally also tell us other \n"
+"    information about yourself that will be displayed to other MetaBrainz"
+" users and the public."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:103
+msgid ""
+"Additionally, in order to edit the databases you will need to provide a "
+"confirmed email address. This email address will be held in \n"
+"    confidence, the only method of revealing your email address to "
+"another user is if you choose to send a message to another \n"
+"    user and enable the option to \"reveal my email address\". Changing "
+"the email address stored with your account will require you to \n"
+"    verify the new address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:109
 msgid "Edits and Notes"
 msgstr "Ediciones y notas"
 
-#: metabrainz/templates/index/privacy.html:114
+#: metabrainz/templates/index/privacy.html:111
+msgid ""
+"If you make any changes to a MetaBrainz project database, such as adding "
+"any data, the details of those changes will be visible to \n"
+"    other logged-in users and the change will be associated with your "
+"username."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:115
 msgid "Subscriptions on MusicBrainz"
 msgstr "Subscripciones en MusicBrainz"
 
-#: metabrainz/templates/index/privacy.html:131
+#: metabrainz/templates/index/privacy.html:117
+msgid ""
+"As a logged-in user you can subscribe to one or more artists, labels, "
+"collections or other editors. The act of subscribing causes \n"
+"    any edits made to (or by in the case of another editor) those "
+"entities to be emailed to you. By default, other users can see your \n"
+"    list of subscriptions, however, you can opt out of this by editing "
+"the appropriate preference."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:123
+msgid ""
+"This does not provide \"perfect\" privacy though, in some cases it will "
+"be possible to infer information about the contents of your \n"
+"    subscription list even though you have disallowed others from viewing"
+" that list directly. This imperfection arises because various \n"
+"    parts of the system behave differently depending on whether or not an"
+" entity has any subscribers; also, the number of users \n"
+"    subscribed to each artist is available via the artist pages. In the "
+"most extreme (possibly contrived) example, imagine that all \n"
+"    users have their subscriptions set to \"public\", except for exactly "
+"one user whose list is \"private\". In that case, any discrepancy \n"
+"    for a given artist between the shown list of subscribers and the "
+"total number of subscribers must be down to that one user. Thus, \n"
+"    you can infer what artists are on that user's list."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:132
 msgid "Third-party sites"
 msgstr "Sitios de terceros"
 
-#: metabrainz/templates/index/privacy.html:145
+#: metabrainz/templates/index/privacy.html:134
+#, python-format
+msgid ""
+"Our code reviews are done on GitHub, which is not under the control of "
+"MetaBrainz. Participating in code reviews or other\n"
+"    tasks carried out on GitHub are subject to <a "
+"href=\"%(github_url)s\">GitHub's privacy policy</a>."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:140
+#, python-format
+msgid ""
+"Our translations platform is provided and hosted by Weblate, which has a "
+"data processing agreement with MetaBrainz.\n"
+"    Participating in translations is subject to <a "
+"href=\"%(weblate_url)s\">dedicated legal terms</a>.\n"
+"    Any translations you make will be submitted to our Git repositories "
+"and publicly associated with your username;\n"
+"    if you so choose, you can also publicly associate them with your own "
+"verified email address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:147
 msgid "MetaBrainz donors"
 msgstr "Donantes"
 
-#: metabrainz/templates/index/privacy.html:147
+#: metabrainz/templates/index/privacy.html:149
 msgid ""
 "When you make a donation to the MetaBrainz Foundation, we are legally\n"
 "    required to collect your personal information and keep it in our "
@@ -1476,7 +2488,7 @@ msgstr ""
 "legal de almacenar tus datos personales por si somos auditados por el "
 "IRS. Nunca facilitaremos tu información personal a nadie más."
 
-#: metabrainz/templates/index/privacy.html:153
+#: metabrainz/templates/index/privacy.html:155
 msgid ""
 "We believe in transparent finances, which means that we list all "
 "donations\n"
@@ -1490,11 +2502,34 @@ msgstr ""
 "junto al importe donado, salvo que indiques durante el proceso de "
 "donación que quieres hacer una donación anónima."
 
-#: metabrainz/templates/index/privacy.html:158
+#: metabrainz/templates/index/privacy.html:160
 msgid "Exceptions"
 msgstr "Excepciones"
 
-#: frontend/js/src/Profile.tsx:598
+#: metabrainz/templates/index/privacy.html:162
+msgid ""
+"<i><b>Please note</b>: Reasonable exceptions may apply to the above "
+"policy, for example to comply with applicable laws.\n"
+"    Also, members of the MetaBrainz team and other personnel contracted "
+"to provide services to MetaBrainz may have access to\n"
+"    our infrastructure and could therefore view any information contained"
+" therein. However all personnel are contractually bound\n"
+"    by non-disclosure clauses which prevent them from making any such "
+"information available to others."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:171
+#, python-format
+msgid ""
+"If you have any questions about our GDPR statement, please <a "
+"href=\"%(contact_url)s\">contact us</a>. To report\n"
+"   any privacy problems, violations or leaks, our GDPR representative is "
+"our Interim Executive Director Nicolás Tamargo and for\n"
+"   privacy issues contact him at <strong><a "
+"href=\"mailto:gdpr@metabrainz.org\">gdpr@metabrainz.org</a></strong>."
+msgstr ""
+
+#: frontend/js/src/Profile.tsx:603
 #: frontend/js/src/forms/ProfileChangePassword.tsx:22
 #: frontend/js/src/forms/ProfileChangePassword.tsx:111
 #: metabrainz/templates/index/profile-change-password.html:3
@@ -1811,6 +2846,11 @@ msgstr ""
 #: metabrainz/templates/index/team.html:26
 msgid "He lives on in our hearts and in open source."
 msgstr "Sigue vivo en nuestros corazones, y en la comunidad de código abierto."
+
+#: metabrainz/templates/index/team.html:29
+#: metabrainz/templates/index/team.html:315
+msgid "you’re welcome to try"
+msgstr ""
 
 #: metabrainz/templates/index/team.html:39
 msgid ""
@@ -2442,8 +3482,10 @@ msgstr "Cheques estadounidenses"
 
 #: metabrainz/templates/payments/donate.html:146
 msgid ""
-"Due to the increased unreliability of the US Postal Service we have "
-"stopped accepting paper checks. Sorry!"
+"Due to the increased unreliability of the US Postal Service and the "
+"relatively large fees involved, we ask you to only send a paper check if "
+"it is the only possible option. Due to the fees, we will not cash checks "
+"for less than $25."
 msgstr ""
 
 #: metabrainz/templates/payments/donate.html:241
@@ -3376,8 +4418,8 @@ msgid "Monthly balance sheets"
 msgstr "Balances de situación mensuales"
 
 #: frontend/js/src/Profile.tsx:520
-#: frontend/js/src/forms/SignupCommercial.tsx:175
-#: frontend/js/src/forms/SignupCommercial.tsx:554
+#: frontend/js/src/forms/SignupCommercial.tsx:180
+#: frontend/js/src/forms/SignupCommercial.tsx:558
 #: frontend/js/src/forms/SignupNonCommercial.tsx:106
 #: frontend/js/src/forms/SignupNonCommercial.tsx:318
 #: metabrainz/templates/supporters/account-type.html:3
@@ -3398,6 +4440,7 @@ msgid "Non-commercial / Personal"
 msgstr "Uso no comercial / personal"
 
 #: frontend/js/src/Profile.tsx:235
+#: frontend/js/src/forms/SignupNonCommercial.tsx:107
 #: frontend/js/src/forms/SignupNonCommercial.tsx:151
 #: metabrainz/templates/supporters/account-type.html:42
 msgid "Non-commercial"
@@ -3411,47 +4454,41 @@ msgstr "$0.00 al mes o más"
 msgid "Personal or university assignment user."
 msgstr "Uso personal o para una tarea universitaria."
 
-#: metabrainz/templates/supporters/account-type.html:48
-#: metabrainz/templates/supporters/account-type.html:90
-#: metabrainz/templates/supporters/account-type.html:141
-msgid "Upgrade"
-msgstr ""
-
 #: frontend/js/src/Profile.tsx:235
-#: frontend/js/src/forms/SignupCommercial.tsx:176
-#: frontend/js/src/forms/SignupCommercial.tsx:228
-#: metabrainz/templates/supporters/account-type.html:61
+#: frontend/js/src/forms/SignupCommercial.tsx:181
+#: frontend/js/src/forms/SignupCommercial.tsx:233
+#: metabrainz/templates/supporters/account-type.html:56
 msgid "Commercial"
 msgstr "Comercial"
 
-#: metabrainz/templates/supporters/account-type.html:83
-#: metabrainz/templates/supporters/account-type.html:135
+#: metabrainz/templates/supporters/account-type.html:78
+#: metabrainz/templates/supporters/account-type.html:125
 #, python-format
 msgid "$%(tier_price)s/month and up"
 msgstr "$%(tier_price)s al mes o más"
 
-#: metabrainz/templates/supporters/account-type.html:87
-#: metabrainz/templates/supporters/account-type.html:138
+#: metabrainz/templates/supporters/account-type.html:82
+#: metabrainz/templates/supporters/account-type.html:128
 msgid "More info"
 msgstr "Más información"
 
-#: metabrainz/templates/supporters/account-type.html:104
+#: metabrainz/templates/supporters/account-type.html:94
 msgid "View all tiers"
 msgstr "Mostrar todos los niveles"
 
-#: metabrainz/templates/supporters/account-type.html:112
+#: metabrainz/templates/supporters/account-type.html:102
 msgid "Some of our Unicorn members"
 msgstr "Algunos de nuestros simpatizantes de nivel Unicornio"
 
-#: metabrainz/templates/supporters/account-type.html:123
+#: metabrainz/templates/supporters/account-type.html:113
 msgid "See all our supporters"
 msgstr "Ver todos nuestros simpatizantes"
 
-#: metabrainz/templates/supporters/account-type.html:151
+#: metabrainz/templates/supporters/account-type.html:136
 msgid "View featured tiers"
 msgstr "Mostrar niveles principales"
 
-#: metabrainz/templates/supporters/account-type.html:158
+#: metabrainz/templates/supporters/account-type.html:143
 #, python-format
 msgid ""
 "If you are not sure which tier to pick, please\n"
@@ -3459,10 +4496,6 @@ msgid ""
 msgstr ""
 "Si no sabes qué nivel elegir, <a href=\"%(contact_url)s\">ponte en "
 "contacto con nosotros</a>."
-
-#: metabrainz/templates/supporters/account-type.html:166
-msgid "Back to Profile"
-msgstr "Volver al perfil"
 
 #: metabrainz/templates/supporters/bad-standing.html:3
 #: metabrainz/templates/supporters/bad-standing.html:6
@@ -3526,9 +4559,9 @@ msgid "Forgot your username"
 msgstr "Nombre de usuario olvidado"
 
 #: frontend/js/src/forms/ResetPassword.tsx:79
-#: frontend/js/src/forms/SignupCommercial.tsx:320
+#: frontend/js/src/forms/SignupCommercial.tsx:325
 #: frontend/js/src/forms/SignupNonCommercial.tsx:227
-#: frontend/js/src/forms/SignupUser.tsx:169
+#: frontend/js/src/forms/SignupUser.tsx:175
 #: metabrainz/templates/users/reauthenticate.html:3
 #: metabrainz/templates/users/reauthenticate.html:6
 msgid "Confirm Password"
@@ -3538,56 +4571,61 @@ msgstr "Confirmación de la contraseña"
 msgid "Please re-enter your password to continue."
 msgstr "Reintroduce tu contraseña para continuar."
 
-#: frontend/js/src/ProfileDelete.tsx:108
+#: frontend/js/src/ProfileDelete.tsx:110
 #: frontend/js/src/forms/DeleteApplication.tsx:53
 #: frontend/js/src/forms/OAuthPrompt.tsx:54
 #: frontend/js/src/forms/ProfileChangePassword.tsx:104
 #: frontend/js/src/forms/ProfileEdit.tsx:105
-#: metabrainz/templates/users/reauthenticate.html:23
+#: metabrainz/templates/users/reauthenticate.html:28
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: metabrainz/templates/users/reauthenticate.html:24
+#: metabrainz/templates/users/reauthenticate.html:29
 msgid "Continue"
 msgstr "Continuar"
+
+#: frontend/js/src/forms/utils.tsx:202
+#: metabrainz/templates/users/reauthenticate.html:40
+msgid "Password must not exceed 72 bytes."
+msgstr ""
 
 #: frontend/js/src/forms/ResetPassword.tsx:27
 #: metabrainz/templates/users/reset-password.html:3
 msgid "Reset your password"
 msgstr "Reemplaza tu contraseña"
 
-#: frontend/js/src/hooks/useEmailValidation.ts:41 metabrainz/user/forms.py:15
+#: frontend/js/src/hooks/useEmailValidation.ts:41 metabrainz/user/forms.py:16
 msgid "Registration from this email domain is not allowed."
 msgstr "No se permite el registro desde este dominio de correo electrónico."
 
 #: frontend/js/src/forms/LoginUser.tsx:50
 #: frontend/js/src/forms/LostPassword.tsx:45
-#: frontend/js/src/forms/SignupCommercial.tsx:270
+#: frontend/js/src/forms/SignupCommercial.tsx:275
 #: frontend/js/src/forms/SignupNonCommercial.tsx:175
-#: frontend/js/src/forms/SignupUser.tsx:114 metabrainz/user/forms.py:20
-#: metabrainz/user/forms.py:45 metabrainz/user/forms.py:62
+#: frontend/js/src/forms/SignupUser.tsx:120 metabrainz/user/forms.py:22
+#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:75
 msgid "Username"
 msgstr "Nombre de usuario"
 
 #: frontend/js/src/forms/LoginUser.tsx:42
 #: frontend/js/src/forms/LostPassword.tsx:37
-#: frontend/js/src/forms/SignupCommercial.tsx:153
+#: frontend/js/src/forms/SignupCommercial.tsx:158
 #: frontend/js/src/forms/SignupNonCommercial.tsx:84
-#: frontend/js/src/forms/SignupUser.tsx:67 metabrainz/user/forms.py:21
-#: metabrainz/user/forms.py:45 metabrainz/user/forms.py:62
+#: frontend/js/src/forms/SignupUser.tsx:73 metabrainz/user/forms.py:26
+#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:75
 msgid "Username is required!"
 msgstr "Debes indicar el nombre de usuario."
 
 #: frontend/js/src/forms/LoginUser.tsx:63
 #: frontend/js/src/forms/ResetPassword.tsx:72
-#: frontend/js/src/forms/SignupCommercial.tsx:308
+#: frontend/js/src/forms/SignupCommercial.tsx:313
 #: frontend/js/src/forms/SignupNonCommercial.tsx:214
-#: frontend/js/src/forms/SignupUser.tsx:157 metabrainz/user/forms.py:46
-#: metabrainz/user/forms.py:52
+#: frontend/js/src/forms/SignupUser.tsx:163 metabrainz/user/forms.py:53
+#: metabrainz/user/forms.py:62
 msgid "Password"
 msgstr "Contraseña"
 
-#: frontend/js/src/forms/LoginUser.tsx:76 metabrainz/user/forms.py:47
+#: frontend/js/src/forms/LoginUser.tsx:76 metabrainz/user/forms.py:57
 msgid "Remember me"
 msgstr "Recordarme"
 
@@ -3599,11 +4637,11 @@ msgstr "Nombre de usuario invalido."
 msgid "Username contains invalid or invisible characters."
 msgstr "El nombre de usuario contiene caracteres no válidos o invisibles."
 
-#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:181
+#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:220
 msgid "Hide password"
 msgstr "Ocultar contraseña"
 
-#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:181
+#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:220
 msgid "Show password"
 msgstr "Mostrar contraseña"
 
@@ -3660,11 +4698,11 @@ msgstr "Acceso"
 msgid "Revoke access"
 msgstr "Revocar el acceso"
 
-#: frontend/js/src/OAuthError.tsx:17
+#: frontend/js/src/OAuthError.tsx:18
 msgid "OAuth2 Error"
 msgstr "Error de OAuth2"
 
-#: frontend/js/src/OAuthError.tsx:18
+#: frontend/js/src/OAuthError.tsx:19
 msgid "An error occurred during OAuth authentication process."
 msgstr "Ha habido un error durante el proceso de autorización de OAuth."
 
@@ -3696,11 +4734,9 @@ msgstr ""
 
 #: frontend/js/src/Profile.tsx:109
 msgid ""
-"Are you sure you want to generate new access token? Current token will be"
-" revoked!"
+"Are you sure you want to generate a new access token? The current token "
+"will be revoked!"
 msgstr ""
-"¿Seguro que quieres generar un nuevo token de acceso? ¡El token actual "
-"será anulado!"
 
 #: frontend/js/src/Profile.tsx:118
 msgid "Failed to generate new access token!"
@@ -3834,8 +4870,8 @@ msgid "Contact Information"
 msgstr "Información de contacto"
 
 #: frontend/js/src/Profile.tsx:310 frontend/js/src/forms/ProfileEdit.tsx:70
-#: frontend/js/src/forms/SignupCommercial.tsx:284
-#: frontend/js/src/forms/SignupCommercial.tsx:333
+#: frontend/js/src/forms/SignupCommercial.tsx:289
+#: frontend/js/src/forms/SignupCommercial.tsx:338
 #: frontend/js/src/forms/SignupNonCommercial.tsx:189
 #: frontend/js/src/forms/SignupNonCommercial.tsx:241
 msgid "Contact name"
@@ -3963,7 +4999,7 @@ msgstr "Zona de riesgo"
 msgid "Once you delete your account, there is no going back. Please be certain."
 msgstr "Si eliminas tu cuenta, no podemos recuperarla. Piénsatelo bien."
 
-#: frontend/js/src/Profile.tsx:550 frontend/js/src/ProfileDelete.tsx:105
+#: frontend/js/src/Profile.tsx:550 frontend/js/src/ProfileDelete.tsx:107
 msgid "Delete My Account"
 msgstr "Quiero eliminar mi cuenta"
 
@@ -3975,39 +5011,39 @@ msgstr "Eliminar mi cuenta"
 msgid "Need to delete your account?"
 msgstr "¿Tienes que eliminar tu cuenta?"
 
-#: frontend/js/src/Profile.tsx:574
+#: frontend/js/src/Profile.tsx:575
 msgid ""
 "Deletion of supporter accounts requires manual review. Please contact us "
-"at"
+"at <email />."
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:594
+#: frontend/js/src/Profile.tsx:599
 msgid "Security"
 msgstr "Seguridad"
 
-#: frontend/js/src/Profile.tsx:626
+#: frontend/js/src/Profile.tsx:631
 msgid "MetaBrainz Applications"
 msgstr "Aplicaciones de MetaBrainz"
 
-#: frontend/js/src/Profile.tsx:630
+#: frontend/js/src/Profile.tsx:635
 msgid ""
 "With your MetaBrainz account, you can access every project in the "
 "MetaBrainz family:"
 msgstr "Con tu cuenta de MetaBrainz podrás acceder a todos nuestros proyectos:"
 
-#: frontend/js/src/Profile.tsx:643
+#: frontend/js/src/Profile.tsx:648
 msgid "The open-source music encyclopedia"
 msgstr "La enciclopedia de código abierto sobre música"
 
-#: frontend/js/src/Profile.tsx:655
+#: frontend/js/src/Profile.tsx:660
 msgid "Track, visualise and share the music you listen to"
 msgstr "Documenta, visualiza y comparte la música que escuchas"
 
-#: frontend/js/src/Profile.tsx:667
+#: frontend/js/src/Profile.tsx:672
 msgid "The open-source book database"
 msgstr "La base de datos de código abierto sobre libros"
 
-#: frontend/js/src/Profile.tsx:679
+#: frontend/js/src/Profile.tsx:684
 msgid "Creative Commons licensed reviews"
 msgstr "Reseñas con licencias Creative Commons"
 
@@ -4030,8 +5066,8 @@ msgid "Permanently remove all your account information"
 msgstr "Eliminaremos toda la información de tu cuenta de forma irreversible"
 
 #: frontend/js/src/ProfileDelete.tsx:64
-msgid "Revoke all your API tokens and access"
-msgstr "Anulará todos tus tokens y el acceso a la API de replicación"
+msgid "Revoke all your tokens and access to the replication API"
+msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:65
 msgid "Remove your supporter status (if applicable)"
@@ -4042,16 +5078,18 @@ msgid "Log you out of all MetaBrainz services"
 msgstr "Te desconectaremos de todos los servicios de MetaBrainz"
 
 #: frontend/js/src/ProfileDelete.tsx:70
-msgid "Your username will be reserved and cannot be reused."
-msgstr "Tu nombre de usuario quedará bloqueado y no podrá ser reutilizado."
+msgid ""
+"Your username will be reserved and cannot be reused without the "
+"intervention of an administrator."
+msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:82
+#: frontend/js/src/ProfileDelete.tsx:84
 msgid "To confirm, type your username '<username />' below:"
 msgstr ""
 "Para confirmar que quieres eliminar tu cuenta, introduce tu nombre de "
 "usuario «<username />»:"
 
-#: frontend/js/src/ProfileDelete.tsx:105
+#: frontend/js/src/ProfileDelete.tsx:107
 msgid "Deleting..."
 msgstr "Eliminando..."
 
@@ -4063,83 +5101,7 @@ msgstr "Perfil"
 msgid "Close"
 msgstr "Cerrar"
 
-#: frontend/js/src/forms/ConditionsModal.tsx:23
-msgid "Licensing"
-msgstr "Licencias"
-
-#: frontend/js/src/forms/ConditionsModal.tsx:25
-msgid ""
-"Any contributions you make to any MetaBrainz service will be released "
-"into the Public Domain and/or licensed under a Creative Commons by-nc-sa "
-"license. Furthermore, you give the MetaBrainz Foundation the right to "
-"license this data for commercial use."
-msgstr ""
-"Todas tus contribuciones a un servicio de MetaBrainz serán liberadas al "
-"dominio público y/o publicadas bajo una licencia Creative Commons by-nc-"
-"sa. También das permiso a la MetaBrainz Foundation para licenciar estos "
-"datos para uso comercial."
-
-#: frontend/js/src/forms/ConditionsModal.tsx:30
-msgid "Please read our <licenseLink>license page</licenseLink> for more details."
-msgstr ""
-"Para saber más, consulta nuestra <licenseLink>página de información de "
-"licencias</licenseLink>."
-
-#: frontend/js/src/forms/ConditionsModal.tsx:45
-msgid ""
-"MetaBrainz strongly believes in the privacy of its users. Any personal "
-"information you choose to provide will not be sold or shared with anyone "
-"else."
-msgstr ""
-"En MetaBrainz damos gran importancia a la privacidad de nuestros "
-"usuarios. Nunca compartiremos ni venderemos ninguna información personal "
-"que nos suministres."
-
-#: frontend/js/src/forms/ConditionsModal.tsx:50
-msgid ""
-"Please read our <privacyLink>privacy policy</privacyLink> for more "
-"details."
-msgstr ""
-"Para saber más, consulta nuestra <privacyLink>política de "
-"privacidad</privacyLink>."
-
-#: frontend/js/src/forms/ConditionsModal.tsx:59
-msgid "GDPR compliance"
-msgstr "Cumplimiento del RGPD"
-
-#: frontend/js/src/forms/ConditionsModal.tsx:61
-msgid ""
-"You may remove your personal information from our services anytime by "
-"deleting your account."
-msgstr ""
-"Puedes eliminar tu cuenta en cualquier momento para eliminar tu "
-"información personal almacenada por nuestros servicios."
-
-#: frontend/js/src/forms/ConditionsModal.tsx:66
-msgid ""
-"Please read our <gdprLink>GDPR compliance statement</gdprLink> for more "
-"details."
-msgstr ""
-"Para saber más, consulta nuestra <gdprLink>declaración de cumplimiento "
-"del RGPD</gdprLink>."
-
-#: frontend/js/src/forms/ConditionsModal.tsx:78
-msgid ""
-"Creating an account on MetaBrainz will give you access to all of our "
-"projects, such as MusicBrainz, ListenBrainz, BookBrainz, and more."
-msgstr ""
-"Creando una cuenta en MetaBrainz podrás acceder a todos nuestros "
-"proyectos, como MusicBrainz, ListenBrainz, BookBrainz, etc."
-
-#: frontend/js/src/forms/ConditionsModal.tsx:82
-msgid ""
-"We create a placeholder account for all the MetaBrainz projects when you "
-"sign up, and you are one log-in away from activating them."
-msgstr ""
-"Crearemos una cuenta provisional en cada proyecto de MetaBrainz, que "
-"puedes activar iniciando sesión en cada uno de ellos."
-
-#: frontend/js/src/forms/ConditionsModal.tsx:91
+#: frontend/js/src/forms/ConditionsModal.tsx:29
 msgid "Sounds good"
 msgstr "De acuerdo"
 
@@ -4227,8 +5189,8 @@ msgstr "¿Has olvidado tu nombre de usuario?"
 msgid "Forgot your password?"
 msgstr "¿Has olvidado tu contraseña?"
 
-#: frontend/js/src/forms/LoginUser.tsx:109
-msgid "Don't have an account?"
+#: frontend/js/src/forms/LoginUser.tsx:110
+msgid "Don't have an account? <signupLink>Sign up</signupLink>"
 msgstr ""
 
 #: frontend/js/src/forms/LostPassword.tsx:38
@@ -4257,15 +5219,91 @@ msgstr "Tu identidad en MetaBrainz"
 msgid "Allow access"
 msgstr "Permitir el acceso"
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:71
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:10
+msgid "Licensing"
+msgstr "Licencias"
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:12
+msgid ""
+"Any contributions you make to any MetaBrainz service will be released "
+"into the Public Domain and/or licensed under a Creative Commons by-nc-sa "
+"license. Furthermore, you give the MetaBrainz Foundation the right to "
+"license this data for commercial use."
+msgstr ""
+"Todas tus contribuciones a un servicio de MetaBrainz serán liberadas al "
+"dominio público y/o publicadas bajo una licencia Creative Commons by-nc-"
+"sa. También das permiso a la MetaBrainz Foundation para licenciar estos "
+"datos para uso comercial."
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:17
+msgid "Please read our <licenseLink>license page</licenseLink> for more details."
+msgstr ""
+"Para saber más, consulta nuestra <licenseLink>página de información de "
+"licencias</licenseLink>."
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:34
+msgid ""
+"MetaBrainz strongly believes in the privacy of its users. Any personal "
+"information you choose to provide will not be sold or shared with anyone "
+"else."
+msgstr ""
+"En MetaBrainz damos gran importancia a la privacidad de nuestros "
+"usuarios. Nunca compartiremos ni venderemos ninguna información personal "
+"que nos suministres."
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:39
+msgid ""
+"Please read our <privacyLink>privacy policy</privacyLink> for more "
+"details."
+msgstr ""
+"Para saber más, consulta nuestra <privacyLink>política de "
+"privacidad</privacyLink>."
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:50
+msgid "GDPR compliance"
+msgstr "Cumplimiento del RGPD"
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:52
+msgid ""
+"You may remove your personal information from our services anytime by "
+"deleting your account."
+msgstr ""
+"Puedes eliminar tu cuenta en cualquier momento para eliminar tu "
+"información personal almacenada por nuestros servicios."
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:57
+msgid ""
+"Please read our <gdprLink>GDPR compliance statement</gdprLink> for more "
+"details."
+msgstr ""
+"Para saber más, consulta nuestra <gdprLink>declaración de cumplimiento "
+"del RGPD</gdprLink>."
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:71
+msgid ""
+"Creating an account on MetaBrainz will give you access to all of our "
+"projects, such as MusicBrainz, ListenBrainz, BookBrainz, and more."
+msgstr ""
+"Creando una cuenta en MetaBrainz podrás acceder a todos nuestros "
+"proyectos, como MusicBrainz, ListenBrainz, BookBrainz, etc."
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:75
+msgid ""
+"We create a placeholder account for all the MetaBrainz projects when you "
+"sign up, and you are one log-in away from activating them."
+msgstr ""
+"Crearemos una cuenta provisional en cada proyecto de MetaBrainz, que "
+"puedes activar iniciando sesión en cada uno de ellos."
+
+#: frontend/js/src/forms/ProfileChangePassword.tsx:70
 msgid "Current Password"
 msgstr "Contraseña actual"
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:80
+#: frontend/js/src/forms/ProfileChangePassword.tsx:79
 msgid "New Password"
 msgstr "Nueva contraseña"
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:89
+#: frontend/js/src/forms/ProfileChangePassword.tsx:88
 msgid "Confirm New Password"
 msgstr "Confirmación de la nueva contraseña"
 
@@ -4277,31 +5315,29 @@ msgstr "Actualizar"
 msgid "Reset Password"
 msgstr "Reemplazar la contraseña"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:38
-msgid "If you would like to support us with more than $"
+#: frontend/js/src/forms/SignupCommercial.tsx:40
+msgid ""
+"If you would like to support us with more than ${{minPledge}}, please "
+"enter the actual amount here:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:39
-msgid ", please enter the actual amount here:"
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:144
+#: frontend/js/src/forms/SignupCommercial.tsx:149
 #: frontend/js/src/forms/SignupNonCommercial.tsx:75
-#: frontend/js/src/forms/SignupUser.tsx:87
+#: frontend/js/src/forms/SignupUser.tsx:93
 msgid "Captcha is required!"
 msgstr "Debes completar el captcha."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:179
+#: frontend/js/src/forms/SignupCommercial.tsx:184
 #: frontend/js/src/forms/SignupNonCommercial.tsx:110
 #: frontend/js/src/forms/SignupUser.tsx:46
 msgid "Access all MetaBrainz projects"
 msgstr "Accede a todos nuestros proyectos"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:182
+#: frontend/js/src/forms/SignupCommercial.tsx:187
 msgid "Note:"
 msgstr "Nota:"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:184
+#: frontend/js/src/forms/SignupCommercial.tsx:189
 msgid ""
 "Signing up for any tier other than the <italic>Stealth startup</italic> "
 "tier will publicly list your company on this web site. However, we will "
@@ -4311,54 +5347,53 @@ msgstr ""
 "modo sigilo»</italic>, tu empresa aparecerá en nuestro sitio web (pero no"
 " publicaremos tu información privada)."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:221
+#: frontend/js/src/forms/SignupCommercial.tsx:226
 #: frontend/js/src/forms/SignupNonCommercial.tsx:145
 msgid "Account type"
 msgstr "Tipo de cuenta"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:234
+#: frontend/js/src/forms/SignupCommercial.tsx:239
 msgid "Selected tier"
 msgstr "Nivel seleccionado"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:242
-#, fuzzy
-msgid "month and up"
-msgstr "al mes o más"
+#: frontend/js/src/forms/SignupCommercial.tsx:247
+msgid "${{tierPrice}}/month and up"
+msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:250
+#: frontend/js/src/forms/SignupCommercial.tsx:255
 msgid "Change account type or tier"
 msgstr "Cambiar tipo de cuenta o nivel"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:261
+#: frontend/js/src/forms/SignupCommercial.tsx:266
 #: frontend/js/src/forms/SignupNonCommercial.tsx:166
 msgid "Your account:"
 msgstr "Tu cuenta:"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:271
+#: frontend/js/src/forms/SignupCommercial.tsx:276
 #: frontend/js/src/forms/SignupNonCommercial.tsx:176
-#: frontend/js/src/forms/SignupUser.tsx:114
+#: frontend/js/src/forms/SignupUser.tsx:120
 msgid "(public)"
 msgstr "(público)"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:291
+#: frontend/js/src/forms/SignupCommercial.tsx:296
 #: frontend/js/src/forms/SignupNonCommercial.tsx:196
-#: frontend/js/src/forms/SignupUser.tsx:127
+#: frontend/js/src/forms/SignupUser.tsx:133
 msgid "E-mail address"
 msgstr "Dirección de correo"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:295
+#: frontend/js/src/forms/SignupCommercial.tsx:300
 #: frontend/js/src/forms/SignupNonCommercial.tsx:200
-#: frontend/js/src/forms/SignupUser.tsx:131
+#: frontend/js/src/forms/SignupUser.tsx:137
 msgid "(checking...)"
 msgstr "(comprobando...)"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:314
+#: frontend/js/src/forms/SignupCommercial.tsx:319
 #: frontend/js/src/forms/SignupNonCommercial.tsx:220
-#: frontend/js/src/forms/SignupUser.tsx:163
+#: frontend/js/src/forms/SignupUser.tsx:169
 msgid "Must be at least 8 characters"
 msgstr "Al menos 8 caracteres"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:348
+#: frontend/js/src/forms/SignupCommercial.tsx:353
 msgid ""
 "If you don't have an organization name, you probably want to become a "
 "supporter as a <nonCommercialLink>Non-commercial / "
@@ -4368,7 +5403,7 @@ msgstr ""
 "registrarte como un simpatizante <nonCommercialLink>de uso no comercial /"
 " personal</nonCommercialLink>."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:358
+#: frontend/js/src/forms/SignupCommercial.tsx:363
 msgid ""
 "If you don't have an organization name, you probably want to sign up as a"
 " <nonCommercialLink>Non-commercial / Personal</nonCommercialLink> user."
@@ -4377,7 +5412,7 @@ msgstr ""
 "crear una cuenta de usuario <nonCommercialLink>de uso no comercial / "
 "personal</nonCommercialLink>."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:378
+#: frontend/js/src/forms/SignupCommercial.tsx:383
 msgid ""
 "Please tell us a little about your company and whether you plan to use "
 "our <apiLink>API</apiLink> or to <hostLink>host your own copy</hostLink> "
@@ -4387,15 +5422,15 @@ msgstr ""
 "<apiLink>API</apiLink> o <hostLink>alojar vuestra propia copia</hostLink>"
 " de los datos."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:404
+#: frontend/js/src/forms/SignupCommercial.tsx:408
 msgid "Logo URL"
 msgstr "URL de tu logo"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:405
+#: frontend/js/src/forms/SignupCommercial.tsx:409
 msgid "(preferably in SVG format)"
 msgstr "(a ser posible en formato SVG)"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:408
+#: frontend/js/src/forms/SignupCommercial.tsx:412
 msgid ""
 "Image should be about 250 pixels wide on a white or transparent "
 "background. We will host it on our site."
@@ -4403,28 +5438,26 @@ msgstr ""
 "La imagen debería tener unos 250 píxeles de ancho y un fondo blanco o "
 "transparente. La alojaremos en nuestro sitio web."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:421
+#: frontend/js/src/forms/SignupCommercial.tsx:425
 msgid ""
 "URL to where developers can use your APIs using MusicBrainz IDs, if "
-"available.."
+"available."
 msgstr ""
-"URL en la que otros desarrolladores pueden acceder a tu API usando IDs de"
-" MusicBrainz, si la tienes."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:430
+#: frontend/js/src/forms/SignupCommercial.tsx:434
 msgid "Your project"
 msgstr "Tu proyecto"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:434
+#: frontend/js/src/forms/SignupCommercial.tsx:438
 #: frontend/js/src/forms/SignupNonCommercial.tsx:261
 msgid "(max 150 characters)"
 msgstr "(150 caracteres o menos)"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:451
+#: frontend/js/src/forms/SignupCommercial.tsx:455
 msgid "Billing address"
 msgstr "Dirección de facturación"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:502
+#: frontend/js/src/forms/SignupCommercial.tsx:506
 msgid ""
 "I agree to support the MetaBrainz Foundation when my organization is able"
 " to do so."
@@ -4432,17 +5465,18 @@ msgstr ""
 "Apoyaré a la MetaBrainz Foundation cuando mi organización pueda "
 "permitírselo."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:507
+#: frontend/js/src/forms/SignupCommercial.tsx:511
+#: frontend/js/src/forms/SignupNonCommercial.tsx:284
 msgid ""
-"I also agree that if I generate a Live Data Feed access token, that I "
-"treat my access token as a secret and will not share this token publicly "
-"or commit it to a source code repository."
+"I also agree that if I generate a Live Data Feed access token, then I "
+"will treat my access token as a secret and will not share this token "
+"publicly or commit it to a source code repository."
 msgstr ""
 "Además, si genero un token de acceso al Live Data Feed, prometo "
 "considerar el token como un secreto y no compartirlo públicamente ni "
 "añadirlo a un repositorio de códigos fuente."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:515
+#: frontend/js/src/forms/SignupCommercial.tsx:519
 msgid ""
 "The following information will be shown publicly: organization name, "
 "logo, website and API URLs, data usage description."
@@ -4450,7 +5484,7 @@ msgstr ""
 "Mostraremos públicamente los siguientes datos: nombre de la organización,"
 " logo, URLs del sitio web y la API, y descripción del uso de los datos."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:520
+#: frontend/js/src/forms/SignupCommercial.tsx:524
 msgid ""
 "We'll send you more details about payment process once your application "
 "is approved."
@@ -4458,36 +5492,27 @@ msgstr ""
 "Te enviaremos más información sobre el proceso de pago una vez hayamos "
 "aceptado tu aplicación."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:552
+#: frontend/js/src/forms/SignupCommercial.tsx:556
 #: frontend/js/src/forms/SignupNonCommercial.tsx:316
-#: frontend/js/src/forms/SignupUser.tsx:224
+#: frontend/js/src/forms/SignupUser.tsx:230
 msgid "Validating..."
 msgstr "Convalidando..."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:564
+#: frontend/js/src/forms/SignupCommercial.tsx:568
 #: frontend/js/src/forms/SignupNonCommercial.tsx:329
 msgid "Back to profile"
 msgstr "Volver al perfil"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:569
-#: frontend/js/src/forms/SignupNonCommercial.tsx:334
-msgid "Not a supporter?"
+#: frontend/js/src/forms/SignupCommercial.tsx:574
+#: frontend/js/src/forms/SignupNonCommercial.tsx:335
+msgid "Not a supporter? <signupLink>Create a user account</signupLink>"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:570
-#: frontend/js/src/forms/SignupNonCommercial.tsx:335
-msgid "Create a user account"
-msgstr "Crea una cuenta de usuario"
-
-#: frontend/js/src/forms/SignupCommercial.tsx:573
-#: frontend/js/src/forms/SignupNonCommercial.tsx:338
-#: frontend/js/src/forms/SignupUser.tsx:231
-msgid "Already have an account?"
-msgstr "¿Ya tienes una cuenta?"
-
-#: frontend/js/src/forms/SignupNonCommercial.tsx:107
-msgid "non-commercial"
-msgstr "Uso no comercial"
+#: frontend/js/src/forms/SignupCommercial.tsx:583
+#: frontend/js/src/forms/SignupNonCommercial.tsx:344
+#: frontend/js/src/forms/SignupUser.tsx:238
+msgid "Already have an account? <loginLink>Sign in</loginLink>"
+msgstr ""
 
 #: frontend/js/src/forms/SignupNonCommercial.tsx:113
 msgid ""
@@ -4520,29 +5545,20 @@ msgstr ""
 "Usaré los datos de MetaBrainz exclusivamente para uso personal o no "
 "comercial (menos de $500 de ingresos al año)."
 
-#: frontend/js/src/forms/SignupNonCommercial.tsx:284
-msgid ""
-"I also agree that if I generate a Live Data Feed access token, then I "
-"will treat my access token as a secret and will not share this token "
-"publicly or commit it to a source code repository."
-msgstr ""
-"Además, si genero un token de acceso al Live Data Feed, prometo "
-"considerar el token como un secreto y no compartirlo públicamente ni "
-"añadirlo a un repositorio de códigos fuente."
-
 #: frontend/js/src/forms/SignupUser.tsx:43
 msgid "Create your account"
 msgstr "Crea tu cuenta"
 
-#: frontend/js/src/forms/SignupUser.tsx:50
-msgid "Registration started by"
-msgstr "Creación de cuenta iniciada por"
+#: frontend/js/src/forms/SignupUser.tsx:51
+msgid "Registration started by <client />"
+msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:69
+#: frontend/js/src/forms/SignupUser.tsx:75
+#: frontend/js/src/hooks/useEmailValidation.ts:82
 msgid "Invalid email address."
 msgstr "La dirección de correo no es válida."
 
-#: frontend/js/src/forms/SignupUser.tsx:150
+#: frontend/js/src/forms/SignupUser.tsx:156
 msgid ""
 "This username and email were provided by the app that started "
 "registration. You can change them later from MetaBrainz settings."
@@ -4551,7 +5567,7 @@ msgstr ""
 "por la aplicación a través de la que iniciaste la creación de cuenta. "
 "Puedes cambiarlos más adelante desde las opciones de MetaBrainz."
 
-#: frontend/js/src/forms/SignupUser.tsx:182
+#: frontend/js/src/forms/SignupUser.tsx:188
 msgid ""
 "I accept that my contributions will be released into the public domain or"
 " licensed for use."
@@ -4559,15 +5575,15 @@ msgstr ""
 "Acepto que mis contribuciones sean liberadas al dominio público o "
 "licenciadas para su uso."
 
-#: frontend/js/src/forms/SignupUser.tsx:191
+#: frontend/js/src/forms/SignupUser.tsx:197
 msgid "We will never share your personal information."
 msgstr "Nunca compartiremos tu información personal."
 
-#: frontend/js/src/forms/SignupUser.tsx:200
+#: frontend/js/src/forms/SignupUser.tsx:206
 msgid "Click here to read more"
 msgstr "Haz clic aquí para saber más"
 
-#: frontend/js/src/forms/SignupUser.tsx:224
+#: frontend/js/src/forms/SignupUser.tsx:230
 msgid "Create account"
 msgstr "Crear cuenta"
 
@@ -4578,10 +5594,6 @@ msgstr "Esta dirección de correo ya ha sido registrada."
 #: frontend/js/src/hooks/useEmailValidation.ts:47
 msgid "Email validation failed"
 msgstr "Error al convalidar la dirección de correo"
-
-#: frontend/js/src/hooks/useEmailValidation.ts:82
-msgid "Invalid email address"
-msgstr "La dirección de correo no es válida"
 
 #~ msgid "You need to specify amount!"
 #~ msgstr "¡Tiene que especificar una cantidad!"
@@ -5487,9 +6499,9 @@ msgstr "La dirección de correo no es válida"
 #~ " new access token? Current token will"
 #~ " be revoked!"
 #~ msgstr ""
-#~ "Are you sure you want to generate"
-#~ " new access token? Current token will"
-#~ " be revoked!"
+#~ "¿Seguro que quieres generar un nuevo "
+#~ "token de acceso? ¡El token actual "
+#~ "será anulado!"
 
 #~ msgid "Sign up <small>Commercial</small>"
 #~ msgstr "Sign up <small>Commercial</small>"
@@ -5548,9 +6560,9 @@ msgstr "La dirección de correo no es válida"
 #~ "your APIs using MusicBrainz IDs, if "
 #~ "available.."
 #~ msgstr ""
-#~ "URL to where developers can use "
-#~ "your APIs using MusicBrainz IDs, if "
-#~ "available.."
+#~ "URL en la que otros desarrolladores "
+#~ "pueden acceder a tu API usando IDs"
+#~ " de MusicBrainz, si la tienes."
 
 #~ msgid "(max 150 characters)"
 #~ msgstr "(max 150 characters)"
@@ -5893,4 +6905,121 @@ msgstr "La dirección de correo no es válida"
 
 #~ msgid "Privacy policy"
 #~ msgstr "Política de privacidad"
+
+#~ msgid "You need to specify website of the organization."
+#~ msgstr "Tienes que indicar el sitio web de la organización."
+
+#~ msgid ""
+#~ "We are currently evaluating our overall"
+#~ " online advertising strategy. We are "
+#~ "evaluating advertising, traffic optimization,\n"
+#~ ""
+#~ "    search engine optimization and "
+#~ "software monitization technologies. If you "
+#~ "provide these professional services, please"
+#~ " provide a detailed\n"
+#~ "    deck of your comprehensive services"
+#~ " to the following email address. "
+#~ "<em>Please respect our other non-media"
+#~ " teams and do not contact us \n"
+#~ "    regarding these services on any "
+#~ "other of our email addresses. We "
+#~ "will disregard the entirety of your "
+#~ "submissions if you contact us any "
+#~ "other way!</em>"
+#~ msgstr ""
+#~ "Estamos reevaluando nuestras estrategias de"
+#~ " márketing, incluyendo anuncios, optimización "
+#~ "de tráfico, SEO y monetización de "
+#~ "software. Si quieres ofrecernos estos "
+#~ "servicios, envía un correo con toda "
+#~ "la información sobre tu oferta a "
+#~ "la dirección de correo indicada. <em>Por"
+#~ " favor, por respeto a los esfuerzos"
+#~ " del resto de nuestro equipo que "
+#~ "no se encarga del márketing, no "
+#~ "nos escribas sobre estos temas usando"
+#~ " nuestras otras direcciones de correo. "
+#~ "¡No haremos caso a ningún correo "
+#~ "sobre este tema que sea enviado a"
+#~ " cualquier otra dirección!</em>"
+
+#~ msgid ""
+#~ "Please come ask your questions at "
+#~ "our <a href=\"%(forums_url)s\">forums</a>! We "
+#~ "would love to\n"
+#~ "    answer any questions you may have."
+#~ msgstr ""
+#~ "¡Puedes publicar tus preguntas en "
+#~ "nuestro <a href=\"%(forums_url)s\">foro</a>! Tanto"
+#~ " la comunidad como nuestro equipo "
+#~ "estaremos encantados de ayudarte."
+
+#~ msgid ""
+#~ "Due to the increased unreliability of"
+#~ " the US Postal Service we have "
+#~ "stopped accepting paper checks. Sorry!"
+#~ msgstr ""
+
+#~ msgid "Upgrade"
+#~ msgstr ""
+
+#~ msgid "Back to Profile"
+#~ msgstr "Volver al perfil"
+
+#~ msgid ""
+#~ "Deletion of supporter accounts requires "
+#~ "manual review. Please contact us at"
+#~ msgstr ""
+
+#~ msgid "Revoke all your API tokens and access"
+#~ msgstr "Anulará todos tus tokens y el acceso a la API de replicación"
+
+#~ msgid "Your username will be reserved and cannot be reused."
+#~ msgstr "Tu nombre de usuario quedará bloqueado y no podrá ser reutilizado."
+
+#~ msgid "Don't have an account?"
+#~ msgstr ""
+
+#~ msgid "If you would like to support us with more than $"
+#~ msgstr ""
+
+#~ msgid ", please enter the actual amount here:"
+#~ msgstr ""
+
+#~ msgid "month and up"
+#~ msgstr "al mes o más"
+
+#~ msgid ""
+#~ "I also agree that if I generate"
+#~ " a Live Data Feed access token, "
+#~ "that I treat my access token as"
+#~ " a secret and will not share "
+#~ "this token publicly or commit it "
+#~ "to a source code repository."
+#~ msgstr ""
+#~ "Además, si genero un token de "
+#~ "acceso al Live Data Feed, prometo "
+#~ "considerar el token como un secreto "
+#~ "y no compartirlo públicamente ni "
+#~ "añadirlo a un repositorio de códigos "
+#~ "fuente."
+
+#~ msgid "Not a supporter?"
+#~ msgstr ""
+
+#~ msgid "Create a user account"
+#~ msgstr "Crea una cuenta de usuario"
+
+#~ msgid "Already have an account?"
+#~ msgstr "¿Ya tienes una cuenta?"
+
+#~ msgid "non-commercial"
+#~ msgstr "Uso no comercial"
+
+#~ msgid "Registration started by"
+#~ msgstr "Creación de cuenta iniciada por"
+
+#~ msgid "Invalid email address"
+#~ msgstr "La dirección de correo no es válida"
 

--- a/metabrainz/translations/et/LC_MESSAGES/messages.po
+++ b/metabrainz/translations/et/LC_MESSAGES/messages.po
@@ -8,179 +8,263 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-07-25 16:21+0200\n"
+"POT-Creation-Date: 2026-09-08 11:18+0200\n"
 "PO-Revision-Date: 2026-09-01 10:12+0000\n"
 "Last-Translator: Priit Jõerüüt "
 "<jmmbrz@users.noreply.translations.metabrainz.org>\n"
 "Language: et\n"
-"Language-Team: Estonian <https://translations.metabrainz.org/projects/"
-"metabrainz/website/et/>\n"
+"Language-Team: Estonian "
+"<https://translations.metabrainz.org/projects/metabrainz/website/et/>\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.18.0\n"
-"X-Generator: Weblate 2026.8.1\n"
 
-#: metabrainz/index/forms.py:46
+#: metabrainz/errors.py:24
+msgid "Authorization was declined."
+msgstr ""
+
+#: metabrainz/errors.py:25
+msgid "The authorization request was invalid."
+msgstr ""
+
+#: metabrainz/errors.py:26
+msgid "The application could not be authenticated."
+msgstr ""
+
+#: metabrainz/errors.py:27
+msgid "This application is not allowed to request authorization."
+msgstr ""
+
+#: metabrainz/errors.py:28
+msgid "The application asked for a response type this server does not support."
+msgstr ""
+
+#: metabrainz/errors.py:29
+msgid "The permissions requested by the application are invalid."
+msgstr ""
+
+#: metabrainz/errors.py:30
+msgid "You need to sign in to continue."
+msgstr ""
+
+#: metabrainz/errors.py:31
+msgid "Your consent is required to continue."
+msgstr ""
+
+#: metabrainz/password.py:12
+#, python-format
+msgid "Password must not exceed %(max_bytes)s bytes."
+msgstr ""
+
+#: metabrainz/index/forms.py:48
 #, python-format
 msgid "'%(value)s' is not a valid choice for this field"
 msgstr "„%(value)s“ pole korrektne väärtus selle välja jaoks"
 
 #: frontend/js/src/forms/ProfileEdit.tsx:27
-#: frontend/js/src/forms/SignupCommercial.tsx:154
+#: frontend/js/src/forms/SignupCommercial.tsx:159
 #: frontend/js/src/forms/SignupNonCommercial.tsx:85
-#: frontend/js/src/forms/SignupUser.tsx:70
-#: frontend/js/src/hooks/useEmailValidation.ts:78 metabrainz/index/forms.py:57
-#: metabrainz/user/forms.py:25 metabrainz/user/forms.py:57
-#: metabrainz/user/forms.py:63
+#: frontend/js/src/forms/SignupUser.tsx:76
+#: frontend/js/src/hooks/useEmailValidation.ts:78 metabrainz/index/forms.py:59
+#: metabrainz/user/forms.py:31 metabrainz/user/forms.py:70
+#: metabrainz/user/forms.py:76
 msgid "Email address is required!"
 msgstr "E-posti aadressi sisestamine on kohustuslik!"
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:34
-#: metabrainz/index/forms.py:63
+#: metabrainz/index/forms.py:65
 msgid "Current password is required!"
 msgstr "Senise salasõna sisestamine on kohustuslik!"
 
 #: frontend/js/src/forms/LoginUser.tsx:43
 #: frontend/js/src/forms/ProfileChangePassword.tsx:37
 #: frontend/js/src/forms/ResetPassword.tsx:39
-#: frontend/js/src/forms/SignupCommercial.tsx:156
+#: frontend/js/src/forms/SignupCommercial.tsx:161
 #: frontend/js/src/forms/SignupNonCommercial.tsx:87
-#: frontend/js/src/forms/SignupUser.tsx:72 metabrainz/index/forms.py:66
-#: metabrainz/user/forms.py:29 metabrainz/user/forms.py:46
-#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:69
+#: frontend/js/src/forms/SignupUser.tsx:78 metabrainz/index/forms.py:69
+#: metabrainz/user/forms.py:35 metabrainz/user/forms.py:54
+#: metabrainz/user/forms.py:63 metabrainz/user/forms.py:82
 msgid "Password is required!"
 msgstr "Salasõna sisestamine on kohustuslik!"
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:41
-#: frontend/js/src/forms/SignupCommercial.tsx:160
+#: frontend/js/src/forms/SignupCommercial.tsx:165
 #: frontend/js/src/forms/SignupNonCommercial.tsx:91
-#: frontend/js/src/forms/SignupUser.tsx:76 metabrainz/index/forms.py:70
-#: metabrainz/user/forms.py:33 metabrainz/user/forms.py:73
+#: frontend/js/src/forms/SignupUser.tsx:82 metabrainz/index/forms.py:74
+#: metabrainz/user/forms.py:40 metabrainz/user/forms.py:87
 msgid "Confirm Password is required!"
 msgstr "Salasõna kordamine on kohustuslik!"
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:46
 #: frontend/js/src/forms/ResetPassword.tsx:48
-#: frontend/js/src/forms/SignupCommercial.tsx:165
+#: frontend/js/src/forms/SignupCommercial.tsx:170
 #: frontend/js/src/forms/SignupNonCommercial.tsx:96
-#: frontend/js/src/forms/SignupUser.tsx:81 metabrainz/index/forms.py:72
-#: metabrainz/user/forms.py:35 metabrainz/user/forms.py:75
+#: frontend/js/src/forms/SignupUser.tsx:87 metabrainz/index/forms.py:76
+#: metabrainz/user/forms.py:42 metabrainz/user/forms.py:89
 msgid "Confirm Password should match password!"
 msgstr "Korratud saalsõna peaks vastama esmalt sisestatuga!"
 
 #: frontend/js/src/Applications.tsx:56 frontend/js/src/Applications.tsx:86
 #: frontend/js/src/Profile.tsx:272 frontend/js/src/Profile.tsx:482
-#: metabrainz/index/forms.py:78
+#: metabrainz/index/forms.py:82
 msgid "Name"
 msgstr "Nimi"
 
-#: metabrainz/index/forms.py:79
+#: metabrainz/index/forms.py:83
 msgid "Contact name field is empty."
 msgstr "Kontaktinime väli on tühi."
 
-#: metabrainz/index/views.py:234
+#: metabrainz/index/views.py:251
 msgid "Profile updated successfully."
 msgstr "Profiil on kenasti uuendatud."
 
-#: metabrainz/index/views.py:261
+#: metabrainz/index/views.py:278
 msgid "Current password is incorrect."
 msgstr "Praegune salasõna pole õige."
 
-#: metabrainz/index/views.py:266
+#: metabrainz/index/views.py:283
 msgid "Password changed successfully."
 msgstr "Salasõna on kenasti muudetud."
 
-#: metabrainz/index/views.py:372
+#: metabrainz/index/views.py:389
 msgid "You have updated an application!"
 msgstr "Sa oled rakendust uuendanud!"
 
-#: metabrainz/index/views.py:424
+#: metabrainz/index/views.py:441
 msgid "You have deleted an application."
 msgstr "Sa oled rakenduse kustutanud."
 
-#: metabrainz/index/views.py:426
+#: metabrainz/index/views.py:443
 msgid "Failed to delete an application."
 msgstr "Rakenduse kustutamine ei õnnestunud."
 
-#: metabrainz/index/views.py:449
+#: metabrainz/index/views.py:466
 msgid "Revoked tokens successfully!"
 msgstr "Tunnuslubade tühistamine õnnestus!"
 
-#: metabrainz/index/views.py:478
+#: metabrainz/index/views.py:495
 msgid "Your account has been deleted."
 msgstr "Sinu kasutajakonto on kustutatud."
 
-#: frontend/js/src/forms/CreateApplication.tsx:106 metabrainz/oauth/forms.py:58
+#: frontend/js/src/forms/CreateApplication.tsx:106 metabrainz/oauth/forms.py:57
 msgid "Application Name"
 msgstr "Rakenduse nimi"
 
-#: metabrainz/oauth/forms.py:59
+#: metabrainz/oauth/forms.py:58
 msgid "Application name field is empty."
 msgstr "Rakenduse nime väli on tühi."
 
-#: frontend/js/src/forms/CreateApplication.tsx:60 metabrainz/oauth/forms.py:60
+#: frontend/js/src/forms/CreateApplication.tsx:60 metabrainz/oauth/forms.py:59
 msgid "Application name needs to be at least 3 characters long."
 msgstr "Rakenduse nimi peab olema vähemalt 3 tähemärki pikk."
 
-#: frontend/js/src/forms/CreateApplication.tsx:64 metabrainz/oauth/forms.py:61
+#: frontend/js/src/forms/CreateApplication.tsx:64 metabrainz/oauth/forms.py:60
 msgid "Application name needs to be at most 64 characters long."
 msgstr "Rakenduse nimi võib olla kuni 64 tähemärki pikk."
 
-#: frontend/js/src/forms/CreateApplication.tsx:114 metabrainz/oauth/forms.py:63
+#: frontend/js/src/forms/CreateApplication.tsx:114 metabrainz/oauth/forms.py:62
 msgid "Description"
 msgstr "Kirjeldus"
 
-#: metabrainz/oauth/forms.py:64
+#: metabrainz/oauth/forms.py:63
 msgid "Client description field is empty."
 msgstr "Kliendi kirjelduse väli on tühi."
 
-#: metabrainz/oauth/forms.py:65
+#: metabrainz/oauth/forms.py:64
 msgid "Client description needs to be at least 3 characters long."
 msgstr "Kliendi kirjeldus peab olema vähemalt 3 tähemärki pikk."
 
-#: metabrainz/oauth/forms.py:66
+#: metabrainz/oauth/forms.py:65
 msgid "Client description needs to be at most 512 characters long."
 msgstr "Kliendi kirjeldus võib olla kuni 64 tähemärki pikk."
 
-#: frontend/js/src/forms/CreateApplication.tsx:122 metabrainz/oauth/forms.py:68
+#: frontend/js/src/forms/CreateApplication.tsx:122 metabrainz/oauth/forms.py:67
 msgid "Homepage"
 msgstr "Koduleht"
 
-#: metabrainz/oauth/forms.py:69
+#: metabrainz/oauth/forms.py:68
 msgid "Homepage field is empty."
 msgstr "Kodulehe väli on tühi."
 
-#: metabrainz/oauth/forms.py:70
+#: metabrainz/oauth/forms.py:69
 msgid "Homepage is not a valid URI."
 msgstr "Kodulehe aadress (URI) on vigane."
 
-#: metabrainz/oauth/forms.py:71
+#: metabrainz/oauth/forms.py:70
 msgid "Homepage URL must use http or https"
 msgstr "Kodulehe võrguaadressi alguses peab olema http või https"
 
-#: metabrainz/oauth/forms.py:73
+#: metabrainz/oauth/forms.py:72
 msgid "Authorization callback URL"
 msgstr "Autoriseerimisel kasutatav tagasipäringute võrguaadress"
 
-#: metabrainz/oauth/forms.py:74
+#: metabrainz/oauth/forms.py:73
 msgid "Authorization callback URL field is empty."
 msgstr "Autoriseerimisel kasutatav tagasipäringute võrguaadressi väli on tühi."
 
-#: metabrainz/oauth/forms.py:75
+#: metabrainz/oauth/forms.py:74
 msgid "Authorization callback URL is invalid."
 msgstr "Autoriseerimisel kasutatav tagasipäringute võrguaadress on vigane."
 
-#: metabrainz/oauth/forms.py:76
+#: metabrainz/oauth/forms.py:75
 msgid "Authorization callback URL must use http or https."
 msgstr ""
-"Autoriseerimisel kasutatav tagasipäringute võrguaadressi alguses peab olema "
-"http või https."
+"Autoriseerimisel kasutatav tagasipäringute võrguaadressi alguses peab "
+"olema http või https."
 
-#: metabrainz/oauth/forms.py:81 metabrainz/oauth/forms.py:85
+#: metabrainz/oauth/forms.py:80 metabrainz/oauth/forms.py:84
 msgid "Confirm"
 msgstr "Kinnita"
+
+#: metabrainz/oauth/scopes.py:15
+msgid "View your public account information"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:16
+msgid "View your email address"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:17
+msgid "View and modify your private tags"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:18
+msgid "View and modify your private ratings"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:19
+msgid "View and modify your private collections"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:20
+msgid "Submit new ISRCs to the database"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:21
+msgid "Submit new barcodes to the database"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:22
+msgid "Sign you in and view your unique user id"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:23
+msgid "Submit listens to ListenBrainz."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:24
+msgid "Create and modify CritiqueBrainz reviews."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:25
+msgid "Submit and delete votes on CritiqueBrainz reviews."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:26
+msgid "Modify profile info and delete profile on CritiqueBrainz."
+msgstr ""
 
 #: metabrainz/payments/views.py:164
 msgid ""
@@ -189,8 +273,8 @@ msgid ""
 "donation appears in the list due to processing delays."
 msgstr ""
 "Täname sind MetaBrainz Foundationile tehtud annetuse eest. Hindame sinu "
-"toetust väga! Töötlemisviivituste tõttu võib kuluda mõni aeg, enne kui sinu "
-"rahaline toetus saab loendis kuvatud."
+"toetust väga! Töötlemisviivituste tõttu võib kuluda mõni aeg, enne kui "
+"sinu rahaline toetus saab loendis kuvatud."
 
 #: metabrainz/payments/views.py:171
 msgid ""
@@ -227,180 +311,187 @@ msgid "Requested annual report was not found."
 msgstr "Soovitud aastaaruannet ei leidu."
 
 #: frontend/js/src/forms/ProfileEdit.tsx:30
-#: frontend/js/src/forms/SignupCommercial.tsx:139
+#: frontend/js/src/forms/SignupCommercial.tsx:144
 #: frontend/js/src/forms/SignupNonCommercial.tsx:70
-#: metabrainz/supporter/forms.py:13
+#: metabrainz/supporter/forms.py:15
 msgid "Contact name is required!"
 msgstr "Kontakti nime lisamine on kohustuslik!"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:437
+#: frontend/js/src/forms/SignupCommercial.tsx:441
 #: frontend/js/src/forms/SignupNonCommercial.tsx:264
-#: metabrainz/supporter/forms.py:15
+#: metabrainz/supporter/forms.py:17
 msgid ""
 "Can you please tell us more about the project in which you'd like to use "
 "our data? Do you plan to self host the data or use our APIs?"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:137
+#: frontend/js/src/forms/SignupCommercial.tsx:142
 #: frontend/js/src/forms/SignupNonCommercial.tsx:68
-#: metabrainz/supporter/forms.py:17
+#: metabrainz/supporter/forms.py:19
 msgid "Please, tell us how you (will) use our data."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:138
+#: frontend/js/src/forms/SignupCommercial.tsx:143
 #: frontend/js/src/forms/SignupNonCommercial.tsx:69
-#: metabrainz/supporter/forms.py:18
+#: metabrainz/supporter/forms.py:20
 msgid "Please, limit usage description to 500 characters."
 msgstr "Palun koosta kirjeldus kuni 500-tähemärgisena."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:141
-#: frontend/js/src/forms/SignupCommercial.tsx:142
+#: frontend/js/src/forms/SignupCommercial.tsx:146
+#: frontend/js/src/forms/SignupCommercial.tsx:147
 #: frontend/js/src/forms/SignupNonCommercial.tsx:72
 #: frontend/js/src/forms/SignupNonCommercial.tsx:73
-#: frontend/js/src/forms/SignupUser.tsx:84
-#: frontend/js/src/forms/SignupUser.tsx:85 metabrainz/supporter/forms.py:21
-#: metabrainz/user/forms.py:38
+#: frontend/js/src/forms/SignupUser.tsx:90
+#: frontend/js/src/forms/SignupUser.tsx:91 metabrainz/supporter/forms.py:23
+#: metabrainz/user/forms.py:45
 msgid "You need to accept the agreement!"
 msgstr "Sa pead lepinguga nõustuma!"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:342
-#: metabrainz/supporter/forms.py:27
+#: frontend/js/src/forms/SignupCommercial.tsx:347
+#: metabrainz/supporter/forms.py:29
 msgid "Organization name"
 msgstr "Organisatsiooni nimi"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:113
-#: metabrainz/supporter/forms.py:28
+#: frontend/js/src/forms/SignupCommercial.tsx:115
+#: metabrainz/supporter/forms.py:30
 msgid "You need to specify the name of your organization."
 msgstr "Sa pead määratlema organisatsiooni nime."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:373
-#: metabrainz/supporter/forms.py:30
+#: frontend/js/src/forms/SignupCommercial.tsx:378
+#: metabrainz/supporter/forms.py:32
 msgid "Organization description"
 msgstr "Organisatsiooni kirjeldus"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:116
-#: metabrainz/supporter/forms.py:31
+#: frontend/js/src/forms/SignupCommercial.tsx:118
+#: metabrainz/supporter/forms.py:33
 msgid "You need to provide description of your organization."
 msgstr "Sa pead määratlema organisatsiooni kirjelduse."
 
 #: frontend/js/src/Profile.tsx:278
-#: frontend/js/src/forms/SignupCommercial.tsx:396
-#: metabrainz/supporter/forms.py:34
+#: frontend/js/src/forms/SignupCommercial.tsx:401
+#: metabrainz/supporter/forms.py:36
 msgid "Website URL"
 msgstr "Veebisaidi aadress"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:119
-#: metabrainz/supporter/forms.py:35
-msgid "You need to specify website of the organization."
-msgstr "Sa pead määratlema veebisaidi võrguaadressi."
+#: frontend/js/src/forms/SignupCommercial.tsx:121
+#: frontend/js/src/forms/SignupCommercial.tsx:123
+#: metabrainz/supporter/forms.py:38 metabrainz/supporter/forms.py:42
+msgid "Website URL must be a valid URL."
+msgstr ""
 
-#: metabrainz/supporter/forms.py:37
+#: metabrainz/supporter/forms.py:45
 msgid "Logo image URL"
 msgstr "Logo võrguaadress"
 
 #: frontend/js/src/Profile.tsx:284
-#: frontend/js/src/forms/SignupCommercial.tsx:418
-#: metabrainz/supporter/forms.py:38
+#: frontend/js/src/forms/SignupCommercial.tsx:422
+#: metabrainz/supporter/forms.py:46
 msgid "API URL"
 msgstr "API võrguaadress"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:457
-#: metabrainz/supporter/forms.py:40
+#: frontend/js/src/forms/SignupCommercial.tsx:461
+#: metabrainz/supporter/forms.py:48
 msgid "Street"
 msgstr "Tänav"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:123
-#: metabrainz/supporter/forms.py:41
+#: frontend/js/src/forms/SignupCommercial.tsx:128
+#: metabrainz/supporter/forms.py:49
 msgid "You need to specify street."
 msgstr "Sa pead sisestama tänava."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:465
-#: metabrainz/supporter/forms.py:43
+#: frontend/js/src/forms/SignupCommercial.tsx:469
+#: metabrainz/supporter/forms.py:51
 msgid "City"
 msgstr "Linn"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:124
-#: metabrainz/supporter/forms.py:44
+#: frontend/js/src/forms/SignupCommercial.tsx:129
+#: metabrainz/supporter/forms.py:52
 msgid "You need to specify city."
 msgstr "Sa pead sisestama linna."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:473
-#: metabrainz/supporter/forms.py:46
+#: frontend/js/src/forms/SignupCommercial.tsx:477
+#: metabrainz/supporter/forms.py:54
 msgid "State / Province"
 msgstr "Osariik / Provints"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:126
-#: metabrainz/supporter/forms.py:47
+#: frontend/js/src/forms/SignupCommercial.tsx:131
+#: metabrainz/supporter/forms.py:55
 msgid "You need to specify state/province."
 msgstr "Sa pead sisestama osariigi või provintsi."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:481
-#: metabrainz/supporter/forms.py:49
+#: frontend/js/src/forms/SignupCommercial.tsx:485
+#: metabrainz/supporter/forms.py:57
 msgid "Postcode"
 msgstr "Sihtnumber"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:128
-#: metabrainz/supporter/forms.py:50
+#: frontend/js/src/forms/SignupCommercial.tsx:133
+#: metabrainz/supporter/forms.py:58
 msgid "You need to specify postcode."
 msgstr "Sa pead sisestama sihtnumbri."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:489
-#: metabrainz/supporter/forms.py:52
+#: frontend/js/src/forms/SignupCommercial.tsx:493
+#: metabrainz/supporter/forms.py:60
 msgid "Country"
 msgstr "Riik"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:129
-#: metabrainz/supporter/forms.py:53
+#: frontend/js/src/forms/SignupCommercial.tsx:134
+#: metabrainz/supporter/forms.py:61
 msgid "You need to specify country."
 msgstr "Sa pead sisestama riigi."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:132
-#: metabrainz/supporter/forms.py:64
+#: frontend/js/src/forms/SignupCommercial.tsx:137
+#: metabrainz/supporter/forms.py:72
 msgid ""
 "Custom amount must be more than threshold amount for selected tier or "
 "equal to it!"
 msgstr ""
-"Sinu sisestatud summa peab olema valitud taseme künnisest suurem või sellega "
-"võrdne!"
+"Sinu sisestatud summa peab olema valitud taseme künnisest suurem või "
+"sellega võrdne!"
 
-#: metabrainz/supporter/views.py:46 metabrainz/supporter/views.py:119
-#: metabrainz/supporter/views.py:220
+#: metabrainz/supporter/views.py:54
+msgid ""
+"The verification email could not be sent. Please request a new one from "
+"your profile."
+msgstr ""
+
+#: metabrainz/supporter/views.py:85 metabrainz/supporter/views.py:158
+#: metabrainz/supporter/views.py:260
 msgid "You are already a supporter."
 msgstr "Sa juba oled toetaja."
 
-#: metabrainz/supporter/views.py:61
+#: metabrainz/supporter/views.py:100
 msgid "Can't find tier with a specified ID."
 msgstr ""
 
-#: metabrainz/supporter/views.py:127
+#: metabrainz/supporter/views.py:166
 msgid "You need to choose support tier before signing up!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:137
+#: metabrainz/supporter/views.py:176
 msgid "You need to choose existing tier before signing up!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:164
+#: metabrainz/supporter/views.py:204
 msgid ""
 "Thanks for becoming a supporter! Your application will be reviewed soon. "
 "We will send you updates via email."
 msgstr ""
 
-#: metabrainz/supporter/views.py:187
+#: metabrainz/supporter/views.py:228
 msgid ""
 "Thanks for signing up! Your application will be reviewed soon. We will "
 "send you updates via email."
 msgstr ""
 
-#: metabrainz/supporter/views.py:248
+#: metabrainz/supporter/views.py:288
 msgid "Thanks for becoming a supporter!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:274
+#: metabrainz/supporter/views.py:312
 msgid "Thanks for signing up! Please check your inbox to complete verification."
 msgstr ""
 
-#: metabrainz/supporter/views.py:302
+#: metabrainz/supporter/views.py:340
 msgid "Can't generate new token unless account is active."
 msgstr ""
 
@@ -434,7 +525,7 @@ msgstr "Pood"
 msgid "Policies"
 msgstr "Reeglid"
 
-#: metabrainz/templates/base.html:55 metabrainz/templates/index/gdpr.html:178
+#: metabrainz/templates/base.html:55
 #: metabrainz/templates/index/social-contract.html:3
 #: metabrainz/templates/index/social-contract.html:6
 #: metabrainz/templates/navbar.html:34
@@ -444,14 +535,15 @@ msgstr "Ühiskondlik lepe"
 #: metabrainz/templates/base.html:56
 #: metabrainz/templates/index/code-of-conduct.html:3
 #: metabrainz/templates/index/code-of-conduct.html:16
-#: metabrainz/templates/index/gdpr.html:181 metabrainz/templates/navbar.html:35
+#: metabrainz/templates/navbar.html:35
 msgid "Code of Conduct"
 msgstr "Tegevuse põhimõtted"
 
+#: frontend/js/src/PrivacySummary.tsx:11
 #: frontend/js/src/forms/ConditionsModal.tsx:21
-#: metabrainz/templates/base.html:57 metabrainz/templates/index/gdpr.html:184
-#: metabrainz/templates/index/privacy.html:6
+#: metabrainz/templates/base.html:57 metabrainz/templates/index/privacy.html:6
 #: metabrainz/templates/navbar.html:36
+#: metabrainz/templates/users/privacy-summary.html:3
 msgid "Privacy Policy"
 msgstr "Andmekaitsepõhimõtted"
 
@@ -484,10 +576,7 @@ msgstr "Sponsorid"
 msgid "Supporters"
 msgstr "Toetajad"
 
-#: frontend/js/src/forms/LoginUser.tsx:103
-#: frontend/js/src/forms/SignupCommercial.tsx:574
-#: frontend/js/src/forms/SignupNonCommercial.tsx:339
-#: frontend/js/src/forms/SignupUser.tsx:232 metabrainz/templates/base.html:73
+#: frontend/js/src/forms/LoginUser.tsx:103 metabrainz/templates/base.html:73
 #: metabrainz/templates/navbar.html:66 metabrainz/templates/users/login.html:3
 msgid "Sign in"
 msgstr "Logi sisse"
@@ -509,26 +598,26 @@ msgid "Contact us"
 msgstr "Kontakt"
 
 #: metabrainz/templates/base.html:85
-#: metabrainz/templates/index/contact.html:105
+#: metabrainz/templates/index/contact.html:106
 msgid "Blog"
 msgstr "Ajaveeb"
 
-#: metabrainz/templates/base.html:86 metabrainz/templates/index/contact.html:90
+#: metabrainz/templates/base.html:86 metabrainz/templates/index/contact.html:91
 msgid "Chat"
 msgstr "Vestle meiega"
 
 #: metabrainz/templates/base.html:87
-#: metabrainz/templates/index/contact.html:106
+#: metabrainz/templates/index/contact.html:107
 msgid "Mastodon"
 msgstr "Jälgi Mastodonis"
 
 #: metabrainz/templates/base.html:88
-#: metabrainz/templates/index/contact.html:107
+#: metabrainz/templates/index/contact.html:108
 msgid "Bluesky"
 msgstr "Jälgi BlueSky's"
 
 #: metabrainz/templates/base.html:89
-#: metabrainz/templates/index/contact.html:108
+#: metabrainz/templates/index/contact.html:109
 msgid "Instagram"
 msgstr "Jälgi Instagramis"
 
@@ -584,15 +673,14 @@ msgstr "Rahandusaruanded"
 msgid "Donate"
 msgstr "Toeta rahaliselt"
 
-#: frontend/js/src/forms/LoginUser.tsx:110
-#: frontend/js/src/forms/SignupCommercial.tsx:175
-#: frontend/js/src/forms/SignupCommercial.tsx:555
+#: frontend/js/src/forms/SignupCommercial.tsx:180
+#: frontend/js/src/forms/SignupCommercial.tsx:559
 #: frontend/js/src/forms/SignupNonCommercial.tsx:106
 #: frontend/js/src/forms/SignupNonCommercial.tsx:319
 #: metabrainz/templates/navbar.html:65
-#: metabrainz/templates/supporters/account-type.html:51
-#: metabrainz/templates/supporters/account-type.html:93
-#: metabrainz/templates/supporters/account-type.html:144
+#: metabrainz/templates/supporters/account-type.html:47
+#: metabrainz/templates/supporters/account-type.html:84
+#: metabrainz/templates/supporters/account-type.html:130
 #: metabrainz/templates/users/signup.html:3
 msgid "Sign up"
 msgstr "Liitu"
@@ -899,8 +987,430 @@ msgstr ""
 msgid "Introduction"
 msgstr ""
 
-#: metabrainz/templates/index/conflict-policy.html:55
+#: metabrainz/templates/index/conflict-policy.html:17
+msgid ""
+"Conflicts between people arise in open source projects constantly and the"
+" projects by the \n"
+"    MetaBrainz Foundation are no different. This policy aims to establish"
+" a clear and unambiguous \n"
+"    policy for reporting and addressing conflicts in our community. In "
+"this policy we aim to \n"
+"    establish a fair practice that balances the need for confidentiality "
+"and our desire for \n"
+"    transparency in our operations."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:25
+#, python-format
+msgid ""
+"Before you continue to read this policy, we encourage you to review our "
+"existing community policies \n"
+"    including our <a href=\"%(social_contract_url)s\">Social "
+"Contract</a>, \n"
+"    <a href=\"%(code_of_conduct_url)s\">the Code of Conduct</a>, \n"
+"    and our <a href=\"%(privacy_policy_url)s\">Privacy Policy</a>. These "
+"policies establish the norms and rules for \n"
+"    participation in our projects; these policies apply equally to the "
+"contractors of the MetaBrainz \n"
+"    Foundation and any participants in our projects."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:37
+msgid ""
+"This policy divides conflicts into two categories: Private and public. "
+"Private conflicts are conflicts \n"
+"    that involve *confidential* information regarding contributors, "
+"contractors or supporters. Otherwise, any conflicts \n"
+"    that do not involve confidential information are considered to be "
+"public conflicts. For instance, a \n"
+"    conflict between a contractor and the Executive Director (aka BDFL) "
+"that involves contractor pay is \n"
+"    considered a private conflict because pay rates are confidential "
+"information. A public conflict in edit \n"
+"    notes between two editors in our community does not involve "
+"confidential information and therefore should \n"
+"    be considered a public conflict."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:47
+msgid ""
+"When conflicts arise we aim to disclose as much information as possible "
+"about the conflict in a timely \n"
+"    fashion. When conflicts contain confidential matters we will aim to "
+"disclose as much information as \n"
+"    possible, while fully respecting the confidentiality of the people "
+"involved in the conflict. With any \n"
+"    private conflict we will aim to extract the relevant lessons for the "
+"team and community in an effort to \n"
+"    evolve our policies to prevent future conflicts. Should the involved "
+"parties disagree whether a conflict \n"
+"    is private or public, the question about the nature of the conflict "
+"will be presented for the next higher \n"
+"    level in the chain of command to decide. (e.g. if a community member "
+"and the community manager disagree on \n"
+"    a conflict being public or private, the Executive Director shall "
+"decide if the conflict is public or private)."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:58
 msgid "Reporting and Response"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:61
+msgid ""
+"We aim to not have conflict in our community, but we recognize that in "
+"reality conflicts will arise and we \n"
+"    must be prepared to address them in a fair manner. When conflicts "
+"arise, we prefer to have community or team \n"
+"    members resolve the conflicts among themselves, using our existing "
+"policies as guidelines for resolving the \n"
+"    conflict."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:69
+msgid ""
+"If you do not feel comfortable resolving a conflict on your own, you "
+"should feel free to report the conflict to \n"
+"    us. How you address the conflict depends on who is involved in the "
+"conflict and your comfort level. Please see \n"
+"    the detailed sections below on how and with whom to address your "
+"conflict. We aim to address conflicts as soon \n"
+"    as possible in an effort to prevent them from escalating "
+"unnecessarily."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:75
+msgid "Direct conflict resolution"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:78
+msgid ""
+"In direct conflict resolution, the involved parties will attempt to "
+"resolve the conflict themselves without \n"
+"   involving any MetaBrainz Foundation team member. You should aim to use"
+" direct resolution when the conflict does \n"
+"   not involve the violation of one of our policies or if the conflict is"
+" minor."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:84
+#, python-format
+msgid ""
+"For instance, if a user uses a rude tone, is disruptive or flagrantly "
+"ignores our project guidelines, we suggest \n"
+"    that you use direct conflict resolution to resolve the conflict. Some"
+" resources that might give you some suggestions \n"
+"    on how to go about resolving the conflict might be this <a "
+"href=\"%(conflict_resolution_primer_url)s\">\n"
+"    conflict resolution primer</a> and <a "
+"href=\"%(difficult_conversations_url)s\">how to\n"
+"    have difficult conversations at work</a>."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:93
+msgid "Informal reporting"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:96
+msgid ""
+"You may use informal reporting of a conflict if you aim to communicate a "
+"concern or incident without \n"
+"    seeking a corrective outcome. Informal reporting may also be an "
+"option if you have not been personally \n"
+"    victimized, but you’ve witnessed a violation of our policies or where"
+" you wish to maintain confidentiality \n"
+"    throughout the entire reporting process."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:103
+msgid ""
+"For editing in MusicBrainz you may informally report a user using the "
+"“Report this user for bad behavior” \n"
+"    link from the user’s profile. For reporting bad user behavior in "
+"other of our projects, please report them to our \n"
+"    community manager by mailing <span class=\"backemail\">gro.zniarbatem"
+"@reganam-ytinummoc</span> . For conflicts \n"
+"    that involve the community manager, report them by mailing <span "
+"class=\"backemail\">gro.zniarbatem@de</span> ."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:110
+msgid ""
+"Depending the the severity of the issue, repeated informal complaints may"
+" eventually require a formal response \n"
+"    from the MetaBrainz team. If an involved party requires anonymity, "
+"the conflict becomes a private conflict. If at \n"
+"    all possible minor issues should be resolved in a public forum in "
+"order for all people to witness and learn from \n"
+"    the issue at hand."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:116
+msgid "Formal complaint process"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:119
+msgid ""
+"All complaints about conflicts should be submitted via email. To whom a "
+"complaint should be mailed and who will \n"
+"    carry out the investigation will be described in the next section."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:124
+msgid "All complaint submissions to the Foundation should include the following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:128
+msgid ""
+"Contact info, if it is different than the email used to submit the "
+"conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:129
+msgid "Who was involved in the conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:130
+msgid "Where and when the incident happened"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:131
+msgid ""
+"A description of what happened -- ideally with links (e.g. chatlogs, edit"
+" notes) that outlines what \n"
+"         happened so that the persons evaluating the conflict may "
+"understand the issue at hand"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:133
+msgid ""
+"Any related pieces of information that provide more context on the "
+"conflict (e.g. links, screenshots)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:134
+msgid "An indication if this conflict is ongoing or not"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:139
+msgid "The investigation that follows aims to determine:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:143
+msgid "The nature and severity of the incident"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:144
+msgid ""
+"Whether or not the incident is considered a violation of MetaBrainz’ "
+"conduct policies or core values"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:145
+msgid ""
+"The amount of harm experienced by the person who submitted the complaint "
+"and the broader MetaBrainz community \n"
+"         as a result of the incident"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:147
+msgid ""
+"Whether there have been prior complaints against the individual or "
+"individuals reported"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:148
+msgid "Whether the incident is ongoing"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:152
+msgid ""
+"The following potential forms of resolution may apply to any team members"
+" involved in the conflict:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:155
+#: metabrainz/templates/index/conflict-policy.html:168
+msgid "Nothing (if it has been found no violation occurred)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:156
+msgid "Creating a plan to improve the performance"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:157
+msgid "Creating a negative performance evaluation"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:158
+msgid "Mediation, an intervention by a third party to resolve the conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:159
+msgid "Suspension or forced leave"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:160
+msgid "Termination of contract"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:164
+msgid ""
+"The following potential forms of resolution may apply to non team members"
+" involved in the conflict:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:169
+msgid "A reprimand, either public or private"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:170
+msgid "Suspension of the users’ account"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:171
+msgid "Deletion of the users’ account"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:172
+msgid ""
+"Removal of user privileges (e.g. if an auto editor commits a serious "
+"offence, they may lose their auto editor status)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:175
+msgid "Filing a complaint"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:178
+msgid ""
+"NOTE: For complaints not about MetaBrainz staff, please see the "
+"<em>Informal reporting</em> section above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:182
+msgid ""
+"If the complaint does not involve the Executive Director (ED), do the "
+"following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:186
+msgid ""
+"If team member has directly violated conduct policies or engaged in "
+"otherwise harmful behavior, a formal complaint should be filed."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:187
+msgid ""
+"Mail <span class=\"backemail\">gro.zniarbatem@de</span> and include the "
+"complaint information outlined above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:188
+msgid ""
+"You should expect a response within a working day acknowledging the "
+"complaint."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:189
+msgid ""
+"The complaint will be investigated by the ED, member(s) of the board of "
+"directors or a neutral third party."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:190
+msgid ""
+"Once the investigation has been completed, the ED, with the support of "
+"others involved in the investigation will respond. The \n"
+"        ED will respond to incidents no later than 7 working days after a"
+" complaint has been filed with either a resolution or an \n"
+"        explanation of why the process must be extended."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:196
+msgid "If a complaint involves the Executive Director, do the following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:200
+msgid ""
+"If the Executive Director has directly violated conduct policies or "
+"engaged in otherwise harmful behavior, \n"
+"        a formal complaint should be filed with the board of directors."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:202
+msgid ""
+"Mail <span class=\"backemail\">gro.zniarbatem@noituloser-tcilfnoc</span> "
+"and include the complaint information outlined above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:203
+msgid ""
+"You should get a response within 5 working days acknowledging the "
+"complaint."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:204
+msgid ""
+"The complaint will be investigated by the member(s) of the board of "
+"directors, the community manager, a neutral \n"
+"        third party or a combination thereof."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:206
+msgid ""
+"Once the investigation has been completed, the board, with the support of"
+" others involved in the investigation \n"
+"        will respond. The board will aim to respond to incidents no later"
+" than 15 working days after a complaint has been filed \n"
+"        with either a resolution or an explanation of why the process "
+"must be extended."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:211
+msgid "Confidentiality"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:214
+msgid ""
+"Confidentiality is an important aspect of conflict resolution and all of "
+"the conflicts brought to the attention of the foundation \n"
+"    will be evaluated with confidentiality in mind and acted upon "
+"accordingly."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:219
+msgid ""
+"We work hard to make all of the actions of the foundation as transparent "
+"and open as possible. In cases where we cannot \n"
+"    disclose all aspects of a conflict we will disclose that a conflict "
+"is or has occurred and we will attempt to disclose the \n"
+"    appropriate amount of information about the conflict while balancing "
+"the need for confidentiality and our desire to learn \n"
+"    from conflicts so that we as a foundation and community can learn "
+"from these conflicts and improve our policies to avoid the \n"
+"    conflicts in the future."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:227
+msgid ""
+"Any breaches of confidentiality will be treated as severe breaches of our"
+" conduct policies."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:230
+msgid "Retaliation"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:233
+msgid ""
+"We will not allow retaliation for any contractor or volunteer that files "
+"a complaint or is involved in an investigation. If you \n"
+"    believe that you are being treated negatively because of your "
+"involvement in a complaint please report this complaint directly \n"
+"    to the ED at <span class=\"backemail\">gro.zniarbatem@de</span> or "
+"the board at \n"
+"    <span class=\"backemail\">gro.zniarbatem@noituloser-tcilfnoc</span>."
 msgstr ""
 
 #: metabrainz/templates/index/contact.html:3
@@ -981,7 +1491,7 @@ msgstr "Reklaamipäringud"
 msgid ""
 "We are currently evaluating our overall online advertising strategy. We "
 "are evaluating advertising, traffic optimization,\n"
-"    search engine optimization and software monitization technologies. If"
+"    search engine optimization and software monetization technologies. If"
 " you provide these professional services, please provide a detailed\n"
 "    deck of your comprehensive services to the following email address. "
 "<em>Please respect our other non-media teams and do not contact us \n"
@@ -1056,11 +1566,11 @@ msgstr "Foorumid"
 #, python-format
 msgid ""
 "Please come ask your questions at our <a "
-"href=\"%(forums_url)s\">forums</a>! We would love to\n"
-"    answer any questions you may have."
+"href=\"%(forums_url)s\">forums</a>!\n"
+"    The community and the team will be more than happy to help you."
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:92
+#: metabrainz/templates/index/contact.html:93
 #, python-format
 msgid ""
 "The MetaBrainz/MusicBrainz/ListenBrainz team and community hang out\n"
@@ -1070,15 +1580,15 @@ msgid ""
 "    <a href=\"%(chatlogs_url)s\">chat log archives</a>."
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:101
+#: metabrainz/templates/index/contact.html:102
 msgid "Social media"
 msgstr "Sotsiaalmeedia"
 
-#: metabrainz/templates/index/contact.html:103
+#: metabrainz/templates/index/contact.html:104
 msgid "You can follow us on these social channels:"
 msgstr "Sa võid meid jälgida neis sotsiaalmeediakanaleis:"
 
-#: metabrainz/templates/index/contact.html:112
+#: metabrainz/templates/index/contact.html:113
 msgid "Mailing address"
 msgstr "E-posti aadress"
 
@@ -1091,33 +1601,349 @@ msgstr "MetaBrainzi andmekogud"
 msgid "GDPR Compliance Statement"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:37
+#: metabrainz/templates/index/gdpr.html:10
+msgid ""
+"The General Data Protection Regulation is a complex EU regulation that "
+"stipulates many points for protecting private data of\n"
+"    users on the Internet. Even though this is an EU regulation, it has a"
+" worldwide impact due to the nature of the Internet.\n"
+"    The MetaBrainz Foundation with its collection of projects is also "
+"affected by this regulation. We’ve been learning and adapting\n"
+"    our sites to be compliant with the GDPR – sadly this regulation isn’t"
+" entirely black and white and there is an incredible\n"
+"    amount of room left for interpretation of these rules."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:17
+msgid ""
+"The good news is that this regulation is roughly in line with our "
+"established practices: We’ve always held private information\n"
+"    in a high regard and applied the sort of rules to ourselves as we "
+"wish to have our own private data treated. Luckily, this\n"
+"    makes our compliance effort considerably easier. We’ve made two "
+"significant changes to how we treat your data and also adopted\n"
+"    terminology as used in the GDPR in order to use the same languages "
+"that many other sites are now adopting. Please keep reading\n"
+"    to find out the exact details of what we are doing to comply."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:24
+#, python-format
+msgid ""
+"However, we do ask for your compassion and help in our process of "
+"complying with the GDPR. As we already mentioned, the GDPR is\n"
+"    a complex set of rules that are not fully clarified yet. We’ve taken "
+"action on the steps that are clear to us and we’re following\n"
+"    ongoing conversations on points that are in gray zones or unclear to "
+"us. We’ve made our best initial effort on compliance and\n"
+"    promise to keep working on it as the picture becomes more clear. If "
+"you believe that we could improve our compliance, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a> and let us know what we "
+"can do to improve. It would also help us if you\n"
+"    could provide concrete discussion or examples to help us understand "
+"and take action on your suggestion."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:33
+msgid ""
+"Finally, below are the key sections of the GDPR as we understand them and"
+" how they affect your data in our ecosystem. Where\n"
+"    possible, we provide links for deeper understanding, links for you to"
+" examine our relevant code and links to tickets to follow\n"
+"    the process of improving our compliance."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:38
 msgid "Right to be forgotten"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:77
+#: metabrainz/templates/index/gdpr.html:41
+msgid ""
+"Summary: <i>Provide the user with the ability to remove their private "
+"data from our services</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:44
+msgid ""
+"The most important aspect of the right to be forgotten is the ability to "
+"delete your account. Once you request for us to delete\n"
+"    your account, we will remove any personally identifying information "
+"you may have provided us from your account (name, email\n"
+"    address, gender, biography, URL, etc.). The visible name on your "
+"account will be changed to “Deleted User #####” and effectively\n"
+"    the account will no longer be identifiable as your account."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:50
+msgid ""
+"However, given the nature of our projects where we work on collaborative "
+"databases, your contributions that are not personally\n"
+"    identifying are valuable assets to our database and these "
+"contributions will not be removed from our databases. But we will\n"
+"    ensure that these contributions no longer contain personally "
+"identifying data."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:55
+#, python-format
+msgid ""
+"Our process of automatically deleting your accounts across the MetaBrainz"
+" ecosystem is not complete yet (see below for a set of\n"
+"    tickets where you can track our progress). If you would like to "
+"delete your accounts in the MetaBrainz ecosystem or mark a\n"
+"    donation that is currently public as a private donation, please <a "
+"href=\"%(contact_url)s\">contact us</a>\n"
+"    and we will address your request as soon as possible."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:62
+#: metabrainz/templates/index/gdpr.html:182
+msgid "Links:"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:66
+#, python-format
+msgid ""
+"<a href=\"%(editor_deletion_doc_url)s\">How we delete accounts\n"
+"       in MusicBrainz</a> (warning, geek content ahead!)"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:70
+msgid ""
+"Implement sitewide user account deletion in\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/MBS-9680\">MusicBrainz</a>,"
+"\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/AB-337\">AcousticBrainz</a>,"
+"\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/BB-260\">BookBrainz</a>,\n"
+"         <a href=\"https://tickets.metabrainz.org/browse/MEB-103\">the "
+"MetaBrainz Site</a>,\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/LB-354\">ListenBrainz</a>, "
+"and\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/CB-307\">CritiqueBrainz</a>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:80
 msgid "Restriction of processing"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:110
+#: metabrainz/templates/index/gdpr.html:83
+msgid ""
+"Summary: <i>To allow the user to control how their personally identifying"
+" data is being used.</i>"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:86
+msgid ""
+"Except for the ListenBrainz and AcousticBrainz projects, we do not "
+"process personally identifying data. Any personally\n"
+"    identifying data that our projects store is for the purpose of being "
+"able to contact you about your contributions to our database\n"
+"    (email address) or for voluntarily showing information about you to "
+"other users (biography, homepage, location, etc)."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:91
+#, python-format
+msgid ""
+"The ListenBrainz project differs in that the Listens (metadata about what"
+" music you have listened to) are stored on our servers\n"
+"    and <a href=\"%(listenbrainz_data_url)s\">made available to the "
+"public</a>. We believe Listens to be personally identifying\n"
+"    data and furthermore, we have goals of creating open source "
+"recommendation engines with this data, which involves processing the\n"
+"    user’s data. These two points are fundamental goals of the "
+"ListenBrainz project and we do not see a reasonable way to reach another"
+"\n"
+"    compromise position."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:99
+msgid ""
+"Because of this, we are going to require users to either acknowledge that"
+" we may process their Listen data or alternatively to\n"
+"    delete their account, including all of their Listens. Please note "
+"that if you decide to delete your ListenBrainz account, it may\n"
+"    take up to two weeks for all of your listens to no longer be included"
+" in our efforts to build a recommendation engine."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:104
+msgid ""
+"We have always made it clear that the data in ListenBrainz was to be "
+"public and that we plan to build new tools with your data, so\n"
+"    this should not come as a surprise to our users."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:108
+msgid ""
+"The AcousticBrainz project does not track who submits data to the "
+"database. If you create an account and use our data creation\n"
+"    tools (e.g. create a dataset or participate in a challenge) then we "
+"link your participation and the things that you create to\n"
+"    your account. If you choose to delete your account then we keep the "
+"non personally identifying data that you create, but anonymize\n"
+"    it so that it cannot be linked back to you."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:114
 msgid "Right to data portability / exporting your data"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:150
+#: metabrainz/templates/index/gdpr.html:117
+msgid ""
+"Summary: <i>You have the right to access/download the data we store about"
+" you</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:120
+msgid ""
+"Except for the ListenBrainz and AcousticBrainz projects, we do not store "
+"personally identifying data beyond the\n"
+"    information that is available in your public profile on each of our "
+"projects. Since this data is plainly available in your\n"
+"    profile we do not provide a means for you to export this data."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:125
+msgid "There are the following exceptions to this:"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:129
+msgid ""
+"<b>IP addresses</b>: If you visit one of our sites the IP address of your"
+" computer is stored in our web logs for 7 days\n"
+"        before our servers automatically delete them. This data is almost"
+" never used by anyone: the only time we look at the\n"
+"        IP addresses is if our sites are adversely impacted by the "
+"actions of some unknown users. In that case, we may investigate\n"
+"        the logs to identify the IP address that needs to be blocked in "
+"order to restore the stability of our service.\n"
+"        This data is not available to anyone but the contractors of the "
+"MetaBrainz Foundation and is not available to download\n"
+"        to anyone at all."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:137
+#, python-format
+msgid ""
+"<b>ListenBrainz Listen data</b>: Users may <a "
+"href=\"%(listenbrainz_export_url)s\">export their ListenBrainz Listen\n"
+"        data</a> directly from the site. The user Listen data is also "
+"included in the <a href=\"%(listenbrainz_data_url)s\">ListenBrainz\n"
+"        data dumps</a> that are available for public download."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:146
+msgid ""
+"All of the non personally identifying data, such as your metadata "
+"contributions, are publicly visible, available for download\n"
+"    and available via the project APIs. For details about this data, "
+"downloads and APIs please check the documentation for the\n"
+"    respective projects you are interested in."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:151
+#, python-format
+msgid ""
+"Anyone wishing to get a list of financial donations they have made to the"
+" MetaBrainz Foundation, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a> and provide your "
+"MusicBrainz editor name so that we can look up\n"
+"    your donations."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:157
 msgid "Right to rectification"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:165
+#: metabrainz/templates/index/gdpr.html:160
+msgid "Summary: <i>You have the right to correct your data</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:163
+msgid ""
+"All of our projects allow their users to update their personally "
+"identifying information in their profiles. Furthermore, most\n"
+"    of our projects allow the editing of their own metadata "
+"contributions. If you find that some of your data is incorrect, please\n"
+"    feel free to edit the data since we provide the tools to do so."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:168
+#, python-format
+msgid ""
+"If anyone who has made a financial donation to the MetaBrainz Foundation "
+"would like to make their donation private, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:173
 msgid "Right to be informed"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:188
+#: metabrainz/templates/index/gdpr.html:175
+msgid ""
+"Summary: <i>You have the right to be informed about how we use your data "
+"in plain English</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:178
+msgid ""
+"Our privacy policy, as well as other policies, have always been written "
+"by humans for human consumption. We abhor legalese and\n"
+"    not speaking in direct terms."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:186
+msgid "Social contract"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:189
+msgid "Code of conduct"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:192
+msgid "Privacy policy"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:196
 msgid "Right to access"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:198
-#: metabrainz/templates/index/privacy.html:166
+#: metabrainz/templates/index/gdpr.html:199
+msgid ""
+"Summary: <i>You have the right to access the data that we collect about "
+"you</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:202
+msgid ""
+"All of our projects make all of the data we collect on your behalf, "
+"privately identifying or not, available to you. The\n"
+"    only exception to this are the IP addresses we store for 7 days – see"
+" above for details."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:206
+#: metabrainz/templates/index/privacy.html:168
 msgid "Privacy/GDPR Representative"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:209
+#, python-format
+msgid ""
+"If you have any questions about our privacy policy, please <a "
+"href=\"%(contact_url)s\">contact us</a>. To report\n"
+"   any privacy problems, violations or leaks, our GDPR representative is "
+"our Interim Executive Director Nicolás Tamargo and for\n"
+"   privacy issues contact him at <strong><a "
+"href=\"mailto:gdpr@metabrainz.org\">gdpr@metabrainz.org</a></strong>."
 msgstr ""
 
 #: metabrainz/templates/index/index.html:6
@@ -1154,7 +1980,8 @@ msgid ""
 "An open music encyclopedia that collects music metadata and makes it\n"
 "              available to the public"
 msgstr ""
-"MusicBrainz on vaba muusikaentsüklopeedia, mis kogub andmeid muusika kohta\n"
+"MusicBrainz on vaba muusikaentsüklopeedia, mis kogub andmeid muusika "
+"kohta\n"
 "                        ja teeb need üldsusele kättesaadavaks"
 
 #: metabrainz/templates/index/index.html:40
@@ -1224,7 +2051,7 @@ msgid ""
 "      <a href=\"%(about_url)s\">about</a> page."
 msgstr ""
 
-#: frontend/js/src/forms/ConditionsModal.tsx:43
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:32
 #: metabrainz/templates/index/privacy.html:3
 msgid "Privacy"
 msgstr "Privaatsus"
@@ -1232,6 +2059,44 @@ msgstr "Privaatsus"
 #: metabrainz/templates/index/privacy.html:8
 msgid "Summary"
 msgstr "Kokkuvõte"
+
+#: metabrainz/templates/index/privacy.html:12
+msgid ""
+"You do not have to provide any personal data to be able to browse the "
+"contents of the databases published by MetaBrainz."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:15
+msgid ""
+"You do not have to provide any personally-identifying information if you "
+"choose not to."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:18
+msgid ""
+"We will never reveal your email address on MetaBrainz controlled web "
+"sites."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:22
+msgid ""
+"In order to get maximum value out of the MetaBrainz projects, you may "
+"want to create an account and log in. \n"
+"    Doing so grants you the ability to: edit the databases, contribute "
+"your own data, communicate with other users, and keep track \n"
+"    of recently released music from artists in your MusicBrainz "
+"collection. If you choose to create an account then the minimum we \n"
+"    ask is that you: choose a unique username and password, use a web "
+"browser that accepts \"session\" cookies, and provide a verified \n"
+"    email address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:29
+msgid ""
+"If you do not create an account (or are not logged in) you will not have "
+"access to the above listed features, however, you will \n"
+"    still have full access to browse and examine the databases."
+msgstr ""
 
 #: metabrainz/templates/index/privacy.html:33
 msgid "Applicable to all users"
@@ -1241,39 +2106,197 @@ msgstr "Kehtib kõigile kasutajatele"
 msgid "Cookies"
 msgstr "Küpsised"
 
+#: metabrainz/templates/index/privacy.html:37
+msgid "We use two cookies that contain sensitive information:"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:42
+msgid ""
+"<b>remember_login</b>: If you choose the \"Log in permanently\" option "
+"when logging in to one of our sites; the cookie will be used to \n"
+"      remember your login details."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:46
+msgid ""
+"<b>musicbrainz_server_session, session, or connect.sid</b>: If you are "
+"logged into one of our sites, your current session ID is stored in this "
+"cookie."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:51
+msgid ""
+"We may store dynamic preference information in other cookies, but these "
+"do not contain any sensitive information."
+msgstr ""
+
 #: metabrainz/templates/index/privacy.html:54
 msgid "Web and FTP access logs"
 msgstr "Veebiliikluse ja FTP-ligipääsu logid"
+
+#: metabrainz/templates/index/privacy.html:57
+msgid ""
+"In a practice similar to other web sites (and APIs) we keep logs of all "
+"web requests made against our servers. These logs include: your IP\n"
+"    address, your browser's (or API client's) \"User-Agent\" string, and "
+"which page (or API endpoint) you requested with which parameters. "
+"Aggregate information about web and FTP traffic is\n"
+"    made available to the public via our site usage pages."
+msgstr ""
 
 #: metabrainz/templates/index/privacy.html:62
 msgid "Third-Party content"
 msgstr "Kolmandate osapoolte sisu"
 
-#: metabrainz/templates/index/privacy.html:92
+#: metabrainz/templates/index/privacy.html:64
+msgid ""
+"Our projects' web pages may load some third-party content. Some, but "
+"possibly not all sites are listed below:"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:69
+#, python-format
+msgid ""
+"Cover art and other images: These are provided by the various cover art "
+"sites that have given MusicBrainz permission to do so and our own \n"
+"      <a href=\"%(caa_url)s\">Cover Art Archive</a>. This means that the "
+"relevant site will know (if they want to) your IP \n"
+"      address, User-Agent string, etc., and which MusicBrainz web page "
+"you were visiting (the one which included the cover art image)."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:75
+msgid ""
+"AcoustID: Our fingerprints tab loads fingerprint information from "
+"acoustid.org."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:78
+msgid ""
+"MTCaptcha: Our account creation page loads third party content in order "
+"to prevent spammers from creating accounts."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:83
+msgid ""
+"<i>The above information assumes that you are using \"normal\" web "
+"browser settings, whereby images are always loaded and HTTP referrer \n"
+"    information is always sent.</i>"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:88
+msgid ""
+"It is impractical to constantly modify this privacy policy when "
+"MetaBrainz projects change which third party content they utilize. We "
+"will \n"
+"    aim to use common sense, respect to our community and community "
+"review when adding more content from third party sites. We will also \n"
+"    periodically review our policy to ensure that it remains current."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:93
 msgid "Applicable to account holders"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:94
+#: metabrainz/templates/index/privacy.html:95
 msgid "Account creation"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:108
+#: metabrainz/templates/index/privacy.html:97
+msgid ""
+"When creating an account with a MetaBrainz project you need to pick a "
+"unique username and choose a password, the username you pick is the \n"
+"    only name associated with your account and will be what other "
+"MetaBrainz users know you as. You may optionally also tell us other \n"
+"    information about yourself that will be displayed to other MetaBrainz"
+" users and the public."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:103
+msgid ""
+"Additionally, in order to edit the databases you will need to provide a "
+"confirmed email address. This email address will be held in \n"
+"    confidence, the only method of revealing your email address to "
+"another user is if you choose to send a message to another \n"
+"    user and enable the option to \"reveal my email address\". Changing "
+"the email address stored with your account will require you to \n"
+"    verify the new address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:109
 msgid "Edits and Notes"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:114
+#: metabrainz/templates/index/privacy.html:111
+msgid ""
+"If you make any changes to a MetaBrainz project database, such as adding "
+"any data, the details of those changes will be visible to \n"
+"    other logged-in users and the change will be associated with your "
+"username."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:115
 msgid "Subscriptions on MusicBrainz"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:131
+#: metabrainz/templates/index/privacy.html:117
+msgid ""
+"As a logged-in user you can subscribe to one or more artists, labels, "
+"collections or other editors. The act of subscribing causes \n"
+"    any edits made to (or by in the case of another editor) those "
+"entities to be emailed to you. By default, other users can see your \n"
+"    list of subscriptions, however, you can opt out of this by editing "
+"the appropriate preference."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:123
+msgid ""
+"This does not provide \"perfect\" privacy though, in some cases it will "
+"be possible to infer information about the contents of your \n"
+"    subscription list even though you have disallowed others from viewing"
+" that list directly. This imperfection arises because various \n"
+"    parts of the system behave differently depending on whether or not an"
+" entity has any subscribers; also, the number of users \n"
+"    subscribed to each artist is available via the artist pages. In the "
+"most extreme (possibly contrived) example, imagine that all \n"
+"    users have their subscriptions set to \"public\", except for exactly "
+"one user whose list is \"private\". In that case, any discrepancy \n"
+"    for a given artist between the shown list of subscribers and the "
+"total number of subscribers must be down to that one user. Thus, \n"
+"    you can infer what artists are on that user's list."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:132
 msgid "Third-party sites"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:145
-msgid "MetaBrainz donors"
+#: metabrainz/templates/index/privacy.html:134
+#, python-format
+msgid ""
+"Our code reviews are done on GitHub, which is not under the control of "
+"MetaBrainz. Participating in code reviews or other\n"
+"    tasks carried out on GitHub are subject to <a "
+"href=\"%(github_url)s\">GitHub's privacy policy</a>."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:140
+#, python-format
+msgid ""
+"Our translations platform is provided and hosted by Weblate, which has a "
+"data processing agreement with MetaBrainz.\n"
+"    Participating in translations is subject to <a "
+"href=\"%(weblate_url)s\">dedicated legal terms</a>.\n"
+"    Any translations you make will be submitted to our Git repositories "
+"and publicly associated with your username;\n"
+"    if you so choose, you can also publicly associate them with your own "
+"verified email address."
 msgstr ""
 
 #: metabrainz/templates/index/privacy.html:147
+msgid "MetaBrainz donors"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:149
 msgid ""
 "When you make a donation to the MetaBrainz Foundation, we are legally\n"
 "    required to collect your personal information and keep it in our "
@@ -1283,7 +2306,7 @@ msgid ""
 "    information to anyone else, ever."
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:153
+#: metabrainz/templates/index/privacy.html:155
 msgid ""
 "We believe in transparent finances, which means that we list all "
 "donations\n"
@@ -1293,11 +2316,34 @@ msgid ""
 "process."
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:158
+#: metabrainz/templates/index/privacy.html:160
 msgid "Exceptions"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:598
+#: metabrainz/templates/index/privacy.html:162
+msgid ""
+"<i><b>Please note</b>: Reasonable exceptions may apply to the above "
+"policy, for example to comply with applicable laws.\n"
+"    Also, members of the MetaBrainz team and other personnel contracted "
+"to provide services to MetaBrainz may have access to\n"
+"    our infrastructure and could therefore view any information contained"
+" therein. However all personnel are contractually bound\n"
+"    by non-disclosure clauses which prevent them from making any such "
+"information available to others."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:171
+#, python-format
+msgid ""
+"If you have any questions about our GDPR statement, please <a "
+"href=\"%(contact_url)s\">contact us</a>. To report\n"
+"   any privacy problems, violations or leaks, our GDPR representative is "
+"our Interim Executive Director Nicolás Tamargo and for\n"
+"   privacy issues contact him at <strong><a "
+"href=\"mailto:gdpr@metabrainz.org\">gdpr@metabrainz.org</a></strong>."
+msgstr ""
+
+#: frontend/js/src/Profile.tsx:603
 #: frontend/js/src/forms/ProfileChangePassword.tsx:22
 #: frontend/js/src/forms/ProfileChangePassword.tsx:111
 #: metabrainz/templates/index/profile-change-password.html:3
@@ -1541,6 +2587,11 @@ msgstr ""
 
 #: metabrainz/templates/index/team.html:26
 msgid "He lives on in our hearts and in open source."
+msgstr ""
+
+#: metabrainz/templates/index/team.html:29
+#: metabrainz/templates/index/team.html:315
+msgid "you’re welcome to try"
 msgstr ""
 
 #: metabrainz/templates/index/team.html:39
@@ -2038,8 +3089,10 @@ msgstr ""
 
 #: metabrainz/templates/payments/donate.html:146
 msgid ""
-"Due to the increased unreliability of the US Postal Service we have "
-"stopped accepting paper checks. Sorry!"
+"Due to the increased unreliability of the US Postal Service and the "
+"relatively large fees involved, we ask you to only send a paper check if "
+"it is the only possible option. Due to the fees, we will not cash checks "
+"for less than $25."
 msgstr ""
 
 #: metabrainz/templates/payments/donate.html:241
@@ -2923,8 +3976,8 @@ msgid "Monthly balance sheets"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:520
-#: frontend/js/src/forms/SignupCommercial.tsx:175
-#: frontend/js/src/forms/SignupCommercial.tsx:554
+#: frontend/js/src/forms/SignupCommercial.tsx:180
+#: frontend/js/src/forms/SignupCommercial.tsx:558
 #: frontend/js/src/forms/SignupNonCommercial.tsx:106
 #: frontend/js/src/forms/SignupNonCommercial.tsx:318
 #: metabrainz/templates/supporters/account-type.html:3
@@ -2945,6 +3998,7 @@ msgid "Non-commercial / Personal"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:235
+#: frontend/js/src/forms/SignupNonCommercial.tsx:107
 #: frontend/js/src/forms/SignupNonCommercial.tsx:151
 #: metabrainz/templates/supporters/account-type.html:42
 msgid "Non-commercial"
@@ -2958,55 +4012,45 @@ msgstr ""
 msgid "Personal or university assignment user."
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:48
-#: metabrainz/templates/supporters/account-type.html:90
-#: metabrainz/templates/supporters/account-type.html:141
-msgid "Upgrade"
-msgstr ""
-
 #: frontend/js/src/Profile.tsx:235
-#: frontend/js/src/forms/SignupCommercial.tsx:176
-#: frontend/js/src/forms/SignupCommercial.tsx:228
-#: metabrainz/templates/supporters/account-type.html:61
+#: frontend/js/src/forms/SignupCommercial.tsx:181
+#: frontend/js/src/forms/SignupCommercial.tsx:233
+#: metabrainz/templates/supporters/account-type.html:56
 msgid "Commercial"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:83
-#: metabrainz/templates/supporters/account-type.html:135
+#: metabrainz/templates/supporters/account-type.html:78
+#: metabrainz/templates/supporters/account-type.html:125
 #, python-format
 msgid "$%(tier_price)s/month and up"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:87
-#: metabrainz/templates/supporters/account-type.html:138
+#: metabrainz/templates/supporters/account-type.html:82
+#: metabrainz/templates/supporters/account-type.html:128
 msgid "More info"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:104
+#: metabrainz/templates/supporters/account-type.html:94
 msgid "View all tiers"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:112
+#: metabrainz/templates/supporters/account-type.html:102
 msgid "Some of our Unicorn members"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:123
+#: metabrainz/templates/supporters/account-type.html:113
 msgid "See all our supporters"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:151
+#: metabrainz/templates/supporters/account-type.html:136
 msgid "View featured tiers"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:158
+#: metabrainz/templates/supporters/account-type.html:143
 #, python-format
 msgid ""
 "If you are not sure which tier to pick, please\n"
 "      <a href=\"%(contact_url)s\">contact us</a>."
-msgstr ""
-
-#: metabrainz/templates/supporters/account-type.html:166
-msgid "Back to Profile"
 msgstr ""
 
 #: metabrainz/templates/supporters/bad-standing.html:3
@@ -3068,9 +4112,9 @@ msgid "Forgot your username"
 msgstr "Kas unustasid oma kasutajanime"
 
 #: frontend/js/src/forms/ResetPassword.tsx:79
-#: frontend/js/src/forms/SignupCommercial.tsx:320
+#: frontend/js/src/forms/SignupCommercial.tsx:325
 #: frontend/js/src/forms/SignupNonCommercial.tsx:227
-#: frontend/js/src/forms/SignupUser.tsx:169
+#: frontend/js/src/forms/SignupUser.tsx:175
 #: metabrainz/templates/users/reauthenticate.html:3
 #: metabrainz/templates/users/reauthenticate.html:6
 msgid "Confirm Password"
@@ -3080,56 +4124,61 @@ msgstr "Kinnita salasõna"
 msgid "Please re-enter your password to continue."
 msgstr "Jätkamiseks palun sisesta salasõna uuesti."
 
-#: frontend/js/src/ProfileDelete.tsx:108
+#: frontend/js/src/ProfileDelete.tsx:110
 #: frontend/js/src/forms/DeleteApplication.tsx:53
 #: frontend/js/src/forms/OAuthPrompt.tsx:54
 #: frontend/js/src/forms/ProfileChangePassword.tsx:104
 #: frontend/js/src/forms/ProfileEdit.tsx:105
-#: metabrainz/templates/users/reauthenticate.html:23
+#: metabrainz/templates/users/reauthenticate.html:28
 msgid "Cancel"
 msgstr "Katkesta"
 
-#: metabrainz/templates/users/reauthenticate.html:24
+#: metabrainz/templates/users/reauthenticate.html:29
 msgid "Continue"
 msgstr "Jätka"
+
+#: frontend/js/src/forms/utils.tsx:202
+#: metabrainz/templates/users/reauthenticate.html:40
+msgid "Password must not exceed 72 bytes."
+msgstr ""
 
 #: frontend/js/src/forms/ResetPassword.tsx:27
 #: metabrainz/templates/users/reset-password.html:3
 msgid "Reset your password"
 msgstr "Lähtesta oma salasõna"
 
-#: frontend/js/src/hooks/useEmailValidation.ts:41 metabrainz/user/forms.py:15
+#: frontend/js/src/hooks/useEmailValidation.ts:41 metabrainz/user/forms.py:16
 msgid "Registration from this email domain is not allowed."
 msgstr "Registreerimine pole selle e-postidomeeni puhul lubatud."
 
 #: frontend/js/src/forms/LoginUser.tsx:50
 #: frontend/js/src/forms/LostPassword.tsx:45
-#: frontend/js/src/forms/SignupCommercial.tsx:270
+#: frontend/js/src/forms/SignupCommercial.tsx:275
 #: frontend/js/src/forms/SignupNonCommercial.tsx:175
-#: frontend/js/src/forms/SignupUser.tsx:114 metabrainz/user/forms.py:20
-#: metabrainz/user/forms.py:45 metabrainz/user/forms.py:62
+#: frontend/js/src/forms/SignupUser.tsx:120 metabrainz/user/forms.py:22
+#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:75
 msgid "Username"
 msgstr "Kasutajanimi"
 
 #: frontend/js/src/forms/LoginUser.tsx:42
 #: frontend/js/src/forms/LostPassword.tsx:37
-#: frontend/js/src/forms/SignupCommercial.tsx:153
+#: frontend/js/src/forms/SignupCommercial.tsx:158
 #: frontend/js/src/forms/SignupNonCommercial.tsx:84
-#: frontend/js/src/forms/SignupUser.tsx:67 metabrainz/user/forms.py:21
-#: metabrainz/user/forms.py:45 metabrainz/user/forms.py:62
+#: frontend/js/src/forms/SignupUser.tsx:73 metabrainz/user/forms.py:26
+#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:75
 msgid "Username is required!"
 msgstr "Kasutajanime sisestamine on kohustuslik!"
 
 #: frontend/js/src/forms/LoginUser.tsx:63
 #: frontend/js/src/forms/ResetPassword.tsx:72
-#: frontend/js/src/forms/SignupCommercial.tsx:308
+#: frontend/js/src/forms/SignupCommercial.tsx:313
 #: frontend/js/src/forms/SignupNonCommercial.tsx:214
-#: frontend/js/src/forms/SignupUser.tsx:157 metabrainz/user/forms.py:46
-#: metabrainz/user/forms.py:52
+#: frontend/js/src/forms/SignupUser.tsx:163 metabrainz/user/forms.py:53
+#: metabrainz/user/forms.py:62
 msgid "Password"
 msgstr "Salasõna"
 
-#: frontend/js/src/forms/LoginUser.tsx:76 metabrainz/user/forms.py:47
+#: frontend/js/src/forms/LoginUser.tsx:76 metabrainz/user/forms.py:57
 msgid "Remember me"
 msgstr "Jäta mind meelde"
 
@@ -3141,11 +4190,11 @@ msgstr "Kasutajanimi pole korrektne."
 msgid "Username contains invalid or invisible characters."
 msgstr "Kasutajanimes on vigaseid või nähtamatuid tähemärke."
 
-#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:181
+#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:220
 msgid "Hide password"
 msgstr "Peida salasõna"
 
-#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:181
+#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:220
 msgid "Show password"
 msgstr "Näita salasõna"
 
@@ -3202,11 +4251,11 @@ msgstr "Juurdepääs"
 msgid "Revoke access"
 msgstr "Tühista juurdepääs"
 
-#: frontend/js/src/OAuthError.tsx:17
+#: frontend/js/src/OAuthError.tsx:18
 msgid "OAuth2 Error"
 msgstr "Viga OAuth2 kasutamisel"
 
-#: frontend/js/src/OAuthError.tsx:18
+#: frontend/js/src/OAuthError.tsx:19
 msgid "An error occurred during OAuth authentication process."
 msgstr ""
 
@@ -3236,8 +4285,8 @@ msgstr ""
 
 #: frontend/js/src/Profile.tsx:109
 msgid ""
-"Are you sure you want to generate new access token? Current token will be"
-" revoked!"
+"Are you sure you want to generate a new access token? The current token "
+"will be revoked!"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:118
@@ -3352,8 +4401,8 @@ msgid "Contact Information"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:310 frontend/js/src/forms/ProfileEdit.tsx:70
-#: frontend/js/src/forms/SignupCommercial.tsx:284
-#: frontend/js/src/forms/SignupCommercial.tsx:333
+#: frontend/js/src/forms/SignupCommercial.tsx:289
+#: frontend/js/src/forms/SignupCommercial.tsx:338
 #: frontend/js/src/forms/SignupNonCommercial.tsx:189
 #: frontend/js/src/forms/SignupNonCommercial.tsx:241
 msgid "Contact name"
@@ -3468,7 +4517,7 @@ msgstr ""
 msgid "Once you delete your account, there is no going back. Please be certain."
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:550 frontend/js/src/ProfileDelete.tsx:105
+#: frontend/js/src/Profile.tsx:550 frontend/js/src/ProfileDelete.tsx:107
 msgid "Delete My Account"
 msgstr ""
 
@@ -3480,39 +4529,39 @@ msgstr ""
 msgid "Need to delete your account?"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:574
+#: frontend/js/src/Profile.tsx:575
 msgid ""
 "Deletion of supporter accounts requires manual review. Please contact us "
-"at"
+"at <email />."
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:594
+#: frontend/js/src/Profile.tsx:599
 msgid "Security"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:626
+#: frontend/js/src/Profile.tsx:631
 msgid "MetaBrainz Applications"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:630
+#: frontend/js/src/Profile.tsx:635
 msgid ""
 "With your MetaBrainz account, you can access every project in the "
 "MetaBrainz family:"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:643
+#: frontend/js/src/Profile.tsx:648
 msgid "The open-source music encyclopedia"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:655
+#: frontend/js/src/Profile.tsx:660
 msgid "Track, visualise and share the music you listen to"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:667
+#: frontend/js/src/Profile.tsx:672
 msgid "The open-source book database"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:679
+#: frontend/js/src/Profile.tsx:684
 msgid "Creative Commons licensed reviews"
 msgstr ""
 
@@ -3535,7 +4584,7 @@ msgid "Permanently remove all your account information"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:64
-msgid "Revoke all your API tokens and access"
+msgid "Revoke all your tokens and access to the replication API"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:65
@@ -3547,14 +4596,16 @@ msgid "Log you out of all MetaBrainz services"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:70
-msgid "Your username will be reserved and cannot be reused."
+msgid ""
+"Your username will be reserved and cannot be reused without the "
+"intervention of an administrator."
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:82
+#: frontend/js/src/ProfileDelete.tsx:84
 msgid "To confirm, type your username '<username />' below:"
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:105
+#: frontend/js/src/ProfileDelete.tsx:107
 msgid "Deleting..."
 msgstr ""
 
@@ -3566,64 +4617,7 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: frontend/js/src/forms/ConditionsModal.tsx:23
-msgid "Licensing"
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:25
-msgid ""
-"Any contributions you make to any MetaBrainz service will be released "
-"into the Public Domain and/or licensed under a Creative Commons by-nc-sa "
-"license. Furthermore, you give the MetaBrainz Foundation the right to "
-"license this data for commercial use."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:30
-msgid "Please read our <licenseLink>license page</licenseLink> for more details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:45
-msgid ""
-"MetaBrainz strongly believes in the privacy of its users. Any personal "
-"information you choose to provide will not be sold or shared with anyone "
-"else."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:50
-msgid ""
-"Please read our <privacyLink>privacy policy</privacyLink> for more "
-"details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:59
-msgid "GDPR compliance"
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:61
-msgid ""
-"You may remove your personal information from our services anytime by "
-"deleting your account."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:66
-msgid ""
-"Please read our <gdprLink>GDPR compliance statement</gdprLink> for more "
-"details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:78
-msgid ""
-"Creating an account on MetaBrainz will give you access to all of our "
-"projects, such as MusicBrainz, ListenBrainz, BookBrainz, and more."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:82
-msgid ""
-"We create a placeholder account for all the MetaBrainz projects when you "
-"sign up, and you are one log-in away from activating them."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:91
+#: frontend/js/src/forms/ConditionsModal.tsx:29
 msgid "Sounds good"
 msgstr ""
 
@@ -3709,8 +4703,8 @@ msgstr ""
 msgid "Forgot your password?"
 msgstr "Kas unustasid oma salasõna?"
 
-#: frontend/js/src/forms/LoginUser.tsx:109
-msgid "Don't have an account?"
+#: frontend/js/src/forms/LoginUser.tsx:110
+msgid "Don't have an account? <signupLink>Sign up</signupLink>"
 msgstr ""
 
 #: frontend/js/src/forms/LostPassword.tsx:38
@@ -3739,15 +4733,72 @@ msgstr ""
 msgid "Allow access"
 msgstr ""
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:71
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:10
+msgid "Licensing"
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:12
+msgid ""
+"Any contributions you make to any MetaBrainz service will be released "
+"into the Public Domain and/or licensed under a Creative Commons by-nc-sa "
+"license. Furthermore, you give the MetaBrainz Foundation the right to "
+"license this data for commercial use."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:17
+msgid "Please read our <licenseLink>license page</licenseLink> for more details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:34
+msgid ""
+"MetaBrainz strongly believes in the privacy of its users. Any personal "
+"information you choose to provide will not be sold or shared with anyone "
+"else."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:39
+msgid ""
+"Please read our <privacyLink>privacy policy</privacyLink> for more "
+"details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:50
+msgid "GDPR compliance"
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:52
+msgid ""
+"You may remove your personal information from our services anytime by "
+"deleting your account."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:57
+msgid ""
+"Please read our <gdprLink>GDPR compliance statement</gdprLink> for more "
+"details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:71
+msgid ""
+"Creating an account on MetaBrainz will give you access to all of our "
+"projects, such as MusicBrainz, ListenBrainz, BookBrainz, and more."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:75
+msgid ""
+"We create a placeholder account for all the MetaBrainz projects when you "
+"sign up, and you are one log-in away from activating them."
+msgstr ""
+
+#: frontend/js/src/forms/ProfileChangePassword.tsx:70
 msgid "Current Password"
 msgstr "Senine salasõna"
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:80
+#: frontend/js/src/forms/ProfileChangePassword.tsx:79
 msgid "New Password"
 msgstr "Uus salasõna"
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:89
+#: frontend/js/src/forms/ProfileChangePassword.tsx:88
 msgid "Confirm New Password"
 msgstr "Korda uut salasõna"
 
@@ -3759,190 +4810,180 @@ msgstr ""
 msgid "Reset Password"
 msgstr "Lähtesta salasõna"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:38
-msgid "If you would like to support us with more than $"
+#: frontend/js/src/forms/SignupCommercial.tsx:40
+msgid ""
+"If you would like to support us with more than ${{minPledge}}, please "
+"enter the actual amount here:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:39
-msgid ", please enter the actual amount here:"
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:144
+#: frontend/js/src/forms/SignupCommercial.tsx:149
 #: frontend/js/src/forms/SignupNonCommercial.tsx:75
-#: frontend/js/src/forms/SignupUser.tsx:87
+#: frontend/js/src/forms/SignupUser.tsx:93
 msgid "Captcha is required!"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:179
+#: frontend/js/src/forms/SignupCommercial.tsx:184
 #: frontend/js/src/forms/SignupNonCommercial.tsx:110
 #: frontend/js/src/forms/SignupUser.tsx:46
 msgid "Access all MetaBrainz projects"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:182
+#: frontend/js/src/forms/SignupCommercial.tsx:187
 msgid "Note:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:184
+#: frontend/js/src/forms/SignupCommercial.tsx:189
 msgid ""
 "Signing up for any tier other than the <italic>Stealth startup</italic> "
 "tier will publicly list your company on this web site. However, we will "
 "not publish any of your private details."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:221
+#: frontend/js/src/forms/SignupCommercial.tsx:226
 #: frontend/js/src/forms/SignupNonCommercial.tsx:145
 msgid "Account type"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:234
+#: frontend/js/src/forms/SignupCommercial.tsx:239
 msgid "Selected tier"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:242
-msgid "month and up"
+#: frontend/js/src/forms/SignupCommercial.tsx:247
+msgid "${{tierPrice}}/month and up"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:250
+#: frontend/js/src/forms/SignupCommercial.tsx:255
 msgid "Change account type or tier"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:261
+#: frontend/js/src/forms/SignupCommercial.tsx:266
 #: frontend/js/src/forms/SignupNonCommercial.tsx:166
 msgid "Your account:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:271
+#: frontend/js/src/forms/SignupCommercial.tsx:276
 #: frontend/js/src/forms/SignupNonCommercial.tsx:176
-#: frontend/js/src/forms/SignupUser.tsx:114
+#: frontend/js/src/forms/SignupUser.tsx:120
 msgid "(public)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:291
+#: frontend/js/src/forms/SignupCommercial.tsx:296
 #: frontend/js/src/forms/SignupNonCommercial.tsx:196
-#: frontend/js/src/forms/SignupUser.tsx:127
+#: frontend/js/src/forms/SignupUser.tsx:133
 msgid "E-mail address"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:295
+#: frontend/js/src/forms/SignupCommercial.tsx:300
 #: frontend/js/src/forms/SignupNonCommercial.tsx:200
-#: frontend/js/src/forms/SignupUser.tsx:131
+#: frontend/js/src/forms/SignupUser.tsx:137
 msgid "(checking...)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:314
+#: frontend/js/src/forms/SignupCommercial.tsx:319
 #: frontend/js/src/forms/SignupNonCommercial.tsx:220
-#: frontend/js/src/forms/SignupUser.tsx:163
+#: frontend/js/src/forms/SignupUser.tsx:169
 msgid "Must be at least 8 characters"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:348
+#: frontend/js/src/forms/SignupCommercial.tsx:353
 msgid ""
 "If you don't have an organization name, you probably want to become a "
 "supporter as a <nonCommercialLink>Non-commercial / "
 "Personal</nonCommercialLink> supporter."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:358
+#: frontend/js/src/forms/SignupCommercial.tsx:363
 msgid ""
 "If you don't have an organization name, you probably want to sign up as a"
 " <nonCommercialLink>Non-commercial / Personal</nonCommercialLink> user."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:378
+#: frontend/js/src/forms/SignupCommercial.tsx:383
 msgid ""
 "Please tell us a little about your company and whether you plan to use "
 "our <apiLink>API</apiLink> or to <hostLink>host your own copy</hostLink> "
 "of the data."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:404
+#: frontend/js/src/forms/SignupCommercial.tsx:408
 msgid "Logo URL"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:405
+#: frontend/js/src/forms/SignupCommercial.tsx:409
 msgid "(preferably in SVG format)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:408
+#: frontend/js/src/forms/SignupCommercial.tsx:412
 msgid ""
 "Image should be about 250 pixels wide on a white or transparent "
 "background. We will host it on our site."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:421
+#: frontend/js/src/forms/SignupCommercial.tsx:425
 msgid ""
 "URL to where developers can use your APIs using MusicBrainz IDs, if "
-"available.."
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:430
-msgid "Your project"
+"available."
 msgstr ""
 
 #: frontend/js/src/forms/SignupCommercial.tsx:434
+msgid "Your project"
+msgstr ""
+
+#: frontend/js/src/forms/SignupCommercial.tsx:438
 #: frontend/js/src/forms/SignupNonCommercial.tsx:261
 msgid "(max 150 characters)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:451
+#: frontend/js/src/forms/SignupCommercial.tsx:455
 msgid "Billing address"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:502
+#: frontend/js/src/forms/SignupCommercial.tsx:506
 msgid ""
 "I agree to support the MetaBrainz Foundation when my organization is able"
 " to do so."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:507
+#: frontend/js/src/forms/SignupCommercial.tsx:511
+#: frontend/js/src/forms/SignupNonCommercial.tsx:284
 msgid ""
-"I also agree that if I generate a Live Data Feed access token, that I "
-"treat my access token as a secret and will not share this token publicly "
-"or commit it to a source code repository."
+"I also agree that if I generate a Live Data Feed access token, then I "
+"will treat my access token as a secret and will not share this token "
+"publicly or commit it to a source code repository."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:515
+#: frontend/js/src/forms/SignupCommercial.tsx:519
 msgid ""
 "The following information will be shown publicly: organization name, "
 "logo, website and API URLs, data usage description."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:520
+#: frontend/js/src/forms/SignupCommercial.tsx:524
 msgid ""
 "We'll send you more details about payment process once your application "
 "is approved."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:552
+#: frontend/js/src/forms/SignupCommercial.tsx:556
 #: frontend/js/src/forms/SignupNonCommercial.tsx:316
-#: frontend/js/src/forms/SignupUser.tsx:224
+#: frontend/js/src/forms/SignupUser.tsx:230
 msgid "Validating..."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:564
+#: frontend/js/src/forms/SignupCommercial.tsx:568
 #: frontend/js/src/forms/SignupNonCommercial.tsx:329
 msgid "Back to profile"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:569
-#: frontend/js/src/forms/SignupNonCommercial.tsx:334
-msgid "Not a supporter?"
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:570
+#: frontend/js/src/forms/SignupCommercial.tsx:574
 #: frontend/js/src/forms/SignupNonCommercial.tsx:335
-msgid "Create a user account"
+msgid "Not a supporter? <signupLink>Create a user account</signupLink>"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:573
-#: frontend/js/src/forms/SignupNonCommercial.tsx:338
-#: frontend/js/src/forms/SignupUser.tsx:231
-msgid "Already have an account?"
-msgstr ""
-
-#: frontend/js/src/forms/SignupNonCommercial.tsx:107
-msgid "non-commercial"
+#: frontend/js/src/forms/SignupCommercial.tsx:583
+#: frontend/js/src/forms/SignupNonCommercial.tsx:344
+#: frontend/js/src/forms/SignupUser.tsx:238
+msgid "Already have an account? <loginLink>Sign in</loginLink>"
 msgstr ""
 
 #: frontend/js/src/forms/SignupNonCommercial.tsx:113
@@ -3970,46 +5011,40 @@ msgid ""
 "income per year) or personal uses only."
 msgstr ""
 
-#: frontend/js/src/forms/SignupNonCommercial.tsx:284
-msgid ""
-"I also agree that if I generate a Live Data Feed access token, then I "
-"will treat my access token as a secret and will not share this token "
-"publicly or commit it to a source code repository."
-msgstr ""
-
 #: frontend/js/src/forms/SignupUser.tsx:43
 msgid "Create your account"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:50
-msgid "Registration started by"
+#: frontend/js/src/forms/SignupUser.tsx:51
+msgid "Registration started by <client />"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:69
+#: frontend/js/src/forms/SignupUser.tsx:75
+#: frontend/js/src/hooks/useEmailValidation.ts:82
 msgid "Invalid email address."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:150
+#: frontend/js/src/forms/SignupUser.tsx:156
 msgid ""
 "This username and email were provided by the app that started "
 "registration. You can change them later from MetaBrainz settings."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:182
+#: frontend/js/src/forms/SignupUser.tsx:188
 msgid ""
 "I accept that my contributions will be released into the public domain or"
 " licensed for use."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:191
+#: frontend/js/src/forms/SignupUser.tsx:197
 msgid "We will never share your personal information."
 msgstr "Me iialgi ei jaga sinu isikuandmeid."
 
-#: frontend/js/src/forms/SignupUser.tsx:200
+#: frontend/js/src/forms/SignupUser.tsx:206
 msgid "Click here to read more"
 msgstr "Lisateabe lugemiseks klõpsa siia"
 
-#: frontend/js/src/forms/SignupUser.tsx:224
+#: frontend/js/src/forms/SignupUser.tsx:230
 msgid "Create account"
 msgstr "Loo kasutajakonto"
 
@@ -4020,10 +5055,6 @@ msgstr "See e-posti aadress on juba registreeritud."
 #: frontend/js/src/hooks/useEmailValidation.ts:47
 msgid "Email validation failed"
 msgstr "E-posti aadressi õigsuse kontrollimine ei õnnestunud"
-
-#: frontend/js/src/hooks/useEmailValidation.ts:82
-msgid "Invalid email address"
-msgstr "Vigane e-posti aadress"
 
 #~ msgid "You need to specify amount!"
 #~ msgstr ""
@@ -5328,3 +6359,96 @@ msgstr "Vigane e-posti aadress"
 
 #~ msgid "Privacy policy"
 #~ msgstr ""
+
+#~ msgid "You need to specify website of the organization."
+#~ msgstr "Sa pead määratlema veebisaidi võrguaadressi."
+
+#~ msgid ""
+#~ "We are currently evaluating our overall"
+#~ " online advertising strategy. We are "
+#~ "evaluating advertising, traffic optimization,\n"
+#~ ""
+#~ "    search engine optimization and "
+#~ "software monitization technologies. If you "
+#~ "provide these professional services, please"
+#~ " provide a detailed\n"
+#~ "    deck of your comprehensive services"
+#~ " to the following email address. "
+#~ "<em>Please respect our other non-media"
+#~ " teams and do not contact us \n"
+#~ "    regarding these services on any "
+#~ "other of our email addresses. We "
+#~ "will disregard the entirety of your "
+#~ "submissions if you contact us any "
+#~ "other way!</em>"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Please come ask your questions at "
+#~ "our <a href=\"%(forums_url)s\">forums</a>! We "
+#~ "would love to\n"
+#~ "    answer any questions you may have."
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Due to the increased unreliability of"
+#~ " the US Postal Service we have "
+#~ "stopped accepting paper checks. Sorry!"
+#~ msgstr ""
+
+#~ msgid "Upgrade"
+#~ msgstr ""
+
+#~ msgid "Back to Profile"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Deletion of supporter accounts requires "
+#~ "manual review. Please contact us at"
+#~ msgstr ""
+
+#~ msgid "Revoke all your API tokens and access"
+#~ msgstr ""
+
+#~ msgid "Your username will be reserved and cannot be reused."
+#~ msgstr ""
+
+#~ msgid "Don't have an account?"
+#~ msgstr ""
+
+#~ msgid "If you would like to support us with more than $"
+#~ msgstr ""
+
+#~ msgid ", please enter the actual amount here:"
+#~ msgstr ""
+
+#~ msgid "month and up"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "I also agree that if I generate"
+#~ " a Live Data Feed access token, "
+#~ "that I treat my access token as"
+#~ " a secret and will not share "
+#~ "this token publicly or commit it "
+#~ "to a source code repository."
+#~ msgstr ""
+
+#~ msgid "Not a supporter?"
+#~ msgstr ""
+
+#~ msgid "Create a user account"
+#~ msgstr ""
+
+#~ msgid "Already have an account?"
+#~ msgstr ""
+
+#~ msgid "non-commercial"
+#~ msgstr ""
+
+#~ msgid "Registration started by"
+#~ msgstr ""
+
+#~ msgid "Invalid email address"
+#~ msgstr "Vigane e-posti aadress"
+

--- a/metabrainz/translations/fi/LC_MESSAGES/messages.po
+++ b/metabrainz/translations/fi/LC_MESSAGES/messages.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-07-25 16:21+0200\n"
+"POT-Creation-Date: 2026-09-08 11:18+0200\n"
 "PO-Revision-Date: 2026-06-12 00:52+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: fi\n"
@@ -21,162 +21,247 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.18.0\n"
 
-#: metabrainz/index/forms.py:46
+#: metabrainz/errors.py:24
+msgid "Authorization was declined."
+msgstr ""
+
+#: metabrainz/errors.py:25
+msgid "The authorization request was invalid."
+msgstr ""
+
+#: metabrainz/errors.py:26
+msgid "The application could not be authenticated."
+msgstr ""
+
+#: metabrainz/errors.py:27
+msgid "This application is not allowed to request authorization."
+msgstr ""
+
+#: metabrainz/errors.py:28
+msgid "The application asked for a response type this server does not support."
+msgstr ""
+
+#: metabrainz/errors.py:29
+msgid "The permissions requested by the application are invalid."
+msgstr ""
+
+#: metabrainz/errors.py:30
+msgid "You need to sign in to continue."
+msgstr ""
+
+#: metabrainz/errors.py:31
+msgid "Your consent is required to continue."
+msgstr ""
+
+#: metabrainz/password.py:12
+#, python-format
+msgid "Password must not exceed %(max_bytes)s bytes."
+msgstr ""
+
+#: metabrainz/index/forms.py:48
 #, python-format
 msgid "'%(value)s' is not a valid choice for this field"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileEdit.tsx:27
-#: frontend/js/src/forms/SignupCommercial.tsx:154
+#: frontend/js/src/forms/SignupCommercial.tsx:159
 #: frontend/js/src/forms/SignupNonCommercial.tsx:85
-#: frontend/js/src/forms/SignupUser.tsx:70
-#: frontend/js/src/hooks/useEmailValidation.ts:78 metabrainz/index/forms.py:57
-#: metabrainz/user/forms.py:25 metabrainz/user/forms.py:57
-#: metabrainz/user/forms.py:63
+#: frontend/js/src/forms/SignupUser.tsx:76
+#: frontend/js/src/hooks/useEmailValidation.ts:78 metabrainz/index/forms.py:59
+#: metabrainz/user/forms.py:31 metabrainz/user/forms.py:70
+#: metabrainz/user/forms.py:76
 msgid "Email address is required!"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:34
-#: metabrainz/index/forms.py:63
+#: metabrainz/index/forms.py:65
 msgid "Current password is required!"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:43
 #: frontend/js/src/forms/ProfileChangePassword.tsx:37
 #: frontend/js/src/forms/ResetPassword.tsx:39
-#: frontend/js/src/forms/SignupCommercial.tsx:156
+#: frontend/js/src/forms/SignupCommercial.tsx:161
 #: frontend/js/src/forms/SignupNonCommercial.tsx:87
-#: frontend/js/src/forms/SignupUser.tsx:72 metabrainz/index/forms.py:66
-#: metabrainz/user/forms.py:29 metabrainz/user/forms.py:46
-#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:69
+#: frontend/js/src/forms/SignupUser.tsx:78 metabrainz/index/forms.py:69
+#: metabrainz/user/forms.py:35 metabrainz/user/forms.py:54
+#: metabrainz/user/forms.py:63 metabrainz/user/forms.py:82
 msgid "Password is required!"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:41
-#: frontend/js/src/forms/SignupCommercial.tsx:160
+#: frontend/js/src/forms/SignupCommercial.tsx:165
 #: frontend/js/src/forms/SignupNonCommercial.tsx:91
-#: frontend/js/src/forms/SignupUser.tsx:76 metabrainz/index/forms.py:70
-#: metabrainz/user/forms.py:33 metabrainz/user/forms.py:73
+#: frontend/js/src/forms/SignupUser.tsx:82 metabrainz/index/forms.py:74
+#: metabrainz/user/forms.py:40 metabrainz/user/forms.py:87
 msgid "Confirm Password is required!"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:46
 #: frontend/js/src/forms/ResetPassword.tsx:48
-#: frontend/js/src/forms/SignupCommercial.tsx:165
+#: frontend/js/src/forms/SignupCommercial.tsx:170
 #: frontend/js/src/forms/SignupNonCommercial.tsx:96
-#: frontend/js/src/forms/SignupUser.tsx:81 metabrainz/index/forms.py:72
-#: metabrainz/user/forms.py:35 metabrainz/user/forms.py:75
+#: frontend/js/src/forms/SignupUser.tsx:87 metabrainz/index/forms.py:76
+#: metabrainz/user/forms.py:42 metabrainz/user/forms.py:89
 msgid "Confirm Password should match password!"
 msgstr ""
 
 #: frontend/js/src/Applications.tsx:56 frontend/js/src/Applications.tsx:86
 #: frontend/js/src/Profile.tsx:272 frontend/js/src/Profile.tsx:482
-#: metabrainz/index/forms.py:78
+#: metabrainz/index/forms.py:82
 msgid "Name"
 msgstr "Nimi"
 
-#: metabrainz/index/forms.py:79
+#: metabrainz/index/forms.py:83
 msgid "Contact name field is empty."
 msgstr ""
 
-#: metabrainz/index/views.py:234
+#: metabrainz/index/views.py:251
 msgid "Profile updated successfully."
 msgstr ""
 
-#: metabrainz/index/views.py:261
+#: metabrainz/index/views.py:278
 msgid "Current password is incorrect."
 msgstr ""
 
-#: metabrainz/index/views.py:266
+#: metabrainz/index/views.py:283
 msgid "Password changed successfully."
 msgstr ""
 
-#: metabrainz/index/views.py:372
+#: metabrainz/index/views.py:389
 msgid "You have updated an application!"
 msgstr ""
 
-#: metabrainz/index/views.py:424
+#: metabrainz/index/views.py:441
 msgid "You have deleted an application."
 msgstr ""
 
-#: metabrainz/index/views.py:426
+#: metabrainz/index/views.py:443
 msgid "Failed to delete an application."
 msgstr ""
 
-#: metabrainz/index/views.py:449
+#: metabrainz/index/views.py:466
 msgid "Revoked tokens successfully!"
 msgstr ""
 
-#: metabrainz/index/views.py:478
+#: metabrainz/index/views.py:495
 msgid "Your account has been deleted."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:106 metabrainz/oauth/forms.py:58
+#: frontend/js/src/forms/CreateApplication.tsx:106 metabrainz/oauth/forms.py:57
 msgid "Application Name"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:59
+#: metabrainz/oauth/forms.py:58
 msgid "Application name field is empty."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:60 metabrainz/oauth/forms.py:60
+#: frontend/js/src/forms/CreateApplication.tsx:60 metabrainz/oauth/forms.py:59
 msgid "Application name needs to be at least 3 characters long."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:64 metabrainz/oauth/forms.py:61
+#: frontend/js/src/forms/CreateApplication.tsx:64 metabrainz/oauth/forms.py:60
 msgid "Application name needs to be at most 64 characters long."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:114 metabrainz/oauth/forms.py:63
+#: frontend/js/src/forms/CreateApplication.tsx:114 metabrainz/oauth/forms.py:62
 msgid "Description"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:64
+#: metabrainz/oauth/forms.py:63
 msgid "Client description field is empty."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:65
+#: metabrainz/oauth/forms.py:64
 msgid "Client description needs to be at least 3 characters long."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:66
+#: metabrainz/oauth/forms.py:65
 msgid "Client description needs to be at most 512 characters long."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:122 metabrainz/oauth/forms.py:68
+#: frontend/js/src/forms/CreateApplication.tsx:122 metabrainz/oauth/forms.py:67
 msgid "Homepage"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:69
+#: metabrainz/oauth/forms.py:68
 msgid "Homepage field is empty."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:70
+#: metabrainz/oauth/forms.py:69
 msgid "Homepage is not a valid URI."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:71
+#: metabrainz/oauth/forms.py:70
 msgid "Homepage URL must use http or https"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:73
+#: metabrainz/oauth/forms.py:72
 msgid "Authorization callback URL"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:74
+#: metabrainz/oauth/forms.py:73
 msgid "Authorization callback URL field is empty."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:75
+#: metabrainz/oauth/forms.py:74
 msgid "Authorization callback URL is invalid."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:76
+#: metabrainz/oauth/forms.py:75
 msgid "Authorization callback URL must use http or https."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:81 metabrainz/oauth/forms.py:85
+#: metabrainz/oauth/forms.py:80 metabrainz/oauth/forms.py:84
 msgid "Confirm"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:15
+msgid "View your public account information"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:16
+msgid "View your email address"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:17
+msgid "View and modify your private tags"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:18
+msgid "View and modify your private ratings"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:19
+msgid "View and modify your private collections"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:20
+msgid "Submit new ISRCs to the database"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:21
+msgid "Submit new barcodes to the database"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:22
+msgid "Sign you in and view your unique user id"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:23
+msgid "Submit listens to ListenBrainz."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:24
+msgid "Create and modify CritiqueBrainz reviews."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:25
+msgid "Submit and delete votes on CritiqueBrainz reviews."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:26
+msgid "Modify profile info and delete profile on CritiqueBrainz."
 msgstr ""
 
 #: metabrainz/payments/views.py:164
@@ -221,178 +306,185 @@ msgid "Requested annual report was not found."
 msgstr ""
 
 #: frontend/js/src/forms/ProfileEdit.tsx:30
-#: frontend/js/src/forms/SignupCommercial.tsx:139
+#: frontend/js/src/forms/SignupCommercial.tsx:144
 #: frontend/js/src/forms/SignupNonCommercial.tsx:70
-#: metabrainz/supporter/forms.py:13
+#: metabrainz/supporter/forms.py:15
 msgid "Contact name is required!"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:437
+#: frontend/js/src/forms/SignupCommercial.tsx:441
 #: frontend/js/src/forms/SignupNonCommercial.tsx:264
-#: metabrainz/supporter/forms.py:15
+#: metabrainz/supporter/forms.py:17
 msgid ""
 "Can you please tell us more about the project in which you'd like to use "
 "our data? Do you plan to self host the data or use our APIs?"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:137
+#: frontend/js/src/forms/SignupCommercial.tsx:142
 #: frontend/js/src/forms/SignupNonCommercial.tsx:68
-#: metabrainz/supporter/forms.py:17
+#: metabrainz/supporter/forms.py:19
 msgid "Please, tell us how you (will) use our data."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:138
+#: frontend/js/src/forms/SignupCommercial.tsx:143
 #: frontend/js/src/forms/SignupNonCommercial.tsx:69
-#: metabrainz/supporter/forms.py:18
+#: metabrainz/supporter/forms.py:20
 msgid "Please, limit usage description to 500 characters."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:141
-#: frontend/js/src/forms/SignupCommercial.tsx:142
+#: frontend/js/src/forms/SignupCommercial.tsx:146
+#: frontend/js/src/forms/SignupCommercial.tsx:147
 #: frontend/js/src/forms/SignupNonCommercial.tsx:72
 #: frontend/js/src/forms/SignupNonCommercial.tsx:73
-#: frontend/js/src/forms/SignupUser.tsx:84
-#: frontend/js/src/forms/SignupUser.tsx:85 metabrainz/supporter/forms.py:21
-#: metabrainz/user/forms.py:38
+#: frontend/js/src/forms/SignupUser.tsx:90
+#: frontend/js/src/forms/SignupUser.tsx:91 metabrainz/supporter/forms.py:23
+#: metabrainz/user/forms.py:45
 msgid "You need to accept the agreement!"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:342
-#: metabrainz/supporter/forms.py:27
+#: frontend/js/src/forms/SignupCommercial.tsx:347
+#: metabrainz/supporter/forms.py:29
 msgid "Organization name"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:113
-#: metabrainz/supporter/forms.py:28
+#: frontend/js/src/forms/SignupCommercial.tsx:115
+#: metabrainz/supporter/forms.py:30
 msgid "You need to specify the name of your organization."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:373
-#: metabrainz/supporter/forms.py:30
+#: frontend/js/src/forms/SignupCommercial.tsx:378
+#: metabrainz/supporter/forms.py:32
 msgid "Organization description"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:116
-#: metabrainz/supporter/forms.py:31
+#: frontend/js/src/forms/SignupCommercial.tsx:118
+#: metabrainz/supporter/forms.py:33
 msgid "You need to provide description of your organization."
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:278
-#: frontend/js/src/forms/SignupCommercial.tsx:396
-#: metabrainz/supporter/forms.py:34
+#: frontend/js/src/forms/SignupCommercial.tsx:401
+#: metabrainz/supporter/forms.py:36
 msgid "Website URL"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:119
-#: metabrainz/supporter/forms.py:35
-msgid "You need to specify website of the organization."
+#: frontend/js/src/forms/SignupCommercial.tsx:121
+#: frontend/js/src/forms/SignupCommercial.tsx:123
+#: metabrainz/supporter/forms.py:38 metabrainz/supporter/forms.py:42
+msgid "Website URL must be a valid URL."
 msgstr ""
 
-#: metabrainz/supporter/forms.py:37
+#: metabrainz/supporter/forms.py:45
 msgid "Logo image URL"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:284
-#: frontend/js/src/forms/SignupCommercial.tsx:418
-#: metabrainz/supporter/forms.py:38
+#: frontend/js/src/forms/SignupCommercial.tsx:422
+#: metabrainz/supporter/forms.py:46
 msgid "API URL"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:457
-#: metabrainz/supporter/forms.py:40
+#: frontend/js/src/forms/SignupCommercial.tsx:461
+#: metabrainz/supporter/forms.py:48
 msgid "Street"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:123
-#: metabrainz/supporter/forms.py:41
+#: frontend/js/src/forms/SignupCommercial.tsx:128
+#: metabrainz/supporter/forms.py:49
 msgid "You need to specify street."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:465
-#: metabrainz/supporter/forms.py:43
+#: frontend/js/src/forms/SignupCommercial.tsx:469
+#: metabrainz/supporter/forms.py:51
 msgid "City"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:124
-#: metabrainz/supporter/forms.py:44
+#: frontend/js/src/forms/SignupCommercial.tsx:129
+#: metabrainz/supporter/forms.py:52
 msgid "You need to specify city."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:473
-#: metabrainz/supporter/forms.py:46
+#: frontend/js/src/forms/SignupCommercial.tsx:477
+#: metabrainz/supporter/forms.py:54
 msgid "State / Province"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:126
-#: metabrainz/supporter/forms.py:47
+#: frontend/js/src/forms/SignupCommercial.tsx:131
+#: metabrainz/supporter/forms.py:55
 msgid "You need to specify state/province."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:481
-#: metabrainz/supporter/forms.py:49
+#: frontend/js/src/forms/SignupCommercial.tsx:485
+#: metabrainz/supporter/forms.py:57
 msgid "Postcode"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:128
-#: metabrainz/supporter/forms.py:50
+#: frontend/js/src/forms/SignupCommercial.tsx:133
+#: metabrainz/supporter/forms.py:58
 msgid "You need to specify postcode."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:489
-#: metabrainz/supporter/forms.py:52
+#: frontend/js/src/forms/SignupCommercial.tsx:493
+#: metabrainz/supporter/forms.py:60
 msgid "Country"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:129
-#: metabrainz/supporter/forms.py:53
+#: frontend/js/src/forms/SignupCommercial.tsx:134
+#: metabrainz/supporter/forms.py:61
 msgid "You need to specify country."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:132
-#: metabrainz/supporter/forms.py:64
+#: frontend/js/src/forms/SignupCommercial.tsx:137
+#: metabrainz/supporter/forms.py:72
 msgid ""
 "Custom amount must be more than threshold amount for selected tier or "
 "equal to it!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:46 metabrainz/supporter/views.py:119
-#: metabrainz/supporter/views.py:220
+#: metabrainz/supporter/views.py:54
+msgid ""
+"The verification email could not be sent. Please request a new one from "
+"your profile."
+msgstr ""
+
+#: metabrainz/supporter/views.py:85 metabrainz/supporter/views.py:158
+#: metabrainz/supporter/views.py:260
 msgid "You are already a supporter."
 msgstr ""
 
-#: metabrainz/supporter/views.py:61
+#: metabrainz/supporter/views.py:100
 msgid "Can't find tier with a specified ID."
 msgstr ""
 
-#: metabrainz/supporter/views.py:127
+#: metabrainz/supporter/views.py:166
 msgid "You need to choose support tier before signing up!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:137
+#: metabrainz/supporter/views.py:176
 msgid "You need to choose existing tier before signing up!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:164
+#: metabrainz/supporter/views.py:204
 msgid ""
 "Thanks for becoming a supporter! Your application will be reviewed soon. "
 "We will send you updates via email."
 msgstr ""
 
-#: metabrainz/supporter/views.py:187
+#: metabrainz/supporter/views.py:228
 msgid ""
 "Thanks for signing up! Your application will be reviewed soon. We will "
 "send you updates via email."
 msgstr ""
 
-#: metabrainz/supporter/views.py:248
+#: metabrainz/supporter/views.py:288
 msgid "Thanks for becoming a supporter!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:274
+#: metabrainz/supporter/views.py:312
 msgid "Thanks for signing up! Please check your inbox to complete verification."
 msgstr ""
 
-#: metabrainz/supporter/views.py:302
+#: metabrainz/supporter/views.py:340
 msgid "Can't generate new token unless account is active."
 msgstr ""
 
@@ -426,7 +518,7 @@ msgstr ""
 msgid "Policies"
 msgstr ""
 
-#: metabrainz/templates/base.html:55 metabrainz/templates/index/gdpr.html:178
+#: metabrainz/templates/base.html:55
 #: metabrainz/templates/index/social-contract.html:3
 #: metabrainz/templates/index/social-contract.html:6
 #: metabrainz/templates/navbar.html:34
@@ -436,14 +528,15 @@ msgstr ""
 #: metabrainz/templates/base.html:56
 #: metabrainz/templates/index/code-of-conduct.html:3
 #: metabrainz/templates/index/code-of-conduct.html:16
-#: metabrainz/templates/index/gdpr.html:181 metabrainz/templates/navbar.html:35
+#: metabrainz/templates/navbar.html:35
 msgid "Code of Conduct"
 msgstr ""
 
+#: frontend/js/src/PrivacySummary.tsx:11
 #: frontend/js/src/forms/ConditionsModal.tsx:21
-#: metabrainz/templates/base.html:57 metabrainz/templates/index/gdpr.html:184
-#: metabrainz/templates/index/privacy.html:6
+#: metabrainz/templates/base.html:57 metabrainz/templates/index/privacy.html:6
 #: metabrainz/templates/navbar.html:36
+#: metabrainz/templates/users/privacy-summary.html:3
 msgid "Privacy Policy"
 msgstr ""
 
@@ -476,10 +569,7 @@ msgstr ""
 msgid "Supporters"
 msgstr ""
 
-#: frontend/js/src/forms/LoginUser.tsx:103
-#: frontend/js/src/forms/SignupCommercial.tsx:574
-#: frontend/js/src/forms/SignupNonCommercial.tsx:339
-#: frontend/js/src/forms/SignupUser.tsx:232 metabrainz/templates/base.html:73
+#: frontend/js/src/forms/LoginUser.tsx:103 metabrainz/templates/base.html:73
 #: metabrainz/templates/navbar.html:66 metabrainz/templates/users/login.html:3
 msgid "Sign in"
 msgstr ""
@@ -501,26 +591,26 @@ msgid "Contact us"
 msgstr ""
 
 #: metabrainz/templates/base.html:85
-#: metabrainz/templates/index/contact.html:105
+#: metabrainz/templates/index/contact.html:106
 msgid "Blog"
 msgstr ""
 
-#: metabrainz/templates/base.html:86 metabrainz/templates/index/contact.html:90
+#: metabrainz/templates/base.html:86 metabrainz/templates/index/contact.html:91
 msgid "Chat"
 msgstr ""
 
 #: metabrainz/templates/base.html:87
-#: metabrainz/templates/index/contact.html:106
+#: metabrainz/templates/index/contact.html:107
 msgid "Mastodon"
 msgstr ""
 
 #: metabrainz/templates/base.html:88
-#: metabrainz/templates/index/contact.html:107
+#: metabrainz/templates/index/contact.html:108
 msgid "Bluesky"
 msgstr ""
 
 #: metabrainz/templates/base.html:89
-#: metabrainz/templates/index/contact.html:108
+#: metabrainz/templates/index/contact.html:109
 msgid "Instagram"
 msgstr ""
 
@@ -576,15 +666,14 @@ msgstr ""
 msgid "Donate"
 msgstr ""
 
-#: frontend/js/src/forms/LoginUser.tsx:110
-#: frontend/js/src/forms/SignupCommercial.tsx:175
-#: frontend/js/src/forms/SignupCommercial.tsx:555
+#: frontend/js/src/forms/SignupCommercial.tsx:180
+#: frontend/js/src/forms/SignupCommercial.tsx:559
 #: frontend/js/src/forms/SignupNonCommercial.tsx:106
 #: frontend/js/src/forms/SignupNonCommercial.tsx:319
 #: metabrainz/templates/navbar.html:65
-#: metabrainz/templates/supporters/account-type.html:51
-#: metabrainz/templates/supporters/account-type.html:93
-#: metabrainz/templates/supporters/account-type.html:144
+#: metabrainz/templates/supporters/account-type.html:47
+#: metabrainz/templates/supporters/account-type.html:84
+#: metabrainz/templates/supporters/account-type.html:130
 #: metabrainz/templates/users/signup.html:3
 msgid "Sign up"
 msgstr ""
@@ -891,8 +980,430 @@ msgstr ""
 msgid "Introduction"
 msgstr ""
 
-#: metabrainz/templates/index/conflict-policy.html:55
+#: metabrainz/templates/index/conflict-policy.html:17
+msgid ""
+"Conflicts between people arise in open source projects constantly and the"
+" projects by the \n"
+"    MetaBrainz Foundation are no different. This policy aims to establish"
+" a clear and unambiguous \n"
+"    policy for reporting and addressing conflicts in our community. In "
+"this policy we aim to \n"
+"    establish a fair practice that balances the need for confidentiality "
+"and our desire for \n"
+"    transparency in our operations."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:25
+#, python-format
+msgid ""
+"Before you continue to read this policy, we encourage you to review our "
+"existing community policies \n"
+"    including our <a href=\"%(social_contract_url)s\">Social "
+"Contract</a>, \n"
+"    <a href=\"%(code_of_conduct_url)s\">the Code of Conduct</a>, \n"
+"    and our <a href=\"%(privacy_policy_url)s\">Privacy Policy</a>. These "
+"policies establish the norms and rules for \n"
+"    participation in our projects; these policies apply equally to the "
+"contractors of the MetaBrainz \n"
+"    Foundation and any participants in our projects."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:37
+msgid ""
+"This policy divides conflicts into two categories: Private and public. "
+"Private conflicts are conflicts \n"
+"    that involve *confidential* information regarding contributors, "
+"contractors or supporters. Otherwise, any conflicts \n"
+"    that do not involve confidential information are considered to be "
+"public conflicts. For instance, a \n"
+"    conflict between a contractor and the Executive Director (aka BDFL) "
+"that involves contractor pay is \n"
+"    considered a private conflict because pay rates are confidential "
+"information. A public conflict in edit \n"
+"    notes between two editors in our community does not involve "
+"confidential information and therefore should \n"
+"    be considered a public conflict."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:47
+msgid ""
+"When conflicts arise we aim to disclose as much information as possible "
+"about the conflict in a timely \n"
+"    fashion. When conflicts contain confidential matters we will aim to "
+"disclose as much information as \n"
+"    possible, while fully respecting the confidentiality of the people "
+"involved in the conflict. With any \n"
+"    private conflict we will aim to extract the relevant lessons for the "
+"team and community in an effort to \n"
+"    evolve our policies to prevent future conflicts. Should the involved "
+"parties disagree whether a conflict \n"
+"    is private or public, the question about the nature of the conflict "
+"will be presented for the next higher \n"
+"    level in the chain of command to decide. (e.g. if a community member "
+"and the community manager disagree on \n"
+"    a conflict being public or private, the Executive Director shall "
+"decide if the conflict is public or private)."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:58
 msgid "Reporting and Response"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:61
+msgid ""
+"We aim to not have conflict in our community, but we recognize that in "
+"reality conflicts will arise and we \n"
+"    must be prepared to address them in a fair manner. When conflicts "
+"arise, we prefer to have community or team \n"
+"    members resolve the conflicts among themselves, using our existing "
+"policies as guidelines for resolving the \n"
+"    conflict."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:69
+msgid ""
+"If you do not feel comfortable resolving a conflict on your own, you "
+"should feel free to report the conflict to \n"
+"    us. How you address the conflict depends on who is involved in the "
+"conflict and your comfort level. Please see \n"
+"    the detailed sections below on how and with whom to address your "
+"conflict. We aim to address conflicts as soon \n"
+"    as possible in an effort to prevent them from escalating "
+"unnecessarily."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:75
+msgid "Direct conflict resolution"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:78
+msgid ""
+"In direct conflict resolution, the involved parties will attempt to "
+"resolve the conflict themselves without \n"
+"   involving any MetaBrainz Foundation team member. You should aim to use"
+" direct resolution when the conflict does \n"
+"   not involve the violation of one of our policies or if the conflict is"
+" minor."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:84
+#, python-format
+msgid ""
+"For instance, if a user uses a rude tone, is disruptive or flagrantly "
+"ignores our project guidelines, we suggest \n"
+"    that you use direct conflict resolution to resolve the conflict. Some"
+" resources that might give you some suggestions \n"
+"    on how to go about resolving the conflict might be this <a "
+"href=\"%(conflict_resolution_primer_url)s\">\n"
+"    conflict resolution primer</a> and <a "
+"href=\"%(difficult_conversations_url)s\">how to\n"
+"    have difficult conversations at work</a>."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:93
+msgid "Informal reporting"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:96
+msgid ""
+"You may use informal reporting of a conflict if you aim to communicate a "
+"concern or incident without \n"
+"    seeking a corrective outcome. Informal reporting may also be an "
+"option if you have not been personally \n"
+"    victimized, but you’ve witnessed a violation of our policies or where"
+" you wish to maintain confidentiality \n"
+"    throughout the entire reporting process."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:103
+msgid ""
+"For editing in MusicBrainz you may informally report a user using the "
+"“Report this user for bad behavior” \n"
+"    link from the user’s profile. For reporting bad user behavior in "
+"other of our projects, please report them to our \n"
+"    community manager by mailing <span class=\"backemail\">gro.zniarbatem"
+"@reganam-ytinummoc</span> . For conflicts \n"
+"    that involve the community manager, report them by mailing <span "
+"class=\"backemail\">gro.zniarbatem@de</span> ."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:110
+msgid ""
+"Depending the the severity of the issue, repeated informal complaints may"
+" eventually require a formal response \n"
+"    from the MetaBrainz team. If an involved party requires anonymity, "
+"the conflict becomes a private conflict. If at \n"
+"    all possible minor issues should be resolved in a public forum in "
+"order for all people to witness and learn from \n"
+"    the issue at hand."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:116
+msgid "Formal complaint process"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:119
+msgid ""
+"All complaints about conflicts should be submitted via email. To whom a "
+"complaint should be mailed and who will \n"
+"    carry out the investigation will be described in the next section."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:124
+msgid "All complaint submissions to the Foundation should include the following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:128
+msgid ""
+"Contact info, if it is different than the email used to submit the "
+"conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:129
+msgid "Who was involved in the conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:130
+msgid "Where and when the incident happened"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:131
+msgid ""
+"A description of what happened -- ideally with links (e.g. chatlogs, edit"
+" notes) that outlines what \n"
+"         happened so that the persons evaluating the conflict may "
+"understand the issue at hand"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:133
+msgid ""
+"Any related pieces of information that provide more context on the "
+"conflict (e.g. links, screenshots)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:134
+msgid "An indication if this conflict is ongoing or not"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:139
+msgid "The investigation that follows aims to determine:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:143
+msgid "The nature and severity of the incident"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:144
+msgid ""
+"Whether or not the incident is considered a violation of MetaBrainz’ "
+"conduct policies or core values"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:145
+msgid ""
+"The amount of harm experienced by the person who submitted the complaint "
+"and the broader MetaBrainz community \n"
+"         as a result of the incident"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:147
+msgid ""
+"Whether there have been prior complaints against the individual or "
+"individuals reported"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:148
+msgid "Whether the incident is ongoing"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:152
+msgid ""
+"The following potential forms of resolution may apply to any team members"
+" involved in the conflict:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:155
+#: metabrainz/templates/index/conflict-policy.html:168
+msgid "Nothing (if it has been found no violation occurred)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:156
+msgid "Creating a plan to improve the performance"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:157
+msgid "Creating a negative performance evaluation"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:158
+msgid "Mediation, an intervention by a third party to resolve the conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:159
+msgid "Suspension or forced leave"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:160
+msgid "Termination of contract"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:164
+msgid ""
+"The following potential forms of resolution may apply to non team members"
+" involved in the conflict:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:169
+msgid "A reprimand, either public or private"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:170
+msgid "Suspension of the users’ account"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:171
+msgid "Deletion of the users’ account"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:172
+msgid ""
+"Removal of user privileges (e.g. if an auto editor commits a serious "
+"offence, they may lose their auto editor status)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:175
+msgid "Filing a complaint"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:178
+msgid ""
+"NOTE: For complaints not about MetaBrainz staff, please see the "
+"<em>Informal reporting</em> section above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:182
+msgid ""
+"If the complaint does not involve the Executive Director (ED), do the "
+"following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:186
+msgid ""
+"If team member has directly violated conduct policies or engaged in "
+"otherwise harmful behavior, a formal complaint should be filed."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:187
+msgid ""
+"Mail <span class=\"backemail\">gro.zniarbatem@de</span> and include the "
+"complaint information outlined above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:188
+msgid ""
+"You should expect a response within a working day acknowledging the "
+"complaint."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:189
+msgid ""
+"The complaint will be investigated by the ED, member(s) of the board of "
+"directors or a neutral third party."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:190
+msgid ""
+"Once the investigation has been completed, the ED, with the support of "
+"others involved in the investigation will respond. The \n"
+"        ED will respond to incidents no later than 7 working days after a"
+" complaint has been filed with either a resolution or an \n"
+"        explanation of why the process must be extended."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:196
+msgid "If a complaint involves the Executive Director, do the following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:200
+msgid ""
+"If the Executive Director has directly violated conduct policies or "
+"engaged in otherwise harmful behavior, \n"
+"        a formal complaint should be filed with the board of directors."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:202
+msgid ""
+"Mail <span class=\"backemail\">gro.zniarbatem@noituloser-tcilfnoc</span> "
+"and include the complaint information outlined above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:203
+msgid ""
+"You should get a response within 5 working days acknowledging the "
+"complaint."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:204
+msgid ""
+"The complaint will be investigated by the member(s) of the board of "
+"directors, the community manager, a neutral \n"
+"        third party or a combination thereof."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:206
+msgid ""
+"Once the investigation has been completed, the board, with the support of"
+" others involved in the investigation \n"
+"        will respond. The board will aim to respond to incidents no later"
+" than 15 working days after a complaint has been filed \n"
+"        with either a resolution or an explanation of why the process "
+"must be extended."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:211
+msgid "Confidentiality"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:214
+msgid ""
+"Confidentiality is an important aspect of conflict resolution and all of "
+"the conflicts brought to the attention of the foundation \n"
+"    will be evaluated with confidentiality in mind and acted upon "
+"accordingly."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:219
+msgid ""
+"We work hard to make all of the actions of the foundation as transparent "
+"and open as possible. In cases where we cannot \n"
+"    disclose all aspects of a conflict we will disclose that a conflict "
+"is or has occurred and we will attempt to disclose the \n"
+"    appropriate amount of information about the conflict while balancing "
+"the need for confidentiality and our desire to learn \n"
+"    from conflicts so that we as a foundation and community can learn "
+"from these conflicts and improve our policies to avoid the \n"
+"    conflicts in the future."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:227
+msgid ""
+"Any breaches of confidentiality will be treated as severe breaches of our"
+" conduct policies."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:230
+msgid "Retaliation"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:233
+msgid ""
+"We will not allow retaliation for any contractor or volunteer that files "
+"a complaint or is involved in an investigation. If you \n"
+"    believe that you are being treated negatively because of your "
+"involvement in a complaint please report this complaint directly \n"
+"    to the ED at <span class=\"backemail\">gro.zniarbatem@de</span> or "
+"the board at \n"
+"    <span class=\"backemail\">gro.zniarbatem@noituloser-tcilfnoc</span>."
 msgstr ""
 
 #: metabrainz/templates/index/contact.html:3
@@ -973,7 +1484,7 @@ msgstr ""
 msgid ""
 "We are currently evaluating our overall online advertising strategy. We "
 "are evaluating advertising, traffic optimization,\n"
-"    search engine optimization and software monitization technologies. If"
+"    search engine optimization and software monetization technologies. If"
 " you provide these professional services, please provide a detailed\n"
 "    deck of your comprehensive services to the following email address. "
 "<em>Please respect our other non-media teams and do not contact us \n"
@@ -1048,11 +1559,11 @@ msgstr "Foorumit"
 #, python-format
 msgid ""
 "Please come ask your questions at our <a "
-"href=\"%(forums_url)s\">forums</a>! We would love to\n"
-"    answer any questions you may have."
+"href=\"%(forums_url)s\">forums</a>!\n"
+"    The community and the team will be more than happy to help you."
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:92
+#: metabrainz/templates/index/contact.html:93
 #, python-format
 msgid ""
 "The MetaBrainz/MusicBrainz/ListenBrainz team and community hang out\n"
@@ -1062,15 +1573,15 @@ msgid ""
 "    <a href=\"%(chatlogs_url)s\">chat log archives</a>."
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:101
+#: metabrainz/templates/index/contact.html:102
 msgid "Social media"
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:103
+#: metabrainz/templates/index/contact.html:104
 msgid "You can follow us on these social channels:"
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:112
+#: metabrainz/templates/index/contact.html:113
 msgid "Mailing address"
 msgstr ""
 
@@ -1083,33 +1594,349 @@ msgstr ""
 msgid "GDPR Compliance Statement"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:37
+#: metabrainz/templates/index/gdpr.html:10
+msgid ""
+"The General Data Protection Regulation is a complex EU regulation that "
+"stipulates many points for protecting private data of\n"
+"    users on the Internet. Even though this is an EU regulation, it has a"
+" worldwide impact due to the nature of the Internet.\n"
+"    The MetaBrainz Foundation with its collection of projects is also "
+"affected by this regulation. We’ve been learning and adapting\n"
+"    our sites to be compliant with the GDPR – sadly this regulation isn’t"
+" entirely black and white and there is an incredible\n"
+"    amount of room left for interpretation of these rules."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:17
+msgid ""
+"The good news is that this regulation is roughly in line with our "
+"established practices: We’ve always held private information\n"
+"    in a high regard and applied the sort of rules to ourselves as we "
+"wish to have our own private data treated. Luckily, this\n"
+"    makes our compliance effort considerably easier. We’ve made two "
+"significant changes to how we treat your data and also adopted\n"
+"    terminology as used in the GDPR in order to use the same languages "
+"that many other sites are now adopting. Please keep reading\n"
+"    to find out the exact details of what we are doing to comply."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:24
+#, python-format
+msgid ""
+"However, we do ask for your compassion and help in our process of "
+"complying with the GDPR. As we already mentioned, the GDPR is\n"
+"    a complex set of rules that are not fully clarified yet. We’ve taken "
+"action on the steps that are clear to us and we’re following\n"
+"    ongoing conversations on points that are in gray zones or unclear to "
+"us. We’ve made our best initial effort on compliance and\n"
+"    promise to keep working on it as the picture becomes more clear. If "
+"you believe that we could improve our compliance, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a> and let us know what we "
+"can do to improve. It would also help us if you\n"
+"    could provide concrete discussion or examples to help us understand "
+"and take action on your suggestion."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:33
+msgid ""
+"Finally, below are the key sections of the GDPR as we understand them and"
+" how they affect your data in our ecosystem. Where\n"
+"    possible, we provide links for deeper understanding, links for you to"
+" examine our relevant code and links to tickets to follow\n"
+"    the process of improving our compliance."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:38
 msgid "Right to be forgotten"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:77
+#: metabrainz/templates/index/gdpr.html:41
+msgid ""
+"Summary: <i>Provide the user with the ability to remove their private "
+"data from our services</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:44
+msgid ""
+"The most important aspect of the right to be forgotten is the ability to "
+"delete your account. Once you request for us to delete\n"
+"    your account, we will remove any personally identifying information "
+"you may have provided us from your account (name, email\n"
+"    address, gender, biography, URL, etc.). The visible name on your "
+"account will be changed to “Deleted User #####” and effectively\n"
+"    the account will no longer be identifiable as your account."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:50
+msgid ""
+"However, given the nature of our projects where we work on collaborative "
+"databases, your contributions that are not personally\n"
+"    identifying are valuable assets to our database and these "
+"contributions will not be removed from our databases. But we will\n"
+"    ensure that these contributions no longer contain personally "
+"identifying data."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:55
+#, python-format
+msgid ""
+"Our process of automatically deleting your accounts across the MetaBrainz"
+" ecosystem is not complete yet (see below for a set of\n"
+"    tickets where you can track our progress). If you would like to "
+"delete your accounts in the MetaBrainz ecosystem or mark a\n"
+"    donation that is currently public as a private donation, please <a "
+"href=\"%(contact_url)s\">contact us</a>\n"
+"    and we will address your request as soon as possible."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:62
+#: metabrainz/templates/index/gdpr.html:182
+msgid "Links:"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:66
+#, python-format
+msgid ""
+"<a href=\"%(editor_deletion_doc_url)s\">How we delete accounts\n"
+"       in MusicBrainz</a> (warning, geek content ahead!)"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:70
+msgid ""
+"Implement sitewide user account deletion in\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/MBS-9680\">MusicBrainz</a>,"
+"\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/AB-337\">AcousticBrainz</a>,"
+"\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/BB-260\">BookBrainz</a>,\n"
+"         <a href=\"https://tickets.metabrainz.org/browse/MEB-103\">the "
+"MetaBrainz Site</a>,\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/LB-354\">ListenBrainz</a>, "
+"and\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/CB-307\">CritiqueBrainz</a>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:80
 msgid "Restriction of processing"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:110
+#: metabrainz/templates/index/gdpr.html:83
+msgid ""
+"Summary: <i>To allow the user to control how their personally identifying"
+" data is being used.</i>"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:86
+msgid ""
+"Except for the ListenBrainz and AcousticBrainz projects, we do not "
+"process personally identifying data. Any personally\n"
+"    identifying data that our projects store is for the purpose of being "
+"able to contact you about your contributions to our database\n"
+"    (email address) or for voluntarily showing information about you to "
+"other users (biography, homepage, location, etc)."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:91
+#, python-format
+msgid ""
+"The ListenBrainz project differs in that the Listens (metadata about what"
+" music you have listened to) are stored on our servers\n"
+"    and <a href=\"%(listenbrainz_data_url)s\">made available to the "
+"public</a>. We believe Listens to be personally identifying\n"
+"    data and furthermore, we have goals of creating open source "
+"recommendation engines with this data, which involves processing the\n"
+"    user’s data. These two points are fundamental goals of the "
+"ListenBrainz project and we do not see a reasonable way to reach another"
+"\n"
+"    compromise position."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:99
+msgid ""
+"Because of this, we are going to require users to either acknowledge that"
+" we may process their Listen data or alternatively to\n"
+"    delete their account, including all of their Listens. Please note "
+"that if you decide to delete your ListenBrainz account, it may\n"
+"    take up to two weeks for all of your listens to no longer be included"
+" in our efforts to build a recommendation engine."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:104
+msgid ""
+"We have always made it clear that the data in ListenBrainz was to be "
+"public and that we plan to build new tools with your data, so\n"
+"    this should not come as a surprise to our users."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:108
+msgid ""
+"The AcousticBrainz project does not track who submits data to the "
+"database. If you create an account and use our data creation\n"
+"    tools (e.g. create a dataset or participate in a challenge) then we "
+"link your participation and the things that you create to\n"
+"    your account. If you choose to delete your account then we keep the "
+"non personally identifying data that you create, but anonymize\n"
+"    it so that it cannot be linked back to you."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:114
 msgid "Right to data portability / exporting your data"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:150
+#: metabrainz/templates/index/gdpr.html:117
+msgid ""
+"Summary: <i>You have the right to access/download the data we store about"
+" you</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:120
+msgid ""
+"Except for the ListenBrainz and AcousticBrainz projects, we do not store "
+"personally identifying data beyond the\n"
+"    information that is available in your public profile on each of our "
+"projects. Since this data is plainly available in your\n"
+"    profile we do not provide a means for you to export this data."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:125
+msgid "There are the following exceptions to this:"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:129
+msgid ""
+"<b>IP addresses</b>: If you visit one of our sites the IP address of your"
+" computer is stored in our web logs for 7 days\n"
+"        before our servers automatically delete them. This data is almost"
+" never used by anyone: the only time we look at the\n"
+"        IP addresses is if our sites are adversely impacted by the "
+"actions of some unknown users. In that case, we may investigate\n"
+"        the logs to identify the IP address that needs to be blocked in "
+"order to restore the stability of our service.\n"
+"        This data is not available to anyone but the contractors of the "
+"MetaBrainz Foundation and is not available to download\n"
+"        to anyone at all."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:137
+#, python-format
+msgid ""
+"<b>ListenBrainz Listen data</b>: Users may <a "
+"href=\"%(listenbrainz_export_url)s\">export their ListenBrainz Listen\n"
+"        data</a> directly from the site. The user Listen data is also "
+"included in the <a href=\"%(listenbrainz_data_url)s\">ListenBrainz\n"
+"        data dumps</a> that are available for public download."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:146
+msgid ""
+"All of the non personally identifying data, such as your metadata "
+"contributions, are publicly visible, available for download\n"
+"    and available via the project APIs. For details about this data, "
+"downloads and APIs please check the documentation for the\n"
+"    respective projects you are interested in."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:151
+#, python-format
+msgid ""
+"Anyone wishing to get a list of financial donations they have made to the"
+" MetaBrainz Foundation, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a> and provide your "
+"MusicBrainz editor name so that we can look up\n"
+"    your donations."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:157
 msgid "Right to rectification"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:165
+#: metabrainz/templates/index/gdpr.html:160
+msgid "Summary: <i>You have the right to correct your data</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:163
+msgid ""
+"All of our projects allow their users to update their personally "
+"identifying information in their profiles. Furthermore, most\n"
+"    of our projects allow the editing of their own metadata "
+"contributions. If you find that some of your data is incorrect, please\n"
+"    feel free to edit the data since we provide the tools to do so."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:168
+#, python-format
+msgid ""
+"If anyone who has made a financial donation to the MetaBrainz Foundation "
+"would like to make their donation private, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:173
 msgid "Right to be informed"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:188
+#: metabrainz/templates/index/gdpr.html:175
+msgid ""
+"Summary: <i>You have the right to be informed about how we use your data "
+"in plain English</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:178
+msgid ""
+"Our privacy policy, as well as other policies, have always been written "
+"by humans for human consumption. We abhor legalese and\n"
+"    not speaking in direct terms."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:186
+msgid "Social contract"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:189
+msgid "Code of conduct"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:192
+msgid "Privacy policy"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:196
 msgid "Right to access"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:198
-#: metabrainz/templates/index/privacy.html:166
+#: metabrainz/templates/index/gdpr.html:199
+msgid ""
+"Summary: <i>You have the right to access the data that we collect about "
+"you</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:202
+msgid ""
+"All of our projects make all of the data we collect on your behalf, "
+"privately identifying or not, available to you. The\n"
+"    only exception to this are the IP addresses we store for 7 days – see"
+" above for details."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:206
+#: metabrainz/templates/index/privacy.html:168
 msgid "Privacy/GDPR Representative"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:209
+#, python-format
+msgid ""
+"If you have any questions about our privacy policy, please <a "
+"href=\"%(contact_url)s\">contact us</a>. To report\n"
+"   any privacy problems, violations or leaks, our GDPR representative is "
+"our Interim Executive Director Nicolás Tamargo and for\n"
+"   privacy issues contact him at <strong><a "
+"href=\"mailto:gdpr@metabrainz.org\">gdpr@metabrainz.org</a></strong>."
 msgstr ""
 
 #: metabrainz/templates/index/index.html:6
@@ -1214,13 +2041,51 @@ msgid ""
 "      <a href=\"%(about_url)s\">about</a> page."
 msgstr ""
 
-#: frontend/js/src/forms/ConditionsModal.tsx:43
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:32
 #: metabrainz/templates/index/privacy.html:3
 msgid "Privacy"
 msgstr "Yksityisyys"
 
 #: metabrainz/templates/index/privacy.html:8
 msgid "Summary"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:12
+msgid ""
+"You do not have to provide any personal data to be able to browse the "
+"contents of the databases published by MetaBrainz."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:15
+msgid ""
+"You do not have to provide any personally-identifying information if you "
+"choose not to."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:18
+msgid ""
+"We will never reveal your email address on MetaBrainz controlled web "
+"sites."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:22
+msgid ""
+"In order to get maximum value out of the MetaBrainz projects, you may "
+"want to create an account and log in. \n"
+"    Doing so grants you the ability to: edit the databases, contribute "
+"your own data, communicate with other users, and keep track \n"
+"    of recently released music from artists in your MusicBrainz "
+"collection. If you choose to create an account then the minimum we \n"
+"    ask is that you: choose a unique username and password, use a web "
+"browser that accepts \"session\" cookies, and provide a verified \n"
+"    email address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:29
+msgid ""
+"If you do not create an account (or are not logged in) you will not have "
+"access to the above listed features, however, you will \n"
+"    still have full access to browse and examine the databases."
 msgstr ""
 
 #: metabrainz/templates/index/privacy.html:33
@@ -1231,39 +2096,197 @@ msgstr ""
 msgid "Cookies"
 msgstr ""
 
+#: metabrainz/templates/index/privacy.html:37
+msgid "We use two cookies that contain sensitive information:"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:42
+msgid ""
+"<b>remember_login</b>: If you choose the \"Log in permanently\" option "
+"when logging in to one of our sites; the cookie will be used to \n"
+"      remember your login details."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:46
+msgid ""
+"<b>musicbrainz_server_session, session, or connect.sid</b>: If you are "
+"logged into one of our sites, your current session ID is stored in this "
+"cookie."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:51
+msgid ""
+"We may store dynamic preference information in other cookies, but these "
+"do not contain any sensitive information."
+msgstr ""
+
 #: metabrainz/templates/index/privacy.html:54
 msgid "Web and FTP access logs"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:57
+msgid ""
+"In a practice similar to other web sites (and APIs) we keep logs of all "
+"web requests made against our servers. These logs include: your IP\n"
+"    address, your browser's (or API client's) \"User-Agent\" string, and "
+"which page (or API endpoint) you requested with which parameters. "
+"Aggregate information about web and FTP traffic is\n"
+"    made available to the public via our site usage pages."
 msgstr ""
 
 #: metabrainz/templates/index/privacy.html:62
 msgid "Third-Party content"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:92
+#: metabrainz/templates/index/privacy.html:64
+msgid ""
+"Our projects' web pages may load some third-party content. Some, but "
+"possibly not all sites are listed below:"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:69
+#, python-format
+msgid ""
+"Cover art and other images: These are provided by the various cover art "
+"sites that have given MusicBrainz permission to do so and our own \n"
+"      <a href=\"%(caa_url)s\">Cover Art Archive</a>. This means that the "
+"relevant site will know (if they want to) your IP \n"
+"      address, User-Agent string, etc., and which MusicBrainz web page "
+"you were visiting (the one which included the cover art image)."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:75
+msgid ""
+"AcoustID: Our fingerprints tab loads fingerprint information from "
+"acoustid.org."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:78
+msgid ""
+"MTCaptcha: Our account creation page loads third party content in order "
+"to prevent spammers from creating accounts."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:83
+msgid ""
+"<i>The above information assumes that you are using \"normal\" web "
+"browser settings, whereby images are always loaded and HTTP referrer \n"
+"    information is always sent.</i>"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:88
+msgid ""
+"It is impractical to constantly modify this privacy policy when "
+"MetaBrainz projects change which third party content they utilize. We "
+"will \n"
+"    aim to use common sense, respect to our community and community "
+"review when adding more content from third party sites. We will also \n"
+"    periodically review our policy to ensure that it remains current."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:93
 msgid "Applicable to account holders"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:94
+#: metabrainz/templates/index/privacy.html:95
 msgid "Account creation"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:108
+#: metabrainz/templates/index/privacy.html:97
+msgid ""
+"When creating an account with a MetaBrainz project you need to pick a "
+"unique username and choose a password, the username you pick is the \n"
+"    only name associated with your account and will be what other "
+"MetaBrainz users know you as. You may optionally also tell us other \n"
+"    information about yourself that will be displayed to other MetaBrainz"
+" users and the public."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:103
+msgid ""
+"Additionally, in order to edit the databases you will need to provide a "
+"confirmed email address. This email address will be held in \n"
+"    confidence, the only method of revealing your email address to "
+"another user is if you choose to send a message to another \n"
+"    user and enable the option to \"reveal my email address\". Changing "
+"the email address stored with your account will require you to \n"
+"    verify the new address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:109
 msgid "Edits and Notes"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:114
+#: metabrainz/templates/index/privacy.html:111
+msgid ""
+"If you make any changes to a MetaBrainz project database, such as adding "
+"any data, the details of those changes will be visible to \n"
+"    other logged-in users and the change will be associated with your "
+"username."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:115
 msgid "Subscriptions on MusicBrainz"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:131
+#: metabrainz/templates/index/privacy.html:117
+msgid ""
+"As a logged-in user you can subscribe to one or more artists, labels, "
+"collections or other editors. The act of subscribing causes \n"
+"    any edits made to (or by in the case of another editor) those "
+"entities to be emailed to you. By default, other users can see your \n"
+"    list of subscriptions, however, you can opt out of this by editing "
+"the appropriate preference."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:123
+msgid ""
+"This does not provide \"perfect\" privacy though, in some cases it will "
+"be possible to infer information about the contents of your \n"
+"    subscription list even though you have disallowed others from viewing"
+" that list directly. This imperfection arises because various \n"
+"    parts of the system behave differently depending on whether or not an"
+" entity has any subscribers; also, the number of users \n"
+"    subscribed to each artist is available via the artist pages. In the "
+"most extreme (possibly contrived) example, imagine that all \n"
+"    users have their subscriptions set to \"public\", except for exactly "
+"one user whose list is \"private\". In that case, any discrepancy \n"
+"    for a given artist between the shown list of subscribers and the "
+"total number of subscribers must be down to that one user. Thus, \n"
+"    you can infer what artists are on that user's list."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:132
 msgid "Third-party sites"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:145
-msgid "MetaBrainz donors"
+#: metabrainz/templates/index/privacy.html:134
+#, python-format
+msgid ""
+"Our code reviews are done on GitHub, which is not under the control of "
+"MetaBrainz. Participating in code reviews or other\n"
+"    tasks carried out on GitHub are subject to <a "
+"href=\"%(github_url)s\">GitHub's privacy policy</a>."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:140
+#, python-format
+msgid ""
+"Our translations platform is provided and hosted by Weblate, which has a "
+"data processing agreement with MetaBrainz.\n"
+"    Participating in translations is subject to <a "
+"href=\"%(weblate_url)s\">dedicated legal terms</a>.\n"
+"    Any translations you make will be submitted to our Git repositories "
+"and publicly associated with your username;\n"
+"    if you so choose, you can also publicly associate them with your own "
+"verified email address."
 msgstr ""
 
 #: metabrainz/templates/index/privacy.html:147
+msgid "MetaBrainz donors"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:149
 msgid ""
 "When you make a donation to the MetaBrainz Foundation, we are legally\n"
 "    required to collect your personal information and keep it in our "
@@ -1273,7 +2296,7 @@ msgid ""
 "    information to anyone else, ever."
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:153
+#: metabrainz/templates/index/privacy.html:155
 msgid ""
 "We believe in transparent finances, which means that we list all "
 "donations\n"
@@ -1283,11 +2306,34 @@ msgid ""
 "process."
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:158
+#: metabrainz/templates/index/privacy.html:160
 msgid "Exceptions"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:598
+#: metabrainz/templates/index/privacy.html:162
+msgid ""
+"<i><b>Please note</b>: Reasonable exceptions may apply to the above "
+"policy, for example to comply with applicable laws.\n"
+"    Also, members of the MetaBrainz team and other personnel contracted "
+"to provide services to MetaBrainz may have access to\n"
+"    our infrastructure and could therefore view any information contained"
+" therein. However all personnel are contractually bound\n"
+"    by non-disclosure clauses which prevent them from making any such "
+"information available to others."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:171
+#, python-format
+msgid ""
+"If you have any questions about our GDPR statement, please <a "
+"href=\"%(contact_url)s\">contact us</a>. To report\n"
+"   any privacy problems, violations or leaks, our GDPR representative is "
+"our Interim Executive Director Nicolás Tamargo and for\n"
+"   privacy issues contact him at <strong><a "
+"href=\"mailto:gdpr@metabrainz.org\">gdpr@metabrainz.org</a></strong>."
+msgstr ""
+
+#: frontend/js/src/Profile.tsx:603
 #: frontend/js/src/forms/ProfileChangePassword.tsx:22
 #: frontend/js/src/forms/ProfileChangePassword.tsx:111
 #: metabrainz/templates/index/profile-change-password.html:3
@@ -1531,6 +2577,11 @@ msgstr ""
 
 #: metabrainz/templates/index/team.html:26
 msgid "He lives on in our hearts and in open source."
+msgstr ""
+
+#: metabrainz/templates/index/team.html:29
+#: metabrainz/templates/index/team.html:315
+msgid "you’re welcome to try"
 msgstr ""
 
 #: metabrainz/templates/index/team.html:39
@@ -2028,8 +3079,10 @@ msgstr ""
 
 #: metabrainz/templates/payments/donate.html:146
 msgid ""
-"Due to the increased unreliability of the US Postal Service we have "
-"stopped accepting paper checks. Sorry!"
+"Due to the increased unreliability of the US Postal Service and the "
+"relatively large fees involved, we ask you to only send a paper check if "
+"it is the only possible option. Due to the fees, we will not cash checks "
+"for less than $25."
 msgstr ""
 
 #: metabrainz/templates/payments/donate.html:241
@@ -2913,8 +3966,8 @@ msgid "Monthly balance sheets"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:520
-#: frontend/js/src/forms/SignupCommercial.tsx:175
-#: frontend/js/src/forms/SignupCommercial.tsx:554
+#: frontend/js/src/forms/SignupCommercial.tsx:180
+#: frontend/js/src/forms/SignupCommercial.tsx:558
 #: frontend/js/src/forms/SignupNonCommercial.tsx:106
 #: frontend/js/src/forms/SignupNonCommercial.tsx:318
 #: metabrainz/templates/supporters/account-type.html:3
@@ -2935,6 +3988,7 @@ msgid "Non-commercial / Personal"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:235
+#: frontend/js/src/forms/SignupNonCommercial.tsx:107
 #: frontend/js/src/forms/SignupNonCommercial.tsx:151
 #: metabrainz/templates/supporters/account-type.html:42
 msgid "Non-commercial"
@@ -2948,55 +4002,45 @@ msgstr ""
 msgid "Personal or university assignment user."
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:48
-#: metabrainz/templates/supporters/account-type.html:90
-#: metabrainz/templates/supporters/account-type.html:141
-msgid "Upgrade"
-msgstr ""
-
 #: frontend/js/src/Profile.tsx:235
-#: frontend/js/src/forms/SignupCommercial.tsx:176
-#: frontend/js/src/forms/SignupCommercial.tsx:228
-#: metabrainz/templates/supporters/account-type.html:61
+#: frontend/js/src/forms/SignupCommercial.tsx:181
+#: frontend/js/src/forms/SignupCommercial.tsx:233
+#: metabrainz/templates/supporters/account-type.html:56
 msgid "Commercial"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:83
-#: metabrainz/templates/supporters/account-type.html:135
+#: metabrainz/templates/supporters/account-type.html:78
+#: metabrainz/templates/supporters/account-type.html:125
 #, python-format
 msgid "$%(tier_price)s/month and up"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:87
-#: metabrainz/templates/supporters/account-type.html:138
+#: metabrainz/templates/supporters/account-type.html:82
+#: metabrainz/templates/supporters/account-type.html:128
 msgid "More info"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:104
+#: metabrainz/templates/supporters/account-type.html:94
 msgid "View all tiers"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:112
+#: metabrainz/templates/supporters/account-type.html:102
 msgid "Some of our Unicorn members"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:123
+#: metabrainz/templates/supporters/account-type.html:113
 msgid "See all our supporters"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:151
+#: metabrainz/templates/supporters/account-type.html:136
 msgid "View featured tiers"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:158
+#: metabrainz/templates/supporters/account-type.html:143
 #, python-format
 msgid ""
 "If you are not sure which tier to pick, please\n"
 "      <a href=\"%(contact_url)s\">contact us</a>."
-msgstr ""
-
-#: metabrainz/templates/supporters/account-type.html:166
-msgid "Back to Profile"
 msgstr ""
 
 #: metabrainz/templates/supporters/bad-standing.html:3
@@ -3058,9 +4102,9 @@ msgid "Forgot your username"
 msgstr ""
 
 #: frontend/js/src/forms/ResetPassword.tsx:79
-#: frontend/js/src/forms/SignupCommercial.tsx:320
+#: frontend/js/src/forms/SignupCommercial.tsx:325
 #: frontend/js/src/forms/SignupNonCommercial.tsx:227
-#: frontend/js/src/forms/SignupUser.tsx:169
+#: frontend/js/src/forms/SignupUser.tsx:175
 #: metabrainz/templates/users/reauthenticate.html:3
 #: metabrainz/templates/users/reauthenticate.html:6
 msgid "Confirm Password"
@@ -3070,17 +4114,22 @@ msgstr ""
 msgid "Please re-enter your password to continue."
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:108
+#: frontend/js/src/ProfileDelete.tsx:110
 #: frontend/js/src/forms/DeleteApplication.tsx:53
 #: frontend/js/src/forms/OAuthPrompt.tsx:54
 #: frontend/js/src/forms/ProfileChangePassword.tsx:104
 #: frontend/js/src/forms/ProfileEdit.tsx:105
-#: metabrainz/templates/users/reauthenticate.html:23
+#: metabrainz/templates/users/reauthenticate.html:28
 msgid "Cancel"
 msgstr ""
 
-#: metabrainz/templates/users/reauthenticate.html:24
+#: metabrainz/templates/users/reauthenticate.html:29
 msgid "Continue"
+msgstr ""
+
+#: frontend/js/src/forms/utils.tsx:202
+#: metabrainz/templates/users/reauthenticate.html:40
+msgid "Password must not exceed 72 bytes."
 msgstr ""
 
 #: frontend/js/src/forms/ResetPassword.tsx:27
@@ -3088,38 +4137,38 @@ msgstr ""
 msgid "Reset your password"
 msgstr ""
 
-#: frontend/js/src/hooks/useEmailValidation.ts:41 metabrainz/user/forms.py:15
+#: frontend/js/src/hooks/useEmailValidation.ts:41 metabrainz/user/forms.py:16
 msgid "Registration from this email domain is not allowed."
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:50
 #: frontend/js/src/forms/LostPassword.tsx:45
-#: frontend/js/src/forms/SignupCommercial.tsx:270
+#: frontend/js/src/forms/SignupCommercial.tsx:275
 #: frontend/js/src/forms/SignupNonCommercial.tsx:175
-#: frontend/js/src/forms/SignupUser.tsx:114 metabrainz/user/forms.py:20
-#: metabrainz/user/forms.py:45 metabrainz/user/forms.py:62
+#: frontend/js/src/forms/SignupUser.tsx:120 metabrainz/user/forms.py:22
+#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:75
 msgid "Username"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:42
 #: frontend/js/src/forms/LostPassword.tsx:37
-#: frontend/js/src/forms/SignupCommercial.tsx:153
+#: frontend/js/src/forms/SignupCommercial.tsx:158
 #: frontend/js/src/forms/SignupNonCommercial.tsx:84
-#: frontend/js/src/forms/SignupUser.tsx:67 metabrainz/user/forms.py:21
-#: metabrainz/user/forms.py:45 metabrainz/user/forms.py:62
+#: frontend/js/src/forms/SignupUser.tsx:73 metabrainz/user/forms.py:26
+#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:75
 msgid "Username is required!"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:63
 #: frontend/js/src/forms/ResetPassword.tsx:72
-#: frontend/js/src/forms/SignupCommercial.tsx:308
+#: frontend/js/src/forms/SignupCommercial.tsx:313
 #: frontend/js/src/forms/SignupNonCommercial.tsx:214
-#: frontend/js/src/forms/SignupUser.tsx:157 metabrainz/user/forms.py:46
-#: metabrainz/user/forms.py:52
+#: frontend/js/src/forms/SignupUser.tsx:163 metabrainz/user/forms.py:53
+#: metabrainz/user/forms.py:62
 msgid "Password"
 msgstr ""
 
-#: frontend/js/src/forms/LoginUser.tsx:76 metabrainz/user/forms.py:47
+#: frontend/js/src/forms/LoginUser.tsx:76 metabrainz/user/forms.py:57
 msgid "Remember me"
 msgstr ""
 
@@ -3131,11 +4180,11 @@ msgstr ""
 msgid "Username contains invalid or invisible characters."
 msgstr ""
 
-#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:181
+#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:220
 msgid "Hide password"
 msgstr ""
 
-#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:181
+#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:220
 msgid "Show password"
 msgstr ""
 
@@ -3192,11 +4241,11 @@ msgstr ""
 msgid "Revoke access"
 msgstr ""
 
-#: frontend/js/src/OAuthError.tsx:17
+#: frontend/js/src/OAuthError.tsx:18
 msgid "OAuth2 Error"
 msgstr ""
 
-#: frontend/js/src/OAuthError.tsx:18
+#: frontend/js/src/OAuthError.tsx:19
 msgid "An error occurred during OAuth authentication process."
 msgstr ""
 
@@ -3226,8 +4275,8 @@ msgstr ""
 
 #: frontend/js/src/Profile.tsx:109
 msgid ""
-"Are you sure you want to generate new access token? Current token will be"
-" revoked!"
+"Are you sure you want to generate a new access token? The current token "
+"will be revoked!"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:118
@@ -3342,8 +4391,8 @@ msgid "Contact Information"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:310 frontend/js/src/forms/ProfileEdit.tsx:70
-#: frontend/js/src/forms/SignupCommercial.tsx:284
-#: frontend/js/src/forms/SignupCommercial.tsx:333
+#: frontend/js/src/forms/SignupCommercial.tsx:289
+#: frontend/js/src/forms/SignupCommercial.tsx:338
 #: frontend/js/src/forms/SignupNonCommercial.tsx:189
 #: frontend/js/src/forms/SignupNonCommercial.tsx:241
 msgid "Contact name"
@@ -3458,7 +4507,7 @@ msgstr ""
 msgid "Once you delete your account, there is no going back. Please be certain."
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:550 frontend/js/src/ProfileDelete.tsx:105
+#: frontend/js/src/Profile.tsx:550 frontend/js/src/ProfileDelete.tsx:107
 msgid "Delete My Account"
 msgstr ""
 
@@ -3470,39 +4519,39 @@ msgstr ""
 msgid "Need to delete your account?"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:574
+#: frontend/js/src/Profile.tsx:575
 msgid ""
 "Deletion of supporter accounts requires manual review. Please contact us "
-"at"
+"at <email />."
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:594
+#: frontend/js/src/Profile.tsx:599
 msgid "Security"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:626
+#: frontend/js/src/Profile.tsx:631
 msgid "MetaBrainz Applications"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:630
+#: frontend/js/src/Profile.tsx:635
 msgid ""
 "With your MetaBrainz account, you can access every project in the "
 "MetaBrainz family:"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:643
+#: frontend/js/src/Profile.tsx:648
 msgid "The open-source music encyclopedia"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:655
+#: frontend/js/src/Profile.tsx:660
 msgid "Track, visualise and share the music you listen to"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:667
+#: frontend/js/src/Profile.tsx:672
 msgid "The open-source book database"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:679
+#: frontend/js/src/Profile.tsx:684
 msgid "Creative Commons licensed reviews"
 msgstr ""
 
@@ -3525,7 +4574,7 @@ msgid "Permanently remove all your account information"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:64
-msgid "Revoke all your API tokens and access"
+msgid "Revoke all your tokens and access to the replication API"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:65
@@ -3537,14 +4586,16 @@ msgid "Log you out of all MetaBrainz services"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:70
-msgid "Your username will be reserved and cannot be reused."
+msgid ""
+"Your username will be reserved and cannot be reused without the "
+"intervention of an administrator."
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:82
+#: frontend/js/src/ProfileDelete.tsx:84
 msgid "To confirm, type your username '<username />' below:"
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:105
+#: frontend/js/src/ProfileDelete.tsx:107
 msgid "Deleting..."
 msgstr ""
 
@@ -3556,64 +4607,7 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: frontend/js/src/forms/ConditionsModal.tsx:23
-msgid "Licensing"
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:25
-msgid ""
-"Any contributions you make to any MetaBrainz service will be released "
-"into the Public Domain and/or licensed under a Creative Commons by-nc-sa "
-"license. Furthermore, you give the MetaBrainz Foundation the right to "
-"license this data for commercial use."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:30
-msgid "Please read our <licenseLink>license page</licenseLink> for more details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:45
-msgid ""
-"MetaBrainz strongly believes in the privacy of its users. Any personal "
-"information you choose to provide will not be sold or shared with anyone "
-"else."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:50
-msgid ""
-"Please read our <privacyLink>privacy policy</privacyLink> for more "
-"details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:59
-msgid "GDPR compliance"
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:61
-msgid ""
-"You may remove your personal information from our services anytime by "
-"deleting your account."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:66
-msgid ""
-"Please read our <gdprLink>GDPR compliance statement</gdprLink> for more "
-"details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:78
-msgid ""
-"Creating an account on MetaBrainz will give you access to all of our "
-"projects, such as MusicBrainz, ListenBrainz, BookBrainz, and more."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:82
-msgid ""
-"We create a placeholder account for all the MetaBrainz projects when you "
-"sign up, and you are one log-in away from activating them."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:91
+#: frontend/js/src/forms/ConditionsModal.tsx:29
 msgid "Sounds good"
 msgstr ""
 
@@ -3700,8 +4694,8 @@ msgstr ""
 msgid "Forgot your password?"
 msgstr ""
 
-#: frontend/js/src/forms/LoginUser.tsx:109
-msgid "Don't have an account?"
+#: frontend/js/src/forms/LoginUser.tsx:110
+msgid "Don't have an account? <signupLink>Sign up</signupLink>"
 msgstr ""
 
 #: frontend/js/src/forms/LostPassword.tsx:38
@@ -3730,15 +4724,72 @@ msgstr ""
 msgid "Allow access"
 msgstr ""
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:71
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:10
+msgid "Licensing"
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:12
+msgid ""
+"Any contributions you make to any MetaBrainz service will be released "
+"into the Public Domain and/or licensed under a Creative Commons by-nc-sa "
+"license. Furthermore, you give the MetaBrainz Foundation the right to "
+"license this data for commercial use."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:17
+msgid "Please read our <licenseLink>license page</licenseLink> for more details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:34
+msgid ""
+"MetaBrainz strongly believes in the privacy of its users. Any personal "
+"information you choose to provide will not be sold or shared with anyone "
+"else."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:39
+msgid ""
+"Please read our <privacyLink>privacy policy</privacyLink> for more "
+"details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:50
+msgid "GDPR compliance"
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:52
+msgid ""
+"You may remove your personal information from our services anytime by "
+"deleting your account."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:57
+msgid ""
+"Please read our <gdprLink>GDPR compliance statement</gdprLink> for more "
+"details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:71
+msgid ""
+"Creating an account on MetaBrainz will give you access to all of our "
+"projects, such as MusicBrainz, ListenBrainz, BookBrainz, and more."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:75
+msgid ""
+"We create a placeholder account for all the MetaBrainz projects when you "
+"sign up, and you are one log-in away from activating them."
+msgstr ""
+
+#: frontend/js/src/forms/ProfileChangePassword.tsx:70
 msgid "Current Password"
 msgstr ""
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:80
+#: frontend/js/src/forms/ProfileChangePassword.tsx:79
 msgid "New Password"
 msgstr ""
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:89
+#: frontend/js/src/forms/ProfileChangePassword.tsx:88
 msgid "Confirm New Password"
 msgstr ""
 
@@ -3750,190 +4801,180 @@ msgstr ""
 msgid "Reset Password"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:38
-msgid "If you would like to support us with more than $"
+#: frontend/js/src/forms/SignupCommercial.tsx:40
+msgid ""
+"If you would like to support us with more than ${{minPledge}}, please "
+"enter the actual amount here:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:39
-msgid ", please enter the actual amount here:"
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:144
+#: frontend/js/src/forms/SignupCommercial.tsx:149
 #: frontend/js/src/forms/SignupNonCommercial.tsx:75
-#: frontend/js/src/forms/SignupUser.tsx:87
+#: frontend/js/src/forms/SignupUser.tsx:93
 msgid "Captcha is required!"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:179
+#: frontend/js/src/forms/SignupCommercial.tsx:184
 #: frontend/js/src/forms/SignupNonCommercial.tsx:110
 #: frontend/js/src/forms/SignupUser.tsx:46
 msgid "Access all MetaBrainz projects"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:182
+#: frontend/js/src/forms/SignupCommercial.tsx:187
 msgid "Note:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:184
+#: frontend/js/src/forms/SignupCommercial.tsx:189
 msgid ""
 "Signing up for any tier other than the <italic>Stealth startup</italic> "
 "tier will publicly list your company on this web site. However, we will "
 "not publish any of your private details."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:221
+#: frontend/js/src/forms/SignupCommercial.tsx:226
 #: frontend/js/src/forms/SignupNonCommercial.tsx:145
 msgid "Account type"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:234
+#: frontend/js/src/forms/SignupCommercial.tsx:239
 msgid "Selected tier"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:242
-msgid "month and up"
+#: frontend/js/src/forms/SignupCommercial.tsx:247
+msgid "${{tierPrice}}/month and up"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:250
+#: frontend/js/src/forms/SignupCommercial.tsx:255
 msgid "Change account type or tier"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:261
+#: frontend/js/src/forms/SignupCommercial.tsx:266
 #: frontend/js/src/forms/SignupNonCommercial.tsx:166
 msgid "Your account:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:271
+#: frontend/js/src/forms/SignupCommercial.tsx:276
 #: frontend/js/src/forms/SignupNonCommercial.tsx:176
-#: frontend/js/src/forms/SignupUser.tsx:114
+#: frontend/js/src/forms/SignupUser.tsx:120
 msgid "(public)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:291
+#: frontend/js/src/forms/SignupCommercial.tsx:296
 #: frontend/js/src/forms/SignupNonCommercial.tsx:196
-#: frontend/js/src/forms/SignupUser.tsx:127
+#: frontend/js/src/forms/SignupUser.tsx:133
 msgid "E-mail address"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:295
+#: frontend/js/src/forms/SignupCommercial.tsx:300
 #: frontend/js/src/forms/SignupNonCommercial.tsx:200
-#: frontend/js/src/forms/SignupUser.tsx:131
+#: frontend/js/src/forms/SignupUser.tsx:137
 msgid "(checking...)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:314
+#: frontend/js/src/forms/SignupCommercial.tsx:319
 #: frontend/js/src/forms/SignupNonCommercial.tsx:220
-#: frontend/js/src/forms/SignupUser.tsx:163
+#: frontend/js/src/forms/SignupUser.tsx:169
 msgid "Must be at least 8 characters"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:348
+#: frontend/js/src/forms/SignupCommercial.tsx:353
 msgid ""
 "If you don't have an organization name, you probably want to become a "
 "supporter as a <nonCommercialLink>Non-commercial / "
 "Personal</nonCommercialLink> supporter."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:358
+#: frontend/js/src/forms/SignupCommercial.tsx:363
 msgid ""
 "If you don't have an organization name, you probably want to sign up as a"
 " <nonCommercialLink>Non-commercial / Personal</nonCommercialLink> user."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:378
+#: frontend/js/src/forms/SignupCommercial.tsx:383
 msgid ""
 "Please tell us a little about your company and whether you plan to use "
 "our <apiLink>API</apiLink> or to <hostLink>host your own copy</hostLink> "
 "of the data."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:404
+#: frontend/js/src/forms/SignupCommercial.tsx:408
 msgid "Logo URL"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:405
+#: frontend/js/src/forms/SignupCommercial.tsx:409
 msgid "(preferably in SVG format)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:408
+#: frontend/js/src/forms/SignupCommercial.tsx:412
 msgid ""
 "Image should be about 250 pixels wide on a white or transparent "
 "background. We will host it on our site."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:421
+#: frontend/js/src/forms/SignupCommercial.tsx:425
 msgid ""
 "URL to where developers can use your APIs using MusicBrainz IDs, if "
-"available.."
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:430
-msgid "Your project"
+"available."
 msgstr ""
 
 #: frontend/js/src/forms/SignupCommercial.tsx:434
+msgid "Your project"
+msgstr ""
+
+#: frontend/js/src/forms/SignupCommercial.tsx:438
 #: frontend/js/src/forms/SignupNonCommercial.tsx:261
 msgid "(max 150 characters)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:451
+#: frontend/js/src/forms/SignupCommercial.tsx:455
 msgid "Billing address"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:502
+#: frontend/js/src/forms/SignupCommercial.tsx:506
 msgid ""
 "I agree to support the MetaBrainz Foundation when my organization is able"
 " to do so."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:507
+#: frontend/js/src/forms/SignupCommercial.tsx:511
+#: frontend/js/src/forms/SignupNonCommercial.tsx:284
 msgid ""
-"I also agree that if I generate a Live Data Feed access token, that I "
-"treat my access token as a secret and will not share this token publicly "
-"or commit it to a source code repository."
+"I also agree that if I generate a Live Data Feed access token, then I "
+"will treat my access token as a secret and will not share this token "
+"publicly or commit it to a source code repository."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:515
+#: frontend/js/src/forms/SignupCommercial.tsx:519
 msgid ""
 "The following information will be shown publicly: organization name, "
 "logo, website and API URLs, data usage description."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:520
+#: frontend/js/src/forms/SignupCommercial.tsx:524
 msgid ""
 "We'll send you more details about payment process once your application "
 "is approved."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:552
+#: frontend/js/src/forms/SignupCommercial.tsx:556
 #: frontend/js/src/forms/SignupNonCommercial.tsx:316
-#: frontend/js/src/forms/SignupUser.tsx:224
+#: frontend/js/src/forms/SignupUser.tsx:230
 msgid "Validating..."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:564
+#: frontend/js/src/forms/SignupCommercial.tsx:568
 #: frontend/js/src/forms/SignupNonCommercial.tsx:329
 msgid "Back to profile"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:569
-#: frontend/js/src/forms/SignupNonCommercial.tsx:334
-msgid "Not a supporter?"
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:570
+#: frontend/js/src/forms/SignupCommercial.tsx:574
 #: frontend/js/src/forms/SignupNonCommercial.tsx:335
-msgid "Create a user account"
+msgid "Not a supporter? <signupLink>Create a user account</signupLink>"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:573
-#: frontend/js/src/forms/SignupNonCommercial.tsx:338
-#: frontend/js/src/forms/SignupUser.tsx:231
-msgid "Already have an account?"
-msgstr ""
-
-#: frontend/js/src/forms/SignupNonCommercial.tsx:107
-msgid "non-commercial"
+#: frontend/js/src/forms/SignupCommercial.tsx:583
+#: frontend/js/src/forms/SignupNonCommercial.tsx:344
+#: frontend/js/src/forms/SignupUser.tsx:238
+msgid "Already have an account? <loginLink>Sign in</loginLink>"
 msgstr ""
 
 #: frontend/js/src/forms/SignupNonCommercial.tsx:113
@@ -3961,46 +5002,40 @@ msgid ""
 "income per year) or personal uses only."
 msgstr ""
 
-#: frontend/js/src/forms/SignupNonCommercial.tsx:284
-msgid ""
-"I also agree that if I generate a Live Data Feed access token, then I "
-"will treat my access token as a secret and will not share this token "
-"publicly or commit it to a source code repository."
-msgstr ""
-
 #: frontend/js/src/forms/SignupUser.tsx:43
 msgid "Create your account"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:50
-msgid "Registration started by"
+#: frontend/js/src/forms/SignupUser.tsx:51
+msgid "Registration started by <client />"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:69
+#: frontend/js/src/forms/SignupUser.tsx:75
+#: frontend/js/src/hooks/useEmailValidation.ts:82
 msgid "Invalid email address."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:150
+#: frontend/js/src/forms/SignupUser.tsx:156
 msgid ""
 "This username and email were provided by the app that started "
 "registration. You can change them later from MetaBrainz settings."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:182
+#: frontend/js/src/forms/SignupUser.tsx:188
 msgid ""
 "I accept that my contributions will be released into the public domain or"
 " licensed for use."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:191
+#: frontend/js/src/forms/SignupUser.tsx:197
 msgid "We will never share your personal information."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:200
+#: frontend/js/src/forms/SignupUser.tsx:206
 msgid "Click here to read more"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:224
+#: frontend/js/src/forms/SignupUser.tsx:230
 msgid "Create account"
 msgstr ""
 
@@ -4010,10 +5045,6 @@ msgstr ""
 
 #: frontend/js/src/hooks/useEmailValidation.ts:47
 msgid "Email validation failed"
-msgstr ""
-
-#: frontend/js/src/hooks/useEmailValidation.ts:82
-msgid "Invalid email address"
 msgstr ""
 
 #~ msgid "You need to specify amount!"
@@ -5316,4 +6347,96 @@ msgstr ""
 
 #~ msgid "Privacy policy"
 #~ msgstr "Yksityisyys"
+
+#~ msgid "You need to specify website of the organization."
+#~ msgstr ""
+
+#~ msgid ""
+#~ "We are currently evaluating our overall"
+#~ " online advertising strategy. We are "
+#~ "evaluating advertising, traffic optimization,\n"
+#~ ""
+#~ "    search engine optimization and "
+#~ "software monitization technologies. If you "
+#~ "provide these professional services, please"
+#~ " provide a detailed\n"
+#~ "    deck of your comprehensive services"
+#~ " to the following email address. "
+#~ "<em>Please respect our other non-media"
+#~ " teams and do not contact us \n"
+#~ "    regarding these services on any "
+#~ "other of our email addresses. We "
+#~ "will disregard the entirety of your "
+#~ "submissions if you contact us any "
+#~ "other way!</em>"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Please come ask your questions at "
+#~ "our <a href=\"%(forums_url)s\">forums</a>! We "
+#~ "would love to\n"
+#~ "    answer any questions you may have."
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Due to the increased unreliability of"
+#~ " the US Postal Service we have "
+#~ "stopped accepting paper checks. Sorry!"
+#~ msgstr ""
+
+#~ msgid "Upgrade"
+#~ msgstr ""
+
+#~ msgid "Back to Profile"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Deletion of supporter accounts requires "
+#~ "manual review. Please contact us at"
+#~ msgstr ""
+
+#~ msgid "Revoke all your API tokens and access"
+#~ msgstr ""
+
+#~ msgid "Your username will be reserved and cannot be reused."
+#~ msgstr ""
+
+#~ msgid "Don't have an account?"
+#~ msgstr ""
+
+#~ msgid "If you would like to support us with more than $"
+#~ msgstr ""
+
+#~ msgid ", please enter the actual amount here:"
+#~ msgstr ""
+
+#~ msgid "month and up"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "I also agree that if I generate"
+#~ " a Live Data Feed access token, "
+#~ "that I treat my access token as"
+#~ " a secret and will not share "
+#~ "this token publicly or commit it "
+#~ "to a source code repository."
+#~ msgstr ""
+
+#~ msgid "Not a supporter?"
+#~ msgstr ""
+
+#~ msgid "Create a user account"
+#~ msgstr ""
+
+#~ msgid "Already have an account?"
+#~ msgstr ""
+
+#~ msgid "non-commercial"
+#~ msgstr ""
+
+#~ msgid "Registration started by"
+#~ msgstr ""
+
+#~ msgid "Invalid email address"
+#~ msgstr ""
 

--- a/metabrainz/translations/fr/LC_MESSAGES/messages.po
+++ b/metabrainz/translations/fr/LC_MESSAGES/messages.po
@@ -11,178 +11,262 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-07-25 16:21+0200\n"
+"POT-Creation-Date: 2026-09-08 11:18+0200\n"
 "PO-Revision-Date: 2026-07-31 17:31+0000\n"
 "Last-Translator: mr_monkey "
 "<mr_monkey@users.noreply.translations.metabrainz.org>\n"
 "Language: fr\n"
-"Language-Team: French <https://translations.metabrainz.org/projects/"
-"metabrainz/website/fr/>\n"
-"Plural-Forms: nplurals=3; plural=(n == 0 || n == 1) ? 0 : ((n != 0 && n % "
-"1000000 == 0) ? 1 : 2);\n"
+"Language-Team: French "
+"<https://translations.metabrainz.org/projects/metabrainz/website/fr/>\n"
+"Plural-Forms: nplurals=3; plural=(n == 0 || n == 1) ? 0 : ((n != 0 && n %"
+" 1000000 == 0) ? 1 : 2);\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.18.0\n"
-"X-Generator: Weblate 2026.7.1\n"
 
-#: metabrainz/index/forms.py:46
+#: metabrainz/errors.py:24
+msgid "Authorization was declined."
+msgstr ""
+
+#: metabrainz/errors.py:25
+msgid "The authorization request was invalid."
+msgstr ""
+
+#: metabrainz/errors.py:26
+msgid "The application could not be authenticated."
+msgstr ""
+
+#: metabrainz/errors.py:27
+msgid "This application is not allowed to request authorization."
+msgstr ""
+
+#: metabrainz/errors.py:28
+msgid "The application asked for a response type this server does not support."
+msgstr ""
+
+#: metabrainz/errors.py:29
+msgid "The permissions requested by the application are invalid."
+msgstr ""
+
+#: metabrainz/errors.py:30
+msgid "You need to sign in to continue."
+msgstr ""
+
+#: metabrainz/errors.py:31
+msgid "Your consent is required to continue."
+msgstr ""
+
+#: metabrainz/password.py:12
+#, python-format
+msgid "Password must not exceed %(max_bytes)s bytes."
+msgstr ""
+
+#: metabrainz/index/forms.py:48
 #, python-format
 msgid "'%(value)s' is not a valid choice for this field"
 msgstr "«%(value)s» n'est pas un choix valide pour ce champ"
 
 #: frontend/js/src/forms/ProfileEdit.tsx:27
-#: frontend/js/src/forms/SignupCommercial.tsx:154
+#: frontend/js/src/forms/SignupCommercial.tsx:159
 #: frontend/js/src/forms/SignupNonCommercial.tsx:85
-#: frontend/js/src/forms/SignupUser.tsx:70
-#: frontend/js/src/hooks/useEmailValidation.ts:78 metabrainz/index/forms.py:57
-#: metabrainz/user/forms.py:25 metabrainz/user/forms.py:57
-#: metabrainz/user/forms.py:63
+#: frontend/js/src/forms/SignupUser.tsx:76
+#: frontend/js/src/hooks/useEmailValidation.ts:78 metabrainz/index/forms.py:59
+#: metabrainz/user/forms.py:31 metabrainz/user/forms.py:70
+#: metabrainz/user/forms.py:76
 msgid "Email address is required!"
 msgstr "Une adresse email est requise !"
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:34
-#: metabrainz/index/forms.py:63
+#: metabrainz/index/forms.py:65
 msgid "Current password is required!"
 msgstr "Le mot de passe actuel est requis !"
 
 #: frontend/js/src/forms/LoginUser.tsx:43
 #: frontend/js/src/forms/ProfileChangePassword.tsx:37
 #: frontend/js/src/forms/ResetPassword.tsx:39
-#: frontend/js/src/forms/SignupCommercial.tsx:156
+#: frontend/js/src/forms/SignupCommercial.tsx:161
 #: frontend/js/src/forms/SignupNonCommercial.tsx:87
-#: frontend/js/src/forms/SignupUser.tsx:72 metabrainz/index/forms.py:66
-#: metabrainz/user/forms.py:29 metabrainz/user/forms.py:46
-#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:69
+#: frontend/js/src/forms/SignupUser.tsx:78 metabrainz/index/forms.py:69
+#: metabrainz/user/forms.py:35 metabrainz/user/forms.py:54
+#: metabrainz/user/forms.py:63 metabrainz/user/forms.py:82
 msgid "Password is required!"
 msgstr "Un mot de passe est requis !"
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:41
-#: frontend/js/src/forms/SignupCommercial.tsx:160
+#: frontend/js/src/forms/SignupCommercial.tsx:165
 #: frontend/js/src/forms/SignupNonCommercial.tsx:91
-#: frontend/js/src/forms/SignupUser.tsx:76 metabrainz/index/forms.py:70
-#: metabrainz/user/forms.py:33 metabrainz/user/forms.py:73
+#: frontend/js/src/forms/SignupUser.tsx:82 metabrainz/index/forms.py:74
+#: metabrainz/user/forms.py:40 metabrainz/user/forms.py:87
 msgid "Confirm Password is required!"
 msgstr "La confirmation du mot de passe est requise !"
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:46
 #: frontend/js/src/forms/ResetPassword.tsx:48
-#: frontend/js/src/forms/SignupCommercial.tsx:165
+#: frontend/js/src/forms/SignupCommercial.tsx:170
 #: frontend/js/src/forms/SignupNonCommercial.tsx:96
-#: frontend/js/src/forms/SignupUser.tsx:81 metabrainz/index/forms.py:72
-#: metabrainz/user/forms.py:35 metabrainz/user/forms.py:75
+#: frontend/js/src/forms/SignupUser.tsx:87 metabrainz/index/forms.py:76
+#: metabrainz/user/forms.py:42 metabrainz/user/forms.py:89
 msgid "Confirm Password should match password!"
 msgstr "La confirmation du mot de passe ne correspond pas !"
 
 #: frontend/js/src/Applications.tsx:56 frontend/js/src/Applications.tsx:86
 #: frontend/js/src/Profile.tsx:272 frontend/js/src/Profile.tsx:482
-#: metabrainz/index/forms.py:78
+#: metabrainz/index/forms.py:82
 msgid "Name"
 msgstr "Nom"
 
-#: metabrainz/index/forms.py:79
+#: metabrainz/index/forms.py:83
 msgid "Contact name field is empty."
 msgstr "Le champ \"Nom du contact\" est vide."
 
-#: metabrainz/index/views.py:234
+#: metabrainz/index/views.py:251
 msgid "Profile updated successfully."
 msgstr "Profil mis à jour avec succès."
 
-#: metabrainz/index/views.py:261
+#: metabrainz/index/views.py:278
 msgid "Current password is incorrect."
 msgstr "Le mot de passe actuel est incorrect."
 
-#: metabrainz/index/views.py:266
+#: metabrainz/index/views.py:283
 msgid "Password changed successfully."
 msgstr "Mot de passe mis à jour avec succès."
 
-#: metabrainz/index/views.py:372
+#: metabrainz/index/views.py:389
 msgid "You have updated an application!"
 msgstr "Vous avez mis une application à jour !"
 
-#: metabrainz/index/views.py:424
+#: metabrainz/index/views.py:441
 msgid "You have deleted an application."
 msgstr "Vous avez supprimé une application."
 
-#: metabrainz/index/views.py:426
+#: metabrainz/index/views.py:443
 msgid "Failed to delete an application."
 msgstr "Échec lors de la suppression d'une application."
 
-#: metabrainz/index/views.py:449
+#: metabrainz/index/views.py:466
 msgid "Revoked tokens successfully!"
 msgstr "Clés révoquées avec succès !"
 
-#: metabrainz/index/views.py:478
+#: metabrainz/index/views.py:495
 msgid "Your account has been deleted."
 msgstr "Votre compte a été supprimé."
 
-#: frontend/js/src/forms/CreateApplication.tsx:106 metabrainz/oauth/forms.py:58
+#: frontend/js/src/forms/CreateApplication.tsx:106 metabrainz/oauth/forms.py:57
 msgid "Application Name"
 msgstr "Nom de l’application"
 
-#: metabrainz/oauth/forms.py:59
+#: metabrainz/oauth/forms.py:58
 msgid "Application name field is empty."
 msgstr "Le champ \"Nom de l’application\" est vide."
 
-#: frontend/js/src/forms/CreateApplication.tsx:60 metabrainz/oauth/forms.py:60
+#: frontend/js/src/forms/CreateApplication.tsx:60 metabrainz/oauth/forms.py:59
 msgid "Application name needs to be at least 3 characters long."
 msgstr "Le nom de l’application doit comporter au moins 3 caractères."
 
-#: frontend/js/src/forms/CreateApplication.tsx:64 metabrainz/oauth/forms.py:61
+#: frontend/js/src/forms/CreateApplication.tsx:64 metabrainz/oauth/forms.py:60
 msgid "Application name needs to be at most 64 characters long."
 msgstr "Le nom de l’application ne peut comporter plus de 64 caractères."
 
-#: frontend/js/src/forms/CreateApplication.tsx:114 metabrainz/oauth/forms.py:63
+#: frontend/js/src/forms/CreateApplication.tsx:114 metabrainz/oauth/forms.py:62
 msgid "Description"
 msgstr "Description"
 
-#: metabrainz/oauth/forms.py:64
+#: metabrainz/oauth/forms.py:63
 msgid "Client description field is empty."
 msgstr "Le champ \"Description\" est vide."
 
-#: metabrainz/oauth/forms.py:65
+#: metabrainz/oauth/forms.py:64
 msgid "Client description needs to be at least 3 characters long."
 msgstr "La description doit comporter au moins 3 caractères."
 
-#: metabrainz/oauth/forms.py:66
+#: metabrainz/oauth/forms.py:65
 msgid "Client description needs to be at most 512 characters long."
 msgstr "La description ne peut comporter plus de 512 caractères."
 
-#: frontend/js/src/forms/CreateApplication.tsx:122 metabrainz/oauth/forms.py:68
+#: frontend/js/src/forms/CreateApplication.tsx:122 metabrainz/oauth/forms.py:67
 msgid "Homepage"
 msgstr "Site web"
 
-#: metabrainz/oauth/forms.py:69
+#: metabrainz/oauth/forms.py:68
 msgid "Homepage field is empty."
 msgstr "Le champ \"Site web\" est vide."
 
-#: metabrainz/oauth/forms.py:70
+#: metabrainz/oauth/forms.py:69
 msgid "Homepage is not a valid URI."
 msgstr "Le site web n’a pas une URI valide."
 
-#: metabrainz/oauth/forms.py:71
+#: metabrainz/oauth/forms.py:70
 msgid "Homepage URL must use http or https"
 msgstr "Le site web doit commencer par http ou https"
 
-#: metabrainz/oauth/forms.py:73
+#: metabrainz/oauth/forms.py:72
 msgid "Authorization callback URL"
 msgstr "URL de rappel d’autorisation"
 
-#: metabrainz/oauth/forms.py:74
+#: metabrainz/oauth/forms.py:73
 msgid "Authorization callback URL field is empty."
 msgstr "Le champ d’URL de rappel d’autorisation est vide."
 
-#: metabrainz/oauth/forms.py:75
+#: metabrainz/oauth/forms.py:74
 msgid "Authorization callback URL is invalid."
 msgstr "L’URL de rappel d’autorisation est invalide."
 
-#: metabrainz/oauth/forms.py:76
+#: metabrainz/oauth/forms.py:75
 msgid "Authorization callback URL must use http or https."
 msgstr "L'URL de redirection d'autorisation doit commencer par http ou https."
 
-#: metabrainz/oauth/forms.py:81 metabrainz/oauth/forms.py:85
+#: metabrainz/oauth/forms.py:80 metabrainz/oauth/forms.py:84
 msgid "Confirm"
 msgstr "Confirmer"
+
+#: metabrainz/oauth/scopes.py:15
+msgid "View your public account information"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:16
+msgid "View your email address"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:17
+msgid "View and modify your private tags"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:18
+msgid "View and modify your private ratings"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:19
+msgid "View and modify your private collections"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:20
+msgid "Submit new ISRCs to the database"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:21
+msgid "Submit new barcodes to the database"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:22
+msgid "Sign you in and view your unique user id"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:23
+msgid "Submit listens to ListenBrainz."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:24
+msgid "Create and modify CritiqueBrainz reviews."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:25
+msgid "Submit and delete votes on CritiqueBrainz reviews."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:26
+msgid "Modify profile info and delete profile on CritiqueBrainz."
+msgstr ""
 
 #: metabrainz/payments/views.py:164
 msgid ""
@@ -207,8 +291,8 @@ msgid ""
 "We're sorry to see that you won't be donating today. We hope that you'll "
 "change your mind!"
 msgstr ""
-"Nous sommes désolés de voir que vous ne ferez pas de donation aujourd'hui. "
-"Nous espérons que vous changerez d'avis !"
+"Nous sommes désolés de voir que vous ne ferez pas de donation "
+"aujourd'hui. Nous espérons que vous changerez d'avis !"
 
 #: metabrainz/payments/views.py:188
 msgid ""
@@ -239,15 +323,15 @@ msgid "Requested annual report was not found."
 msgstr "Le rapport annuel demandé n’a pas été trouvé."
 
 #: frontend/js/src/forms/ProfileEdit.tsx:30
-#: frontend/js/src/forms/SignupCommercial.tsx:139
+#: frontend/js/src/forms/SignupCommercial.tsx:144
 #: frontend/js/src/forms/SignupNonCommercial.tsx:70
-#: metabrainz/supporter/forms.py:13
+#: metabrainz/supporter/forms.py:15
 msgid "Contact name is required!"
 msgstr "Le nom du contact est requis !"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:437
+#: frontend/js/src/forms/SignupCommercial.tsx:441
 #: frontend/js/src/forms/SignupNonCommercial.tsx:264
-#: metabrainz/supporter/forms.py:15
+#: metabrainz/supporter/forms.py:17
 msgid ""
 "Can you please tell us more about the project in which you'd like to use "
 "our data? Do you plan to self host the data or use our APIs?"
@@ -255,144 +339,151 @@ msgstr ""
 "Pourriez vous nous en dire plus sur votre projet utilisant nos données ? "
 "Comptez vous auto-héberger les données ou utiliser nos API ?"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:137
+#: frontend/js/src/forms/SignupCommercial.tsx:142
 #: frontend/js/src/forms/SignupNonCommercial.tsx:68
-#: metabrainz/supporter/forms.py:17
+#: metabrainz/supporter/forms.py:19
 msgid "Please, tell us how you (will) use our data."
 msgstr "Veuillez nous dire comment vous comptez utiliser nos données."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:138
+#: frontend/js/src/forms/SignupCommercial.tsx:143
 #: frontend/js/src/forms/SignupNonCommercial.tsx:69
-#: metabrainz/supporter/forms.py:18
+#: metabrainz/supporter/forms.py:20
 msgid "Please, limit usage description to 500 characters."
 msgstr "Veuillez limiter votre description à 500 caractères."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:141
-#: frontend/js/src/forms/SignupCommercial.tsx:142
+#: frontend/js/src/forms/SignupCommercial.tsx:146
+#: frontend/js/src/forms/SignupCommercial.tsx:147
 #: frontend/js/src/forms/SignupNonCommercial.tsx:72
 #: frontend/js/src/forms/SignupNonCommercial.tsx:73
-#: frontend/js/src/forms/SignupUser.tsx:84
-#: frontend/js/src/forms/SignupUser.tsx:85 metabrainz/supporter/forms.py:21
-#: metabrainz/user/forms.py:38
+#: frontend/js/src/forms/SignupUser.tsx:90
+#: frontend/js/src/forms/SignupUser.tsx:91 metabrainz/supporter/forms.py:23
+#: metabrainz/user/forms.py:45
 msgid "You need to accept the agreement!"
 msgstr "Vous devez accepter l'accord !"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:342
-#: metabrainz/supporter/forms.py:27
+#: frontend/js/src/forms/SignupCommercial.tsx:347
+#: metabrainz/supporter/forms.py:29
 msgid "Organization name"
 msgstr "Nom de l'organisation"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:113
-#: metabrainz/supporter/forms.py:28
+#: frontend/js/src/forms/SignupCommercial.tsx:115
+#: metabrainz/supporter/forms.py:30
 msgid "You need to specify the name of your organization."
 msgstr "Vous devez spécifier le nom de votre organisation."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:373
-#: metabrainz/supporter/forms.py:30
+#: frontend/js/src/forms/SignupCommercial.tsx:378
+#: metabrainz/supporter/forms.py:32
 msgid "Organization description"
 msgstr "Description de l'organisation"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:116
-#: metabrainz/supporter/forms.py:31
+#: frontend/js/src/forms/SignupCommercial.tsx:118
+#: metabrainz/supporter/forms.py:33
 msgid "You need to provide description of your organization."
 msgstr "Vous devez indiquer la description de votre organisation."
 
 #: frontend/js/src/Profile.tsx:278
-#: frontend/js/src/forms/SignupCommercial.tsx:396
-#: metabrainz/supporter/forms.py:34
+#: frontend/js/src/forms/SignupCommercial.tsx:401
+#: metabrainz/supporter/forms.py:36
 msgid "Website URL"
 msgstr "URL du site web"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:119
-#: metabrainz/supporter/forms.py:35
-msgid "You need to specify website of the organization."
-msgstr "Vous devez spécifier le site internet de votre organisation."
+#: frontend/js/src/forms/SignupCommercial.tsx:121
+#: frontend/js/src/forms/SignupCommercial.tsx:123
+#: metabrainz/supporter/forms.py:38 metabrainz/supporter/forms.py:42
+msgid "Website URL must be a valid URL."
+msgstr ""
 
-#: metabrainz/supporter/forms.py:37
+#: metabrainz/supporter/forms.py:45
 msgid "Logo image URL"
 msgstr "URL du logo"
 
 #: frontend/js/src/Profile.tsx:284
-#: frontend/js/src/forms/SignupCommercial.tsx:418
-#: metabrainz/supporter/forms.py:38
+#: frontend/js/src/forms/SignupCommercial.tsx:422
+#: metabrainz/supporter/forms.py:46
 msgid "API URL"
 msgstr "URL de l'API"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:457
-#: metabrainz/supporter/forms.py:40
+#: frontend/js/src/forms/SignupCommercial.tsx:461
+#: metabrainz/supporter/forms.py:48
 msgid "Street"
 msgstr "Rue"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:123
-#: metabrainz/supporter/forms.py:41
+#: frontend/js/src/forms/SignupCommercial.tsx:128
+#: metabrainz/supporter/forms.py:49
 msgid "You need to specify street."
 msgstr "Vous devez spécifier une rue."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:465
-#: metabrainz/supporter/forms.py:43
+#: frontend/js/src/forms/SignupCommercial.tsx:469
+#: metabrainz/supporter/forms.py:51
 msgid "City"
 msgstr "Ville"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:124
-#: metabrainz/supporter/forms.py:44
+#: frontend/js/src/forms/SignupCommercial.tsx:129
+#: metabrainz/supporter/forms.py:52
 msgid "You need to specify city."
 msgstr "Vous devez spécifier une ville."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:473
-#: metabrainz/supporter/forms.py:46
+#: frontend/js/src/forms/SignupCommercial.tsx:477
+#: metabrainz/supporter/forms.py:54
 msgid "State / Province"
 msgstr "État / Région"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:126
-#: metabrainz/supporter/forms.py:47
+#: frontend/js/src/forms/SignupCommercial.tsx:131
+#: metabrainz/supporter/forms.py:55
 msgid "You need to specify state/province."
 msgstr "Vous devez spécifier un état ou une région."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:481
-#: metabrainz/supporter/forms.py:49
+#: frontend/js/src/forms/SignupCommercial.tsx:485
+#: metabrainz/supporter/forms.py:57
 msgid "Postcode"
 msgstr "Code postal"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:128
-#: metabrainz/supporter/forms.py:50
+#: frontend/js/src/forms/SignupCommercial.tsx:133
+#: metabrainz/supporter/forms.py:58
 msgid "You need to specify postcode."
 msgstr "Vous devez spécifier un code postal."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:489
-#: metabrainz/supporter/forms.py:52
+#: frontend/js/src/forms/SignupCommercial.tsx:493
+#: metabrainz/supporter/forms.py:60
 msgid "Country"
 msgstr "Pays"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:129
-#: metabrainz/supporter/forms.py:53
+#: frontend/js/src/forms/SignupCommercial.tsx:134
+#: metabrainz/supporter/forms.py:61
 msgid "You need to specify country."
 msgstr "Vous devez spécifier un pays."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:132
-#: metabrainz/supporter/forms.py:64
+#: frontend/js/src/forms/SignupCommercial.tsx:137
+#: metabrainz/supporter/forms.py:72
 msgid ""
 "Custom amount must be more than threshold amount for selected tier or "
 "equal to it!"
 msgstr "Le montant doit être supérieur ou égal au seuil du palier sélectionné !"
 
-#: metabrainz/supporter/views.py:46 metabrainz/supporter/views.py:119
-#: metabrainz/supporter/views.py:220
+#: metabrainz/supporter/views.py:54
+msgid ""
+"The verification email could not be sent. Please request a new one from "
+"your profile."
+msgstr ""
+
+#: metabrainz/supporter/views.py:85 metabrainz/supporter/views.py:158
+#: metabrainz/supporter/views.py:260
 msgid "You are already a supporter."
 msgstr "Vous êtes déjà un supporter."
 
-#: metabrainz/supporter/views.py:61
+#: metabrainz/supporter/views.py:100
 msgid "Can't find tier with a specified ID."
 msgstr "Impossible de trouver le palier avec l'identifiant spécifié."
 
-#: metabrainz/supporter/views.py:127
+#: metabrainz/supporter/views.py:166
 msgid "You need to choose support tier before signing up!"
 msgstr "Vous devez choisir un palier de soutien avant de vous inscrire !"
 
-#: metabrainz/supporter/views.py:137
+#: metabrainz/supporter/views.py:176
 msgid "You need to choose existing tier before signing up!"
 msgstr "Vous devez choisir un palier existant avant de vous inscrire !"
 
-#: metabrainz/supporter/views.py:164
+#: metabrainz/supporter/views.py:204
 msgid ""
 "Thanks for becoming a supporter! Your application will be reviewed soon. "
 "We will send you updates via email."
@@ -400,7 +491,7 @@ msgstr ""
 "Merci de votre soutien ! Votre demande sera examinée prochainement. Nous "
 "vous tiendrons informés par email."
 
-#: metabrainz/supporter/views.py:187
+#: metabrainz/supporter/views.py:228
 msgid ""
 "Thanks for signing up! Your application will be reviewed soon. We will "
 "send you updates via email."
@@ -408,17 +499,17 @@ msgstr ""
 "Merci de votre inscription ! Votre demande sera examinée prochainement. "
 "Nous vous tiendrons informés par email."
 
-#: metabrainz/supporter/views.py:248
+#: metabrainz/supporter/views.py:288
 msgid "Thanks for becoming a supporter!"
 msgstr "Merci de votre soutien !"
 
-#: metabrainz/supporter/views.py:274
+#: metabrainz/supporter/views.py:312
 msgid "Thanks for signing up! Please check your inbox to complete verification."
 msgstr ""
 "Merci pour votre inscription ! Veuillez consulter votre boîte de "
 "réception pour finaliser la vérification."
 
-#: metabrainz/supporter/views.py:302
+#: metabrainz/supporter/views.py:340
 msgid "Can't generate new token unless account is active."
 msgstr "Impossible de générer une clé tant que le compte est inactif."
 
@@ -452,7 +543,7 @@ msgstr "Boutique"
 msgid "Policies"
 msgstr "Chartes"
 
-#: metabrainz/templates/base.html:55 metabrainz/templates/index/gdpr.html:178
+#: metabrainz/templates/base.html:55
 #: metabrainz/templates/index/social-contract.html:3
 #: metabrainz/templates/index/social-contract.html:6
 #: metabrainz/templates/navbar.html:34
@@ -462,14 +553,15 @@ msgstr "Contrat social"
 #: metabrainz/templates/base.html:56
 #: metabrainz/templates/index/code-of-conduct.html:3
 #: metabrainz/templates/index/code-of-conduct.html:16
-#: metabrainz/templates/index/gdpr.html:181 metabrainz/templates/navbar.html:35
+#: metabrainz/templates/navbar.html:35
 msgid "Code of Conduct"
 msgstr "Code de conduite"
 
+#: frontend/js/src/PrivacySummary.tsx:11
 #: frontend/js/src/forms/ConditionsModal.tsx:21
-#: metabrainz/templates/base.html:57 metabrainz/templates/index/gdpr.html:184
-#: metabrainz/templates/index/privacy.html:6
+#: metabrainz/templates/base.html:57 metabrainz/templates/index/privacy.html:6
 #: metabrainz/templates/navbar.html:36
+#: metabrainz/templates/users/privacy-summary.html:3
 msgid "Privacy Policy"
 msgstr "Politique de confidentialité"
 
@@ -502,10 +594,7 @@ msgstr "Parrains"
 msgid "Supporters"
 msgstr "Supporters"
 
-#: frontend/js/src/forms/LoginUser.tsx:103
-#: frontend/js/src/forms/SignupCommercial.tsx:574
-#: frontend/js/src/forms/SignupNonCommercial.tsx:339
-#: frontend/js/src/forms/SignupUser.tsx:232 metabrainz/templates/base.html:73
+#: frontend/js/src/forms/LoginUser.tsx:103 metabrainz/templates/base.html:73
 #: metabrainz/templates/navbar.html:66 metabrainz/templates/users/login.html:3
 msgid "Sign in"
 msgstr "Se connecter"
@@ -527,26 +616,26 @@ msgid "Contact us"
 msgstr "Contactez-nous"
 
 #: metabrainz/templates/base.html:85
-#: metabrainz/templates/index/contact.html:105
+#: metabrainz/templates/index/contact.html:106
 msgid "Blog"
 msgstr "Blog"
 
-#: metabrainz/templates/base.html:86 metabrainz/templates/index/contact.html:90
+#: metabrainz/templates/base.html:86 metabrainz/templates/index/contact.html:91
 msgid "Chat"
 msgstr "Chat"
 
 #: metabrainz/templates/base.html:87
-#: metabrainz/templates/index/contact.html:106
+#: metabrainz/templates/index/contact.html:107
 msgid "Mastodon"
 msgstr "Mastodon"
 
 #: metabrainz/templates/base.html:88
-#: metabrainz/templates/index/contact.html:107
+#: metabrainz/templates/index/contact.html:108
 msgid "Bluesky"
 msgstr "Bluesky"
 
 #: metabrainz/templates/base.html:89
-#: metabrainz/templates/index/contact.html:108
+#: metabrainz/templates/index/contact.html:109
 msgid "Instagram"
 msgstr "Instagram"
 
@@ -602,15 +691,14 @@ msgstr "Rapports financiers"
 msgid "Donate"
 msgstr "Faire un don"
 
-#: frontend/js/src/forms/LoginUser.tsx:110
-#: frontend/js/src/forms/SignupCommercial.tsx:175
-#: frontend/js/src/forms/SignupCommercial.tsx:555
+#: frontend/js/src/forms/SignupCommercial.tsx:180
+#: frontend/js/src/forms/SignupCommercial.tsx:559
 #: frontend/js/src/forms/SignupNonCommercial.tsx:106
 #: frontend/js/src/forms/SignupNonCommercial.tsx:319
 #: metabrainz/templates/navbar.html:65
-#: metabrainz/templates/supporters/account-type.html:51
-#: metabrainz/templates/supporters/account-type.html:93
-#: metabrainz/templates/supporters/account-type.html:144
+#: metabrainz/templates/supporters/account-type.html:47
+#: metabrainz/templates/supporters/account-type.html:84
+#: metabrainz/templates/supporters/account-type.html:130
 #: metabrainz/templates/users/signup.html:3
 msgid "Sign up"
 msgstr "S'inscrire"
@@ -642,8 +730,8 @@ msgid ""
 "All endpoints require an access token which you can get from your\n"
 "    <a href=\"%(profile_url)s\">profile page</a>."
 msgstr ""
-"Tous les points de terminaison nécessitent une clé d'accès que vous pouvez "
-"obtenir sur <a href=\"%(profile_url)s\">votre profil</a>."
+"Tous les points de terminaison nécessitent une clé d'accès que vous "
+"pouvez obtenir sur <a href=\"%(profile_url)s\">votre profil</a>."
 
 #: metabrainz/templates/api/info.html:15
 msgid "MusicBrainz Live Data Feed"
@@ -652,8 +740,8 @@ msgstr "Flux de données en direct de MusicBrainz"
 #: metabrainz/templates/api/info.html:16
 msgid "There are two endpoints for fetching live data:"
 msgstr ""
-"Deux points de terminaison permettent de récupérer les données en temps réel "
-":"
+"Deux points de terminaison permettent de récupérer les données en temps "
+"réel :"
 
 #: metabrainz/templates/api/info.html:18
 msgid "Hourly Replication Packets"
@@ -1018,9 +1106,431 @@ msgstr ""
 msgid "Introduction"
 msgstr "Introduction"
 
-#: metabrainz/templates/index/conflict-policy.html:55
+#: metabrainz/templates/index/conflict-policy.html:17
+msgid ""
+"Conflicts between people arise in open source projects constantly and the"
+" projects by the \n"
+"    MetaBrainz Foundation are no different. This policy aims to establish"
+" a clear and unambiguous \n"
+"    policy for reporting and addressing conflicts in our community. In "
+"this policy we aim to \n"
+"    establish a fair practice that balances the need for confidentiality "
+"and our desire for \n"
+"    transparency in our operations."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:25
+#, python-format
+msgid ""
+"Before you continue to read this policy, we encourage you to review our "
+"existing community policies \n"
+"    including our <a href=\"%(social_contract_url)s\">Social "
+"Contract</a>, \n"
+"    <a href=\"%(code_of_conduct_url)s\">the Code of Conduct</a>, \n"
+"    and our <a href=\"%(privacy_policy_url)s\">Privacy Policy</a>. These "
+"policies establish the norms and rules for \n"
+"    participation in our projects; these policies apply equally to the "
+"contractors of the MetaBrainz \n"
+"    Foundation and any participants in our projects."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:37
+msgid ""
+"This policy divides conflicts into two categories: Private and public. "
+"Private conflicts are conflicts \n"
+"    that involve *confidential* information regarding contributors, "
+"contractors or supporters. Otherwise, any conflicts \n"
+"    that do not involve confidential information are considered to be "
+"public conflicts. For instance, a \n"
+"    conflict between a contractor and the Executive Director (aka BDFL) "
+"that involves contractor pay is \n"
+"    considered a private conflict because pay rates are confidential "
+"information. A public conflict in edit \n"
+"    notes between two editors in our community does not involve "
+"confidential information and therefore should \n"
+"    be considered a public conflict."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:47
+msgid ""
+"When conflicts arise we aim to disclose as much information as possible "
+"about the conflict in a timely \n"
+"    fashion. When conflicts contain confidential matters we will aim to "
+"disclose as much information as \n"
+"    possible, while fully respecting the confidentiality of the people "
+"involved in the conflict. With any \n"
+"    private conflict we will aim to extract the relevant lessons for the "
+"team and community in an effort to \n"
+"    evolve our policies to prevent future conflicts. Should the involved "
+"parties disagree whether a conflict \n"
+"    is private or public, the question about the nature of the conflict "
+"will be presented for the next higher \n"
+"    level in the chain of command to decide. (e.g. if a community member "
+"and the community manager disagree on \n"
+"    a conflict being public or private, the Executive Director shall "
+"decide if the conflict is public or private)."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:58
 msgid "Reporting and Response"
 msgstr "Signalement et prise en charge"
+
+#: metabrainz/templates/index/conflict-policy.html:61
+msgid ""
+"We aim to not have conflict in our community, but we recognize that in "
+"reality conflicts will arise and we \n"
+"    must be prepared to address them in a fair manner. When conflicts "
+"arise, we prefer to have community or team \n"
+"    members resolve the conflicts among themselves, using our existing "
+"policies as guidelines for resolving the \n"
+"    conflict."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:69
+msgid ""
+"If you do not feel comfortable resolving a conflict on your own, you "
+"should feel free to report the conflict to \n"
+"    us. How you address the conflict depends on who is involved in the "
+"conflict and your comfort level. Please see \n"
+"    the detailed sections below on how and with whom to address your "
+"conflict. We aim to address conflicts as soon \n"
+"    as possible in an effort to prevent them from escalating "
+"unnecessarily."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:75
+msgid "Direct conflict resolution"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:78
+msgid ""
+"In direct conflict resolution, the involved parties will attempt to "
+"resolve the conflict themselves without \n"
+"   involving any MetaBrainz Foundation team member. You should aim to use"
+" direct resolution when the conflict does \n"
+"   not involve the violation of one of our policies or if the conflict is"
+" minor."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:84
+#, python-format
+msgid ""
+"For instance, if a user uses a rude tone, is disruptive or flagrantly "
+"ignores our project guidelines, we suggest \n"
+"    that you use direct conflict resolution to resolve the conflict. Some"
+" resources that might give you some suggestions \n"
+"    on how to go about resolving the conflict might be this <a "
+"href=\"%(conflict_resolution_primer_url)s\">\n"
+"    conflict resolution primer</a> and <a "
+"href=\"%(difficult_conversations_url)s\">how to\n"
+"    have difficult conversations at work</a>."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:93
+msgid "Informal reporting"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:96
+msgid ""
+"You may use informal reporting of a conflict if you aim to communicate a "
+"concern or incident without \n"
+"    seeking a corrective outcome. Informal reporting may also be an "
+"option if you have not been personally \n"
+"    victimized, but you’ve witnessed a violation of our policies or where"
+" you wish to maintain confidentiality \n"
+"    throughout the entire reporting process."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:103
+msgid ""
+"For editing in MusicBrainz you may informally report a user using the "
+"“Report this user for bad behavior” \n"
+"    link from the user’s profile. For reporting bad user behavior in "
+"other of our projects, please report them to our \n"
+"    community manager by mailing <span class=\"backemail\">gro.zniarbatem"
+"@reganam-ytinummoc</span> . For conflicts \n"
+"    that involve the community manager, report them by mailing <span "
+"class=\"backemail\">gro.zniarbatem@de</span> ."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:110
+msgid ""
+"Depending the the severity of the issue, repeated informal complaints may"
+" eventually require a formal response \n"
+"    from the MetaBrainz team. If an involved party requires anonymity, "
+"the conflict becomes a private conflict. If at \n"
+"    all possible minor issues should be resolved in a public forum in "
+"order for all people to witness and learn from \n"
+"    the issue at hand."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:116
+msgid "Formal complaint process"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:119
+msgid ""
+"All complaints about conflicts should be submitted via email. To whom a "
+"complaint should be mailed and who will \n"
+"    carry out the investigation will be described in the next section."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:124
+msgid "All complaint submissions to the Foundation should include the following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:128
+msgid ""
+"Contact info, if it is different than the email used to submit the "
+"conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:129
+msgid "Who was involved in the conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:130
+msgid "Where and when the incident happened"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:131
+msgid ""
+"A description of what happened -- ideally with links (e.g. chatlogs, edit"
+" notes) that outlines what \n"
+"         happened so that the persons evaluating the conflict may "
+"understand the issue at hand"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:133
+msgid ""
+"Any related pieces of information that provide more context on the "
+"conflict (e.g. links, screenshots)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:134
+msgid "An indication if this conflict is ongoing or not"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:139
+msgid "The investigation that follows aims to determine:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:143
+msgid "The nature and severity of the incident"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:144
+msgid ""
+"Whether or not the incident is considered a violation of MetaBrainz’ "
+"conduct policies or core values"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:145
+msgid ""
+"The amount of harm experienced by the person who submitted the complaint "
+"and the broader MetaBrainz community \n"
+"         as a result of the incident"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:147
+msgid ""
+"Whether there have been prior complaints against the individual or "
+"individuals reported"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:148
+msgid "Whether the incident is ongoing"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:152
+msgid ""
+"The following potential forms of resolution may apply to any team members"
+" involved in the conflict:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:155
+#: metabrainz/templates/index/conflict-policy.html:168
+msgid "Nothing (if it has been found no violation occurred)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:156
+msgid "Creating a plan to improve the performance"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:157
+msgid "Creating a negative performance evaluation"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:158
+msgid "Mediation, an intervention by a third party to resolve the conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:159
+msgid "Suspension or forced leave"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:160
+msgid "Termination of contract"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:164
+msgid ""
+"The following potential forms of resolution may apply to non team members"
+" involved in the conflict:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:169
+msgid "A reprimand, either public or private"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:170
+msgid "Suspension of the users’ account"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:171
+msgid "Deletion of the users’ account"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:172
+msgid ""
+"Removal of user privileges (e.g. if an auto editor commits a serious "
+"offence, they may lose their auto editor status)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:175
+msgid "Filing a complaint"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:178
+msgid ""
+"NOTE: For complaints not about MetaBrainz staff, please see the "
+"<em>Informal reporting</em> section above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:182
+msgid ""
+"If the complaint does not involve the Executive Director (ED), do the "
+"following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:186
+msgid ""
+"If team member has directly violated conduct policies or engaged in "
+"otherwise harmful behavior, a formal complaint should be filed."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:187
+msgid ""
+"Mail <span class=\"backemail\">gro.zniarbatem@de</span> and include the "
+"complaint information outlined above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:188
+msgid ""
+"You should expect a response within a working day acknowledging the "
+"complaint."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:189
+msgid ""
+"The complaint will be investigated by the ED, member(s) of the board of "
+"directors or a neutral third party."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:190
+msgid ""
+"Once the investigation has been completed, the ED, with the support of "
+"others involved in the investigation will respond. The \n"
+"        ED will respond to incidents no later than 7 working days after a"
+" complaint has been filed with either a resolution or an \n"
+"        explanation of why the process must be extended."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:196
+msgid "If a complaint involves the Executive Director, do the following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:200
+msgid ""
+"If the Executive Director has directly violated conduct policies or "
+"engaged in otherwise harmful behavior, \n"
+"        a formal complaint should be filed with the board of directors."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:202
+msgid ""
+"Mail <span class=\"backemail\">gro.zniarbatem@noituloser-tcilfnoc</span> "
+"and include the complaint information outlined above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:203
+msgid ""
+"You should get a response within 5 working days acknowledging the "
+"complaint."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:204
+msgid ""
+"The complaint will be investigated by the member(s) of the board of "
+"directors, the community manager, a neutral \n"
+"        third party or a combination thereof."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:206
+msgid ""
+"Once the investigation has been completed, the board, with the support of"
+" others involved in the investigation \n"
+"        will respond. The board will aim to respond to incidents no later"
+" than 15 working days after a complaint has been filed \n"
+"        with either a resolution or an explanation of why the process "
+"must be extended."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:211
+msgid "Confidentiality"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:214
+msgid ""
+"Confidentiality is an important aspect of conflict resolution and all of "
+"the conflicts brought to the attention of the foundation \n"
+"    will be evaluated with confidentiality in mind and acted upon "
+"accordingly."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:219
+msgid ""
+"We work hard to make all of the actions of the foundation as transparent "
+"and open as possible. In cases where we cannot \n"
+"    disclose all aspects of a conflict we will disclose that a conflict "
+"is or has occurred and we will attempt to disclose the \n"
+"    appropriate amount of information about the conflict while balancing "
+"the need for confidentiality and our desire to learn \n"
+"    from conflicts so that we as a foundation and community can learn "
+"from these conflicts and improve our policies to avoid the \n"
+"    conflicts in the future."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:227
+msgid ""
+"Any breaches of confidentiality will be treated as severe breaches of our"
+" conduct policies."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:230
+msgid "Retaliation"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:233
+msgid ""
+"We will not allow retaliation for any contractor or volunteer that files "
+"a complaint or is involved in an investigation. If you \n"
+"    believe that you are being treated negatively because of your "
+"involvement in a complaint please report this complaint directly \n"
+"    to the ED at <span class=\"backemail\">gro.zniarbatem@de</span> or "
+"the board at \n"
+"    <span class=\"backemail\">gro.zniarbatem@noituloser-tcilfnoc</span>."
+msgstr ""
 
 #: metabrainz/templates/index/contact.html:3
 #: metabrainz/templates/index/contact.html:6
@@ -1127,7 +1637,7 @@ msgstr "Requêtes publicitaires"
 msgid ""
 "We are currently evaluating our overall online advertising strategy. We "
 "are evaluating advertising, traffic optimization,\n"
-"    search engine optimization and software monitization technologies. If"
+"    search engine optimization and software monetization technologies. If"
 " you provide these professional services, please provide a detailed\n"
 "    deck of your comprehensive services to the following email address. "
 "<em>Please respect our other non-media teams and do not contact us \n"
@@ -1135,14 +1645,6 @@ msgid ""
 " disregard the entirety of your submissions if you contact us any other "
 "way!</em>"
 msgstr ""
-"Nous évaluons actuellement notre stratégie globale de publicité en ligne."
-" Nous examinons les technologies de publicité, d'optimisation du trafic, "
-"de référencement naturel et de monétisation logicielle. Si vous proposez "
-"ces services professionnels, veuillez nous faire parvenir une description"
-" détaillée de vos prestations à l'adresse électronique suivante. "
-"<em>Merci de respecter le reste de notre équipe qui ne fait pas de "
-"marketing et de nous contacter uniquement à cette adresse e-mail. Toute "
-"autre communication sera ignorée.</em>"
 
 #: metabrainz/templates/index/contact.html:52
 #, python-format
@@ -1224,14 +1726,11 @@ msgstr "Forums"
 #, python-format
 msgid ""
 "Please come ask your questions at our <a "
-"href=\"%(forums_url)s\">forums</a>! We would love to\n"
-"    answer any questions you may have."
+"href=\"%(forums_url)s\">forums</a>!\n"
+"    The community and the team will be more than happy to help you."
 msgstr ""
-"N'hésitez pas à poser vos questions sur nos <a "
-"href=\"%(forums_url)s\">forums</a> !\n"
-"    Nous serons ravis de répondre à toutes vos questions."
 
-#: metabrainz/templates/index/contact.html:92
+#: metabrainz/templates/index/contact.html:93
 #, python-format
 msgid ""
 "The MetaBrainz/MusicBrainz/ListenBrainz team and community hang out\n"
@@ -1247,15 +1746,15 @@ msgstr ""
 "    et rejoignez la conversation. Vous pouvez également consulter\n"
 "    les <a href=\"%(chatlogs_url)s\">archives des discussions</a>."
 
-#: metabrainz/templates/index/contact.html:101
+#: metabrainz/templates/index/contact.html:102
 msgid "Social media"
 msgstr "Réseaux sociaux"
 
-#: metabrainz/templates/index/contact.html:103
+#: metabrainz/templates/index/contact.html:104
 msgid "You can follow us on these social channels:"
 msgstr "Vous pouvez nous suivre sur ces réseaux sociaux :"
 
-#: metabrainz/templates/index/contact.html:112
+#: metabrainz/templates/index/contact.html:113
 msgid "Mailing address"
 msgstr "Adresse postale"
 
@@ -1268,34 +1767,350 @@ msgstr "Ensembles de données de MetaBrainz"
 msgid "GDPR Compliance Statement"
 msgstr "Déclaration de conformité au RGPD"
 
-#: metabrainz/templates/index/gdpr.html:37
+#: metabrainz/templates/index/gdpr.html:10
+msgid ""
+"The General Data Protection Regulation is a complex EU regulation that "
+"stipulates many points for protecting private data of\n"
+"    users on the Internet. Even though this is an EU regulation, it has a"
+" worldwide impact due to the nature of the Internet.\n"
+"    The MetaBrainz Foundation with its collection of projects is also "
+"affected by this regulation. We’ve been learning and adapting\n"
+"    our sites to be compliant with the GDPR – sadly this regulation isn’t"
+" entirely black and white and there is an incredible\n"
+"    amount of room left for interpretation of these rules."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:17
+msgid ""
+"The good news is that this regulation is roughly in line with our "
+"established practices: We’ve always held private information\n"
+"    in a high regard and applied the sort of rules to ourselves as we "
+"wish to have our own private data treated. Luckily, this\n"
+"    makes our compliance effort considerably easier. We’ve made two "
+"significant changes to how we treat your data and also adopted\n"
+"    terminology as used in the GDPR in order to use the same languages "
+"that many other sites are now adopting. Please keep reading\n"
+"    to find out the exact details of what we are doing to comply."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:24
+#, python-format
+msgid ""
+"However, we do ask for your compassion and help in our process of "
+"complying with the GDPR. As we already mentioned, the GDPR is\n"
+"    a complex set of rules that are not fully clarified yet. We’ve taken "
+"action on the steps that are clear to us and we’re following\n"
+"    ongoing conversations on points that are in gray zones or unclear to "
+"us. We’ve made our best initial effort on compliance and\n"
+"    promise to keep working on it as the picture becomes more clear. If "
+"you believe that we could improve our compliance, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a> and let us know what we "
+"can do to improve. It would also help us if you\n"
+"    could provide concrete discussion or examples to help us understand "
+"and take action on your suggestion."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:33
+msgid ""
+"Finally, below are the key sections of the GDPR as we understand them and"
+" how they affect your data in our ecosystem. Where\n"
+"    possible, we provide links for deeper understanding, links for you to"
+" examine our relevant code and links to tickets to follow\n"
+"    the process of improving our compliance."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:38
 msgid "Right to be forgotten"
 msgstr "Droit à l'oubli"
 
-#: metabrainz/templates/index/gdpr.html:77
+#: metabrainz/templates/index/gdpr.html:41
+msgid ""
+"Summary: <i>Provide the user with the ability to remove their private "
+"data from our services</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:44
+msgid ""
+"The most important aspect of the right to be forgotten is the ability to "
+"delete your account. Once you request for us to delete\n"
+"    your account, we will remove any personally identifying information "
+"you may have provided us from your account (name, email\n"
+"    address, gender, biography, URL, etc.). The visible name on your "
+"account will be changed to “Deleted User #####” and effectively\n"
+"    the account will no longer be identifiable as your account."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:50
+msgid ""
+"However, given the nature of our projects where we work on collaborative "
+"databases, your contributions that are not personally\n"
+"    identifying are valuable assets to our database and these "
+"contributions will not be removed from our databases. But we will\n"
+"    ensure that these contributions no longer contain personally "
+"identifying data."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:55
+#, python-format
+msgid ""
+"Our process of automatically deleting your accounts across the MetaBrainz"
+" ecosystem is not complete yet (see below for a set of\n"
+"    tickets where you can track our progress). If you would like to "
+"delete your accounts in the MetaBrainz ecosystem or mark a\n"
+"    donation that is currently public as a private donation, please <a "
+"href=\"%(contact_url)s\">contact us</a>\n"
+"    and we will address your request as soon as possible."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:62
+#: metabrainz/templates/index/gdpr.html:182
+msgid "Links:"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:66
+#, python-format
+msgid ""
+"<a href=\"%(editor_deletion_doc_url)s\">How we delete accounts\n"
+"       in MusicBrainz</a> (warning, geek content ahead!)"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:70
+msgid ""
+"Implement sitewide user account deletion in\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/MBS-9680\">MusicBrainz</a>,"
+"\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/AB-337\">AcousticBrainz</a>,"
+"\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/BB-260\">BookBrainz</a>,\n"
+"         <a href=\"https://tickets.metabrainz.org/browse/MEB-103\">the "
+"MetaBrainz Site</a>,\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/LB-354\">ListenBrainz</a>, "
+"and\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/CB-307\">CritiqueBrainz</a>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:80
 msgid "Restriction of processing"
 msgstr "Restriction du traitement"
 
-#: metabrainz/templates/index/gdpr.html:110
+#: metabrainz/templates/index/gdpr.html:83
+msgid ""
+"Summary: <i>To allow the user to control how their personally identifying"
+" data is being used.</i>"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:86
+msgid ""
+"Except for the ListenBrainz and AcousticBrainz projects, we do not "
+"process personally identifying data. Any personally\n"
+"    identifying data that our projects store is for the purpose of being "
+"able to contact you about your contributions to our database\n"
+"    (email address) or for voluntarily showing information about you to "
+"other users (biography, homepage, location, etc)."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:91
+#, python-format
+msgid ""
+"The ListenBrainz project differs in that the Listens (metadata about what"
+" music you have listened to) are stored on our servers\n"
+"    and <a href=\"%(listenbrainz_data_url)s\">made available to the "
+"public</a>. We believe Listens to be personally identifying\n"
+"    data and furthermore, we have goals of creating open source "
+"recommendation engines with this data, which involves processing the\n"
+"    user’s data. These two points are fundamental goals of the "
+"ListenBrainz project and we do not see a reasonable way to reach another"
+"\n"
+"    compromise position."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:99
+msgid ""
+"Because of this, we are going to require users to either acknowledge that"
+" we may process their Listen data or alternatively to\n"
+"    delete their account, including all of their Listens. Please note "
+"that if you decide to delete your ListenBrainz account, it may\n"
+"    take up to two weeks for all of your listens to no longer be included"
+" in our efforts to build a recommendation engine."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:104
+msgid ""
+"We have always made it clear that the data in ListenBrainz was to be "
+"public and that we plan to build new tools with your data, so\n"
+"    this should not come as a surprise to our users."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:108
+msgid ""
+"The AcousticBrainz project does not track who submits data to the "
+"database. If you create an account and use our data creation\n"
+"    tools (e.g. create a dataset or participate in a challenge) then we "
+"link your participation and the things that you create to\n"
+"    your account. If you choose to delete your account then we keep the "
+"non personally identifying data that you create, but anonymize\n"
+"    it so that it cannot be linked back to you."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:114
 msgid "Right to data portability / exporting your data"
 msgstr "Droit à la portabilité des données / exportation de vos données"
 
-#: metabrainz/templates/index/gdpr.html:150
+#: metabrainz/templates/index/gdpr.html:117
+msgid ""
+"Summary: <i>You have the right to access/download the data we store about"
+" you</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:120
+msgid ""
+"Except for the ListenBrainz and AcousticBrainz projects, we do not store "
+"personally identifying data beyond the\n"
+"    information that is available in your public profile on each of our "
+"projects. Since this data is plainly available in your\n"
+"    profile we do not provide a means for you to export this data."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:125
+msgid "There are the following exceptions to this:"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:129
+msgid ""
+"<b>IP addresses</b>: If you visit one of our sites the IP address of your"
+" computer is stored in our web logs for 7 days\n"
+"        before our servers automatically delete them. This data is almost"
+" never used by anyone: the only time we look at the\n"
+"        IP addresses is if our sites are adversely impacted by the "
+"actions of some unknown users. In that case, we may investigate\n"
+"        the logs to identify the IP address that needs to be blocked in "
+"order to restore the stability of our service.\n"
+"        This data is not available to anyone but the contractors of the "
+"MetaBrainz Foundation and is not available to download\n"
+"        to anyone at all."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:137
+#, python-format
+msgid ""
+"<b>ListenBrainz Listen data</b>: Users may <a "
+"href=\"%(listenbrainz_export_url)s\">export their ListenBrainz Listen\n"
+"        data</a> directly from the site. The user Listen data is also "
+"included in the <a href=\"%(listenbrainz_data_url)s\">ListenBrainz\n"
+"        data dumps</a> that are available for public download."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:146
+msgid ""
+"All of the non personally identifying data, such as your metadata "
+"contributions, are publicly visible, available for download\n"
+"    and available via the project APIs. For details about this data, "
+"downloads and APIs please check the documentation for the\n"
+"    respective projects you are interested in."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:151
+#, python-format
+msgid ""
+"Anyone wishing to get a list of financial donations they have made to the"
+" MetaBrainz Foundation, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a> and provide your "
+"MusicBrainz editor name so that we can look up\n"
+"    your donations."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:157
 msgid "Right to rectification"
 msgstr "Droit à la rectification"
 
-#: metabrainz/templates/index/gdpr.html:165
+#: metabrainz/templates/index/gdpr.html:160
+msgid "Summary: <i>You have the right to correct your data</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:163
+msgid ""
+"All of our projects allow their users to update their personally "
+"identifying information in their profiles. Furthermore, most\n"
+"    of our projects allow the editing of their own metadata "
+"contributions. If you find that some of your data is incorrect, please\n"
+"    feel free to edit the data since we provide the tools to do so."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:168
+#, python-format
+msgid ""
+"If anyone who has made a financial donation to the MetaBrainz Foundation "
+"would like to make their donation private, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:173
 msgid "Right to be informed"
 msgstr "Droit à l'information"
 
-#: metabrainz/templates/index/gdpr.html:188
+#: metabrainz/templates/index/gdpr.html:175
+msgid ""
+"Summary: <i>You have the right to be informed about how we use your data "
+"in plain English</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:178
+msgid ""
+"Our privacy policy, as well as other policies, have always been written "
+"by humans for human consumption. We abhor legalese and\n"
+"    not speaking in direct terms."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:186
+msgid "Social contract"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:189
+msgid "Code of conduct"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:192
+msgid "Privacy policy"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:196
 msgid "Right to access"
 msgstr "Droit à l'accès"
 
-#: metabrainz/templates/index/gdpr.html:198
-#: metabrainz/templates/index/privacy.html:166
+#: metabrainz/templates/index/gdpr.html:199
+msgid ""
+"Summary: <i>You have the right to access the data that we collect about "
+"you</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:202
+msgid ""
+"All of our projects make all of the data we collect on your behalf, "
+"privately identifying or not, available to you. The\n"
+"    only exception to this are the IP addresses we store for 7 days – see"
+" above for details."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:206
+#: metabrainz/templates/index/privacy.html:168
 msgid "Privacy/GDPR Representative"
 msgstr "Représentant(e) protection des données/RGPD"
+
+#: metabrainz/templates/index/gdpr.html:209
+#, python-format
+msgid ""
+"If you have any questions about our privacy policy, please <a "
+"href=\"%(contact_url)s\">contact us</a>. To report\n"
+"   any privacy problems, violations or leaks, our GDPR representative is "
+"our Interim Executive Director Nicolás Tamargo and for\n"
+"   privacy issues contact him at <strong><a "
+"href=\"mailto:gdpr@metabrainz.org\">gdpr@metabrainz.org</a></strong>."
+msgstr ""
 
 #: metabrainz/templates/index/index.html:6
 msgid "Welcome to MetaBrainz!"
@@ -1439,7 +2254,7 @@ msgstr ""
 "Pour plus d'information sur la fondation, veuillez visiter la page <a "
 "href=\"%(about_url)s\">à propos</a>."
 
-#: frontend/js/src/forms/ConditionsModal.tsx:43
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:32
 #: metabrainz/templates/index/privacy.html:3
 msgid "Privacy"
 msgstr "Confidentialité"
@@ -1447,6 +2262,44 @@ msgstr "Confidentialité"
 #: metabrainz/templates/index/privacy.html:8
 msgid "Summary"
 msgstr "Sommaire"
+
+#: metabrainz/templates/index/privacy.html:12
+msgid ""
+"You do not have to provide any personal data to be able to browse the "
+"contents of the databases published by MetaBrainz."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:15
+msgid ""
+"You do not have to provide any personally-identifying information if you "
+"choose not to."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:18
+msgid ""
+"We will never reveal your email address on MetaBrainz controlled web "
+"sites."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:22
+msgid ""
+"In order to get maximum value out of the MetaBrainz projects, you may "
+"want to create an account and log in. \n"
+"    Doing so grants you the ability to: edit the databases, contribute "
+"your own data, communicate with other users, and keep track \n"
+"    of recently released music from artists in your MusicBrainz "
+"collection. If you choose to create an account then the minimum we \n"
+"    ask is that you: choose a unique username and password, use a web "
+"browser that accepts \"session\" cookies, and provide a verified \n"
+"    email address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:29
+msgid ""
+"If you do not create an account (or are not logged in) you will not have "
+"access to the above listed features, however, you will \n"
+"    still have full access to browse and examine the databases."
+msgstr ""
 
 #: metabrainz/templates/index/privacy.html:33
 msgid "Applicable to all users"
@@ -1456,39 +2309,197 @@ msgstr "S’appliquant à tous les utilisateurs"
 msgid "Cookies"
 msgstr "Cookies"
 
+#: metabrainz/templates/index/privacy.html:37
+msgid "We use two cookies that contain sensitive information:"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:42
+msgid ""
+"<b>remember_login</b>: If you choose the \"Log in permanently\" option "
+"when logging in to one of our sites; the cookie will be used to \n"
+"      remember your login details."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:46
+msgid ""
+"<b>musicbrainz_server_session, session, or connect.sid</b>: If you are "
+"logged into one of our sites, your current session ID is stored in this "
+"cookie."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:51
+msgid ""
+"We may store dynamic preference information in other cookies, but these "
+"do not contain any sensitive information."
+msgstr ""
+
 #: metabrainz/templates/index/privacy.html:54
 msgid "Web and FTP access logs"
 msgstr "Journaux d'accès aux sites web et FTP"
+
+#: metabrainz/templates/index/privacy.html:57
+msgid ""
+"In a practice similar to other web sites (and APIs) we keep logs of all "
+"web requests made against our servers. These logs include: your IP\n"
+"    address, your browser's (or API client's) \"User-Agent\" string, and "
+"which page (or API endpoint) you requested with which parameters. "
+"Aggregate information about web and FTP traffic is\n"
+"    made available to the public via our site usage pages."
+msgstr ""
 
 #: metabrainz/templates/index/privacy.html:62
 msgid "Third-Party content"
 msgstr "Contenu tiers"
 
-#: metabrainz/templates/index/privacy.html:92
+#: metabrainz/templates/index/privacy.html:64
+msgid ""
+"Our projects' web pages may load some third-party content. Some, but "
+"possibly not all sites are listed below:"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:69
+#, python-format
+msgid ""
+"Cover art and other images: These are provided by the various cover art "
+"sites that have given MusicBrainz permission to do so and our own \n"
+"      <a href=\"%(caa_url)s\">Cover Art Archive</a>. This means that the "
+"relevant site will know (if they want to) your IP \n"
+"      address, User-Agent string, etc., and which MusicBrainz web page "
+"you were visiting (the one which included the cover art image)."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:75
+msgid ""
+"AcoustID: Our fingerprints tab loads fingerprint information from "
+"acoustid.org."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:78
+msgid ""
+"MTCaptcha: Our account creation page loads third party content in order "
+"to prevent spammers from creating accounts."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:83
+msgid ""
+"<i>The above information assumes that you are using \"normal\" web "
+"browser settings, whereby images are always loaded and HTTP referrer \n"
+"    information is always sent.</i>"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:88
+msgid ""
+"It is impractical to constantly modify this privacy policy when "
+"MetaBrainz projects change which third party content they utilize. We "
+"will \n"
+"    aim to use common sense, respect to our community and community "
+"review when adding more content from third party sites. We will also \n"
+"    periodically review our policy to ensure that it remains current."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:93
 msgid "Applicable to account holders"
 msgstr "Applicable aux titulaires de compte"
 
-#: metabrainz/templates/index/privacy.html:94
+#: metabrainz/templates/index/privacy.html:95
 msgid "Account creation"
 msgstr "Création de compte"
 
-#: metabrainz/templates/index/privacy.html:108
+#: metabrainz/templates/index/privacy.html:97
+msgid ""
+"When creating an account with a MetaBrainz project you need to pick a "
+"unique username and choose a password, the username you pick is the \n"
+"    only name associated with your account and will be what other "
+"MetaBrainz users know you as. You may optionally also tell us other \n"
+"    information about yourself that will be displayed to other MetaBrainz"
+" users and the public."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:103
+msgid ""
+"Additionally, in order to edit the databases you will need to provide a "
+"confirmed email address. This email address will be held in \n"
+"    confidence, the only method of revealing your email address to "
+"another user is if you choose to send a message to another \n"
+"    user and enable the option to \"reveal my email address\". Changing "
+"the email address stored with your account will require you to \n"
+"    verify the new address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:109
 msgid "Edits and Notes"
 msgstr "Modifications et notes"
 
-#: metabrainz/templates/index/privacy.html:114
+#: metabrainz/templates/index/privacy.html:111
+msgid ""
+"If you make any changes to a MetaBrainz project database, such as adding "
+"any data, the details of those changes will be visible to \n"
+"    other logged-in users and the change will be associated with your "
+"username."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:115
 msgid "Subscriptions on MusicBrainz"
 msgstr "Abonnements sur MusicBrainz"
 
-#: metabrainz/templates/index/privacy.html:131
+#: metabrainz/templates/index/privacy.html:117
+msgid ""
+"As a logged-in user you can subscribe to one or more artists, labels, "
+"collections or other editors. The act of subscribing causes \n"
+"    any edits made to (or by in the case of another editor) those "
+"entities to be emailed to you. By default, other users can see your \n"
+"    list of subscriptions, however, you can opt out of this by editing "
+"the appropriate preference."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:123
+msgid ""
+"This does not provide \"perfect\" privacy though, in some cases it will "
+"be possible to infer information about the contents of your \n"
+"    subscription list even though you have disallowed others from viewing"
+" that list directly. This imperfection arises because various \n"
+"    parts of the system behave differently depending on whether or not an"
+" entity has any subscribers; also, the number of users \n"
+"    subscribed to each artist is available via the artist pages. In the "
+"most extreme (possibly contrived) example, imagine that all \n"
+"    users have their subscriptions set to \"public\", except for exactly "
+"one user whose list is \"private\". In that case, any discrepancy \n"
+"    for a given artist between the shown list of subscribers and the "
+"total number of subscribers must be down to that one user. Thus, \n"
+"    you can infer what artists are on that user's list."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:132
 msgid "Third-party sites"
 msgstr "Sites tiers"
 
-#: metabrainz/templates/index/privacy.html:145
+#: metabrainz/templates/index/privacy.html:134
+#, python-format
+msgid ""
+"Our code reviews are done on GitHub, which is not under the control of "
+"MetaBrainz. Participating in code reviews or other\n"
+"    tasks carried out on GitHub are subject to <a "
+"href=\"%(github_url)s\">GitHub's privacy policy</a>."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:140
+#, python-format
+msgid ""
+"Our translations platform is provided and hosted by Weblate, which has a "
+"data processing agreement with MetaBrainz.\n"
+"    Participating in translations is subject to <a "
+"href=\"%(weblate_url)s\">dedicated legal terms</a>.\n"
+"    Any translations you make will be submitted to our Git repositories "
+"and publicly associated with your username;\n"
+"    if you so choose, you can also publicly associate them with your own "
+"verified email address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:147
 msgid "MetaBrainz donors"
 msgstr "Donateurs"
 
-#: metabrainz/templates/index/privacy.html:147
+#: metabrainz/templates/index/privacy.html:149
 msgid ""
 "When you make a donation to the MetaBrainz Foundation, we are legally\n"
 "    required to collect your personal information and keep it in our "
@@ -1503,7 +2514,7 @@ msgstr ""
 "Nous ne divulguerons jamais vos informations personnelles à qui que ce "
 "soit."
 
-#: metabrainz/templates/index/privacy.html:153
+#: metabrainz/templates/index/privacy.html:155
 msgid ""
 "We believe in transparent finances, which means that we list all "
 "donations\n"
@@ -1517,11 +2528,34 @@ msgstr ""
 "indiquerons uniquement votre nom et le montant du don, à moins que vous "
 "ayez choisi de rester anonyme pendant le processus de don."
 
-#: metabrainz/templates/index/privacy.html:158
+#: metabrainz/templates/index/privacy.html:160
 msgid "Exceptions"
 msgstr "Exceptions"
 
-#: frontend/js/src/Profile.tsx:598
+#: metabrainz/templates/index/privacy.html:162
+msgid ""
+"<i><b>Please note</b>: Reasonable exceptions may apply to the above "
+"policy, for example to comply with applicable laws.\n"
+"    Also, members of the MetaBrainz team and other personnel contracted "
+"to provide services to MetaBrainz may have access to\n"
+"    our infrastructure and could therefore view any information contained"
+" therein. However all personnel are contractually bound\n"
+"    by non-disclosure clauses which prevent them from making any such "
+"information available to others."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:171
+#, python-format
+msgid ""
+"If you have any questions about our GDPR statement, please <a "
+"href=\"%(contact_url)s\">contact us</a>. To report\n"
+"   any privacy problems, violations or leaks, our GDPR representative is "
+"our Interim Executive Director Nicolás Tamargo and for\n"
+"   privacy issues contact him at <strong><a "
+"href=\"mailto:gdpr@metabrainz.org\">gdpr@metabrainz.org</a></strong>."
+msgstr ""
+
+#: frontend/js/src/Profile.tsx:603
 #: frontend/js/src/forms/ProfileChangePassword.tsx:22
 #: frontend/js/src/forms/ProfileChangePassword.tsx:111
 #: metabrainz/templates/index/profile-change-password.html:3
@@ -1839,6 +2873,11 @@ msgstr ""
 #: metabrainz/templates/index/team.html:26
 msgid "He lives on in our hearts and in open source."
 msgstr "Il vit toujours en nous et dans la communauté du logiciel libre."
+
+#: metabrainz/templates/index/team.html:29
+#: metabrainz/templates/index/team.html:315
+msgid "you’re welcome to try"
+msgstr ""
 
 #: metabrainz/templates/index/team.html:39
 msgid ""
@@ -2380,11 +3419,11 @@ msgstr "Chèque américain"
 
 #: metabrainz/templates/payments/donate.html:146
 msgid ""
-"Due to the increased unreliability of the US Postal Service we have "
-"stopped accepting paper checks. Sorry!"
+"Due to the increased unreliability of the US Postal Service and the "
+"relatively large fees involved, we ask you to only send a paper check if "
+"it is the only possible option. Due to the fees, we will not cash checks "
+"for less than $25."
 msgstr ""
-"En raison du manque de fiabilité croissant du service postal américain, "
-"nous n'acceptons plus les chèques papier. Désolé !"
 
 #: metabrainz/templates/payments/donate.html:241
 msgid ""
@@ -2477,8 +3516,8 @@ msgid ""
 "          <a href=\"%(mail_link)s\">payments@metabrainz.org</a>\n"
 "          before you do."
 msgstr ""
-"Si vous souhaitez faire un paiement important, veuillez nous contacter à <a "
-"href=\"%(mail_link)s\">donations@metabrainz.org</a> auparavant."
+"Si vous souhaitez faire un paiement important, veuillez nous contacter à "
+"<a href=\"%(mail_link)s\">donations@metabrainz.org</a> auparavant."
 
 #: metabrainz/templates/payments/payment.html:52
 #: metabrainz/templates/payments/payment.html:159
@@ -2639,12 +3678,12 @@ msgid ""
 "publishing on this site."
 msgstr ""
 "La fondation publie, dans la mesure du possible, l'intégralité de ses "
-"informations financières. Il arrive que des tiers effectuant des paiements à "
-"l'association nous imposent de ne pas divulguer les sommes qui nous sont "
-"versées pour diverses activités. Par exemple, un partenaire de MetaBrainz "
-"nous interdit de publier le détail des revenus issus d'un programme "
-"d'affiliation. Dans ces cas-là, nous anonymisons ces paiements avant leur "
-"publication."
+"informations financières. Il arrive que des tiers effectuant des "
+"paiements à l'association nous imposent de ne pas divulguer les sommes "
+"qui nous sont versées pour diverses activités. Par exemple, un partenaire"
+" de MetaBrainz nous interdit de publier le détail des revenus issus d'un "
+"programme d'affiliation. Dans ces cas-là, nous anonymisons ces paiements "
+"avant leur publication."
 
 #: metabrainz/templates/reports/financial_reports/index.html:25
 #, python-format
@@ -3315,8 +4354,8 @@ msgid "Monthly balance sheets"
 msgstr "Bilans mensuels"
 
 #: frontend/js/src/Profile.tsx:520
-#: frontend/js/src/forms/SignupCommercial.tsx:175
-#: frontend/js/src/forms/SignupCommercial.tsx:554
+#: frontend/js/src/forms/SignupCommercial.tsx:180
+#: frontend/js/src/forms/SignupCommercial.tsx:558
 #: frontend/js/src/forms/SignupNonCommercial.tsx:106
 #: frontend/js/src/forms/SignupNonCommercial.tsx:318
 #: metabrainz/templates/supporters/account-type.html:3
@@ -3337,6 +4376,7 @@ msgid "Non-commercial / Personal"
 msgstr "Non commercial / Personnel"
 
 #: frontend/js/src/Profile.tsx:235
+#: frontend/js/src/forms/SignupNonCommercial.tsx:107
 #: frontend/js/src/forms/SignupNonCommercial.tsx:151
 #: metabrainz/templates/supporters/account-type.html:42
 msgid "Non-commercial"
@@ -3350,47 +4390,41 @@ msgstr "$0.00 par mois ou plus"
 msgid "Personal or university assignment user."
 msgstr "Usage personnel ou projet universitaire."
 
-#: metabrainz/templates/supporters/account-type.html:48
-#: metabrainz/templates/supporters/account-type.html:90
-#: metabrainz/templates/supporters/account-type.html:141
-msgid "Upgrade"
-msgstr "Mettre à jour"
-
 #: frontend/js/src/Profile.tsx:235
-#: frontend/js/src/forms/SignupCommercial.tsx:176
-#: frontend/js/src/forms/SignupCommercial.tsx:228
-#: metabrainz/templates/supporters/account-type.html:61
+#: frontend/js/src/forms/SignupCommercial.tsx:181
+#: frontend/js/src/forms/SignupCommercial.tsx:233
+#: metabrainz/templates/supporters/account-type.html:56
 msgid "Commercial"
 msgstr "Commercial"
 
-#: metabrainz/templates/supporters/account-type.html:83
-#: metabrainz/templates/supporters/account-type.html:135
+#: metabrainz/templates/supporters/account-type.html:78
+#: metabrainz/templates/supporters/account-type.html:125
 #, python-format
 msgid "$%(tier_price)s/month and up"
 msgstr "$%(tier_price)s par mois ou plus"
 
-#: metabrainz/templates/supporters/account-type.html:87
-#: metabrainz/templates/supporters/account-type.html:138
+#: metabrainz/templates/supporters/account-type.html:82
+#: metabrainz/templates/supporters/account-type.html:128
 msgid "More info"
 msgstr "Plus d'information"
 
-#: metabrainz/templates/supporters/account-type.html:104
+#: metabrainz/templates/supporters/account-type.html:94
 msgid "View all tiers"
 msgstr "Voir tous les paliers"
 
-#: metabrainz/templates/supporters/account-type.html:112
+#: metabrainz/templates/supporters/account-type.html:102
 msgid "Some of our Unicorn members"
 msgstr "Quelques-uns de nos soutiens du palier Licorne"
 
-#: metabrainz/templates/supporters/account-type.html:123
+#: metabrainz/templates/supporters/account-type.html:113
 msgid "See all our supporters"
 msgstr "Voir tous nos soutiens"
 
-#: metabrainz/templates/supporters/account-type.html:151
+#: metabrainz/templates/supporters/account-type.html:136
 msgid "View featured tiers"
 msgstr "Voir les paliers en vedette"
 
-#: metabrainz/templates/supporters/account-type.html:158
+#: metabrainz/templates/supporters/account-type.html:143
 #, python-format
 msgid ""
 "If you are not sure which tier to pick, please\n"
@@ -3398,10 +4432,6 @@ msgid ""
 msgstr ""
 "Si vous ne savez pas quel palier choisir,\n"
 "      veuillez <a href=\"%(contact_url)s\">nous contacter</a>."
-
-#: metabrainz/templates/supporters/account-type.html:166
-msgid "Back to Profile"
-msgstr "Retour au profil"
 
 #: metabrainz/templates/supporters/bad-standing.html:3
 #: metabrainz/templates/supporters/bad-standing.html:6
@@ -3475,9 +4505,9 @@ msgid "Forgot your username"
 msgstr "Nom d’utilisateur oublié"
 
 #: frontend/js/src/forms/ResetPassword.tsx:79
-#: frontend/js/src/forms/SignupCommercial.tsx:320
+#: frontend/js/src/forms/SignupCommercial.tsx:325
 #: frontend/js/src/forms/SignupNonCommercial.tsx:227
-#: frontend/js/src/forms/SignupUser.tsx:169
+#: frontend/js/src/forms/SignupUser.tsx:175
 #: metabrainz/templates/users/reauthenticate.html:3
 #: metabrainz/templates/users/reauthenticate.html:6
 msgid "Confirm Password"
@@ -3487,56 +4517,61 @@ msgstr "Confirmation du mot de passe"
 msgid "Please re-enter your password to continue."
 msgstr "Veuillez saisir à nouveau votre mot de passe pour continuer."
 
-#: frontend/js/src/ProfileDelete.tsx:108
+#: frontend/js/src/ProfileDelete.tsx:110
 #: frontend/js/src/forms/DeleteApplication.tsx:53
 #: frontend/js/src/forms/OAuthPrompt.tsx:54
 #: frontend/js/src/forms/ProfileChangePassword.tsx:104
 #: frontend/js/src/forms/ProfileEdit.tsx:105
-#: metabrainz/templates/users/reauthenticate.html:23
+#: metabrainz/templates/users/reauthenticate.html:28
 msgid "Cancel"
 msgstr "Annuler"
 
-#: metabrainz/templates/users/reauthenticate.html:24
+#: metabrainz/templates/users/reauthenticate.html:29
 msgid "Continue"
 msgstr "Continuer"
+
+#: frontend/js/src/forms/utils.tsx:202
+#: metabrainz/templates/users/reauthenticate.html:40
+msgid "Password must not exceed 72 bytes."
+msgstr ""
 
 #: frontend/js/src/forms/ResetPassword.tsx:27
 #: metabrainz/templates/users/reset-password.html:3
 msgid "Reset your password"
 msgstr "Réinitialiser le mot de passe"
 
-#: frontend/js/src/hooks/useEmailValidation.ts:41 metabrainz/user/forms.py:15
+#: frontend/js/src/hooks/useEmailValidation.ts:41 metabrainz/user/forms.py:16
 msgid "Registration from this email domain is not allowed."
 msgstr "L'inscription à partir de ce domaine de messagerie n'est pas autorisée."
 
 #: frontend/js/src/forms/LoginUser.tsx:50
 #: frontend/js/src/forms/LostPassword.tsx:45
-#: frontend/js/src/forms/SignupCommercial.tsx:270
+#: frontend/js/src/forms/SignupCommercial.tsx:275
 #: frontend/js/src/forms/SignupNonCommercial.tsx:175
-#: frontend/js/src/forms/SignupUser.tsx:114 metabrainz/user/forms.py:20
-#: metabrainz/user/forms.py:45 metabrainz/user/forms.py:62
+#: frontend/js/src/forms/SignupUser.tsx:120 metabrainz/user/forms.py:22
+#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:75
 msgid "Username"
 msgstr "Nom d’utilisateur"
 
 #: frontend/js/src/forms/LoginUser.tsx:42
 #: frontend/js/src/forms/LostPassword.tsx:37
-#: frontend/js/src/forms/SignupCommercial.tsx:153
+#: frontend/js/src/forms/SignupCommercial.tsx:158
 #: frontend/js/src/forms/SignupNonCommercial.tsx:84
-#: frontend/js/src/forms/SignupUser.tsx:67 metabrainz/user/forms.py:21
-#: metabrainz/user/forms.py:45 metabrainz/user/forms.py:62
+#: frontend/js/src/forms/SignupUser.tsx:73 metabrainz/user/forms.py:26
+#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:75
 msgid "Username is required!"
 msgstr "Le nom d'utilisasteur est requis !"
 
 #: frontend/js/src/forms/LoginUser.tsx:63
 #: frontend/js/src/forms/ResetPassword.tsx:72
-#: frontend/js/src/forms/SignupCommercial.tsx:308
+#: frontend/js/src/forms/SignupCommercial.tsx:313
 #: frontend/js/src/forms/SignupNonCommercial.tsx:214
-#: frontend/js/src/forms/SignupUser.tsx:157 metabrainz/user/forms.py:46
-#: metabrainz/user/forms.py:52
+#: frontend/js/src/forms/SignupUser.tsx:163 metabrainz/user/forms.py:53
+#: metabrainz/user/forms.py:62
 msgid "Password"
 msgstr "Mot de passe"
 
-#: frontend/js/src/forms/LoginUser.tsx:76 metabrainz/user/forms.py:47
+#: frontend/js/src/forms/LoginUser.tsx:76 metabrainz/user/forms.py:57
 msgid "Remember me"
 msgstr "Se souvenir de moi"
 
@@ -3548,11 +4583,11 @@ msgstr "Nom d’utilisateur non valide."
 msgid "Username contains invalid or invisible characters."
 msgstr "Le nom d’utilisateur contient des caractères invalides ou invisibles."
 
-#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:181
+#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:220
 msgid "Hide password"
 msgstr "Cacher le mot de passe"
 
-#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:181
+#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:220
 msgid "Show password"
 msgstr "Afficher le mot de passe"
 
@@ -3609,11 +4644,11 @@ msgstr "Accès"
 msgid "Revoke access"
 msgstr "Révoquer l’accès"
 
-#: frontend/js/src/OAuthError.tsx:17
+#: frontend/js/src/OAuthError.tsx:18
 msgid "OAuth2 Error"
 msgstr "Erreur OAuth2"
 
-#: frontend/js/src/OAuthError.tsx:18
+#: frontend/js/src/OAuthError.tsx:19
 msgid "An error occurred during OAuth authentication process."
 msgstr "Une erreur s'est produite lors du processus d'authentification OAuth."
 
@@ -3643,11 +4678,9 @@ msgstr "Votre e-mail actuel sera remplacé une fois le nouvel e-mail vérifié."
 
 #: frontend/js/src/Profile.tsx:109
 msgid ""
-"Are you sure you want to generate new access token? Current token will be"
-" revoked!"
+"Are you sure you want to generate a new access token? The current token "
+"will be revoked!"
 msgstr ""
-"Êtes-vous sûr de vouloir générer une nouvelle clé d'accès ? La clé "
-"actuelle sera révoquée !"
 
 #: frontend/js/src/Profile.tsx:118
 msgid "Failed to generate new access token!"
@@ -3780,8 +4813,8 @@ msgid "Contact Information"
 msgstr "Informations de contact"
 
 #: frontend/js/src/Profile.tsx:310 frontend/js/src/forms/ProfileEdit.tsx:70
-#: frontend/js/src/forms/SignupCommercial.tsx:284
-#: frontend/js/src/forms/SignupCommercial.tsx:333
+#: frontend/js/src/forms/SignupCommercial.tsx:289
+#: frontend/js/src/forms/SignupCommercial.tsx:338
 #: frontend/js/src/forms/SignupNonCommercial.tsx:189
 #: frontend/js/src/forms/SignupNonCommercial.tsx:241
 msgid "Contact name"
@@ -3913,7 +4946,7 @@ msgstr ""
 "Une fois votre compte supprimé, vous ne pourrez plus revenir en arrière. "
 "S'il vous plaît, soyez vrai."
 
-#: frontend/js/src/Profile.tsx:550 frontend/js/src/ProfileDelete.tsx:105
+#: frontend/js/src/Profile.tsx:550 frontend/js/src/ProfileDelete.tsx:107
 msgid "Delete My Account"
 msgstr "Supprimer mon compte"
 
@@ -3925,23 +4958,21 @@ msgstr "Suppression de compte"
 msgid "Need to delete your account?"
 msgstr "Vous voulez supprimer votre compte ?"
 
-#: frontend/js/src/Profile.tsx:574
+#: frontend/js/src/Profile.tsx:575
 msgid ""
 "Deletion of supporter accounts requires manual review. Please contact us "
-"at"
+"at <email />."
 msgstr ""
-"La suppression des comptes de supporters nécessite un confirmation manuelle. "
-"Veuillez nous contacter à"
 
-#: frontend/js/src/Profile.tsx:594
+#: frontend/js/src/Profile.tsx:599
 msgid "Security"
 msgstr "Sécurité"
 
-#: frontend/js/src/Profile.tsx:626
+#: frontend/js/src/Profile.tsx:631
 msgid "MetaBrainz Applications"
 msgstr "Applications de MetaBrainz"
 
-#: frontend/js/src/Profile.tsx:630
+#: frontend/js/src/Profile.tsx:635
 msgid ""
 "With your MetaBrainz account, you can access every project in the "
 "MetaBrainz family:"
@@ -3949,19 +4980,19 @@ msgstr ""
 "Avec votre compte MetaBrainz, vous pouvez accéder à tous les projets de "
 "la famille MetaBrainz :"
 
-#: frontend/js/src/Profile.tsx:643
+#: frontend/js/src/Profile.tsx:648
 msgid "The open-source music encyclopedia"
 msgstr "L'encyclopédie musicale libre"
 
-#: frontend/js/src/Profile.tsx:655
+#: frontend/js/src/Profile.tsx:660
 msgid "Track, visualise and share the music you listen to"
 msgstr "Suivez, visualisez et partagez la musique que vous écoutez"
 
-#: frontend/js/src/Profile.tsx:667
+#: frontend/js/src/Profile.tsx:672
 msgid "The open-source book database"
 msgstr "La base de données libre de livres"
 
-#: frontend/js/src/Profile.tsx:679
+#: frontend/js/src/Profile.tsx:684
 msgid "Creative Commons licensed reviews"
 msgstr "Critiques sous licence Creative Commons"
 
@@ -3986,8 +5017,8 @@ msgid "Permanently remove all your account information"
 msgstr "Supprimez définitivement toutes les informations de votre compte"
 
 #: frontend/js/src/ProfileDelete.tsx:64
-msgid "Revoke all your API tokens and access"
-msgstr "Détruire toutes vos clés d'accès et d'API"
+msgid "Revoke all your tokens and access to the replication API"
+msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:65
 msgid "Remove your supporter status (if applicable)"
@@ -3998,16 +5029,18 @@ msgid "Log you out of all MetaBrainz services"
 msgstr "Vous serez déconnecté de tous les services MetaBrainz"
 
 #: frontend/js/src/ProfileDelete.tsx:70
-msgid "Your username will be reserved and cannot be reused."
-msgstr "Votre nom d'utilisateur sera réservé et ne pourra pas être réutilisé."
+msgid ""
+"Your username will be reserved and cannot be reused without the "
+"intervention of an administrator."
+msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:82
+#: frontend/js/src/ProfileDelete.tsx:84
 msgid "To confirm, type your username '<username />' below:"
 msgstr ""
 "Pour confirmer, saisissez votre nom d'utilisateur '<username />' ci-"
 "dessous :"
 
-#: frontend/js/src/ProfileDelete.tsx:105
+#: frontend/js/src/ProfileDelete.tsx:107
 msgid "Deleting..."
 msgstr "Suppression…"
 
@@ -4019,83 +5052,7 @@ msgstr "Profil"
 msgid "Close"
 msgstr "Fermer"
 
-#: frontend/js/src/forms/ConditionsModal.tsx:23
-msgid "Licensing"
-msgstr "Licenses"
-
-#: frontend/js/src/forms/ConditionsModal.tsx:25
-msgid ""
-"Any contributions you make to any MetaBrainz service will be released "
-"into the Public Domain and/or licensed under a Creative Commons by-nc-sa "
-"license. Furthermore, you give the MetaBrainz Foundation the right to "
-"license this data for commercial use."
-msgstr ""
-"Toute contribution que vous apportez à un service MetaBrainz sera publiée"
-" dans le domaine public et/ou sous licence Creative Commons by-nc-sa. De "
-"plus, vous accordez à la Fondation MetaBrainz le droit d'accorder une "
-"licence sur ces données à des fins commerciales."
-
-#: frontend/js/src/forms/ConditionsModal.tsx:30
-msgid "Please read our <licenseLink>license page</licenseLink> for more details."
-msgstr ""
-"Pour en savoir plus, consultez la <licenseLink>page de "
-"licence</licenseLink>."
-
-#: frontend/js/src/forms/ConditionsModal.tsx:45
-msgid ""
-"MetaBrainz strongly believes in the privacy of its users. Any personal "
-"information you choose to provide will not be sold or shared with anyone "
-"else."
-msgstr ""
-"MetaBrainz accorde une grande importance à la confidentialité de nos "
-"utilisateurs.. Les informations personnelles que vous choisissez de "
-"fournir ne seront ni vendues ni partagées avec quiconque."
-
-#: frontend/js/src/forms/ConditionsModal.tsx:50
-msgid ""
-"Please read our <privacyLink>privacy policy</privacyLink> for more "
-"details."
-msgstr ""
-"Veuillez lire notre <privacyLink>politique de "
-"confidentialité</privacyLink> pour plus de détails."
-
-#: frontend/js/src/forms/ConditionsModal.tsx:59
-msgid "GDPR compliance"
-msgstr "Conformité au RGPD"
-
-#: frontend/js/src/forms/ConditionsModal.tsx:61
-msgid ""
-"You may remove your personal information from our services anytime by "
-"deleting your account."
-msgstr ""
-"Vous pouvez supprimer vos informations personnelles de nos services à "
-"tout moment en supprimant votre compte."
-
-#: frontend/js/src/forms/ConditionsModal.tsx:66
-msgid ""
-"Please read our <gdprLink>GDPR compliance statement</gdprLink> for more "
-"details."
-msgstr ""
-"Veuillez lire notre <gdprLink>déclaration de conformité au "
-"RGPD</gdprLink> pour plus de détails."
-
-#: frontend/js/src/forms/ConditionsModal.tsx:78
-msgid ""
-"Creating an account on MetaBrainz will give you access to all of our "
-"projects, such as MusicBrainz, ListenBrainz, BookBrainz, and more."
-msgstr ""
-"Créer un compte sur MetaBrainz vous donnera accès à tous nos projets, "
-"tels que MusicBrainz, ListenBrainz, BookBrainz, et plus encore."
-
-#: frontend/js/src/forms/ConditionsModal.tsx:82
-msgid ""
-"We create a placeholder account for all the MetaBrainz projects when you "
-"sign up, and you are one log-in away from activating them."
-msgstr ""
-"Nous réservons votre compte pour tous les projets MetaBrainz lorsque vous"
-" vous inscrivez, et vous n'êtes qu'à une connexion de les activer."
-
-#: frontend/js/src/forms/ConditionsModal.tsx:91
+#: frontend/js/src/forms/ConditionsModal.tsx:29
 msgid "Sounds good"
 msgstr "Ça me va"
 
@@ -4183,9 +5140,9 @@ msgstr "Nom d’utilisateur oublié ?"
 msgid "Forgot your password?"
 msgstr "Mot de passe oublié ?"
 
-#: frontend/js/src/forms/LoginUser.tsx:109
-msgid "Don't have an account?"
-msgstr "Pas encore de compte ?"
+#: frontend/js/src/forms/LoginUser.tsx:110
+msgid "Don't have an account? <signupLink>Sign up</signupLink>"
+msgstr ""
 
 #: frontend/js/src/forms/LostPassword.tsx:38
 #: frontend/js/src/forms/LostUsername.tsx:36
@@ -4213,15 +5170,91 @@ msgstr "Votre identité sur MetaBrainz"
 msgid "Allow access"
 msgstr "Autoriser l'accès"
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:71
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:10
+msgid "Licensing"
+msgstr "Licenses"
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:12
+msgid ""
+"Any contributions you make to any MetaBrainz service will be released "
+"into the Public Domain and/or licensed under a Creative Commons by-nc-sa "
+"license. Furthermore, you give the MetaBrainz Foundation the right to "
+"license this data for commercial use."
+msgstr ""
+"Toute contribution que vous apportez à un service MetaBrainz sera publiée"
+" dans le domaine public et/ou sous licence Creative Commons by-nc-sa. De "
+"plus, vous accordez à la Fondation MetaBrainz le droit d'accorder une "
+"licence sur ces données à des fins commerciales."
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:17
+msgid "Please read our <licenseLink>license page</licenseLink> for more details."
+msgstr ""
+"Pour en savoir plus, consultez la <licenseLink>page de "
+"licence</licenseLink>."
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:34
+msgid ""
+"MetaBrainz strongly believes in the privacy of its users. Any personal "
+"information you choose to provide will not be sold or shared with anyone "
+"else."
+msgstr ""
+"MetaBrainz accorde une grande importance à la confidentialité de nos "
+"utilisateurs.. Les informations personnelles que vous choisissez de "
+"fournir ne seront ni vendues ni partagées avec quiconque."
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:39
+msgid ""
+"Please read our <privacyLink>privacy policy</privacyLink> for more "
+"details."
+msgstr ""
+"Veuillez lire notre <privacyLink>politique de "
+"confidentialité</privacyLink> pour plus de détails."
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:50
+msgid "GDPR compliance"
+msgstr "Conformité au RGPD"
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:52
+msgid ""
+"You may remove your personal information from our services anytime by "
+"deleting your account."
+msgstr ""
+"Vous pouvez supprimer vos informations personnelles de nos services à "
+"tout moment en supprimant votre compte."
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:57
+msgid ""
+"Please read our <gdprLink>GDPR compliance statement</gdprLink> for more "
+"details."
+msgstr ""
+"Veuillez lire notre <gdprLink>déclaration de conformité au "
+"RGPD</gdprLink> pour plus de détails."
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:71
+msgid ""
+"Creating an account on MetaBrainz will give you access to all of our "
+"projects, such as MusicBrainz, ListenBrainz, BookBrainz, and more."
+msgstr ""
+"Créer un compte sur MetaBrainz vous donnera accès à tous nos projets, "
+"tels que MusicBrainz, ListenBrainz, BookBrainz, et plus encore."
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:75
+msgid ""
+"We create a placeholder account for all the MetaBrainz projects when you "
+"sign up, and you are one log-in away from activating them."
+msgstr ""
+"Nous réservons votre compte pour tous les projets MetaBrainz lorsque vous"
+" vous inscrivez, et vous n'êtes qu'à une connexion de les activer."
+
+#: frontend/js/src/forms/ProfileChangePassword.tsx:70
 msgid "Current Password"
 msgstr "Mot de passe actuel"
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:80
+#: frontend/js/src/forms/ProfileChangePassword.tsx:79
 msgid "New Password"
 msgstr "Nouveau mot de passe"
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:89
+#: frontend/js/src/forms/ProfileChangePassword.tsx:88
 msgid "Confirm New Password"
 msgstr "Confirmer le nouveau mot de passe"
 
@@ -4233,31 +5266,29 @@ msgstr "Actualiser"
 msgid "Reset Password"
 msgstr "Réinitialiser le mot de passe"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:38
-msgid "If you would like to support us with more than $"
-msgstr "Si vous souhaitez nous soutenir avec plus que $"
+#: frontend/js/src/forms/SignupCommercial.tsx:40
+msgid ""
+"If you would like to support us with more than ${{minPledge}}, please "
+"enter the actual amount here:"
+msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:39
-msgid ", please enter the actual amount here:"
-msgstr ", veuillez saisir le montant ici :"
-
-#: frontend/js/src/forms/SignupCommercial.tsx:144
+#: frontend/js/src/forms/SignupCommercial.tsx:149
 #: frontend/js/src/forms/SignupNonCommercial.tsx:75
-#: frontend/js/src/forms/SignupUser.tsx:87
+#: frontend/js/src/forms/SignupUser.tsx:93
 msgid "Captcha is required!"
 msgstr "Veuillez saisir la captcha"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:179
+#: frontend/js/src/forms/SignupCommercial.tsx:184
 #: frontend/js/src/forms/SignupNonCommercial.tsx:110
 #: frontend/js/src/forms/SignupUser.tsx:46
 msgid "Access all MetaBrainz projects"
 msgstr "Accédez à tous nos projets"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:182
+#: frontend/js/src/forms/SignupCommercial.tsx:187
 msgid "Note:"
 msgstr "Note :"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:184
+#: frontend/js/src/forms/SignupCommercial.tsx:189
 msgid ""
 "Signing up for any tier other than the <italic>Stealth startup</italic> "
 "tier will publicly list your company on this web site. However, we will "
@@ -4267,53 +5298,53 @@ msgstr ""
 "startup</italic> répertoriera publiquement votre entreprise sur ce site. "
 "Cependant, nous ne publierons aucune de vos informations privées."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:221
+#: frontend/js/src/forms/SignupCommercial.tsx:226
 #: frontend/js/src/forms/SignupNonCommercial.tsx:145
 msgid "Account type"
 msgstr "Type de compte"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:234
+#: frontend/js/src/forms/SignupCommercial.tsx:239
 msgid "Selected tier"
 msgstr "Palier sélectionné"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:242
-msgid "month and up"
-msgstr "mois ou plus"
+#: frontend/js/src/forms/SignupCommercial.tsx:247
+msgid "${{tierPrice}}/month and up"
+msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:250
+#: frontend/js/src/forms/SignupCommercial.tsx:255
 msgid "Change account type or tier"
 msgstr "Changer de type de compte ou de palier"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:261
+#: frontend/js/src/forms/SignupCommercial.tsx:266
 #: frontend/js/src/forms/SignupNonCommercial.tsx:166
 msgid "Your account:"
 msgstr "Votre compte :"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:271
+#: frontend/js/src/forms/SignupCommercial.tsx:276
 #: frontend/js/src/forms/SignupNonCommercial.tsx:176
-#: frontend/js/src/forms/SignupUser.tsx:114
+#: frontend/js/src/forms/SignupUser.tsx:120
 msgid "(public)"
 msgstr "(publique)"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:291
+#: frontend/js/src/forms/SignupCommercial.tsx:296
 #: frontend/js/src/forms/SignupNonCommercial.tsx:196
-#: frontend/js/src/forms/SignupUser.tsx:127
+#: frontend/js/src/forms/SignupUser.tsx:133
 msgid "E-mail address"
 msgstr "Adresse e-mail"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:295
+#: frontend/js/src/forms/SignupCommercial.tsx:300
 #: frontend/js/src/forms/SignupNonCommercial.tsx:200
-#: frontend/js/src/forms/SignupUser.tsx:131
+#: frontend/js/src/forms/SignupUser.tsx:137
 msgid "(checking...)"
 msgstr "(vérification…)"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:314
+#: frontend/js/src/forms/SignupCommercial.tsx:319
 #: frontend/js/src/forms/SignupNonCommercial.tsx:220
-#: frontend/js/src/forms/SignupUser.tsx:163
+#: frontend/js/src/forms/SignupUser.tsx:169
 msgid "Must be at least 8 characters"
 msgstr "Au moins 8 caractères"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:348
+#: frontend/js/src/forms/SignupCommercial.tsx:353
 msgid ""
 "If you don't have an organization name, you probably want to become a "
 "supporter as a <nonCommercialLink>Non-commercial / "
@@ -4323,7 +5354,7 @@ msgstr ""
 " plutôt vous inscrire comme un compte <nonCommercialLink>d'utilisation "
 "non commerciale/personnelle</nonCommercialLink>."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:358
+#: frontend/js/src/forms/SignupCommercial.tsx:363
 msgid ""
 "If you don't have an organization name, you probably want to sign up as a"
 " <nonCommercialLink>Non-commercial / Personal</nonCommercialLink> user."
@@ -4332,7 +5363,7 @@ msgstr ""
 " plutôt vous inscrire comme utilisateur <nonCommercialLink>d'utilisation "
 "non commerciale/personnelle</nonCommercialLink>."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:378
+#: frontend/js/src/forms/SignupCommercial.tsx:383
 msgid ""
 "Please tell us a little about your company and whether you plan to use "
 "our <apiLink>API</apiLink> or to <hostLink>host your own copy</hostLink> "
@@ -4342,15 +5373,15 @@ msgstr ""
 "d'utiliser notre <apiLink>API</apiLink> ou d'<hostLink>héberger votre "
 "propre copie</hostLink> des données."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:404
+#: frontend/js/src/forms/SignupCommercial.tsx:408
 msgid "Logo URL"
 msgstr "URL du logo"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:405
+#: frontend/js/src/forms/SignupCommercial.tsx:409
 msgid "(preferably in SVG format)"
 msgstr "(si possible au format SVG)"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:408
+#: frontend/js/src/forms/SignupCommercial.tsx:412
 msgid ""
 "Image should be about 250 pixels wide on a white or transparent "
 "background. We will host it on our site."
@@ -4358,28 +5389,26 @@ msgstr ""
 "L'image doit avoir une largeur d'environ 250 pixels sur un fond blanc ou "
 "transparent. Nous l'hébergerons sur notre site."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:421
+#: frontend/js/src/forms/SignupCommercial.tsx:425
 msgid ""
 "URL to where developers can use your APIs using MusicBrainz IDs, if "
-"available.."
+"available."
 msgstr ""
-"URL sur laquelle les développeurs peuvent utiliser vos API à l'aide des "
-"identifiants MusicBrainz, si disponible."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:430
+#: frontend/js/src/forms/SignupCommercial.tsx:434
 msgid "Your project"
 msgstr "Votre projet"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:434
+#: frontend/js/src/forms/SignupCommercial.tsx:438
 #: frontend/js/src/forms/SignupNonCommercial.tsx:261
 msgid "(max 150 characters)"
 msgstr "(max 150 caractères)"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:451
+#: frontend/js/src/forms/SignupCommercial.tsx:455
 msgid "Billing address"
 msgstr "Adresse de facturation"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:502
+#: frontend/js/src/forms/SignupCommercial.tsx:506
 msgid ""
 "I agree to support the MetaBrainz Foundation when my organization is able"
 " to do so."
@@ -4387,17 +5416,18 @@ msgstr ""
 "J'accepte de soutenir financièrement la Fondation MetaBrainz lorsque mon "
 "organisation sera en mesure de le faire."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:507
+#: frontend/js/src/forms/SignupCommercial.tsx:511
+#: frontend/js/src/forms/SignupNonCommercial.tsx:284
 msgid ""
-"I also agree that if I generate a Live Data Feed access token, that I "
-"treat my access token as a secret and will not share this token publicly "
-"or commit it to a source code repository."
+"I also agree that if I generate a Live Data Feed access token, then I "
+"will treat my access token as a secret and will not share this token "
+"publicly or commit it to a source code repository."
 msgstr ""
-"J'accepte également que si je génère une clé d'accès Live Data Feed, je "
-"traite ma clé d'accès comme un secret et je ne la partagerai pas "
-"publiquement ni ne l'ajouterai à un dépôt de code source."
+"J'accepte également que si je génère une clé d'accès pour le Live Data "
+"Feed, je traiterai cette clé comme un secret et ne la partagerai pas "
+"publiquement ni ne l'intégrerai à un dépôt de code source."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:515
+#: frontend/js/src/forms/SignupCommercial.tsx:519
 msgid ""
 "The following information will be shown publicly: organization name, "
 "logo, website and API URLs, data usage description."
@@ -4406,7 +5436,7 @@ msgstr ""
 "l'organisation, logo, URL du site web et de l'API, description de "
 "l'utilisation des données."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:520
+#: frontend/js/src/forms/SignupCommercial.tsx:524
 msgid ""
 "We'll send you more details about payment process once your application "
 "is approved."
@@ -4414,36 +5444,27 @@ msgstr ""
 "Nous vous enverrons plus de détails sur le processus de paiement une fois"
 " votre demande approuvée."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:552
+#: frontend/js/src/forms/SignupCommercial.tsx:556
 #: frontend/js/src/forms/SignupNonCommercial.tsx:316
-#: frontend/js/src/forms/SignupUser.tsx:224
+#: frontend/js/src/forms/SignupUser.tsx:230
 msgid "Validating..."
 msgstr "Validation…"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:564
+#: frontend/js/src/forms/SignupCommercial.tsx:568
 #: frontend/js/src/forms/SignupNonCommercial.tsx:329
 msgid "Back to profile"
 msgstr "Retour au profil"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:569
-#: frontend/js/src/forms/SignupNonCommercial.tsx:334
-msgid "Not a supporter?"
-msgstr "Pas encore un soutien ?"
-
-#: frontend/js/src/forms/SignupCommercial.tsx:570
+#: frontend/js/src/forms/SignupCommercial.tsx:574
 #: frontend/js/src/forms/SignupNonCommercial.tsx:335
-msgid "Create a user account"
-msgstr "Créer un compte utilisateur"
+msgid "Not a supporter? <signupLink>Create a user account</signupLink>"
+msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:573
-#: frontend/js/src/forms/SignupNonCommercial.tsx:338
-#: frontend/js/src/forms/SignupUser.tsx:231
-msgid "Already have an account?"
-msgstr "Vous avez déjà un compte ?"
-
-#: frontend/js/src/forms/SignupNonCommercial.tsx:107
-msgid "non-commercial"
-msgstr "non commercial"
+#: frontend/js/src/forms/SignupCommercial.tsx:583
+#: frontend/js/src/forms/SignupNonCommercial.tsx:344
+#: frontend/js/src/forms/SignupUser.tsx:238
+msgid "Already have an account? <loginLink>Sign in</loginLink>"
+msgstr ""
 
 #: frontend/js/src/forms/SignupNonCommercial.tsx:113
 msgid ""
@@ -4476,29 +5497,20 @@ msgstr ""
 "J'accepte de n'utiliser les données MetaBrainz qu'à des fins non "
 "commerciales (revenus inférieurs à 500 $ par an) ou personnelles."
 
-#: frontend/js/src/forms/SignupNonCommercial.tsx:284
-msgid ""
-"I also agree that if I generate a Live Data Feed access token, then I "
-"will treat my access token as a secret and will not share this token "
-"publicly or commit it to a source code repository."
-msgstr ""
-"J'accepte également que si je génère une clé d'accès pour le Live Data "
-"Feed, je traiterai cette clé comme un secret et ne la partagerai pas "
-"publiquement ni ne l'intégrerai à un dépôt de code source."
-
 #: frontend/js/src/forms/SignupUser.tsx:43
 msgid "Create your account"
 msgstr "Créer votre compte"
 
-#: frontend/js/src/forms/SignupUser.tsx:50
-msgid "Registration started by"
-msgstr "Inscription commencée par"
+#: frontend/js/src/forms/SignupUser.tsx:51
+msgid "Registration started by <client />"
+msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:69
+#: frontend/js/src/forms/SignupUser.tsx:75
+#: frontend/js/src/hooks/useEmailValidation.ts:82
 msgid "Invalid email address."
 msgstr "L'adresse e-mail n'est pas valide."
 
-#: frontend/js/src/forms/SignupUser.tsx:150
+#: frontend/js/src/forms/SignupUser.tsx:156
 msgid ""
 "This username and email were provided by the app that started "
 "registration. You can change them later from MetaBrainz settings."
@@ -4507,7 +5519,7 @@ msgstr ""
 "l'application qui a initié l'inscription. Vous pouvez les modifier "
 "ultérieurement dans votre profil MetaBrainz."
 
-#: frontend/js/src/forms/SignupUser.tsx:182
+#: frontend/js/src/forms/SignupUser.tsx:188
 msgid ""
 "I accept that my contributions will be released into the public domain or"
 " licensed for use."
@@ -4515,15 +5527,15 @@ msgstr ""
 "J'accepte que mes contributions soient placées dans le domaine public ou "
 "fassent l'objet d'une licence d'utilisation."
 
-#: frontend/js/src/forms/SignupUser.tsx:191
+#: frontend/js/src/forms/SignupUser.tsx:197
 msgid "We will never share your personal information."
 msgstr "Nous ne partagerons jamais vos informations personnelles."
 
-#: frontend/js/src/forms/SignupUser.tsx:200
+#: frontend/js/src/forms/SignupUser.tsx:206
 msgid "Click here to read more"
 msgstr "Cliquez ici pour en savoir plus"
 
-#: frontend/js/src/forms/SignupUser.tsx:224
+#: frontend/js/src/forms/SignupUser.tsx:230
 msgid "Create account"
 msgstr "Créer un compte"
 
@@ -4534,10 +5546,6 @@ msgstr "Cette adresse e-mail est déjà enregistrée."
 #: frontend/js/src/hooks/useEmailValidation.ts:47
 msgid "Email validation failed"
 msgstr "Erreur de validation de l'adresse e-mail"
-
-#: frontend/js/src/hooks/useEmailValidation.ts:82
-msgid "Invalid email address"
-msgstr "Adresse e-mail invalide"
 
 #~ msgid "You need to specify amount!"
 #~ msgstr "Vous devez spécifier un montant !"
@@ -5384,6 +6392,9 @@ msgstr "Adresse e-mail invalide"
 #~ " new access token? Current token will"
 #~ " be revoked!"
 #~ msgstr ""
+#~ "Êtes-vous sûr de vouloir générer "
+#~ "une nouvelle clé d'accès ? La clé"
+#~ " actuelle sera révoquée !"
 
 #~ msgid "Sign up <small>Commercial</small>"
 #~ msgstr ""
@@ -5428,6 +6439,9 @@ msgstr "Adresse e-mail invalide"
 #~ "your APIs using MusicBrainz IDs, if "
 #~ "available.."
 #~ msgstr ""
+#~ "URL sur laquelle les développeurs "
+#~ "peuvent utiliser vos API à l'aide "
+#~ "des identifiants MusicBrainz, si disponible."
 
 #~ msgid "(max 150 characters)"
 #~ msgstr "(150 caractères maximum)"
@@ -5756,3 +6770,127 @@ msgstr "Adresse e-mail invalide"
 
 #~ msgid "Privacy policy"
 #~ msgstr "Politique de confidentialité"
+
+#~ msgid "You need to specify website of the organization."
+#~ msgstr "Vous devez spécifier le site internet de votre organisation."
+
+#~ msgid ""
+#~ "We are currently evaluating our overall"
+#~ " online advertising strategy. We are "
+#~ "evaluating advertising, traffic optimization,\n"
+#~ ""
+#~ "    search engine optimization and "
+#~ "software monitization technologies. If you "
+#~ "provide these professional services, please"
+#~ " provide a detailed\n"
+#~ "    deck of your comprehensive services"
+#~ " to the following email address. "
+#~ "<em>Please respect our other non-media"
+#~ " teams and do not contact us \n"
+#~ "    regarding these services on any "
+#~ "other of our email addresses. We "
+#~ "will disregard the entirety of your "
+#~ "submissions if you contact us any "
+#~ "other way!</em>"
+#~ msgstr ""
+#~ "Nous évaluons actuellement notre stratégie "
+#~ "globale de publicité en ligne. Nous "
+#~ "examinons les technologies de publicité, "
+#~ "d'optimisation du trafic, de référencement "
+#~ "naturel et de monétisation logicielle. "
+#~ "Si vous proposez ces services "
+#~ "professionnels, veuillez nous faire parvenir"
+#~ " une description détaillée de vos "
+#~ "prestations à l'adresse électronique suivante."
+#~ " <em>Merci de respecter le reste de"
+#~ " notre équipe qui ne fait pas "
+#~ "de marketing et de nous contacter "
+#~ "uniquement à cette adresse e-mail. Toute"
+#~ " autre communication sera ignorée.</em>"
+
+#~ msgid ""
+#~ "Please come ask your questions at "
+#~ "our <a href=\"%(forums_url)s\">forums</a>! We "
+#~ "would love to\n"
+#~ "    answer any questions you may have."
+#~ msgstr ""
+#~ "N'hésitez pas à poser vos questions "
+#~ "sur nos <a href=\"%(forums_url)s\">forums</a> "
+#~ "!\n"
+#~ "    Nous serons ravis de répondre à toutes vos questions."
+
+#~ msgid ""
+#~ "Due to the increased unreliability of"
+#~ " the US Postal Service we have "
+#~ "stopped accepting paper checks. Sorry!"
+#~ msgstr ""
+#~ "En raison du manque de fiabilité "
+#~ "croissant du service postal américain, "
+#~ "nous n'acceptons plus les chèques "
+#~ "papier. Désolé !"
+
+#~ msgid "Upgrade"
+#~ msgstr "Mettre à jour"
+
+#~ msgid "Back to Profile"
+#~ msgstr "Retour au profil"
+
+#~ msgid ""
+#~ "Deletion of supporter accounts requires "
+#~ "manual review. Please contact us at"
+#~ msgstr ""
+#~ "La suppression des comptes de supporters"
+#~ " nécessite un confirmation manuelle. "
+#~ "Veuillez nous contacter à"
+
+#~ msgid "Revoke all your API tokens and access"
+#~ msgstr "Détruire toutes vos clés d'accès et d'API"
+
+#~ msgid "Your username will be reserved and cannot be reused."
+#~ msgstr "Votre nom d'utilisateur sera réservé et ne pourra pas être réutilisé."
+
+#~ msgid "Don't have an account?"
+#~ msgstr "Pas encore de compte ?"
+
+#~ msgid "If you would like to support us with more than $"
+#~ msgstr "Si vous souhaitez nous soutenir avec plus que $"
+
+#~ msgid ", please enter the actual amount here:"
+#~ msgstr ", veuillez saisir le montant ici :"
+
+#~ msgid "month and up"
+#~ msgstr "mois ou plus"
+
+#~ msgid ""
+#~ "I also agree that if I generate"
+#~ " a Live Data Feed access token, "
+#~ "that I treat my access token as"
+#~ " a secret and will not share "
+#~ "this token publicly or commit it "
+#~ "to a source code repository."
+#~ msgstr ""
+#~ "J'accepte également que si je génère "
+#~ "une clé d'accès Live Data Feed, je"
+#~ " traite ma clé d'accès comme un "
+#~ "secret et je ne la partagerai pas"
+#~ " publiquement ni ne l'ajouterai à un"
+#~ " dépôt de code source."
+
+#~ msgid "Not a supporter?"
+#~ msgstr "Pas encore un soutien ?"
+
+#~ msgid "Create a user account"
+#~ msgstr "Créer un compte utilisateur"
+
+#~ msgid "Already have an account?"
+#~ msgstr "Vous avez déjà un compte ?"
+
+#~ msgid "non-commercial"
+#~ msgstr "non commercial"
+
+#~ msgid "Registration started by"
+#~ msgstr "Inscription commencée par"
+
+#~ msgid "Invalid email address"
+#~ msgstr "Adresse e-mail invalide"
+

--- a/metabrainz/translations/he/LC_MESSAGES/messages.po
+++ b/metabrainz/translations/he/LC_MESSAGES/messages.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-07-25 16:21+0200\n"
+"POT-Creation-Date: 2026-09-08 11:18+0200\n"
 "PO-Revision-Date: 2026-06-12 00:53+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: he\n"
@@ -22,163 +22,248 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.18.0\n"
 
-#: metabrainz/index/forms.py:46
+#: metabrainz/errors.py:24
+msgid "Authorization was declined."
+msgstr ""
+
+#: metabrainz/errors.py:25
+msgid "The authorization request was invalid."
+msgstr ""
+
+#: metabrainz/errors.py:26
+msgid "The application could not be authenticated."
+msgstr ""
+
+#: metabrainz/errors.py:27
+msgid "This application is not allowed to request authorization."
+msgstr ""
+
+#: metabrainz/errors.py:28
+msgid "The application asked for a response type this server does not support."
+msgstr ""
+
+#: metabrainz/errors.py:29
+msgid "The permissions requested by the application are invalid."
+msgstr ""
+
+#: metabrainz/errors.py:30
+msgid "You need to sign in to continue."
+msgstr ""
+
+#: metabrainz/errors.py:31
+msgid "Your consent is required to continue."
+msgstr ""
+
+#: metabrainz/password.py:12
+#, python-format
+msgid "Password must not exceed %(max_bytes)s bytes."
+msgstr ""
+
+#: metabrainz/index/forms.py:48
 #, python-format
 msgid "'%(value)s' is not a valid choice for this field"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileEdit.tsx:27
-#: frontend/js/src/forms/SignupCommercial.tsx:154
+#: frontend/js/src/forms/SignupCommercial.tsx:159
 #: frontend/js/src/forms/SignupNonCommercial.tsx:85
-#: frontend/js/src/forms/SignupUser.tsx:70
-#: frontend/js/src/hooks/useEmailValidation.ts:78 metabrainz/index/forms.py:57
-#: metabrainz/user/forms.py:25 metabrainz/user/forms.py:57
-#: metabrainz/user/forms.py:63
+#: frontend/js/src/forms/SignupUser.tsx:76
+#: frontend/js/src/hooks/useEmailValidation.ts:78 metabrainz/index/forms.py:59
+#: metabrainz/user/forms.py:31 metabrainz/user/forms.py:70
+#: metabrainz/user/forms.py:76
 msgid "Email address is required!"
 msgstr "נדרש כתובת דוא\"ל!"
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:34
-#: metabrainz/index/forms.py:63
+#: metabrainz/index/forms.py:65
 msgid "Current password is required!"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:43
 #: frontend/js/src/forms/ProfileChangePassword.tsx:37
 #: frontend/js/src/forms/ResetPassword.tsx:39
-#: frontend/js/src/forms/SignupCommercial.tsx:156
+#: frontend/js/src/forms/SignupCommercial.tsx:161
 #: frontend/js/src/forms/SignupNonCommercial.tsx:87
-#: frontend/js/src/forms/SignupUser.tsx:72 metabrainz/index/forms.py:66
-#: metabrainz/user/forms.py:29 metabrainz/user/forms.py:46
-#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:69
+#: frontend/js/src/forms/SignupUser.tsx:78 metabrainz/index/forms.py:69
+#: metabrainz/user/forms.py:35 metabrainz/user/forms.py:54
+#: metabrainz/user/forms.py:63 metabrainz/user/forms.py:82
 msgid "Password is required!"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:41
-#: frontend/js/src/forms/SignupCommercial.tsx:160
+#: frontend/js/src/forms/SignupCommercial.tsx:165
 #: frontend/js/src/forms/SignupNonCommercial.tsx:91
-#: frontend/js/src/forms/SignupUser.tsx:76 metabrainz/index/forms.py:70
-#: metabrainz/user/forms.py:33 metabrainz/user/forms.py:73
+#: frontend/js/src/forms/SignupUser.tsx:82 metabrainz/index/forms.py:74
+#: metabrainz/user/forms.py:40 metabrainz/user/forms.py:87
 msgid "Confirm Password is required!"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:46
 #: frontend/js/src/forms/ResetPassword.tsx:48
-#: frontend/js/src/forms/SignupCommercial.tsx:165
+#: frontend/js/src/forms/SignupCommercial.tsx:170
 #: frontend/js/src/forms/SignupNonCommercial.tsx:96
-#: frontend/js/src/forms/SignupUser.tsx:81 metabrainz/index/forms.py:72
-#: metabrainz/user/forms.py:35 metabrainz/user/forms.py:75
+#: frontend/js/src/forms/SignupUser.tsx:87 metabrainz/index/forms.py:76
+#: metabrainz/user/forms.py:42 metabrainz/user/forms.py:89
 msgid "Confirm Password should match password!"
 msgstr ""
 
 #: frontend/js/src/Applications.tsx:56 frontend/js/src/Applications.tsx:86
 #: frontend/js/src/Profile.tsx:272 frontend/js/src/Profile.tsx:482
-#: metabrainz/index/forms.py:78
+#: metabrainz/index/forms.py:82
 msgid "Name"
 msgstr "שם"
 
-#: metabrainz/index/forms.py:79
+#: metabrainz/index/forms.py:83
 msgid "Contact name field is empty."
 msgstr "שדה שם איש קשר ריק."
 
-#: metabrainz/index/views.py:234
+#: metabrainz/index/views.py:251
 msgid "Profile updated successfully."
 msgstr ""
 
-#: metabrainz/index/views.py:261
+#: metabrainz/index/views.py:278
 msgid "Current password is incorrect."
 msgstr ""
 
-#: metabrainz/index/views.py:266
+#: metabrainz/index/views.py:283
 msgid "Password changed successfully."
 msgstr ""
 
-#: metabrainz/index/views.py:372
+#: metabrainz/index/views.py:389
 msgid "You have updated an application!"
 msgstr ""
 
-#: metabrainz/index/views.py:424
+#: metabrainz/index/views.py:441
 msgid "You have deleted an application."
 msgstr ""
 
-#: metabrainz/index/views.py:426
+#: metabrainz/index/views.py:443
 msgid "Failed to delete an application."
 msgstr ""
 
-#: metabrainz/index/views.py:449
+#: metabrainz/index/views.py:466
 msgid "Revoked tokens successfully!"
 msgstr ""
 
-#: metabrainz/index/views.py:478
+#: metabrainz/index/views.py:495
 msgid "Your account has been deleted."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:106 metabrainz/oauth/forms.py:58
+#: frontend/js/src/forms/CreateApplication.tsx:106 metabrainz/oauth/forms.py:57
 msgid "Application Name"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:59
+#: metabrainz/oauth/forms.py:58
 msgid "Application name field is empty."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:60 metabrainz/oauth/forms.py:60
+#: frontend/js/src/forms/CreateApplication.tsx:60 metabrainz/oauth/forms.py:59
 msgid "Application name needs to be at least 3 characters long."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:64 metabrainz/oauth/forms.py:61
+#: frontend/js/src/forms/CreateApplication.tsx:64 metabrainz/oauth/forms.py:60
 msgid "Application name needs to be at most 64 characters long."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:114 metabrainz/oauth/forms.py:63
+#: frontend/js/src/forms/CreateApplication.tsx:114 metabrainz/oauth/forms.py:62
 #, fuzzy
 msgid "Description"
 msgstr "תאור ארגון"
 
-#: metabrainz/oauth/forms.py:64
+#: metabrainz/oauth/forms.py:63
 msgid "Client description field is empty."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:65
+#: metabrainz/oauth/forms.py:64
 msgid "Client description needs to be at least 3 characters long."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:66
+#: metabrainz/oauth/forms.py:65
 msgid "Client description needs to be at most 512 characters long."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:122 metabrainz/oauth/forms.py:68
+#: frontend/js/src/forms/CreateApplication.tsx:122 metabrainz/oauth/forms.py:67
 msgid "Homepage"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:69
+#: metabrainz/oauth/forms.py:68
 msgid "Homepage field is empty."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:70
+#: metabrainz/oauth/forms.py:69
 msgid "Homepage is not a valid URI."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:71
+#: metabrainz/oauth/forms.py:70
 msgid "Homepage URL must use http or https"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:73
+#: metabrainz/oauth/forms.py:72
 msgid "Authorization callback URL"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:74
+#: metabrainz/oauth/forms.py:73
 msgid "Authorization callback URL field is empty."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:75
+#: metabrainz/oauth/forms.py:74
 msgid "Authorization callback URL is invalid."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:76
+#: metabrainz/oauth/forms.py:75
 msgid "Authorization callback URL must use http or https."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:81 metabrainz/oauth/forms.py:85
+#: metabrainz/oauth/forms.py:80 metabrainz/oauth/forms.py:84
 msgid "Confirm"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:15
+msgid "View your public account information"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:16
+msgid "View your email address"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:17
+msgid "View and modify your private tags"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:18
+msgid "View and modify your private ratings"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:19
+msgid "View and modify your private collections"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:20
+msgid "Submit new ISRCs to the database"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:21
+msgid "Submit new barcodes to the database"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:22
+msgid "Sign you in and view your unique user id"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:23
+msgid "Submit listens to ListenBrainz."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:24
+msgid "Create and modify CritiqueBrainz reviews."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:25
+msgid "Submit and delete votes on CritiqueBrainz reviews."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:26
+msgid "Modify profile info and delete profile on CritiqueBrainz."
 msgstr ""
 
 #: metabrainz/payments/views.py:164
@@ -223,178 +308,185 @@ msgid "Requested annual report was not found."
 msgstr "דוח שנתי מבוקש לא נמצא."
 
 #: frontend/js/src/forms/ProfileEdit.tsx:30
-#: frontend/js/src/forms/SignupCommercial.tsx:139
+#: frontend/js/src/forms/SignupCommercial.tsx:144
 #: frontend/js/src/forms/SignupNonCommercial.tsx:70
-#: metabrainz/supporter/forms.py:13
+#: metabrainz/supporter/forms.py:15
 msgid "Contact name is required!"
 msgstr "נדרש שם איש קשר!"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:437
+#: frontend/js/src/forms/SignupCommercial.tsx:441
 #: frontend/js/src/forms/SignupNonCommercial.tsx:264
-#: metabrainz/supporter/forms.py:15
+#: metabrainz/supporter/forms.py:17
 msgid ""
 "Can you please tell us more about the project in which you'd like to use "
 "our data? Do you plan to self host the data or use our APIs?"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:137
+#: frontend/js/src/forms/SignupCommercial.tsx:142
 #: frontend/js/src/forms/SignupNonCommercial.tsx:68
-#: metabrainz/supporter/forms.py:17
+#: metabrainz/supporter/forms.py:19
 msgid "Please, tell us how you (will) use our data."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:138
+#: frontend/js/src/forms/SignupCommercial.tsx:143
 #: frontend/js/src/forms/SignupNonCommercial.tsx:69
-#: metabrainz/supporter/forms.py:18
+#: metabrainz/supporter/forms.py:20
 msgid "Please, limit usage description to 500 characters."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:141
-#: frontend/js/src/forms/SignupCommercial.tsx:142
+#: frontend/js/src/forms/SignupCommercial.tsx:146
+#: frontend/js/src/forms/SignupCommercial.tsx:147
 #: frontend/js/src/forms/SignupNonCommercial.tsx:72
 #: frontend/js/src/forms/SignupNonCommercial.tsx:73
-#: frontend/js/src/forms/SignupUser.tsx:84
-#: frontend/js/src/forms/SignupUser.tsx:85 metabrainz/supporter/forms.py:21
-#: metabrainz/user/forms.py:38
+#: frontend/js/src/forms/SignupUser.tsx:90
+#: frontend/js/src/forms/SignupUser.tsx:91 metabrainz/supporter/forms.py:23
+#: metabrainz/user/forms.py:45
 msgid "You need to accept the agreement!"
 msgstr "נא לאשר את ההסכם!"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:342
-#: metabrainz/supporter/forms.py:27
+#: frontend/js/src/forms/SignupCommercial.tsx:347
+#: metabrainz/supporter/forms.py:29
 msgid "Organization name"
 msgstr "שם ארגון"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:113
-#: metabrainz/supporter/forms.py:28
+#: frontend/js/src/forms/SignupCommercial.tsx:115
+#: metabrainz/supporter/forms.py:30
 msgid "You need to specify the name of your organization."
 msgstr "נדרש להגדיר את שם הארגון."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:373
-#: metabrainz/supporter/forms.py:30
+#: frontend/js/src/forms/SignupCommercial.tsx:378
+#: metabrainz/supporter/forms.py:32
 msgid "Organization description"
 msgstr "תאור ארגון"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:116
-#: metabrainz/supporter/forms.py:31
+#: frontend/js/src/forms/SignupCommercial.tsx:118
+#: metabrainz/supporter/forms.py:33
 msgid "You need to provide description of your organization."
 msgstr "נדרש לספק תאור של הארגון."
 
 #: frontend/js/src/Profile.tsx:278
-#: frontend/js/src/forms/SignupCommercial.tsx:396
-#: metabrainz/supporter/forms.py:34
+#: frontend/js/src/forms/SignupCommercial.tsx:401
+#: metabrainz/supporter/forms.py:36
 msgid "Website URL"
 msgstr "פורטן אתר מרשתת:"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:119
-#: metabrainz/supporter/forms.py:35
-msgid "You need to specify website of the organization."
-msgstr "נא להזין את אתר הארגון."
+#: frontend/js/src/forms/SignupCommercial.tsx:121
+#: frontend/js/src/forms/SignupCommercial.tsx:123
+#: metabrainz/supporter/forms.py:38 metabrainz/supporter/forms.py:42
+msgid "Website URL must be a valid URL."
+msgstr ""
 
-#: metabrainz/supporter/forms.py:37
+#: metabrainz/supporter/forms.py:45
 msgid "Logo image URL"
 msgstr "URL תמונת לוגו"
 
 #: frontend/js/src/Profile.tsx:284
-#: frontend/js/src/forms/SignupCommercial.tsx:418
-#: metabrainz/supporter/forms.py:38
+#: frontend/js/src/forms/SignupCommercial.tsx:422
+#: metabrainz/supporter/forms.py:46
 msgid "API URL"
 msgstr "API URL"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:457
-#: metabrainz/supporter/forms.py:40
+#: frontend/js/src/forms/SignupCommercial.tsx:461
+#: metabrainz/supporter/forms.py:48
 msgid "Street"
 msgstr "רחוב"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:123
-#: metabrainz/supporter/forms.py:41
+#: frontend/js/src/forms/SignupCommercial.tsx:128
+#: metabrainz/supporter/forms.py:49
 msgid "You need to specify street."
 msgstr "נא להזין רחוב."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:465
-#: metabrainz/supporter/forms.py:43
+#: frontend/js/src/forms/SignupCommercial.tsx:469
+#: metabrainz/supporter/forms.py:51
 msgid "City"
 msgstr "עיר"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:124
-#: metabrainz/supporter/forms.py:44
+#: frontend/js/src/forms/SignupCommercial.tsx:129
+#: metabrainz/supporter/forms.py:52
 msgid "You need to specify city."
 msgstr "נא להזין עיר."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:473
-#: metabrainz/supporter/forms.py:46
+#: frontend/js/src/forms/SignupCommercial.tsx:477
+#: metabrainz/supporter/forms.py:54
 msgid "State / Province"
 msgstr "מדינה / מחוז"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:126
-#: metabrainz/supporter/forms.py:47
+#: frontend/js/src/forms/SignupCommercial.tsx:131
+#: metabrainz/supporter/forms.py:55
 msgid "You need to specify state/province."
 msgstr "נא להזין מדינה/מחוז."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:481
-#: metabrainz/supporter/forms.py:49
+#: frontend/js/src/forms/SignupCommercial.tsx:485
+#: metabrainz/supporter/forms.py:57
 msgid "Postcode"
 msgstr "מיקוד"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:128
-#: metabrainz/supporter/forms.py:50
+#: frontend/js/src/forms/SignupCommercial.tsx:133
+#: metabrainz/supporter/forms.py:58
 msgid "You need to specify postcode."
 msgstr "לא להזין מיקוד."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:489
-#: metabrainz/supporter/forms.py:52
+#: frontend/js/src/forms/SignupCommercial.tsx:493
+#: metabrainz/supporter/forms.py:60
 msgid "Country"
 msgstr "ארץ"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:129
-#: metabrainz/supporter/forms.py:53
+#: frontend/js/src/forms/SignupCommercial.tsx:134
+#: metabrainz/supporter/forms.py:61
 msgid "You need to specify country."
 msgstr "נא להזין ארץ."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:132
-#: metabrainz/supporter/forms.py:64
+#: frontend/js/src/forms/SignupCommercial.tsx:137
+#: metabrainz/supporter/forms.py:72
 msgid ""
 "Custom amount must be more than threshold amount for selected tier or "
 "equal to it!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:46 metabrainz/supporter/views.py:119
-#: metabrainz/supporter/views.py:220
+#: metabrainz/supporter/views.py:54
+msgid ""
+"The verification email could not be sent. Please request a new one from "
+"your profile."
+msgstr ""
+
+#: metabrainz/supporter/views.py:85 metabrainz/supporter/views.py:158
+#: metabrainz/supporter/views.py:260
 msgid "You are already a supporter."
 msgstr ""
 
-#: metabrainz/supporter/views.py:61
+#: metabrainz/supporter/views.py:100
 msgid "Can't find tier with a specified ID."
 msgstr ""
 
-#: metabrainz/supporter/views.py:127
+#: metabrainz/supporter/views.py:166
 msgid "You need to choose support tier before signing up!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:137
+#: metabrainz/supporter/views.py:176
 msgid "You need to choose existing tier before signing up!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:164
+#: metabrainz/supporter/views.py:204
 msgid ""
 "Thanks for becoming a supporter! Your application will be reviewed soon. "
 "We will send you updates via email."
 msgstr ""
 
-#: metabrainz/supporter/views.py:187
+#: metabrainz/supporter/views.py:228
 msgid ""
 "Thanks for signing up! Your application will be reviewed soon. We will "
 "send you updates via email."
 msgstr ""
 
-#: metabrainz/supporter/views.py:248
+#: metabrainz/supporter/views.py:288
 msgid "Thanks for becoming a supporter!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:274
+#: metabrainz/supporter/views.py:312
 msgid "Thanks for signing up! Please check your inbox to complete verification."
 msgstr ""
 
-#: metabrainz/supporter/views.py:302
+#: metabrainz/supporter/views.py:340
 msgid "Can't generate new token unless account is active."
 msgstr ""
 
@@ -428,7 +520,7 @@ msgstr ""
 msgid "Policies"
 msgstr ""
 
-#: metabrainz/templates/base.html:55 metabrainz/templates/index/gdpr.html:178
+#: metabrainz/templates/base.html:55
 #: metabrainz/templates/index/social-contract.html:3
 #: metabrainz/templates/index/social-contract.html:6
 #: metabrainz/templates/navbar.html:34
@@ -438,14 +530,15 @@ msgstr ""
 #: metabrainz/templates/base.html:56
 #: metabrainz/templates/index/code-of-conduct.html:3
 #: metabrainz/templates/index/code-of-conduct.html:16
-#: metabrainz/templates/index/gdpr.html:181 metabrainz/templates/navbar.html:35
+#: metabrainz/templates/navbar.html:35
 msgid "Code of Conduct"
 msgstr ""
 
+#: frontend/js/src/PrivacySummary.tsx:11
 #: frontend/js/src/forms/ConditionsModal.tsx:21
-#: metabrainz/templates/base.html:57 metabrainz/templates/index/gdpr.html:184
-#: metabrainz/templates/index/privacy.html:6
+#: metabrainz/templates/base.html:57 metabrainz/templates/index/privacy.html:6
 #: metabrainz/templates/navbar.html:36
+#: metabrainz/templates/users/privacy-summary.html:3
 msgid "Privacy Policy"
 msgstr "מדיניות פרטיות"
 
@@ -479,10 +572,7 @@ msgstr "נותני חסות"
 msgid "Supporters"
 msgstr "תומכים"
 
-#: frontend/js/src/forms/LoginUser.tsx:103
-#: frontend/js/src/forms/SignupCommercial.tsx:574
-#: frontend/js/src/forms/SignupNonCommercial.tsx:339
-#: frontend/js/src/forms/SignupUser.tsx:232 metabrainz/templates/base.html:73
+#: frontend/js/src/forms/LoginUser.tsx:103 metabrainz/templates/base.html:73
 #: metabrainz/templates/navbar.html:66 metabrainz/templates/users/login.html:3
 msgid "Sign in"
 msgstr "התחברו"
@@ -504,26 +594,26 @@ msgid "Contact us"
 msgstr "צרו קשר"
 
 #: metabrainz/templates/base.html:85
-#: metabrainz/templates/index/contact.html:105
+#: metabrainz/templates/index/contact.html:106
 msgid "Blog"
 msgstr "בלוג"
 
-#: metabrainz/templates/base.html:86 metabrainz/templates/index/contact.html:90
+#: metabrainz/templates/base.html:86 metabrainz/templates/index/contact.html:91
 msgid "Chat"
 msgstr ""
 
 #: metabrainz/templates/base.html:87
-#: metabrainz/templates/index/contact.html:106
+#: metabrainz/templates/index/contact.html:107
 msgid "Mastodon"
 msgstr ""
 
 #: metabrainz/templates/base.html:88
-#: metabrainz/templates/index/contact.html:107
+#: metabrainz/templates/index/contact.html:108
 msgid "Bluesky"
 msgstr ""
 
 #: metabrainz/templates/base.html:89
-#: metabrainz/templates/index/contact.html:108
+#: metabrainz/templates/index/contact.html:109
 msgid "Instagram"
 msgstr ""
 
@@ -581,15 +671,14 @@ msgstr "דוחות כספיים"
 msgid "Donate"
 msgstr "תרומה"
 
-#: frontend/js/src/forms/LoginUser.tsx:110
-#: frontend/js/src/forms/SignupCommercial.tsx:175
-#: frontend/js/src/forms/SignupCommercial.tsx:555
+#: frontend/js/src/forms/SignupCommercial.tsx:180
+#: frontend/js/src/forms/SignupCommercial.tsx:559
 #: frontend/js/src/forms/SignupNonCommercial.tsx:106
 #: frontend/js/src/forms/SignupNonCommercial.tsx:319
 #: metabrainz/templates/navbar.html:65
-#: metabrainz/templates/supporters/account-type.html:51
-#: metabrainz/templates/supporters/account-type.html:93
-#: metabrainz/templates/supporters/account-type.html:144
+#: metabrainz/templates/supporters/account-type.html:47
+#: metabrainz/templates/supporters/account-type.html:84
+#: metabrainz/templates/supporters/account-type.html:130
 #: metabrainz/templates/users/signup.html:3
 msgid "Sign up"
 msgstr "רישום"
@@ -897,8 +986,430 @@ msgstr ""
 msgid "Introduction"
 msgstr ""
 
-#: metabrainz/templates/index/conflict-policy.html:55
+#: metabrainz/templates/index/conflict-policy.html:17
+msgid ""
+"Conflicts between people arise in open source projects constantly and the"
+" projects by the \n"
+"    MetaBrainz Foundation are no different. This policy aims to establish"
+" a clear and unambiguous \n"
+"    policy for reporting and addressing conflicts in our community. In "
+"this policy we aim to \n"
+"    establish a fair practice that balances the need for confidentiality "
+"and our desire for \n"
+"    transparency in our operations."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:25
+#, python-format
+msgid ""
+"Before you continue to read this policy, we encourage you to review our "
+"existing community policies \n"
+"    including our <a href=\"%(social_contract_url)s\">Social "
+"Contract</a>, \n"
+"    <a href=\"%(code_of_conduct_url)s\">the Code of Conduct</a>, \n"
+"    and our <a href=\"%(privacy_policy_url)s\">Privacy Policy</a>. These "
+"policies establish the norms and rules for \n"
+"    participation in our projects; these policies apply equally to the "
+"contractors of the MetaBrainz \n"
+"    Foundation and any participants in our projects."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:37
+msgid ""
+"This policy divides conflicts into two categories: Private and public. "
+"Private conflicts are conflicts \n"
+"    that involve *confidential* information regarding contributors, "
+"contractors or supporters. Otherwise, any conflicts \n"
+"    that do not involve confidential information are considered to be "
+"public conflicts. For instance, a \n"
+"    conflict between a contractor and the Executive Director (aka BDFL) "
+"that involves contractor pay is \n"
+"    considered a private conflict because pay rates are confidential "
+"information. A public conflict in edit \n"
+"    notes between two editors in our community does not involve "
+"confidential information and therefore should \n"
+"    be considered a public conflict."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:47
+msgid ""
+"When conflicts arise we aim to disclose as much information as possible "
+"about the conflict in a timely \n"
+"    fashion. When conflicts contain confidential matters we will aim to "
+"disclose as much information as \n"
+"    possible, while fully respecting the confidentiality of the people "
+"involved in the conflict. With any \n"
+"    private conflict we will aim to extract the relevant lessons for the "
+"team and community in an effort to \n"
+"    evolve our policies to prevent future conflicts. Should the involved "
+"parties disagree whether a conflict \n"
+"    is private or public, the question about the nature of the conflict "
+"will be presented for the next higher \n"
+"    level in the chain of command to decide. (e.g. if a community member "
+"and the community manager disagree on \n"
+"    a conflict being public or private, the Executive Director shall "
+"decide if the conflict is public or private)."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:58
 msgid "Reporting and Response"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:61
+msgid ""
+"We aim to not have conflict in our community, but we recognize that in "
+"reality conflicts will arise and we \n"
+"    must be prepared to address them in a fair manner. When conflicts "
+"arise, we prefer to have community or team \n"
+"    members resolve the conflicts among themselves, using our existing "
+"policies as guidelines for resolving the \n"
+"    conflict."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:69
+msgid ""
+"If you do not feel comfortable resolving a conflict on your own, you "
+"should feel free to report the conflict to \n"
+"    us. How you address the conflict depends on who is involved in the "
+"conflict and your comfort level. Please see \n"
+"    the detailed sections below on how and with whom to address your "
+"conflict. We aim to address conflicts as soon \n"
+"    as possible in an effort to prevent them from escalating "
+"unnecessarily."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:75
+msgid "Direct conflict resolution"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:78
+msgid ""
+"In direct conflict resolution, the involved parties will attempt to "
+"resolve the conflict themselves without \n"
+"   involving any MetaBrainz Foundation team member. You should aim to use"
+" direct resolution when the conflict does \n"
+"   not involve the violation of one of our policies or if the conflict is"
+" minor."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:84
+#, python-format
+msgid ""
+"For instance, if a user uses a rude tone, is disruptive or flagrantly "
+"ignores our project guidelines, we suggest \n"
+"    that you use direct conflict resolution to resolve the conflict. Some"
+" resources that might give you some suggestions \n"
+"    on how to go about resolving the conflict might be this <a "
+"href=\"%(conflict_resolution_primer_url)s\">\n"
+"    conflict resolution primer</a> and <a "
+"href=\"%(difficult_conversations_url)s\">how to\n"
+"    have difficult conversations at work</a>."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:93
+msgid "Informal reporting"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:96
+msgid ""
+"You may use informal reporting of a conflict if you aim to communicate a "
+"concern or incident without \n"
+"    seeking a corrective outcome. Informal reporting may also be an "
+"option if you have not been personally \n"
+"    victimized, but you’ve witnessed a violation of our policies or where"
+" you wish to maintain confidentiality \n"
+"    throughout the entire reporting process."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:103
+msgid ""
+"For editing in MusicBrainz you may informally report a user using the "
+"“Report this user for bad behavior” \n"
+"    link from the user’s profile. For reporting bad user behavior in "
+"other of our projects, please report them to our \n"
+"    community manager by mailing <span class=\"backemail\">gro.zniarbatem"
+"@reganam-ytinummoc</span> . For conflicts \n"
+"    that involve the community manager, report them by mailing <span "
+"class=\"backemail\">gro.zniarbatem@de</span> ."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:110
+msgid ""
+"Depending the the severity of the issue, repeated informal complaints may"
+" eventually require a formal response \n"
+"    from the MetaBrainz team. If an involved party requires anonymity, "
+"the conflict becomes a private conflict. If at \n"
+"    all possible minor issues should be resolved in a public forum in "
+"order for all people to witness and learn from \n"
+"    the issue at hand."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:116
+msgid "Formal complaint process"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:119
+msgid ""
+"All complaints about conflicts should be submitted via email. To whom a "
+"complaint should be mailed and who will \n"
+"    carry out the investigation will be described in the next section."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:124
+msgid "All complaint submissions to the Foundation should include the following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:128
+msgid ""
+"Contact info, if it is different than the email used to submit the "
+"conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:129
+msgid "Who was involved in the conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:130
+msgid "Where and when the incident happened"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:131
+msgid ""
+"A description of what happened -- ideally with links (e.g. chatlogs, edit"
+" notes) that outlines what \n"
+"         happened so that the persons evaluating the conflict may "
+"understand the issue at hand"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:133
+msgid ""
+"Any related pieces of information that provide more context on the "
+"conflict (e.g. links, screenshots)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:134
+msgid "An indication if this conflict is ongoing or not"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:139
+msgid "The investigation that follows aims to determine:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:143
+msgid "The nature and severity of the incident"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:144
+msgid ""
+"Whether or not the incident is considered a violation of MetaBrainz’ "
+"conduct policies or core values"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:145
+msgid ""
+"The amount of harm experienced by the person who submitted the complaint "
+"and the broader MetaBrainz community \n"
+"         as a result of the incident"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:147
+msgid ""
+"Whether there have been prior complaints against the individual or "
+"individuals reported"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:148
+msgid "Whether the incident is ongoing"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:152
+msgid ""
+"The following potential forms of resolution may apply to any team members"
+" involved in the conflict:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:155
+#: metabrainz/templates/index/conflict-policy.html:168
+msgid "Nothing (if it has been found no violation occurred)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:156
+msgid "Creating a plan to improve the performance"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:157
+msgid "Creating a negative performance evaluation"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:158
+msgid "Mediation, an intervention by a third party to resolve the conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:159
+msgid "Suspension or forced leave"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:160
+msgid "Termination of contract"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:164
+msgid ""
+"The following potential forms of resolution may apply to non team members"
+" involved in the conflict:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:169
+msgid "A reprimand, either public or private"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:170
+msgid "Suspension of the users’ account"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:171
+msgid "Deletion of the users’ account"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:172
+msgid ""
+"Removal of user privileges (e.g. if an auto editor commits a serious "
+"offence, they may lose their auto editor status)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:175
+msgid "Filing a complaint"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:178
+msgid ""
+"NOTE: For complaints not about MetaBrainz staff, please see the "
+"<em>Informal reporting</em> section above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:182
+msgid ""
+"If the complaint does not involve the Executive Director (ED), do the "
+"following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:186
+msgid ""
+"If team member has directly violated conduct policies or engaged in "
+"otherwise harmful behavior, a formal complaint should be filed."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:187
+msgid ""
+"Mail <span class=\"backemail\">gro.zniarbatem@de</span> and include the "
+"complaint information outlined above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:188
+msgid ""
+"You should expect a response within a working day acknowledging the "
+"complaint."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:189
+msgid ""
+"The complaint will be investigated by the ED, member(s) of the board of "
+"directors or a neutral third party."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:190
+msgid ""
+"Once the investigation has been completed, the ED, with the support of "
+"others involved in the investigation will respond. The \n"
+"        ED will respond to incidents no later than 7 working days after a"
+" complaint has been filed with either a resolution or an \n"
+"        explanation of why the process must be extended."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:196
+msgid "If a complaint involves the Executive Director, do the following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:200
+msgid ""
+"If the Executive Director has directly violated conduct policies or "
+"engaged in otherwise harmful behavior, \n"
+"        a formal complaint should be filed with the board of directors."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:202
+msgid ""
+"Mail <span class=\"backemail\">gro.zniarbatem@noituloser-tcilfnoc</span> "
+"and include the complaint information outlined above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:203
+msgid ""
+"You should get a response within 5 working days acknowledging the "
+"complaint."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:204
+msgid ""
+"The complaint will be investigated by the member(s) of the board of "
+"directors, the community manager, a neutral \n"
+"        third party or a combination thereof."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:206
+msgid ""
+"Once the investigation has been completed, the board, with the support of"
+" others involved in the investigation \n"
+"        will respond. The board will aim to respond to incidents no later"
+" than 15 working days after a complaint has been filed \n"
+"        with either a resolution or an explanation of why the process "
+"must be extended."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:211
+msgid "Confidentiality"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:214
+msgid ""
+"Confidentiality is an important aspect of conflict resolution and all of "
+"the conflicts brought to the attention of the foundation \n"
+"    will be evaluated with confidentiality in mind and acted upon "
+"accordingly."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:219
+msgid ""
+"We work hard to make all of the actions of the foundation as transparent "
+"and open as possible. In cases where we cannot \n"
+"    disclose all aspects of a conflict we will disclose that a conflict "
+"is or has occurred and we will attempt to disclose the \n"
+"    appropriate amount of information about the conflict while balancing "
+"the need for confidentiality and our desire to learn \n"
+"    from conflicts so that we as a foundation and community can learn "
+"from these conflicts and improve our policies to avoid the \n"
+"    conflicts in the future."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:227
+msgid ""
+"Any breaches of confidentiality will be treated as severe breaches of our"
+" conduct policies."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:230
+msgid "Retaliation"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:233
+msgid ""
+"We will not allow retaliation for any contractor or volunteer that files "
+"a complaint or is involved in an investigation. If you \n"
+"    believe that you are being treated negatively because of your "
+"involvement in a complaint please report this complaint directly \n"
+"    to the ED at <span class=\"backemail\">gro.zniarbatem@de</span> or "
+"the board at \n"
+"    <span class=\"backemail\">gro.zniarbatem@noituloser-tcilfnoc</span>."
 msgstr ""
 
 #: metabrainz/templates/index/contact.html:3
@@ -979,7 +1490,7 @@ msgstr ""
 msgid ""
 "We are currently evaluating our overall online advertising strategy. We "
 "are evaluating advertising, traffic optimization,\n"
-"    search engine optimization and software monitization technologies. If"
+"    search engine optimization and software monetization technologies. If"
 " you provide these professional services, please provide a detailed\n"
 "    deck of your comprehensive services to the following email address. "
 "<em>Please respect our other non-media teams and do not contact us \n"
@@ -1054,11 +1565,11 @@ msgstr "פורומים"
 #, python-format
 msgid ""
 "Please come ask your questions at our <a "
-"href=\"%(forums_url)s\">forums</a>! We would love to\n"
-"    answer any questions you may have."
+"href=\"%(forums_url)s\">forums</a>!\n"
+"    The community and the team will be more than happy to help you."
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:92
+#: metabrainz/templates/index/contact.html:93
 #, python-format
 msgid ""
 "The MetaBrainz/MusicBrainz/ListenBrainz team and community hang out\n"
@@ -1068,15 +1579,15 @@ msgid ""
 "    <a href=\"%(chatlogs_url)s\">chat log archives</a>."
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:101
+#: metabrainz/templates/index/contact.html:102
 msgid "Social media"
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:103
+#: metabrainz/templates/index/contact.html:104
 msgid "You can follow us on these social channels:"
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:112
+#: metabrainz/templates/index/contact.html:113
 msgid "Mailing address"
 msgstr "כתובת דואר"
 
@@ -1089,33 +1600,349 @@ msgstr ""
 msgid "GDPR Compliance Statement"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:37
+#: metabrainz/templates/index/gdpr.html:10
+msgid ""
+"The General Data Protection Regulation is a complex EU regulation that "
+"stipulates many points for protecting private data of\n"
+"    users on the Internet. Even though this is an EU regulation, it has a"
+" worldwide impact due to the nature of the Internet.\n"
+"    The MetaBrainz Foundation with its collection of projects is also "
+"affected by this regulation. We’ve been learning and adapting\n"
+"    our sites to be compliant with the GDPR – sadly this regulation isn’t"
+" entirely black and white and there is an incredible\n"
+"    amount of room left for interpretation of these rules."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:17
+msgid ""
+"The good news is that this regulation is roughly in line with our "
+"established practices: We’ve always held private information\n"
+"    in a high regard and applied the sort of rules to ourselves as we "
+"wish to have our own private data treated. Luckily, this\n"
+"    makes our compliance effort considerably easier. We’ve made two "
+"significant changes to how we treat your data and also adopted\n"
+"    terminology as used in the GDPR in order to use the same languages "
+"that many other sites are now adopting. Please keep reading\n"
+"    to find out the exact details of what we are doing to comply."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:24
+#, python-format
+msgid ""
+"However, we do ask for your compassion and help in our process of "
+"complying with the GDPR. As we already mentioned, the GDPR is\n"
+"    a complex set of rules that are not fully clarified yet. We’ve taken "
+"action on the steps that are clear to us and we’re following\n"
+"    ongoing conversations on points that are in gray zones or unclear to "
+"us. We’ve made our best initial effort on compliance and\n"
+"    promise to keep working on it as the picture becomes more clear. If "
+"you believe that we could improve our compliance, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a> and let us know what we "
+"can do to improve. It would also help us if you\n"
+"    could provide concrete discussion or examples to help us understand "
+"and take action on your suggestion."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:33
+msgid ""
+"Finally, below are the key sections of the GDPR as we understand them and"
+" how they affect your data in our ecosystem. Where\n"
+"    possible, we provide links for deeper understanding, links for you to"
+" examine our relevant code and links to tickets to follow\n"
+"    the process of improving our compliance."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:38
 msgid "Right to be forgotten"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:77
+#: metabrainz/templates/index/gdpr.html:41
+msgid ""
+"Summary: <i>Provide the user with the ability to remove their private "
+"data from our services</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:44
+msgid ""
+"The most important aspect of the right to be forgotten is the ability to "
+"delete your account. Once you request for us to delete\n"
+"    your account, we will remove any personally identifying information "
+"you may have provided us from your account (name, email\n"
+"    address, gender, biography, URL, etc.). The visible name on your "
+"account will be changed to “Deleted User #####” and effectively\n"
+"    the account will no longer be identifiable as your account."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:50
+msgid ""
+"However, given the nature of our projects where we work on collaborative "
+"databases, your contributions that are not personally\n"
+"    identifying are valuable assets to our database and these "
+"contributions will not be removed from our databases. But we will\n"
+"    ensure that these contributions no longer contain personally "
+"identifying data."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:55
+#, python-format
+msgid ""
+"Our process of automatically deleting your accounts across the MetaBrainz"
+" ecosystem is not complete yet (see below for a set of\n"
+"    tickets where you can track our progress). If you would like to "
+"delete your accounts in the MetaBrainz ecosystem or mark a\n"
+"    donation that is currently public as a private donation, please <a "
+"href=\"%(contact_url)s\">contact us</a>\n"
+"    and we will address your request as soon as possible."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:62
+#: metabrainz/templates/index/gdpr.html:182
+msgid "Links:"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:66
+#, python-format
+msgid ""
+"<a href=\"%(editor_deletion_doc_url)s\">How we delete accounts\n"
+"       in MusicBrainz</a> (warning, geek content ahead!)"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:70
+msgid ""
+"Implement sitewide user account deletion in\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/MBS-9680\">MusicBrainz</a>,"
+"\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/AB-337\">AcousticBrainz</a>,"
+"\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/BB-260\">BookBrainz</a>,\n"
+"         <a href=\"https://tickets.metabrainz.org/browse/MEB-103\">the "
+"MetaBrainz Site</a>,\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/LB-354\">ListenBrainz</a>, "
+"and\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/CB-307\">CritiqueBrainz</a>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:80
 msgid "Restriction of processing"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:110
+#: metabrainz/templates/index/gdpr.html:83
+msgid ""
+"Summary: <i>To allow the user to control how their personally identifying"
+" data is being used.</i>"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:86
+msgid ""
+"Except for the ListenBrainz and AcousticBrainz projects, we do not "
+"process personally identifying data. Any personally\n"
+"    identifying data that our projects store is for the purpose of being "
+"able to contact you about your contributions to our database\n"
+"    (email address) or for voluntarily showing information about you to "
+"other users (biography, homepage, location, etc)."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:91
+#, python-format
+msgid ""
+"The ListenBrainz project differs in that the Listens (metadata about what"
+" music you have listened to) are stored on our servers\n"
+"    and <a href=\"%(listenbrainz_data_url)s\">made available to the "
+"public</a>. We believe Listens to be personally identifying\n"
+"    data and furthermore, we have goals of creating open source "
+"recommendation engines with this data, which involves processing the\n"
+"    user’s data. These two points are fundamental goals of the "
+"ListenBrainz project and we do not see a reasonable way to reach another"
+"\n"
+"    compromise position."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:99
+msgid ""
+"Because of this, we are going to require users to either acknowledge that"
+" we may process their Listen data or alternatively to\n"
+"    delete their account, including all of their Listens. Please note "
+"that if you decide to delete your ListenBrainz account, it may\n"
+"    take up to two weeks for all of your listens to no longer be included"
+" in our efforts to build a recommendation engine."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:104
+msgid ""
+"We have always made it clear that the data in ListenBrainz was to be "
+"public and that we plan to build new tools with your data, so\n"
+"    this should not come as a surprise to our users."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:108
+msgid ""
+"The AcousticBrainz project does not track who submits data to the "
+"database. If you create an account and use our data creation\n"
+"    tools (e.g. create a dataset or participate in a challenge) then we "
+"link your participation and the things that you create to\n"
+"    your account. If you choose to delete your account then we keep the "
+"non personally identifying data that you create, but anonymize\n"
+"    it so that it cannot be linked back to you."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:114
 msgid "Right to data portability / exporting your data"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:150
+#: metabrainz/templates/index/gdpr.html:117
+msgid ""
+"Summary: <i>You have the right to access/download the data we store about"
+" you</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:120
+msgid ""
+"Except for the ListenBrainz and AcousticBrainz projects, we do not store "
+"personally identifying data beyond the\n"
+"    information that is available in your public profile on each of our "
+"projects. Since this data is plainly available in your\n"
+"    profile we do not provide a means for you to export this data."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:125
+msgid "There are the following exceptions to this:"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:129
+msgid ""
+"<b>IP addresses</b>: If you visit one of our sites the IP address of your"
+" computer is stored in our web logs for 7 days\n"
+"        before our servers automatically delete them. This data is almost"
+" never used by anyone: the only time we look at the\n"
+"        IP addresses is if our sites are adversely impacted by the "
+"actions of some unknown users. In that case, we may investigate\n"
+"        the logs to identify the IP address that needs to be blocked in "
+"order to restore the stability of our service.\n"
+"        This data is not available to anyone but the contractors of the "
+"MetaBrainz Foundation and is not available to download\n"
+"        to anyone at all."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:137
+#, python-format
+msgid ""
+"<b>ListenBrainz Listen data</b>: Users may <a "
+"href=\"%(listenbrainz_export_url)s\">export their ListenBrainz Listen\n"
+"        data</a> directly from the site. The user Listen data is also "
+"included in the <a href=\"%(listenbrainz_data_url)s\">ListenBrainz\n"
+"        data dumps</a> that are available for public download."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:146
+msgid ""
+"All of the non personally identifying data, such as your metadata "
+"contributions, are publicly visible, available for download\n"
+"    and available via the project APIs. For details about this data, "
+"downloads and APIs please check the documentation for the\n"
+"    respective projects you are interested in."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:151
+#, python-format
+msgid ""
+"Anyone wishing to get a list of financial donations they have made to the"
+" MetaBrainz Foundation, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a> and provide your "
+"MusicBrainz editor name so that we can look up\n"
+"    your donations."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:157
 msgid "Right to rectification"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:165
+#: metabrainz/templates/index/gdpr.html:160
+msgid "Summary: <i>You have the right to correct your data</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:163
+msgid ""
+"All of our projects allow their users to update their personally "
+"identifying information in their profiles. Furthermore, most\n"
+"    of our projects allow the editing of their own metadata "
+"contributions. If you find that some of your data is incorrect, please\n"
+"    feel free to edit the data since we provide the tools to do so."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:168
+#, python-format
+msgid ""
+"If anyone who has made a financial donation to the MetaBrainz Foundation "
+"would like to make their donation private, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:173
 msgid "Right to be informed"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:188
+#: metabrainz/templates/index/gdpr.html:175
+msgid ""
+"Summary: <i>You have the right to be informed about how we use your data "
+"in plain English</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:178
+msgid ""
+"Our privacy policy, as well as other policies, have always been written "
+"by humans for human consumption. We abhor legalese and\n"
+"    not speaking in direct terms."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:186
+msgid "Social contract"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:189
+msgid "Code of conduct"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:192
+msgid "Privacy policy"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:196
 msgid "Right to access"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:198
-#: metabrainz/templates/index/privacy.html:166
+#: metabrainz/templates/index/gdpr.html:199
+msgid ""
+"Summary: <i>You have the right to access the data that we collect about "
+"you</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:202
+msgid ""
+"All of our projects make all of the data we collect on your behalf, "
+"privately identifying or not, available to you. The\n"
+"    only exception to this are the IP addresses we store for 7 days – see"
+" above for details."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:206
+#: metabrainz/templates/index/privacy.html:168
 msgid "Privacy/GDPR Representative"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:209
+#, python-format
+msgid ""
+"If you have any questions about our privacy policy, please <a "
+"href=\"%(contact_url)s\">contact us</a>. To report\n"
+"   any privacy problems, violations or leaks, our GDPR representative is "
+"our Interim Executive Director Nicolás Tamargo and for\n"
+"   privacy issues contact him at <strong><a "
+"href=\"mailto:gdpr@metabrainz.org\">gdpr@metabrainz.org</a></strong>."
 msgstr ""
 
 #: metabrainz/templates/index/index.html:6
@@ -1220,7 +2047,7 @@ msgid ""
 "      <a href=\"%(about_url)s\">about</a> page."
 msgstr ""
 
-#: frontend/js/src/forms/ConditionsModal.tsx:43
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:32
 #: metabrainz/templates/index/privacy.html:3
 msgid "Privacy"
 msgstr "פרטיות"
@@ -1228,6 +2055,44 @@ msgstr "פרטיות"
 #: metabrainz/templates/index/privacy.html:8
 msgid "Summary"
 msgstr "סיכום"
+
+#: metabrainz/templates/index/privacy.html:12
+msgid ""
+"You do not have to provide any personal data to be able to browse the "
+"contents of the databases published by MetaBrainz."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:15
+msgid ""
+"You do not have to provide any personally-identifying information if you "
+"choose not to."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:18
+msgid ""
+"We will never reveal your email address on MetaBrainz controlled web "
+"sites."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:22
+msgid ""
+"In order to get maximum value out of the MetaBrainz projects, you may "
+"want to create an account and log in. \n"
+"    Doing so grants you the ability to: edit the databases, contribute "
+"your own data, communicate with other users, and keep track \n"
+"    of recently released music from artists in your MusicBrainz "
+"collection. If you choose to create an account then the minimum we \n"
+"    ask is that you: choose a unique username and password, use a web "
+"browser that accepts \"session\" cookies, and provide a verified \n"
+"    email address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:29
+msgid ""
+"If you do not create an account (or are not logged in) you will not have "
+"access to the above listed features, however, you will \n"
+"    still have full access to browse and examine the databases."
+msgstr ""
 
 #: metabrainz/templates/index/privacy.html:33
 msgid "Applicable to all users"
@@ -1237,39 +2102,197 @@ msgstr ""
 msgid "Cookies"
 msgstr ""
 
+#: metabrainz/templates/index/privacy.html:37
+msgid "We use two cookies that contain sensitive information:"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:42
+msgid ""
+"<b>remember_login</b>: If you choose the \"Log in permanently\" option "
+"when logging in to one of our sites; the cookie will be used to \n"
+"      remember your login details."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:46
+msgid ""
+"<b>musicbrainz_server_session, session, or connect.sid</b>: If you are "
+"logged into one of our sites, your current session ID is stored in this "
+"cookie."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:51
+msgid ""
+"We may store dynamic preference information in other cookies, but these "
+"do not contain any sensitive information."
+msgstr ""
+
 #: metabrainz/templates/index/privacy.html:54
 msgid "Web and FTP access logs"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:57
+msgid ""
+"In a practice similar to other web sites (and APIs) we keep logs of all "
+"web requests made against our servers. These logs include: your IP\n"
+"    address, your browser's (or API client's) \"User-Agent\" string, and "
+"which page (or API endpoint) you requested with which parameters. "
+"Aggregate information about web and FTP traffic is\n"
+"    made available to the public via our site usage pages."
 msgstr ""
 
 #: metabrainz/templates/index/privacy.html:62
 msgid "Third-Party content"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:92
+#: metabrainz/templates/index/privacy.html:64
+msgid ""
+"Our projects' web pages may load some third-party content. Some, but "
+"possibly not all sites are listed below:"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:69
+#, python-format
+msgid ""
+"Cover art and other images: These are provided by the various cover art "
+"sites that have given MusicBrainz permission to do so and our own \n"
+"      <a href=\"%(caa_url)s\">Cover Art Archive</a>. This means that the "
+"relevant site will know (if they want to) your IP \n"
+"      address, User-Agent string, etc., and which MusicBrainz web page "
+"you were visiting (the one which included the cover art image)."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:75
+msgid ""
+"AcoustID: Our fingerprints tab loads fingerprint information from "
+"acoustid.org."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:78
+msgid ""
+"MTCaptcha: Our account creation page loads third party content in order "
+"to prevent spammers from creating accounts."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:83
+msgid ""
+"<i>The above information assumes that you are using \"normal\" web "
+"browser settings, whereby images are always loaded and HTTP referrer \n"
+"    information is always sent.</i>"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:88
+msgid ""
+"It is impractical to constantly modify this privacy policy when "
+"MetaBrainz projects change which third party content they utilize. We "
+"will \n"
+"    aim to use common sense, respect to our community and community "
+"review when adding more content from third party sites. We will also \n"
+"    periodically review our policy to ensure that it remains current."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:93
 msgid "Applicable to account holders"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:94
+#: metabrainz/templates/index/privacy.html:95
 msgid "Account creation"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:108
+#: metabrainz/templates/index/privacy.html:97
+msgid ""
+"When creating an account with a MetaBrainz project you need to pick a "
+"unique username and choose a password, the username you pick is the \n"
+"    only name associated with your account and will be what other "
+"MetaBrainz users know you as. You may optionally also tell us other \n"
+"    information about yourself that will be displayed to other MetaBrainz"
+" users and the public."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:103
+msgid ""
+"Additionally, in order to edit the databases you will need to provide a "
+"confirmed email address. This email address will be held in \n"
+"    confidence, the only method of revealing your email address to "
+"another user is if you choose to send a message to another \n"
+"    user and enable the option to \"reveal my email address\". Changing "
+"the email address stored with your account will require you to \n"
+"    verify the new address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:109
 msgid "Edits and Notes"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:114
+#: metabrainz/templates/index/privacy.html:111
+msgid ""
+"If you make any changes to a MetaBrainz project database, such as adding "
+"any data, the details of those changes will be visible to \n"
+"    other logged-in users and the change will be associated with your "
+"username."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:115
 msgid "Subscriptions on MusicBrainz"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:131
+#: metabrainz/templates/index/privacy.html:117
+msgid ""
+"As a logged-in user you can subscribe to one or more artists, labels, "
+"collections or other editors. The act of subscribing causes \n"
+"    any edits made to (or by in the case of another editor) those "
+"entities to be emailed to you. By default, other users can see your \n"
+"    list of subscriptions, however, you can opt out of this by editing "
+"the appropriate preference."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:123
+msgid ""
+"This does not provide \"perfect\" privacy though, in some cases it will "
+"be possible to infer information about the contents of your \n"
+"    subscription list even though you have disallowed others from viewing"
+" that list directly. This imperfection arises because various \n"
+"    parts of the system behave differently depending on whether or not an"
+" entity has any subscribers; also, the number of users \n"
+"    subscribed to each artist is available via the artist pages. In the "
+"most extreme (possibly contrived) example, imagine that all \n"
+"    users have their subscriptions set to \"public\", except for exactly "
+"one user whose list is \"private\". In that case, any discrepancy \n"
+"    for a given artist between the shown list of subscribers and the "
+"total number of subscribers must be down to that one user. Thus, \n"
+"    you can infer what artists are on that user's list."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:132
 msgid "Third-party sites"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:145
+#: metabrainz/templates/index/privacy.html:134
+#, python-format
+msgid ""
+"Our code reviews are done on GitHub, which is not under the control of "
+"MetaBrainz. Participating in code reviews or other\n"
+"    tasks carried out on GitHub are subject to <a "
+"href=\"%(github_url)s\">GitHub's privacy policy</a>."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:140
+#, python-format
+msgid ""
+"Our translations platform is provided and hosted by Weblate, which has a "
+"data processing agreement with MetaBrainz.\n"
+"    Participating in translations is subject to <a "
+"href=\"%(weblate_url)s\">dedicated legal terms</a>.\n"
+"    Any translations you make will be submitted to our Git repositories "
+"and publicly associated with your username;\n"
+"    if you so choose, you can also publicly associate them with your own "
+"verified email address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:147
 msgid "MetaBrainz donors"
 msgstr "תורמי MetaBrainz"
 
-#: metabrainz/templates/index/privacy.html:147
+#: metabrainz/templates/index/privacy.html:149
 msgid ""
 "When you make a donation to the MetaBrainz Foundation, we are legally\n"
 "    required to collect your personal information and keep it in our "
@@ -1279,7 +2302,7 @@ msgid ""
 "    information to anyone else, ever."
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:153
+#: metabrainz/templates/index/privacy.html:155
 msgid ""
 "We believe in transparent finances, which means that we list all "
 "donations\n"
@@ -1289,11 +2312,34 @@ msgid ""
 "process."
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:158
+#: metabrainz/templates/index/privacy.html:160
 msgid "Exceptions"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:598
+#: metabrainz/templates/index/privacy.html:162
+msgid ""
+"<i><b>Please note</b>: Reasonable exceptions may apply to the above "
+"policy, for example to comply with applicable laws.\n"
+"    Also, members of the MetaBrainz team and other personnel contracted "
+"to provide services to MetaBrainz may have access to\n"
+"    our infrastructure and could therefore view any information contained"
+" therein. However all personnel are contractually bound\n"
+"    by non-disclosure clauses which prevent them from making any such "
+"information available to others."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:171
+#, python-format
+msgid ""
+"If you have any questions about our GDPR statement, please <a "
+"href=\"%(contact_url)s\">contact us</a>. To report\n"
+"   any privacy problems, violations or leaks, our GDPR representative is "
+"our Interim Executive Director Nicolás Tamargo and for\n"
+"   privacy issues contact him at <strong><a "
+"href=\"mailto:gdpr@metabrainz.org\">gdpr@metabrainz.org</a></strong>."
+msgstr ""
+
+#: frontend/js/src/Profile.tsx:603
 #: frontend/js/src/forms/ProfileChangePassword.tsx:22
 #: frontend/js/src/forms/ProfileChangePassword.tsx:111
 #: metabrainz/templates/index/profile-change-password.html:3
@@ -1538,6 +2584,11 @@ msgstr ""
 
 #: metabrainz/templates/index/team.html:26
 msgid "He lives on in our hearts and in open source."
+msgstr ""
+
+#: metabrainz/templates/index/team.html:29
+#: metabrainz/templates/index/team.html:315
+msgid "you’re welcome to try"
 msgstr ""
 
 #: metabrainz/templates/index/team.html:39
@@ -2039,8 +3090,10 @@ msgstr "שק ארה\"ב"
 
 #: metabrainz/templates/payments/donate.html:146
 msgid ""
-"Due to the increased unreliability of the US Postal Service we have "
-"stopped accepting paper checks. Sorry!"
+"Due to the increased unreliability of the US Postal Service and the "
+"relatively large fees involved, we ask you to only send a paper check if "
+"it is the only possible option. Due to the fees, we will not cash checks "
+"for less than $25."
 msgstr ""
 
 #: metabrainz/templates/payments/donate.html:241
@@ -2926,8 +3979,8 @@ msgid "Monthly balance sheets"
 msgstr "מאזן חודשי"
 
 #: frontend/js/src/Profile.tsx:520
-#: frontend/js/src/forms/SignupCommercial.tsx:175
-#: frontend/js/src/forms/SignupCommercial.tsx:554
+#: frontend/js/src/forms/SignupCommercial.tsx:180
+#: frontend/js/src/forms/SignupCommercial.tsx:558
 #: frontend/js/src/forms/SignupNonCommercial.tsx:106
 #: frontend/js/src/forms/SignupNonCommercial.tsx:318
 #: metabrainz/templates/supporters/account-type.html:3
@@ -2948,6 +4001,7 @@ msgid "Non-commercial / Personal"
 msgstr "לא מסחרי/פרטי"
 
 #: frontend/js/src/Profile.tsx:235
+#: frontend/js/src/forms/SignupNonCommercial.tsx:107
 #: frontend/js/src/forms/SignupNonCommercial.tsx:151
 #: metabrainz/templates/supporters/account-type.html:42
 msgid "Non-commercial"
@@ -2961,57 +4015,46 @@ msgstr ""
 msgid "Personal or university assignment user."
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:48
-#: metabrainz/templates/supporters/account-type.html:90
-#: metabrainz/templates/supporters/account-type.html:141
-msgid "Upgrade"
-msgstr ""
-
 #: frontend/js/src/Profile.tsx:235
-#: frontend/js/src/forms/SignupCommercial.tsx:176
-#: frontend/js/src/forms/SignupCommercial.tsx:228
-#: metabrainz/templates/supporters/account-type.html:61
+#: frontend/js/src/forms/SignupCommercial.tsx:181
+#: frontend/js/src/forms/SignupCommercial.tsx:233
+#: metabrainz/templates/supporters/account-type.html:56
 msgid "Commercial"
 msgstr "מסחרי"
 
-#: metabrainz/templates/supporters/account-type.html:83
-#: metabrainz/templates/supporters/account-type.html:135
+#: metabrainz/templates/supporters/account-type.html:78
+#: metabrainz/templates/supporters/account-type.html:125
 #, python-format
 msgid "$%(tier_price)s/month and up"
 msgstr "$%(tier_price)s/לחודש ומעלה"
 
-#: metabrainz/templates/supporters/account-type.html:87
-#: metabrainz/templates/supporters/account-type.html:138
+#: metabrainz/templates/supporters/account-type.html:82
+#: metabrainz/templates/supporters/account-type.html:128
 msgid "More info"
 msgstr "מידע נוסף"
 
-#: metabrainz/templates/supporters/account-type.html:104
+#: metabrainz/templates/supporters/account-type.html:94
 msgid "View all tiers"
 msgstr "הצגת כל השכבות"
 
-#: metabrainz/templates/supporters/account-type.html:112
+#: metabrainz/templates/supporters/account-type.html:102
 msgid "Some of our Unicorn members"
 msgstr "חלק מחברי מועדן חד-קרן שלנו"
 
-#: metabrainz/templates/supporters/account-type.html:123
+#: metabrainz/templates/supporters/account-type.html:113
 msgid "See all our supporters"
 msgstr "צפיה בכל התומכים שלנו"
 
-#: metabrainz/templates/supporters/account-type.html:151
+#: metabrainz/templates/supporters/account-type.html:136
 msgid "View featured tiers"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:158
+#: metabrainz/templates/supporters/account-type.html:143
 #, python-format
 msgid ""
 "If you are not sure which tier to pick, please\n"
 "      <a href=\"%(contact_url)s\">contact us</a>."
 msgstr ""
-
-#: metabrainz/templates/supporters/account-type.html:166
-#, fuzzy
-msgid "Back to Profile"
-msgstr "הפרופיל שלך"
 
 #: metabrainz/templates/supporters/bad-standing.html:3
 #: metabrainz/templates/supporters/bad-standing.html:6
@@ -3072,9 +4115,9 @@ msgid "Forgot your username"
 msgstr ""
 
 #: frontend/js/src/forms/ResetPassword.tsx:79
-#: frontend/js/src/forms/SignupCommercial.tsx:320
+#: frontend/js/src/forms/SignupCommercial.tsx:325
 #: frontend/js/src/forms/SignupNonCommercial.tsx:227
-#: frontend/js/src/forms/SignupUser.tsx:169
+#: frontend/js/src/forms/SignupUser.tsx:175
 #: metabrainz/templates/users/reauthenticate.html:3
 #: metabrainz/templates/users/reauthenticate.html:6
 msgid "Confirm Password"
@@ -3084,17 +4127,22 @@ msgstr ""
 msgid "Please re-enter your password to continue."
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:108
+#: frontend/js/src/ProfileDelete.tsx:110
 #: frontend/js/src/forms/DeleteApplication.tsx:53
 #: frontend/js/src/forms/OAuthPrompt.tsx:54
 #: frontend/js/src/forms/ProfileChangePassword.tsx:104
 #: frontend/js/src/forms/ProfileEdit.tsx:105
-#: metabrainz/templates/users/reauthenticate.html:23
+#: metabrainz/templates/users/reauthenticate.html:28
 msgid "Cancel"
 msgstr ""
 
-#: metabrainz/templates/users/reauthenticate.html:24
+#: metabrainz/templates/users/reauthenticate.html:29
 msgid "Continue"
+msgstr ""
+
+#: frontend/js/src/forms/utils.tsx:202
+#: metabrainz/templates/users/reauthenticate.html:40
+msgid "Password must not exceed 72 bytes."
 msgstr ""
 
 #: frontend/js/src/forms/ResetPassword.tsx:27
@@ -3102,38 +4150,38 @@ msgstr ""
 msgid "Reset your password"
 msgstr ""
 
-#: frontend/js/src/hooks/useEmailValidation.ts:41 metabrainz/user/forms.py:15
+#: frontend/js/src/hooks/useEmailValidation.ts:41 metabrainz/user/forms.py:16
 msgid "Registration from this email domain is not allowed."
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:50
 #: frontend/js/src/forms/LostPassword.tsx:45
-#: frontend/js/src/forms/SignupCommercial.tsx:270
+#: frontend/js/src/forms/SignupCommercial.tsx:275
 #: frontend/js/src/forms/SignupNonCommercial.tsx:175
-#: frontend/js/src/forms/SignupUser.tsx:114 metabrainz/user/forms.py:20
-#: metabrainz/user/forms.py:45 metabrainz/user/forms.py:62
+#: frontend/js/src/forms/SignupUser.tsx:120 metabrainz/user/forms.py:22
+#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:75
 msgid "Username"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:42
 #: frontend/js/src/forms/LostPassword.tsx:37
-#: frontend/js/src/forms/SignupCommercial.tsx:153
+#: frontend/js/src/forms/SignupCommercial.tsx:158
 #: frontend/js/src/forms/SignupNonCommercial.tsx:84
-#: frontend/js/src/forms/SignupUser.tsx:67 metabrainz/user/forms.py:21
-#: metabrainz/user/forms.py:45 metabrainz/user/forms.py:62
+#: frontend/js/src/forms/SignupUser.tsx:73 metabrainz/user/forms.py:26
+#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:75
 msgid "Username is required!"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:63
 #: frontend/js/src/forms/ResetPassword.tsx:72
-#: frontend/js/src/forms/SignupCommercial.tsx:308
+#: frontend/js/src/forms/SignupCommercial.tsx:313
 #: frontend/js/src/forms/SignupNonCommercial.tsx:214
-#: frontend/js/src/forms/SignupUser.tsx:157 metabrainz/user/forms.py:46
-#: metabrainz/user/forms.py:52
+#: frontend/js/src/forms/SignupUser.tsx:163 metabrainz/user/forms.py:53
+#: metabrainz/user/forms.py:62
 msgid "Password"
 msgstr ""
 
-#: frontend/js/src/forms/LoginUser.tsx:76 metabrainz/user/forms.py:47
+#: frontend/js/src/forms/LoginUser.tsx:76 metabrainz/user/forms.py:57
 msgid "Remember me"
 msgstr ""
 
@@ -3145,11 +4193,11 @@ msgstr ""
 msgid "Username contains invalid or invisible characters."
 msgstr ""
 
-#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:181
+#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:220
 msgid "Hide password"
 msgstr ""
 
-#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:181
+#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:220
 msgid "Show password"
 msgstr ""
 
@@ -3207,11 +4255,11 @@ msgstr ""
 msgid "Revoke access"
 msgstr ""
 
-#: frontend/js/src/OAuthError.tsx:17
+#: frontend/js/src/OAuthError.tsx:18
 msgid "OAuth2 Error"
 msgstr ""
 
-#: frontend/js/src/OAuthError.tsx:18
+#: frontend/js/src/OAuthError.tsx:19
 msgid "An error occurred during OAuth authentication process."
 msgstr ""
 
@@ -3241,8 +4289,8 @@ msgstr ""
 
 #: frontend/js/src/Profile.tsx:109
 msgid ""
-"Are you sure you want to generate new access token? Current token will be"
-" revoked!"
+"Are you sure you want to generate a new access token? The current token "
+"will be revoked!"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:118
@@ -3357,8 +4405,8 @@ msgid "Contact Information"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:310 frontend/js/src/forms/ProfileEdit.tsx:70
-#: frontend/js/src/forms/SignupCommercial.tsx:284
-#: frontend/js/src/forms/SignupCommercial.tsx:333
+#: frontend/js/src/forms/SignupCommercial.tsx:289
+#: frontend/js/src/forms/SignupCommercial.tsx:338
 #: frontend/js/src/forms/SignupNonCommercial.tsx:189
 #: frontend/js/src/forms/SignupNonCommercial.tsx:241
 msgid "Contact name"
@@ -3474,7 +4522,7 @@ msgstr ""
 msgid "Once you delete your account, there is no going back. Please be certain."
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:550 frontend/js/src/ProfileDelete.tsx:105
+#: frontend/js/src/Profile.tsx:550 frontend/js/src/ProfileDelete.tsx:107
 msgid "Delete My Account"
 msgstr ""
 
@@ -3486,39 +4534,39 @@ msgstr ""
 msgid "Need to delete your account?"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:574
+#: frontend/js/src/Profile.tsx:575
 msgid ""
 "Deletion of supporter accounts requires manual review. Please contact us "
-"at"
+"at <email />."
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:594
+#: frontend/js/src/Profile.tsx:599
 msgid "Security"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:626
+#: frontend/js/src/Profile.tsx:631
 msgid "MetaBrainz Applications"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:630
+#: frontend/js/src/Profile.tsx:635
 msgid ""
 "With your MetaBrainz account, you can access every project in the "
 "MetaBrainz family:"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:643
+#: frontend/js/src/Profile.tsx:648
 msgid "The open-source music encyclopedia"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:655
+#: frontend/js/src/Profile.tsx:660
 msgid "Track, visualise and share the music you listen to"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:667
+#: frontend/js/src/Profile.tsx:672
 msgid "The open-source book database"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:679
+#: frontend/js/src/Profile.tsx:684
 msgid "Creative Commons licensed reviews"
 msgstr ""
 
@@ -3541,7 +4589,7 @@ msgid "Permanently remove all your account information"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:64
-msgid "Revoke all your API tokens and access"
+msgid "Revoke all your tokens and access to the replication API"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:65
@@ -3553,14 +4601,16 @@ msgid "Log you out of all MetaBrainz services"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:70
-msgid "Your username will be reserved and cannot be reused."
+msgid ""
+"Your username will be reserved and cannot be reused without the "
+"intervention of an administrator."
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:82
+#: frontend/js/src/ProfileDelete.tsx:84
 msgid "To confirm, type your username '<username />' below:"
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:105
+#: frontend/js/src/ProfileDelete.tsx:107
 msgid "Deleting..."
 msgstr ""
 
@@ -3573,64 +4623,7 @@ msgstr "הפרופיל שלך"
 msgid "Close"
 msgstr ""
 
-#: frontend/js/src/forms/ConditionsModal.tsx:23
-msgid "Licensing"
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:25
-msgid ""
-"Any contributions you make to any MetaBrainz service will be released "
-"into the Public Domain and/or licensed under a Creative Commons by-nc-sa "
-"license. Furthermore, you give the MetaBrainz Foundation the right to "
-"license this data for commercial use."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:30
-msgid "Please read our <licenseLink>license page</licenseLink> for more details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:45
-msgid ""
-"MetaBrainz strongly believes in the privacy of its users. Any personal "
-"information you choose to provide will not be sold or shared with anyone "
-"else."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:50
-msgid ""
-"Please read our <privacyLink>privacy policy</privacyLink> for more "
-"details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:59
-msgid "GDPR compliance"
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:61
-msgid ""
-"You may remove your personal information from our services anytime by "
-"deleting your account."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:66
-msgid ""
-"Please read our <gdprLink>GDPR compliance statement</gdprLink> for more "
-"details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:78
-msgid ""
-"Creating an account on MetaBrainz will give you access to all of our "
-"projects, such as MusicBrainz, ListenBrainz, BookBrainz, and more."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:82
-msgid ""
-"We create a placeholder account for all the MetaBrainz projects when you "
-"sign up, and you are one log-in away from activating them."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:91
+#: frontend/js/src/forms/ConditionsModal.tsx:29
 msgid "Sounds good"
 msgstr ""
 
@@ -3719,8 +4712,8 @@ msgstr ""
 msgid "Forgot your password?"
 msgstr ""
 
-#: frontend/js/src/forms/LoginUser.tsx:109
-msgid "Don't have an account?"
+#: frontend/js/src/forms/LoginUser.tsx:110
+msgid "Don't have an account? <signupLink>Sign up</signupLink>"
 msgstr ""
 
 #: frontend/js/src/forms/LostPassword.tsx:38
@@ -3751,15 +4744,72 @@ msgstr ""
 msgid "Allow access"
 msgstr "איפשור גישה"
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:71
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:10
+msgid "Licensing"
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:12
+msgid ""
+"Any contributions you make to any MetaBrainz service will be released "
+"into the Public Domain and/or licensed under a Creative Commons by-nc-sa "
+"license. Furthermore, you give the MetaBrainz Foundation the right to "
+"license this data for commercial use."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:17
+msgid "Please read our <licenseLink>license page</licenseLink> for more details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:34
+msgid ""
+"MetaBrainz strongly believes in the privacy of its users. Any personal "
+"information you choose to provide will not be sold or shared with anyone "
+"else."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:39
+msgid ""
+"Please read our <privacyLink>privacy policy</privacyLink> for more "
+"details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:50
+msgid "GDPR compliance"
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:52
+msgid ""
+"You may remove your personal information from our services anytime by "
+"deleting your account."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:57
+msgid ""
+"Please read our <gdprLink>GDPR compliance statement</gdprLink> for more "
+"details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:71
+msgid ""
+"Creating an account on MetaBrainz will give you access to all of our "
+"projects, such as MusicBrainz, ListenBrainz, BookBrainz, and more."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:75
+msgid ""
+"We create a placeholder account for all the MetaBrainz projects when you "
+"sign up, and you are one log-in away from activating them."
+msgstr ""
+
+#: frontend/js/src/forms/ProfileChangePassword.tsx:70
 msgid "Current Password"
 msgstr ""
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:80
+#: frontend/js/src/forms/ProfileChangePassword.tsx:79
 msgid "New Password"
 msgstr ""
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:89
+#: frontend/js/src/forms/ProfileChangePassword.tsx:88
 msgid "Confirm New Password"
 msgstr ""
 
@@ -3771,196 +4821,185 @@ msgstr ""
 msgid "Reset Password"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:38
-msgid "If you would like to support us with more than $"
+#: frontend/js/src/forms/SignupCommercial.tsx:40
+msgid ""
+"If you would like to support us with more than ${{minPledge}}, please "
+"enter the actual amount here:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:39
-msgid ", please enter the actual amount here:"
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:144
+#: frontend/js/src/forms/SignupCommercial.tsx:149
 #: frontend/js/src/forms/SignupNonCommercial.tsx:75
-#: frontend/js/src/forms/SignupUser.tsx:87
+#: frontend/js/src/forms/SignupUser.tsx:93
 msgid "Captcha is required!"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:179
+#: frontend/js/src/forms/SignupCommercial.tsx:184
 #: frontend/js/src/forms/SignupNonCommercial.tsx:110
 #: frontend/js/src/forms/SignupUser.tsx:46
 #, fuzzy
 msgid "Access all MetaBrainz projects"
 msgstr "פרויקטי MetaBrainz"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:182
+#: frontend/js/src/forms/SignupCommercial.tsx:187
 msgid "Note:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:184
+#: frontend/js/src/forms/SignupCommercial.tsx:189
 msgid ""
 "Signing up for any tier other than the <italic>Stealth startup</italic> "
 "tier will publicly list your company on this web site. However, we will "
 "not publish any of your private details."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:221
+#: frontend/js/src/forms/SignupCommercial.tsx:226
 #: frontend/js/src/forms/SignupNonCommercial.tsx:145
 #, fuzzy
 msgid "Account type"
 msgstr "סוג חשבון"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:234
+#: frontend/js/src/forms/SignupCommercial.tsx:239
 msgid "Selected tier"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:242
-msgid "month and up"
+#: frontend/js/src/forms/SignupCommercial.tsx:247
+msgid "${{tierPrice}}/month and up"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:250
+#: frontend/js/src/forms/SignupCommercial.tsx:255
 msgid "Change account type or tier"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:261
+#: frontend/js/src/forms/SignupCommercial.tsx:266
 #: frontend/js/src/forms/SignupNonCommercial.tsx:166
 msgid "Your account:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:271
+#: frontend/js/src/forms/SignupCommercial.tsx:276
 #: frontend/js/src/forms/SignupNonCommercial.tsx:176
-#: frontend/js/src/forms/SignupUser.tsx:114
+#: frontend/js/src/forms/SignupUser.tsx:120
 msgid "(public)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:291
+#: frontend/js/src/forms/SignupCommercial.tsx:296
 #: frontend/js/src/forms/SignupNonCommercial.tsx:196
-#: frontend/js/src/forms/SignupUser.tsx:127
+#: frontend/js/src/forms/SignupUser.tsx:133
 msgid "E-mail address"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:295
+#: frontend/js/src/forms/SignupCommercial.tsx:300
 #: frontend/js/src/forms/SignupNonCommercial.tsx:200
-#: frontend/js/src/forms/SignupUser.tsx:131
+#: frontend/js/src/forms/SignupUser.tsx:137
 msgid "(checking...)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:314
+#: frontend/js/src/forms/SignupCommercial.tsx:319
 #: frontend/js/src/forms/SignupNonCommercial.tsx:220
-#: frontend/js/src/forms/SignupUser.tsx:163
+#: frontend/js/src/forms/SignupUser.tsx:169
 msgid "Must be at least 8 characters"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:348
+#: frontend/js/src/forms/SignupCommercial.tsx:353
 msgid ""
 "If you don't have an organization name, you probably want to become a "
 "supporter as a <nonCommercialLink>Non-commercial / "
 "Personal</nonCommercialLink> supporter."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:358
+#: frontend/js/src/forms/SignupCommercial.tsx:363
 msgid ""
 "If you don't have an organization name, you probably want to sign up as a"
 " <nonCommercialLink>Non-commercial / Personal</nonCommercialLink> user."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:378
+#: frontend/js/src/forms/SignupCommercial.tsx:383
 msgid ""
 "Please tell us a little about your company and whether you plan to use "
 "our <apiLink>API</apiLink> or to <hostLink>host your own copy</hostLink> "
 "of the data."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:404
+#: frontend/js/src/forms/SignupCommercial.tsx:408
 #, fuzzy
 msgid "Logo URL"
 msgstr "URL תמונת לוגו"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:405
+#: frontend/js/src/forms/SignupCommercial.tsx:409
 msgid "(preferably in SVG format)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:408
+#: frontend/js/src/forms/SignupCommercial.tsx:412
 msgid ""
 "Image should be about 250 pixels wide on a white or transparent "
 "background. We will host it on our site."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:421
+#: frontend/js/src/forms/SignupCommercial.tsx:425
 msgid ""
 "URL to where developers can use your APIs using MusicBrainz IDs, if "
-"available.."
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:430
-msgid "Your project"
+"available."
 msgstr ""
 
 #: frontend/js/src/forms/SignupCommercial.tsx:434
+msgid "Your project"
+msgstr ""
+
+#: frontend/js/src/forms/SignupCommercial.tsx:438
 #: frontend/js/src/forms/SignupNonCommercial.tsx:261
 msgid "(max 150 characters)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:451
+#: frontend/js/src/forms/SignupCommercial.tsx:455
 msgid "Billing address"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:502
+#: frontend/js/src/forms/SignupCommercial.tsx:506
 msgid ""
 "I agree to support the MetaBrainz Foundation when my organization is able"
 " to do so."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:507
+#: frontend/js/src/forms/SignupCommercial.tsx:511
+#: frontend/js/src/forms/SignupNonCommercial.tsx:284
 msgid ""
-"I also agree that if I generate a Live Data Feed access token, that I "
-"treat my access token as a secret and will not share this token publicly "
-"or commit it to a source code repository."
+"I also agree that if I generate a Live Data Feed access token, then I "
+"will treat my access token as a secret and will not share this token "
+"publicly or commit it to a source code repository."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:515
+#: frontend/js/src/forms/SignupCommercial.tsx:519
 msgid ""
 "The following information will be shown publicly: organization name, "
 "logo, website and API URLs, data usage description."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:520
+#: frontend/js/src/forms/SignupCommercial.tsx:524
 msgid ""
 "We'll send you more details about payment process once your application "
 "is approved."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:552
+#: frontend/js/src/forms/SignupCommercial.tsx:556
 #: frontend/js/src/forms/SignupNonCommercial.tsx:316
-#: frontend/js/src/forms/SignupUser.tsx:224
+#: frontend/js/src/forms/SignupUser.tsx:230
 msgid "Validating..."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:564
+#: frontend/js/src/forms/SignupCommercial.tsx:568
 #: frontend/js/src/forms/SignupNonCommercial.tsx:329
 #, fuzzy
 msgid "Back to profile"
 msgstr "הפרופיל שלך"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:569
-#: frontend/js/src/forms/SignupNonCommercial.tsx:334
-msgid "Not a supporter?"
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:570
+#: frontend/js/src/forms/SignupCommercial.tsx:574
 #: frontend/js/src/forms/SignupNonCommercial.tsx:335
-msgid "Create a user account"
+msgid "Not a supporter? <signupLink>Create a user account</signupLink>"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:573
-#: frontend/js/src/forms/SignupNonCommercial.tsx:338
-#: frontend/js/src/forms/SignupUser.tsx:231
-msgid "Already have an account?"
+#: frontend/js/src/forms/SignupCommercial.tsx:583
+#: frontend/js/src/forms/SignupNonCommercial.tsx:344
+#: frontend/js/src/forms/SignupUser.tsx:238
+msgid "Already have an account? <loginLink>Sign in</loginLink>"
 msgstr ""
-
-#: frontend/js/src/forms/SignupNonCommercial.tsx:107
-#, fuzzy
-msgid "non-commercial"
-msgstr "לא מסחרי"
 
 #: frontend/js/src/forms/SignupNonCommercial.tsx:113
 msgid ""
@@ -3987,46 +5026,40 @@ msgid ""
 "income per year) or personal uses only."
 msgstr ""
 
-#: frontend/js/src/forms/SignupNonCommercial.tsx:284
-msgid ""
-"I also agree that if I generate a Live Data Feed access token, then I "
-"will treat my access token as a secret and will not share this token "
-"publicly or commit it to a source code repository."
-msgstr ""
-
 #: frontend/js/src/forms/SignupUser.tsx:43
 msgid "Create your account"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:50
-msgid "Registration started by"
+#: frontend/js/src/forms/SignupUser.tsx:51
+msgid "Registration started by <client />"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:69
+#: frontend/js/src/forms/SignupUser.tsx:75
+#: frontend/js/src/hooks/useEmailValidation.ts:82
 msgid "Invalid email address."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:150
+#: frontend/js/src/forms/SignupUser.tsx:156
 msgid ""
 "This username and email were provided by the app that started "
 "registration. You can change them later from MetaBrainz settings."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:182
+#: frontend/js/src/forms/SignupUser.tsx:188
 msgid ""
 "I accept that my contributions will be released into the public domain or"
 " licensed for use."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:191
+#: frontend/js/src/forms/SignupUser.tsx:197
 msgid "We will never share your personal information."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:200
+#: frontend/js/src/forms/SignupUser.tsx:206
 msgid "Click here to read more"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:224
+#: frontend/js/src/forms/SignupUser.tsx:230
 msgid "Create account"
 msgstr ""
 
@@ -4036,10 +5069,6 @@ msgstr ""
 
 #: frontend/js/src/hooks/useEmailValidation.ts:47
 msgid "Email validation failed"
-msgstr ""
-
-#: frontend/js/src/hooks/useEmailValidation.ts:82
-msgid "Invalid email address"
 msgstr ""
 
 #~ msgid "You need to specify amount!"
@@ -5282,4 +6311,96 @@ msgstr ""
 
 #~ msgid "Privacy policy"
 #~ msgstr "מדיניות פרטיות"
+
+#~ msgid "You need to specify website of the organization."
+#~ msgstr "נא להזין את אתר הארגון."
+
+#~ msgid ""
+#~ "We are currently evaluating our overall"
+#~ " online advertising strategy. We are "
+#~ "evaluating advertising, traffic optimization,\n"
+#~ ""
+#~ "    search engine optimization and "
+#~ "software monitization technologies. If you "
+#~ "provide these professional services, please"
+#~ " provide a detailed\n"
+#~ "    deck of your comprehensive services"
+#~ " to the following email address. "
+#~ "<em>Please respect our other non-media"
+#~ " teams and do not contact us \n"
+#~ "    regarding these services on any "
+#~ "other of our email addresses. We "
+#~ "will disregard the entirety of your "
+#~ "submissions if you contact us any "
+#~ "other way!</em>"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Please come ask your questions at "
+#~ "our <a href=\"%(forums_url)s\">forums</a>! We "
+#~ "would love to\n"
+#~ "    answer any questions you may have."
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Due to the increased unreliability of"
+#~ " the US Postal Service we have "
+#~ "stopped accepting paper checks. Sorry!"
+#~ msgstr ""
+
+#~ msgid "Upgrade"
+#~ msgstr ""
+
+#~ msgid "Back to Profile"
+#~ msgstr "הפרופיל שלך"
+
+#~ msgid ""
+#~ "Deletion of supporter accounts requires "
+#~ "manual review. Please contact us at"
+#~ msgstr ""
+
+#~ msgid "Revoke all your API tokens and access"
+#~ msgstr ""
+
+#~ msgid "Your username will be reserved and cannot be reused."
+#~ msgstr ""
+
+#~ msgid "Don't have an account?"
+#~ msgstr ""
+
+#~ msgid "If you would like to support us with more than $"
+#~ msgstr ""
+
+#~ msgid ", please enter the actual amount here:"
+#~ msgstr ""
+
+#~ msgid "month and up"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "I also agree that if I generate"
+#~ " a Live Data Feed access token, "
+#~ "that I treat my access token as"
+#~ " a secret and will not share "
+#~ "this token publicly or commit it "
+#~ "to a source code repository."
+#~ msgstr ""
+
+#~ msgid "Not a supporter?"
+#~ msgstr ""
+
+#~ msgid "Create a user account"
+#~ msgstr ""
+
+#~ msgid "Already have an account?"
+#~ msgstr ""
+
+#~ msgid "non-commercial"
+#~ msgstr "לא מסחרי"
+
+#~ msgid "Registration started by"
+#~ msgstr ""
+
+#~ msgid "Invalid email address"
+#~ msgstr ""
 

--- a/metabrainz/translations/id_ID/LC_MESSAGES/messages.po
+++ b/metabrainz/translations/id_ID/LC_MESSAGES/messages.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-07-25 16:21+0200\n"
+"POT-Creation-Date: 2026-09-08 11:18+0200\n"
 "PO-Revision-Date: 2026-06-12 00:53+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: id_ID\n"
@@ -21,163 +21,248 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.18.0\n"
 
-#: metabrainz/index/forms.py:46
+#: metabrainz/errors.py:24
+msgid "Authorization was declined."
+msgstr ""
+
+#: metabrainz/errors.py:25
+msgid "The authorization request was invalid."
+msgstr ""
+
+#: metabrainz/errors.py:26
+msgid "The application could not be authenticated."
+msgstr ""
+
+#: metabrainz/errors.py:27
+msgid "This application is not allowed to request authorization."
+msgstr ""
+
+#: metabrainz/errors.py:28
+msgid "The application asked for a response type this server does not support."
+msgstr ""
+
+#: metabrainz/errors.py:29
+msgid "The permissions requested by the application are invalid."
+msgstr ""
+
+#: metabrainz/errors.py:30
+msgid "You need to sign in to continue."
+msgstr ""
+
+#: metabrainz/errors.py:31
+msgid "Your consent is required to continue."
+msgstr ""
+
+#: metabrainz/password.py:12
+#, python-format
+msgid "Password must not exceed %(max_bytes)s bytes."
+msgstr ""
+
+#: metabrainz/index/forms.py:48
 #, python-format
 msgid "'%(value)s' is not a valid choice for this field"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileEdit.tsx:27
-#: frontend/js/src/forms/SignupCommercial.tsx:154
+#: frontend/js/src/forms/SignupCommercial.tsx:159
 #: frontend/js/src/forms/SignupNonCommercial.tsx:85
-#: frontend/js/src/forms/SignupUser.tsx:70
-#: frontend/js/src/hooks/useEmailValidation.ts:78 metabrainz/index/forms.py:57
-#: metabrainz/user/forms.py:25 metabrainz/user/forms.py:57
-#: metabrainz/user/forms.py:63
+#: frontend/js/src/forms/SignupUser.tsx:76
+#: frontend/js/src/hooks/useEmailValidation.ts:78 metabrainz/index/forms.py:59
+#: metabrainz/user/forms.py:31 metabrainz/user/forms.py:70
+#: metabrainz/user/forms.py:76
 msgid "Email address is required!"
 msgstr "Alamat email diperlukan!"
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:34
-#: metabrainz/index/forms.py:63
+#: metabrainz/index/forms.py:65
 msgid "Current password is required!"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:43
 #: frontend/js/src/forms/ProfileChangePassword.tsx:37
 #: frontend/js/src/forms/ResetPassword.tsx:39
-#: frontend/js/src/forms/SignupCommercial.tsx:156
+#: frontend/js/src/forms/SignupCommercial.tsx:161
 #: frontend/js/src/forms/SignupNonCommercial.tsx:87
-#: frontend/js/src/forms/SignupUser.tsx:72 metabrainz/index/forms.py:66
-#: metabrainz/user/forms.py:29 metabrainz/user/forms.py:46
-#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:69
+#: frontend/js/src/forms/SignupUser.tsx:78 metabrainz/index/forms.py:69
+#: metabrainz/user/forms.py:35 metabrainz/user/forms.py:54
+#: metabrainz/user/forms.py:63 metabrainz/user/forms.py:82
 msgid "Password is required!"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:41
-#: frontend/js/src/forms/SignupCommercial.tsx:160
+#: frontend/js/src/forms/SignupCommercial.tsx:165
 #: frontend/js/src/forms/SignupNonCommercial.tsx:91
-#: frontend/js/src/forms/SignupUser.tsx:76 metabrainz/index/forms.py:70
-#: metabrainz/user/forms.py:33 metabrainz/user/forms.py:73
+#: frontend/js/src/forms/SignupUser.tsx:82 metabrainz/index/forms.py:74
+#: metabrainz/user/forms.py:40 metabrainz/user/forms.py:87
 msgid "Confirm Password is required!"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:46
 #: frontend/js/src/forms/ResetPassword.tsx:48
-#: frontend/js/src/forms/SignupCommercial.tsx:165
+#: frontend/js/src/forms/SignupCommercial.tsx:170
 #: frontend/js/src/forms/SignupNonCommercial.tsx:96
-#: frontend/js/src/forms/SignupUser.tsx:81 metabrainz/index/forms.py:72
-#: metabrainz/user/forms.py:35 metabrainz/user/forms.py:75
+#: frontend/js/src/forms/SignupUser.tsx:87 metabrainz/index/forms.py:76
+#: metabrainz/user/forms.py:42 metabrainz/user/forms.py:89
 msgid "Confirm Password should match password!"
 msgstr ""
 
 #: frontend/js/src/Applications.tsx:56 frontend/js/src/Applications.tsx:86
 #: frontend/js/src/Profile.tsx:272 frontend/js/src/Profile.tsx:482
-#: metabrainz/index/forms.py:78
+#: metabrainz/index/forms.py:82
 msgid "Name"
 msgstr "Nama"
 
-#: metabrainz/index/forms.py:79
+#: metabrainz/index/forms.py:83
 msgid "Contact name field is empty."
 msgstr "Bidang nama kontak kosong."
 
-#: metabrainz/index/views.py:234
+#: metabrainz/index/views.py:251
 msgid "Profile updated successfully."
 msgstr ""
 
-#: metabrainz/index/views.py:261
+#: metabrainz/index/views.py:278
 msgid "Current password is incorrect."
 msgstr ""
 
-#: metabrainz/index/views.py:266
+#: metabrainz/index/views.py:283
 msgid "Password changed successfully."
 msgstr ""
 
-#: metabrainz/index/views.py:372
+#: metabrainz/index/views.py:389
 msgid "You have updated an application!"
 msgstr ""
 
-#: metabrainz/index/views.py:424
+#: metabrainz/index/views.py:441
 msgid "You have deleted an application."
 msgstr ""
 
-#: metabrainz/index/views.py:426
+#: metabrainz/index/views.py:443
 msgid "Failed to delete an application."
 msgstr ""
 
-#: metabrainz/index/views.py:449
+#: metabrainz/index/views.py:466
 msgid "Revoked tokens successfully!"
 msgstr ""
 
-#: metabrainz/index/views.py:478
+#: metabrainz/index/views.py:495
 msgid "Your account has been deleted."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:106 metabrainz/oauth/forms.py:58
+#: frontend/js/src/forms/CreateApplication.tsx:106 metabrainz/oauth/forms.py:57
 msgid "Application Name"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:59
+#: metabrainz/oauth/forms.py:58
 msgid "Application name field is empty."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:60 metabrainz/oauth/forms.py:60
+#: frontend/js/src/forms/CreateApplication.tsx:60 metabrainz/oauth/forms.py:59
 msgid "Application name needs to be at least 3 characters long."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:64 metabrainz/oauth/forms.py:61
+#: frontend/js/src/forms/CreateApplication.tsx:64 metabrainz/oauth/forms.py:60
 msgid "Application name needs to be at most 64 characters long."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:114 metabrainz/oauth/forms.py:63
+#: frontend/js/src/forms/CreateApplication.tsx:114 metabrainz/oauth/forms.py:62
 #, fuzzy
 msgid "Description"
 msgstr "Deskripsi organisasi"
 
-#: metabrainz/oauth/forms.py:64
+#: metabrainz/oauth/forms.py:63
 msgid "Client description field is empty."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:65
+#: metabrainz/oauth/forms.py:64
 msgid "Client description needs to be at least 3 characters long."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:66
+#: metabrainz/oauth/forms.py:65
 msgid "Client description needs to be at most 512 characters long."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:122 metabrainz/oauth/forms.py:68
+#: frontend/js/src/forms/CreateApplication.tsx:122 metabrainz/oauth/forms.py:67
 msgid "Homepage"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:69
+#: metabrainz/oauth/forms.py:68
 msgid "Homepage field is empty."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:70
+#: metabrainz/oauth/forms.py:69
 msgid "Homepage is not a valid URI."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:71
+#: metabrainz/oauth/forms.py:70
 msgid "Homepage URL must use http or https"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:73
+#: metabrainz/oauth/forms.py:72
 msgid "Authorization callback URL"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:74
+#: metabrainz/oauth/forms.py:73
 msgid "Authorization callback URL field is empty."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:75
+#: metabrainz/oauth/forms.py:74
 msgid "Authorization callback URL is invalid."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:76
+#: metabrainz/oauth/forms.py:75
 msgid "Authorization callback URL must use http or https."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:81 metabrainz/oauth/forms.py:85
+#: metabrainz/oauth/forms.py:80 metabrainz/oauth/forms.py:84
 msgid "Confirm"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:15
+msgid "View your public account information"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:16
+msgid "View your email address"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:17
+msgid "View and modify your private tags"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:18
+msgid "View and modify your private ratings"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:19
+msgid "View and modify your private collections"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:20
+msgid "Submit new ISRCs to the database"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:21
+msgid "Submit new barcodes to the database"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:22
+msgid "Sign you in and view your unique user id"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:23
+msgid "Submit listens to ListenBrainz."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:24
+msgid "Create and modify CritiqueBrainz reviews."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:25
+msgid "Submit and delete votes on CritiqueBrainz reviews."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:26
+msgid "Modify profile info and delete profile on CritiqueBrainz."
 msgstr ""
 
 #: metabrainz/payments/views.py:164
@@ -235,178 +320,185 @@ msgid "Requested annual report was not found."
 msgstr "Laporan tahunan yang diminta tidak ditemukan."
 
 #: frontend/js/src/forms/ProfileEdit.tsx:30
-#: frontend/js/src/forms/SignupCommercial.tsx:139
+#: frontend/js/src/forms/SignupCommercial.tsx:144
 #: frontend/js/src/forms/SignupNonCommercial.tsx:70
-#: metabrainz/supporter/forms.py:13
+#: metabrainz/supporter/forms.py:15
 msgid "Contact name is required!"
 msgstr "Nama kontak diperlukan!"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:437
+#: frontend/js/src/forms/SignupCommercial.tsx:441
 #: frontend/js/src/forms/SignupNonCommercial.tsx:264
-#: metabrainz/supporter/forms.py:15
+#: metabrainz/supporter/forms.py:17
 msgid ""
 "Can you please tell us more about the project in which you'd like to use "
 "our data? Do you plan to self host the data or use our APIs?"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:137
+#: frontend/js/src/forms/SignupCommercial.tsx:142
 #: frontend/js/src/forms/SignupNonCommercial.tsx:68
-#: metabrainz/supporter/forms.py:17
+#: metabrainz/supporter/forms.py:19
 msgid "Please, tell us how you (will) use our data."
 msgstr "Tolong, beri tahu kami bagaimana Anda (akan) menggunakan data kami."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:138
+#: frontend/js/src/forms/SignupCommercial.tsx:143
 #: frontend/js/src/forms/SignupNonCommercial.tsx:69
-#: metabrainz/supporter/forms.py:18
+#: metabrainz/supporter/forms.py:20
 msgid "Please, limit usage description to 500 characters."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:141
-#: frontend/js/src/forms/SignupCommercial.tsx:142
+#: frontend/js/src/forms/SignupCommercial.tsx:146
+#: frontend/js/src/forms/SignupCommercial.tsx:147
 #: frontend/js/src/forms/SignupNonCommercial.tsx:72
 #: frontend/js/src/forms/SignupNonCommercial.tsx:73
-#: frontend/js/src/forms/SignupUser.tsx:84
-#: frontend/js/src/forms/SignupUser.tsx:85 metabrainz/supporter/forms.py:21
-#: metabrainz/user/forms.py:38
+#: frontend/js/src/forms/SignupUser.tsx:90
+#: frontend/js/src/forms/SignupUser.tsx:91 metabrainz/supporter/forms.py:23
+#: metabrainz/user/forms.py:45
 msgid "You need to accept the agreement!"
 msgstr "Anda harus menerima perjanjiannya!"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:342
-#: metabrainz/supporter/forms.py:27
+#: frontend/js/src/forms/SignupCommercial.tsx:347
+#: metabrainz/supporter/forms.py:29
 msgid "Organization name"
 msgstr "Nama organisasi"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:113
-#: metabrainz/supporter/forms.py:28
+#: frontend/js/src/forms/SignupCommercial.tsx:115
+#: metabrainz/supporter/forms.py:30
 msgid "You need to specify the name of your organization."
 msgstr "Anda perlu menentukan nama organisasi Anda."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:373
-#: metabrainz/supporter/forms.py:30
+#: frontend/js/src/forms/SignupCommercial.tsx:378
+#: metabrainz/supporter/forms.py:32
 msgid "Organization description"
 msgstr "Deskripsi organisasi"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:116
-#: metabrainz/supporter/forms.py:31
+#: frontend/js/src/forms/SignupCommercial.tsx:118
+#: metabrainz/supporter/forms.py:33
 msgid "You need to provide description of your organization."
 msgstr "Anda perlu memberikan deskripsi tentang organisasi Anda."
 
 #: frontend/js/src/Profile.tsx:278
-#: frontend/js/src/forms/SignupCommercial.tsx:396
-#: metabrainz/supporter/forms.py:34
+#: frontend/js/src/forms/SignupCommercial.tsx:401
+#: metabrainz/supporter/forms.py:36
 msgid "Website URL"
 msgstr "URL Situs Web"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:119
-#: metabrainz/supporter/forms.py:35
-msgid "You need to specify website of the organization."
-msgstr "Anda perlu menentukan situs web organisasi."
+#: frontend/js/src/forms/SignupCommercial.tsx:121
+#: frontend/js/src/forms/SignupCommercial.tsx:123
+#: metabrainz/supporter/forms.py:38 metabrainz/supporter/forms.py:42
+msgid "Website URL must be a valid URL."
+msgstr ""
 
-#: metabrainz/supporter/forms.py:37
+#: metabrainz/supporter/forms.py:45
 msgid "Logo image URL"
 msgstr "URL gambar logo"
 
 #: frontend/js/src/Profile.tsx:284
-#: frontend/js/src/forms/SignupCommercial.tsx:418
-#: metabrainz/supporter/forms.py:38
+#: frontend/js/src/forms/SignupCommercial.tsx:422
+#: metabrainz/supporter/forms.py:46
 msgid "API URL"
 msgstr "URL API"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:457
-#: metabrainz/supporter/forms.py:40
+#: frontend/js/src/forms/SignupCommercial.tsx:461
+#: metabrainz/supporter/forms.py:48
 msgid "Street"
 msgstr "Jalan"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:123
-#: metabrainz/supporter/forms.py:41
+#: frontend/js/src/forms/SignupCommercial.tsx:128
+#: metabrainz/supporter/forms.py:49
 msgid "You need to specify street."
 msgstr "Anda perlu menentukan jalan."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:465
-#: metabrainz/supporter/forms.py:43
+#: frontend/js/src/forms/SignupCommercial.tsx:469
+#: metabrainz/supporter/forms.py:51
 msgid "City"
 msgstr "Kota"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:124
-#: metabrainz/supporter/forms.py:44
+#: frontend/js/src/forms/SignupCommercial.tsx:129
+#: metabrainz/supporter/forms.py:52
 msgid "You need to specify city."
 msgstr "Anda perlu menentukan kota."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:473
-#: metabrainz/supporter/forms.py:46
+#: frontend/js/src/forms/SignupCommercial.tsx:477
+#: metabrainz/supporter/forms.py:54
 msgid "State / Province"
 msgstr "Negara Bagian / Provinsi"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:126
-#: metabrainz/supporter/forms.py:47
+#: frontend/js/src/forms/SignupCommercial.tsx:131
+#: metabrainz/supporter/forms.py:55
 msgid "You need to specify state/province."
 msgstr "Anda perlu menentukan negara bagian/provinsi."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:481
-#: metabrainz/supporter/forms.py:49
+#: frontend/js/src/forms/SignupCommercial.tsx:485
+#: metabrainz/supporter/forms.py:57
 msgid "Postcode"
 msgstr "Kode pos"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:128
-#: metabrainz/supporter/forms.py:50
+#: frontend/js/src/forms/SignupCommercial.tsx:133
+#: metabrainz/supporter/forms.py:58
 msgid "You need to specify postcode."
 msgstr "Anda perlu menentukan kode pos."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:489
-#: metabrainz/supporter/forms.py:52
+#: frontend/js/src/forms/SignupCommercial.tsx:493
+#: metabrainz/supporter/forms.py:60
 msgid "Country"
 msgstr "Negara"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:129
-#: metabrainz/supporter/forms.py:53
+#: frontend/js/src/forms/SignupCommercial.tsx:134
+#: metabrainz/supporter/forms.py:61
 msgid "You need to specify country."
 msgstr "Anda perlu menentukan negara."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:132
-#: metabrainz/supporter/forms.py:64
+#: frontend/js/src/forms/SignupCommercial.tsx:137
+#: metabrainz/supporter/forms.py:72
 msgid ""
 "Custom amount must be more than threshold amount for selected tier or "
 "equal to it!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:46 metabrainz/supporter/views.py:119
-#: metabrainz/supporter/views.py:220
+#: metabrainz/supporter/views.py:54
+msgid ""
+"The verification email could not be sent. Please request a new one from "
+"your profile."
+msgstr ""
+
+#: metabrainz/supporter/views.py:85 metabrainz/supporter/views.py:158
+#: metabrainz/supporter/views.py:260
 msgid "You are already a supporter."
 msgstr ""
 
-#: metabrainz/supporter/views.py:61
+#: metabrainz/supporter/views.py:100
 msgid "Can't find tier with a specified ID."
 msgstr "Tidak dapat menemukan tingkat dengan ID yang ditentukan."
 
-#: metabrainz/supporter/views.py:127
+#: metabrainz/supporter/views.py:166
 msgid "You need to choose support tier before signing up!"
 msgstr "Anda harus memilih tingkat dukungan sebelum mendaftar!"
 
-#: metabrainz/supporter/views.py:137
+#: metabrainz/supporter/views.py:176
 msgid "You need to choose existing tier before signing up!"
 msgstr "Anda harus memilih tingkat yang ada sebelum mendaftar!"
 
-#: metabrainz/supporter/views.py:164
+#: metabrainz/supporter/views.py:204
 msgid ""
 "Thanks for becoming a supporter! Your application will be reviewed soon. "
 "We will send you updates via email."
 msgstr ""
 
-#: metabrainz/supporter/views.py:187
+#: metabrainz/supporter/views.py:228
 msgid ""
 "Thanks for signing up! Your application will be reviewed soon. We will "
 "send you updates via email."
 msgstr ""
 
-#: metabrainz/supporter/views.py:248
+#: metabrainz/supporter/views.py:288
 msgid "Thanks for becoming a supporter!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:274
+#: metabrainz/supporter/views.py:312
 msgid "Thanks for signing up! Please check your inbox to complete verification."
 msgstr ""
 
-#: metabrainz/supporter/views.py:302
+#: metabrainz/supporter/views.py:340
 msgid "Can't generate new token unless account is active."
 msgstr "Tidak dapat membuat token baru kecuali akun aktif."
 
@@ -440,7 +532,7 @@ msgstr ""
 msgid "Policies"
 msgstr ""
 
-#: metabrainz/templates/base.html:55 metabrainz/templates/index/gdpr.html:178
+#: metabrainz/templates/base.html:55
 #: metabrainz/templates/index/social-contract.html:3
 #: metabrainz/templates/index/social-contract.html:6
 #: metabrainz/templates/navbar.html:34
@@ -450,14 +542,15 @@ msgstr ""
 #: metabrainz/templates/base.html:56
 #: metabrainz/templates/index/code-of-conduct.html:3
 #: metabrainz/templates/index/code-of-conduct.html:16
-#: metabrainz/templates/index/gdpr.html:181 metabrainz/templates/navbar.html:35
+#: metabrainz/templates/navbar.html:35
 msgid "Code of Conduct"
 msgstr ""
 
+#: frontend/js/src/PrivacySummary.tsx:11
 #: frontend/js/src/forms/ConditionsModal.tsx:21
-#: metabrainz/templates/base.html:57 metabrainz/templates/index/gdpr.html:184
-#: metabrainz/templates/index/privacy.html:6
+#: metabrainz/templates/base.html:57 metabrainz/templates/index/privacy.html:6
 #: metabrainz/templates/navbar.html:36
+#: metabrainz/templates/users/privacy-summary.html:3
 msgid "Privacy Policy"
 msgstr "Kebijakan Privasi"
 
@@ -491,10 +584,7 @@ msgstr "Sponsor"
 msgid "Supporters"
 msgstr "Pendukung "
 
-#: frontend/js/src/forms/LoginUser.tsx:103
-#: frontend/js/src/forms/SignupCommercial.tsx:574
-#: frontend/js/src/forms/SignupNonCommercial.tsx:339
-#: frontend/js/src/forms/SignupUser.tsx:232 metabrainz/templates/base.html:73
+#: frontend/js/src/forms/LoginUser.tsx:103 metabrainz/templates/base.html:73
 #: metabrainz/templates/navbar.html:66 metabrainz/templates/users/login.html:3
 msgid "Sign in"
 msgstr "Masuk "
@@ -516,26 +606,26 @@ msgid "Contact us"
 msgstr "Hubungi Kami "
 
 #: metabrainz/templates/base.html:85
-#: metabrainz/templates/index/contact.html:105
+#: metabrainz/templates/index/contact.html:106
 msgid "Blog"
 msgstr "Blog"
 
-#: metabrainz/templates/base.html:86 metabrainz/templates/index/contact.html:90
+#: metabrainz/templates/base.html:86 metabrainz/templates/index/contact.html:91
 msgid "Chat"
 msgstr ""
 
 #: metabrainz/templates/base.html:87
-#: metabrainz/templates/index/contact.html:106
+#: metabrainz/templates/index/contact.html:107
 msgid "Mastodon"
 msgstr ""
 
 #: metabrainz/templates/base.html:88
-#: metabrainz/templates/index/contact.html:107
+#: metabrainz/templates/index/contact.html:108
 msgid "Bluesky"
 msgstr ""
 
 #: metabrainz/templates/base.html:89
-#: metabrainz/templates/index/contact.html:108
+#: metabrainz/templates/index/contact.html:109
 msgid "Instagram"
 msgstr ""
 
@@ -594,15 +684,14 @@ msgstr "Laporan Finansial "
 msgid "Donate"
 msgstr "Donasi "
 
-#: frontend/js/src/forms/LoginUser.tsx:110
-#: frontend/js/src/forms/SignupCommercial.tsx:175
-#: frontend/js/src/forms/SignupCommercial.tsx:555
+#: frontend/js/src/forms/SignupCommercial.tsx:180
+#: frontend/js/src/forms/SignupCommercial.tsx:559
 #: frontend/js/src/forms/SignupNonCommercial.tsx:106
 #: frontend/js/src/forms/SignupNonCommercial.tsx:319
 #: metabrainz/templates/navbar.html:65
-#: metabrainz/templates/supporters/account-type.html:51
-#: metabrainz/templates/supporters/account-type.html:93
-#: metabrainz/templates/supporters/account-type.html:144
+#: metabrainz/templates/supporters/account-type.html:47
+#: metabrainz/templates/supporters/account-type.html:84
+#: metabrainz/templates/supporters/account-type.html:130
 #: metabrainz/templates/users/signup.html:3
 msgid "Sign up"
 msgstr "Daftar "
@@ -915,8 +1004,430 @@ msgstr ""
 msgid "Introduction"
 msgstr ""
 
-#: metabrainz/templates/index/conflict-policy.html:55
+#: metabrainz/templates/index/conflict-policy.html:17
+msgid ""
+"Conflicts between people arise in open source projects constantly and the"
+" projects by the \n"
+"    MetaBrainz Foundation are no different. This policy aims to establish"
+" a clear and unambiguous \n"
+"    policy for reporting and addressing conflicts in our community. In "
+"this policy we aim to \n"
+"    establish a fair practice that balances the need for confidentiality "
+"and our desire for \n"
+"    transparency in our operations."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:25
+#, python-format
+msgid ""
+"Before you continue to read this policy, we encourage you to review our "
+"existing community policies \n"
+"    including our <a href=\"%(social_contract_url)s\">Social "
+"Contract</a>, \n"
+"    <a href=\"%(code_of_conduct_url)s\">the Code of Conduct</a>, \n"
+"    and our <a href=\"%(privacy_policy_url)s\">Privacy Policy</a>. These "
+"policies establish the norms and rules for \n"
+"    participation in our projects; these policies apply equally to the "
+"contractors of the MetaBrainz \n"
+"    Foundation and any participants in our projects."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:37
+msgid ""
+"This policy divides conflicts into two categories: Private and public. "
+"Private conflicts are conflicts \n"
+"    that involve *confidential* information regarding contributors, "
+"contractors or supporters. Otherwise, any conflicts \n"
+"    that do not involve confidential information are considered to be "
+"public conflicts. For instance, a \n"
+"    conflict between a contractor and the Executive Director (aka BDFL) "
+"that involves contractor pay is \n"
+"    considered a private conflict because pay rates are confidential "
+"information. A public conflict in edit \n"
+"    notes between two editors in our community does not involve "
+"confidential information and therefore should \n"
+"    be considered a public conflict."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:47
+msgid ""
+"When conflicts arise we aim to disclose as much information as possible "
+"about the conflict in a timely \n"
+"    fashion. When conflicts contain confidential matters we will aim to "
+"disclose as much information as \n"
+"    possible, while fully respecting the confidentiality of the people "
+"involved in the conflict. With any \n"
+"    private conflict we will aim to extract the relevant lessons for the "
+"team and community in an effort to \n"
+"    evolve our policies to prevent future conflicts. Should the involved "
+"parties disagree whether a conflict \n"
+"    is private or public, the question about the nature of the conflict "
+"will be presented for the next higher \n"
+"    level in the chain of command to decide. (e.g. if a community member "
+"and the community manager disagree on \n"
+"    a conflict being public or private, the Executive Director shall "
+"decide if the conflict is public or private)."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:58
 msgid "Reporting and Response"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:61
+msgid ""
+"We aim to not have conflict in our community, but we recognize that in "
+"reality conflicts will arise and we \n"
+"    must be prepared to address them in a fair manner. When conflicts "
+"arise, we prefer to have community or team \n"
+"    members resolve the conflicts among themselves, using our existing "
+"policies as guidelines for resolving the \n"
+"    conflict."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:69
+msgid ""
+"If you do not feel comfortable resolving a conflict on your own, you "
+"should feel free to report the conflict to \n"
+"    us. How you address the conflict depends on who is involved in the "
+"conflict and your comfort level. Please see \n"
+"    the detailed sections below on how and with whom to address your "
+"conflict. We aim to address conflicts as soon \n"
+"    as possible in an effort to prevent them from escalating "
+"unnecessarily."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:75
+msgid "Direct conflict resolution"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:78
+msgid ""
+"In direct conflict resolution, the involved parties will attempt to "
+"resolve the conflict themselves without \n"
+"   involving any MetaBrainz Foundation team member. You should aim to use"
+" direct resolution when the conflict does \n"
+"   not involve the violation of one of our policies or if the conflict is"
+" minor."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:84
+#, python-format
+msgid ""
+"For instance, if a user uses a rude tone, is disruptive or flagrantly "
+"ignores our project guidelines, we suggest \n"
+"    that you use direct conflict resolution to resolve the conflict. Some"
+" resources that might give you some suggestions \n"
+"    on how to go about resolving the conflict might be this <a "
+"href=\"%(conflict_resolution_primer_url)s\">\n"
+"    conflict resolution primer</a> and <a "
+"href=\"%(difficult_conversations_url)s\">how to\n"
+"    have difficult conversations at work</a>."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:93
+msgid "Informal reporting"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:96
+msgid ""
+"You may use informal reporting of a conflict if you aim to communicate a "
+"concern or incident without \n"
+"    seeking a corrective outcome. Informal reporting may also be an "
+"option if you have not been personally \n"
+"    victimized, but you’ve witnessed a violation of our policies or where"
+" you wish to maintain confidentiality \n"
+"    throughout the entire reporting process."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:103
+msgid ""
+"For editing in MusicBrainz you may informally report a user using the "
+"“Report this user for bad behavior” \n"
+"    link from the user’s profile. For reporting bad user behavior in "
+"other of our projects, please report them to our \n"
+"    community manager by mailing <span class=\"backemail\">gro.zniarbatem"
+"@reganam-ytinummoc</span> . For conflicts \n"
+"    that involve the community manager, report them by mailing <span "
+"class=\"backemail\">gro.zniarbatem@de</span> ."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:110
+msgid ""
+"Depending the the severity of the issue, repeated informal complaints may"
+" eventually require a formal response \n"
+"    from the MetaBrainz team. If an involved party requires anonymity, "
+"the conflict becomes a private conflict. If at \n"
+"    all possible minor issues should be resolved in a public forum in "
+"order for all people to witness and learn from \n"
+"    the issue at hand."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:116
+msgid "Formal complaint process"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:119
+msgid ""
+"All complaints about conflicts should be submitted via email. To whom a "
+"complaint should be mailed and who will \n"
+"    carry out the investigation will be described in the next section."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:124
+msgid "All complaint submissions to the Foundation should include the following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:128
+msgid ""
+"Contact info, if it is different than the email used to submit the "
+"conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:129
+msgid "Who was involved in the conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:130
+msgid "Where and when the incident happened"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:131
+msgid ""
+"A description of what happened -- ideally with links (e.g. chatlogs, edit"
+" notes) that outlines what \n"
+"         happened so that the persons evaluating the conflict may "
+"understand the issue at hand"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:133
+msgid ""
+"Any related pieces of information that provide more context on the "
+"conflict (e.g. links, screenshots)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:134
+msgid "An indication if this conflict is ongoing or not"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:139
+msgid "The investigation that follows aims to determine:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:143
+msgid "The nature and severity of the incident"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:144
+msgid ""
+"Whether or not the incident is considered a violation of MetaBrainz’ "
+"conduct policies or core values"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:145
+msgid ""
+"The amount of harm experienced by the person who submitted the complaint "
+"and the broader MetaBrainz community \n"
+"         as a result of the incident"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:147
+msgid ""
+"Whether there have been prior complaints against the individual or "
+"individuals reported"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:148
+msgid "Whether the incident is ongoing"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:152
+msgid ""
+"The following potential forms of resolution may apply to any team members"
+" involved in the conflict:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:155
+#: metabrainz/templates/index/conflict-policy.html:168
+msgid "Nothing (if it has been found no violation occurred)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:156
+msgid "Creating a plan to improve the performance"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:157
+msgid "Creating a negative performance evaluation"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:158
+msgid "Mediation, an intervention by a third party to resolve the conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:159
+msgid "Suspension or forced leave"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:160
+msgid "Termination of contract"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:164
+msgid ""
+"The following potential forms of resolution may apply to non team members"
+" involved in the conflict:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:169
+msgid "A reprimand, either public or private"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:170
+msgid "Suspension of the users’ account"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:171
+msgid "Deletion of the users’ account"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:172
+msgid ""
+"Removal of user privileges (e.g. if an auto editor commits a serious "
+"offence, they may lose their auto editor status)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:175
+msgid "Filing a complaint"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:178
+msgid ""
+"NOTE: For complaints not about MetaBrainz staff, please see the "
+"<em>Informal reporting</em> section above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:182
+msgid ""
+"If the complaint does not involve the Executive Director (ED), do the "
+"following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:186
+msgid ""
+"If team member has directly violated conduct policies or engaged in "
+"otherwise harmful behavior, a formal complaint should be filed."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:187
+msgid ""
+"Mail <span class=\"backemail\">gro.zniarbatem@de</span> and include the "
+"complaint information outlined above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:188
+msgid ""
+"You should expect a response within a working day acknowledging the "
+"complaint."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:189
+msgid ""
+"The complaint will be investigated by the ED, member(s) of the board of "
+"directors or a neutral third party."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:190
+msgid ""
+"Once the investigation has been completed, the ED, with the support of "
+"others involved in the investigation will respond. The \n"
+"        ED will respond to incidents no later than 7 working days after a"
+" complaint has been filed with either a resolution or an \n"
+"        explanation of why the process must be extended."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:196
+msgid "If a complaint involves the Executive Director, do the following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:200
+msgid ""
+"If the Executive Director has directly violated conduct policies or "
+"engaged in otherwise harmful behavior, \n"
+"        a formal complaint should be filed with the board of directors."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:202
+msgid ""
+"Mail <span class=\"backemail\">gro.zniarbatem@noituloser-tcilfnoc</span> "
+"and include the complaint information outlined above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:203
+msgid ""
+"You should get a response within 5 working days acknowledging the "
+"complaint."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:204
+msgid ""
+"The complaint will be investigated by the member(s) of the board of "
+"directors, the community manager, a neutral \n"
+"        third party or a combination thereof."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:206
+msgid ""
+"Once the investigation has been completed, the board, with the support of"
+" others involved in the investigation \n"
+"        will respond. The board will aim to respond to incidents no later"
+" than 15 working days after a complaint has been filed \n"
+"        with either a resolution or an explanation of why the process "
+"must be extended."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:211
+msgid "Confidentiality"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:214
+msgid ""
+"Confidentiality is an important aspect of conflict resolution and all of "
+"the conflicts brought to the attention of the foundation \n"
+"    will be evaluated with confidentiality in mind and acted upon "
+"accordingly."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:219
+msgid ""
+"We work hard to make all of the actions of the foundation as transparent "
+"and open as possible. In cases where we cannot \n"
+"    disclose all aspects of a conflict we will disclose that a conflict "
+"is or has occurred and we will attempt to disclose the \n"
+"    appropriate amount of information about the conflict while balancing "
+"the need for confidentiality and our desire to learn \n"
+"    from conflicts so that we as a foundation and community can learn "
+"from these conflicts and improve our policies to avoid the \n"
+"    conflicts in the future."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:227
+msgid ""
+"Any breaches of confidentiality will be treated as severe breaches of our"
+" conduct policies."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:230
+msgid "Retaliation"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:233
+msgid ""
+"We will not allow retaliation for any contractor or volunteer that files "
+"a complaint or is involved in an investigation. If you \n"
+"    believe that you are being treated negatively because of your "
+"involvement in a complaint please report this complaint directly \n"
+"    to the ED at <span class=\"backemail\">gro.zniarbatem@de</span> or "
+"the board at \n"
+"    <span class=\"backemail\">gro.zniarbatem@noituloser-tcilfnoc</span>."
 msgstr ""
 
 #: metabrainz/templates/index/contact.html:3
@@ -997,7 +1508,7 @@ msgstr ""
 msgid ""
 "We are currently evaluating our overall online advertising strategy. We "
 "are evaluating advertising, traffic optimization,\n"
-"    search engine optimization and software monitization technologies. If"
+"    search engine optimization and software monetization technologies. If"
 " you provide these professional services, please provide a detailed\n"
 "    deck of your comprehensive services to the following email address. "
 "<em>Please respect our other non-media teams and do not contact us \n"
@@ -1072,11 +1583,11 @@ msgstr "Forum"
 #, python-format
 msgid ""
 "Please come ask your questions at our <a "
-"href=\"%(forums_url)s\">forums</a>! We would love to\n"
-"    answer any questions you may have."
+"href=\"%(forums_url)s\">forums</a>!\n"
+"    The community and the team will be more than happy to help you."
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:92
+#: metabrainz/templates/index/contact.html:93
 #, python-format
 msgid ""
 "The MetaBrainz/MusicBrainz/ListenBrainz team and community hang out\n"
@@ -1086,15 +1597,15 @@ msgid ""
 "    <a href=\"%(chatlogs_url)s\">chat log archives</a>."
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:101
+#: metabrainz/templates/index/contact.html:102
 msgid "Social media"
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:103
+#: metabrainz/templates/index/contact.html:104
 msgid "You can follow us on these social channels:"
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:112
+#: metabrainz/templates/index/contact.html:113
 msgid "Mailing address"
 msgstr "Alamat surat"
 
@@ -1107,33 +1618,349 @@ msgstr ""
 msgid "GDPR Compliance Statement"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:37
+#: metabrainz/templates/index/gdpr.html:10
+msgid ""
+"The General Data Protection Regulation is a complex EU regulation that "
+"stipulates many points for protecting private data of\n"
+"    users on the Internet. Even though this is an EU regulation, it has a"
+" worldwide impact due to the nature of the Internet.\n"
+"    The MetaBrainz Foundation with its collection of projects is also "
+"affected by this regulation. We’ve been learning and adapting\n"
+"    our sites to be compliant with the GDPR – sadly this regulation isn’t"
+" entirely black and white and there is an incredible\n"
+"    amount of room left for interpretation of these rules."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:17
+msgid ""
+"The good news is that this regulation is roughly in line with our "
+"established practices: We’ve always held private information\n"
+"    in a high regard and applied the sort of rules to ourselves as we "
+"wish to have our own private data treated. Luckily, this\n"
+"    makes our compliance effort considerably easier. We’ve made two "
+"significant changes to how we treat your data and also adopted\n"
+"    terminology as used in the GDPR in order to use the same languages "
+"that many other sites are now adopting. Please keep reading\n"
+"    to find out the exact details of what we are doing to comply."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:24
+#, python-format
+msgid ""
+"However, we do ask for your compassion and help in our process of "
+"complying with the GDPR. As we already mentioned, the GDPR is\n"
+"    a complex set of rules that are not fully clarified yet. We’ve taken "
+"action on the steps that are clear to us and we’re following\n"
+"    ongoing conversations on points that are in gray zones or unclear to "
+"us. We’ve made our best initial effort on compliance and\n"
+"    promise to keep working on it as the picture becomes more clear. If "
+"you believe that we could improve our compliance, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a> and let us know what we "
+"can do to improve. It would also help us if you\n"
+"    could provide concrete discussion or examples to help us understand "
+"and take action on your suggestion."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:33
+msgid ""
+"Finally, below are the key sections of the GDPR as we understand them and"
+" how they affect your data in our ecosystem. Where\n"
+"    possible, we provide links for deeper understanding, links for you to"
+" examine our relevant code and links to tickets to follow\n"
+"    the process of improving our compliance."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:38
 msgid "Right to be forgotten"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:77
+#: metabrainz/templates/index/gdpr.html:41
+msgid ""
+"Summary: <i>Provide the user with the ability to remove their private "
+"data from our services</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:44
+msgid ""
+"The most important aspect of the right to be forgotten is the ability to "
+"delete your account. Once you request for us to delete\n"
+"    your account, we will remove any personally identifying information "
+"you may have provided us from your account (name, email\n"
+"    address, gender, biography, URL, etc.). The visible name on your "
+"account will be changed to “Deleted User #####” and effectively\n"
+"    the account will no longer be identifiable as your account."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:50
+msgid ""
+"However, given the nature of our projects where we work on collaborative "
+"databases, your contributions that are not personally\n"
+"    identifying are valuable assets to our database and these "
+"contributions will not be removed from our databases. But we will\n"
+"    ensure that these contributions no longer contain personally "
+"identifying data."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:55
+#, python-format
+msgid ""
+"Our process of automatically deleting your accounts across the MetaBrainz"
+" ecosystem is not complete yet (see below for a set of\n"
+"    tickets where you can track our progress). If you would like to "
+"delete your accounts in the MetaBrainz ecosystem or mark a\n"
+"    donation that is currently public as a private donation, please <a "
+"href=\"%(contact_url)s\">contact us</a>\n"
+"    and we will address your request as soon as possible."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:62
+#: metabrainz/templates/index/gdpr.html:182
+msgid "Links:"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:66
+#, python-format
+msgid ""
+"<a href=\"%(editor_deletion_doc_url)s\">How we delete accounts\n"
+"       in MusicBrainz</a> (warning, geek content ahead!)"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:70
+msgid ""
+"Implement sitewide user account deletion in\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/MBS-9680\">MusicBrainz</a>,"
+"\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/AB-337\">AcousticBrainz</a>,"
+"\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/BB-260\">BookBrainz</a>,\n"
+"         <a href=\"https://tickets.metabrainz.org/browse/MEB-103\">the "
+"MetaBrainz Site</a>,\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/LB-354\">ListenBrainz</a>, "
+"and\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/CB-307\">CritiqueBrainz</a>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:80
 msgid "Restriction of processing"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:110
+#: metabrainz/templates/index/gdpr.html:83
+msgid ""
+"Summary: <i>To allow the user to control how their personally identifying"
+" data is being used.</i>"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:86
+msgid ""
+"Except for the ListenBrainz and AcousticBrainz projects, we do not "
+"process personally identifying data. Any personally\n"
+"    identifying data that our projects store is for the purpose of being "
+"able to contact you about your contributions to our database\n"
+"    (email address) or for voluntarily showing information about you to "
+"other users (biography, homepage, location, etc)."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:91
+#, python-format
+msgid ""
+"The ListenBrainz project differs in that the Listens (metadata about what"
+" music you have listened to) are stored on our servers\n"
+"    and <a href=\"%(listenbrainz_data_url)s\">made available to the "
+"public</a>. We believe Listens to be personally identifying\n"
+"    data and furthermore, we have goals of creating open source "
+"recommendation engines with this data, which involves processing the\n"
+"    user’s data. These two points are fundamental goals of the "
+"ListenBrainz project and we do not see a reasonable way to reach another"
+"\n"
+"    compromise position."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:99
+msgid ""
+"Because of this, we are going to require users to either acknowledge that"
+" we may process their Listen data or alternatively to\n"
+"    delete their account, including all of their Listens. Please note "
+"that if you decide to delete your ListenBrainz account, it may\n"
+"    take up to two weeks for all of your listens to no longer be included"
+" in our efforts to build a recommendation engine."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:104
+msgid ""
+"We have always made it clear that the data in ListenBrainz was to be "
+"public and that we plan to build new tools with your data, so\n"
+"    this should not come as a surprise to our users."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:108
+msgid ""
+"The AcousticBrainz project does not track who submits data to the "
+"database. If you create an account and use our data creation\n"
+"    tools (e.g. create a dataset or participate in a challenge) then we "
+"link your participation and the things that you create to\n"
+"    your account. If you choose to delete your account then we keep the "
+"non personally identifying data that you create, but anonymize\n"
+"    it so that it cannot be linked back to you."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:114
 msgid "Right to data portability / exporting your data"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:150
+#: metabrainz/templates/index/gdpr.html:117
+msgid ""
+"Summary: <i>You have the right to access/download the data we store about"
+" you</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:120
+msgid ""
+"Except for the ListenBrainz and AcousticBrainz projects, we do not store "
+"personally identifying data beyond the\n"
+"    information that is available in your public profile on each of our "
+"projects. Since this data is plainly available in your\n"
+"    profile we do not provide a means for you to export this data."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:125
+msgid "There are the following exceptions to this:"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:129
+msgid ""
+"<b>IP addresses</b>: If you visit one of our sites the IP address of your"
+" computer is stored in our web logs for 7 days\n"
+"        before our servers automatically delete them. This data is almost"
+" never used by anyone: the only time we look at the\n"
+"        IP addresses is if our sites are adversely impacted by the "
+"actions of some unknown users. In that case, we may investigate\n"
+"        the logs to identify the IP address that needs to be blocked in "
+"order to restore the stability of our service.\n"
+"        This data is not available to anyone but the contractors of the "
+"MetaBrainz Foundation and is not available to download\n"
+"        to anyone at all."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:137
+#, python-format
+msgid ""
+"<b>ListenBrainz Listen data</b>: Users may <a "
+"href=\"%(listenbrainz_export_url)s\">export their ListenBrainz Listen\n"
+"        data</a> directly from the site. The user Listen data is also "
+"included in the <a href=\"%(listenbrainz_data_url)s\">ListenBrainz\n"
+"        data dumps</a> that are available for public download."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:146
+msgid ""
+"All of the non personally identifying data, such as your metadata "
+"contributions, are publicly visible, available for download\n"
+"    and available via the project APIs. For details about this data, "
+"downloads and APIs please check the documentation for the\n"
+"    respective projects you are interested in."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:151
+#, python-format
+msgid ""
+"Anyone wishing to get a list of financial donations they have made to the"
+" MetaBrainz Foundation, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a> and provide your "
+"MusicBrainz editor name so that we can look up\n"
+"    your donations."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:157
 msgid "Right to rectification"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:165
+#: metabrainz/templates/index/gdpr.html:160
+msgid "Summary: <i>You have the right to correct your data</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:163
+msgid ""
+"All of our projects allow their users to update their personally "
+"identifying information in their profiles. Furthermore, most\n"
+"    of our projects allow the editing of their own metadata "
+"contributions. If you find that some of your data is incorrect, please\n"
+"    feel free to edit the data since we provide the tools to do so."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:168
+#, python-format
+msgid ""
+"If anyone who has made a financial donation to the MetaBrainz Foundation "
+"would like to make their donation private, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:173
 msgid "Right to be informed"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:188
+#: metabrainz/templates/index/gdpr.html:175
+msgid ""
+"Summary: <i>You have the right to be informed about how we use your data "
+"in plain English</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:178
+msgid ""
+"Our privacy policy, as well as other policies, have always been written "
+"by humans for human consumption. We abhor legalese and\n"
+"    not speaking in direct terms."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:186
+msgid "Social contract"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:189
+msgid "Code of conduct"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:192
+msgid "Privacy policy"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:196
 msgid "Right to access"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:198
-#: metabrainz/templates/index/privacy.html:166
+#: metabrainz/templates/index/gdpr.html:199
+msgid ""
+"Summary: <i>You have the right to access the data that we collect about "
+"you</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:202
+msgid ""
+"All of our projects make all of the data we collect on your behalf, "
+"privately identifying or not, available to you. The\n"
+"    only exception to this are the IP addresses we store for 7 days – see"
+" above for details."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:206
+#: metabrainz/templates/index/privacy.html:168
 msgid "Privacy/GDPR Representative"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:209
+#, python-format
+msgid ""
+"If you have any questions about our privacy policy, please <a "
+"href=\"%(contact_url)s\">contact us</a>. To report\n"
+"   any privacy problems, violations or leaks, our GDPR representative is "
+"our Interim Executive Director Nicolás Tamargo and for\n"
+"   privacy issues contact him at <strong><a "
+"href=\"mailto:gdpr@metabrainz.org\">gdpr@metabrainz.org</a></strong>."
 msgstr ""
 
 #: metabrainz/templates/index/index.html:6
@@ -1253,7 +2080,7 @@ msgid ""
 "      <a href=\"%(about_url)s\">about</a> page."
 msgstr ""
 
-#: frontend/js/src/forms/ConditionsModal.tsx:43
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:32
 #: metabrainz/templates/index/privacy.html:3
 msgid "Privacy"
 msgstr "Privasi"
@@ -1261,6 +2088,44 @@ msgstr "Privasi"
 #: metabrainz/templates/index/privacy.html:8
 msgid "Summary"
 msgstr "Ringkasan"
+
+#: metabrainz/templates/index/privacy.html:12
+msgid ""
+"You do not have to provide any personal data to be able to browse the "
+"contents of the databases published by MetaBrainz."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:15
+msgid ""
+"You do not have to provide any personally-identifying information if you "
+"choose not to."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:18
+msgid ""
+"We will never reveal your email address on MetaBrainz controlled web "
+"sites."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:22
+msgid ""
+"In order to get maximum value out of the MetaBrainz projects, you may "
+"want to create an account and log in. \n"
+"    Doing so grants you the ability to: edit the databases, contribute "
+"your own data, communicate with other users, and keep track \n"
+"    of recently released music from artists in your MusicBrainz "
+"collection. If you choose to create an account then the minimum we \n"
+"    ask is that you: choose a unique username and password, use a web "
+"browser that accepts \"session\" cookies, and provide a verified \n"
+"    email address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:29
+msgid ""
+"If you do not create an account (or are not logged in) you will not have "
+"access to the above listed features, however, you will \n"
+"    still have full access to browse and examine the databases."
+msgstr ""
 
 #: metabrainz/templates/index/privacy.html:33
 msgid "Applicable to all users"
@@ -1270,40 +2135,198 @@ msgstr ""
 msgid "Cookies"
 msgstr ""
 
+#: metabrainz/templates/index/privacy.html:37
+msgid "We use two cookies that contain sensitive information:"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:42
+msgid ""
+"<b>remember_login</b>: If you choose the \"Log in permanently\" option "
+"when logging in to one of our sites; the cookie will be used to \n"
+"      remember your login details."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:46
+msgid ""
+"<b>musicbrainz_server_session, session, or connect.sid</b>: If you are "
+"logged into one of our sites, your current session ID is stored in this "
+"cookie."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:51
+msgid ""
+"We may store dynamic preference information in other cookies, but these "
+"do not contain any sensitive information."
+msgstr ""
+
 #: metabrainz/templates/index/privacy.html:54
 #, fuzzy
 msgid "Web and FTP access logs"
 msgstr "Log akses web dan FTP (semua pengguna)"
 
+#: metabrainz/templates/index/privacy.html:57
+msgid ""
+"In a practice similar to other web sites (and APIs) we keep logs of all "
+"web requests made against our servers. These logs include: your IP\n"
+"    address, your browser's (or API client's) \"User-Agent\" string, and "
+"which page (or API endpoint) you requested with which parameters. "
+"Aggregate information about web and FTP traffic is\n"
+"    made available to the public via our site usage pages."
+msgstr ""
+
 #: metabrainz/templates/index/privacy.html:62
 msgid "Third-Party content"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:92
+#: metabrainz/templates/index/privacy.html:64
+msgid ""
+"Our projects' web pages may load some third-party content. Some, but "
+"possibly not all sites are listed below:"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:69
+#, python-format
+msgid ""
+"Cover art and other images: These are provided by the various cover art "
+"sites that have given MusicBrainz permission to do so and our own \n"
+"      <a href=\"%(caa_url)s\">Cover Art Archive</a>. This means that the "
+"relevant site will know (if they want to) your IP \n"
+"      address, User-Agent string, etc., and which MusicBrainz web page "
+"you were visiting (the one which included the cover art image)."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:75
+msgid ""
+"AcoustID: Our fingerprints tab loads fingerprint information from "
+"acoustid.org."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:78
+msgid ""
+"MTCaptcha: Our account creation page loads third party content in order "
+"to prevent spammers from creating accounts."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:83
+msgid ""
+"<i>The above information assumes that you are using \"normal\" web "
+"browser settings, whereby images are always loaded and HTTP referrer \n"
+"    information is always sent.</i>"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:88
+msgid ""
+"It is impractical to constantly modify this privacy policy when "
+"MetaBrainz projects change which third party content they utilize. We "
+"will \n"
+"    aim to use common sense, respect to our community and community "
+"review when adding more content from third party sites. We will also \n"
+"    periodically review our policy to ensure that it remains current."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:93
 msgid "Applicable to account holders"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:94
+#: metabrainz/templates/index/privacy.html:95
 msgid "Account creation"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:108
+#: metabrainz/templates/index/privacy.html:97
+msgid ""
+"When creating an account with a MetaBrainz project you need to pick a "
+"unique username and choose a password, the username you pick is the \n"
+"    only name associated with your account and will be what other "
+"MetaBrainz users know you as. You may optionally also tell us other \n"
+"    information about yourself that will be displayed to other MetaBrainz"
+" users and the public."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:103
+msgid ""
+"Additionally, in order to edit the databases you will need to provide a "
+"confirmed email address. This email address will be held in \n"
+"    confidence, the only method of revealing your email address to "
+"another user is if you choose to send a message to another \n"
+"    user and enable the option to \"reveal my email address\". Changing "
+"the email address stored with your account will require you to \n"
+"    verify the new address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:109
 msgid "Edits and Notes"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:114
+#: metabrainz/templates/index/privacy.html:111
+msgid ""
+"If you make any changes to a MetaBrainz project database, such as adding "
+"any data, the details of those changes will be visible to \n"
+"    other logged-in users and the change will be associated with your "
+"username."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:115
 msgid "Subscriptions on MusicBrainz"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:131
+#: metabrainz/templates/index/privacy.html:117
+msgid ""
+"As a logged-in user you can subscribe to one or more artists, labels, "
+"collections or other editors. The act of subscribing causes \n"
+"    any edits made to (or by in the case of another editor) those "
+"entities to be emailed to you. By default, other users can see your \n"
+"    list of subscriptions, however, you can opt out of this by editing "
+"the appropriate preference."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:123
+msgid ""
+"This does not provide \"perfect\" privacy though, in some cases it will "
+"be possible to infer information about the contents of your \n"
+"    subscription list even though you have disallowed others from viewing"
+" that list directly. This imperfection arises because various \n"
+"    parts of the system behave differently depending on whether or not an"
+" entity has any subscribers; also, the number of users \n"
+"    subscribed to each artist is available via the artist pages. In the "
+"most extreme (possibly contrived) example, imagine that all \n"
+"    users have their subscriptions set to \"public\", except for exactly "
+"one user whose list is \"private\". In that case, any discrepancy \n"
+"    for a given artist between the shown list of subscribers and the "
+"total number of subscribers must be down to that one user. Thus, \n"
+"    you can infer what artists are on that user's list."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:132
 msgid "Third-party sites"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:145
+#: metabrainz/templates/index/privacy.html:134
+#, python-format
+msgid ""
+"Our code reviews are done on GitHub, which is not under the control of "
+"MetaBrainz. Participating in code reviews or other\n"
+"    tasks carried out on GitHub are subject to <a "
+"href=\"%(github_url)s\">GitHub's privacy policy</a>."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:140
+#, python-format
+msgid ""
+"Our translations platform is provided and hosted by Weblate, which has a "
+"data processing agreement with MetaBrainz.\n"
+"    Participating in translations is subject to <a "
+"href=\"%(weblate_url)s\">dedicated legal terms</a>.\n"
+"    Any translations you make will be submitted to our Git repositories "
+"and publicly associated with your username;\n"
+"    if you so choose, you can also publicly associate them with your own "
+"verified email address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:147
 msgid "MetaBrainz donors"
 msgstr "Donor MetaBrainz"
 
-#: metabrainz/templates/index/privacy.html:147
+#: metabrainz/templates/index/privacy.html:149
 msgid ""
 "When you make a donation to the MetaBrainz Foundation, we are legally\n"
 "    required to collect your personal information and keep it in our "
@@ -1313,7 +2336,7 @@ msgid ""
 "    information to anyone else, ever."
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:153
+#: metabrainz/templates/index/privacy.html:155
 msgid ""
 "We believe in transparent finances, which means that we list all "
 "donations\n"
@@ -1323,11 +2346,34 @@ msgid ""
 "process."
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:158
+#: metabrainz/templates/index/privacy.html:160
 msgid "Exceptions"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:598
+#: metabrainz/templates/index/privacy.html:162
+msgid ""
+"<i><b>Please note</b>: Reasonable exceptions may apply to the above "
+"policy, for example to comply with applicable laws.\n"
+"    Also, members of the MetaBrainz team and other personnel contracted "
+"to provide services to MetaBrainz may have access to\n"
+"    our infrastructure and could therefore view any information contained"
+" therein. However all personnel are contractually bound\n"
+"    by non-disclosure clauses which prevent them from making any such "
+"information available to others."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:171
+#, python-format
+msgid ""
+"If you have any questions about our GDPR statement, please <a "
+"href=\"%(contact_url)s\">contact us</a>. To report\n"
+"   any privacy problems, violations or leaks, our GDPR representative is "
+"our Interim Executive Director Nicolás Tamargo and for\n"
+"   privacy issues contact him at <strong><a "
+"href=\"mailto:gdpr@metabrainz.org\">gdpr@metabrainz.org</a></strong>."
+msgstr ""
+
+#: frontend/js/src/Profile.tsx:603
 #: frontend/js/src/forms/ProfileChangePassword.tsx:22
 #: frontend/js/src/forms/ProfileChangePassword.tsx:111
 #: metabrainz/templates/index/profile-change-password.html:3
@@ -1572,6 +2618,11 @@ msgstr ""
 
 #: metabrainz/templates/index/team.html:26
 msgid "He lives on in our hearts and in open source."
+msgstr ""
+
+#: metabrainz/templates/index/team.html:29
+#: metabrainz/templates/index/team.html:315
+msgid "you’re welcome to try"
 msgstr ""
 
 #: metabrainz/templates/index/team.html:39
@@ -2071,8 +3122,10 @@ msgstr "Cek AS"
 
 #: metabrainz/templates/payments/donate.html:146
 msgid ""
-"Due to the increased unreliability of the US Postal Service we have "
-"stopped accepting paper checks. Sorry!"
+"Due to the increased unreliability of the US Postal Service and the "
+"relatively large fees involved, we ask you to only send a paper check if "
+"it is the only possible option. Due to the fees, we will not cash checks "
+"for less than $25."
 msgstr ""
 
 #: metabrainz/templates/payments/donate.html:241
@@ -2958,8 +4011,8 @@ msgid "Monthly balance sheets"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:520
-#: frontend/js/src/forms/SignupCommercial.tsx:175
-#: frontend/js/src/forms/SignupCommercial.tsx:554
+#: frontend/js/src/forms/SignupCommercial.tsx:180
+#: frontend/js/src/forms/SignupCommercial.tsx:558
 #: frontend/js/src/forms/SignupNonCommercial.tsx:106
 #: frontend/js/src/forms/SignupNonCommercial.tsx:318
 #: metabrainz/templates/supporters/account-type.html:3
@@ -2981,6 +4034,7 @@ msgid "Non-commercial / Personal"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:235
+#: frontend/js/src/forms/SignupNonCommercial.tsx:107
 #: frontend/js/src/forms/SignupNonCommercial.tsx:151
 #: metabrainz/templates/supporters/account-type.html:42
 msgid "Non-commercial"
@@ -2994,57 +4048,46 @@ msgstr ""
 msgid "Personal or university assignment user."
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:48
-#: metabrainz/templates/supporters/account-type.html:90
-#: metabrainz/templates/supporters/account-type.html:141
-msgid "Upgrade"
-msgstr ""
-
 #: frontend/js/src/Profile.tsx:235
-#: frontend/js/src/forms/SignupCommercial.tsx:176
-#: frontend/js/src/forms/SignupCommercial.tsx:228
-#: metabrainz/templates/supporters/account-type.html:61
+#: frontend/js/src/forms/SignupCommercial.tsx:181
+#: frontend/js/src/forms/SignupCommercial.tsx:233
+#: metabrainz/templates/supporters/account-type.html:56
 msgid "Commercial"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:83
-#: metabrainz/templates/supporters/account-type.html:135
+#: metabrainz/templates/supporters/account-type.html:78
+#: metabrainz/templates/supporters/account-type.html:125
 #, python-format
 msgid "$%(tier_price)s/month and up"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:87
-#: metabrainz/templates/supporters/account-type.html:138
+#: metabrainz/templates/supporters/account-type.html:82
+#: metabrainz/templates/supporters/account-type.html:128
 msgid "More info"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:104
+#: metabrainz/templates/supporters/account-type.html:94
 msgid "View all tiers"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:112
+#: metabrainz/templates/supporters/account-type.html:102
 msgid "Some of our Unicorn members"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:123
+#: metabrainz/templates/supporters/account-type.html:113
 msgid "See all our supporters"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:151
+#: metabrainz/templates/supporters/account-type.html:136
 msgid "View featured tiers"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:158
+#: metabrainz/templates/supporters/account-type.html:143
 #, python-format
 msgid ""
 "If you are not sure which tier to pick, please\n"
 "      <a href=\"%(contact_url)s\">contact us</a>."
 msgstr ""
-
-#: metabrainz/templates/supporters/account-type.html:166
-#, fuzzy
-msgid "Back to Profile"
-msgstr "Profilmu"
 
 #: metabrainz/templates/supporters/bad-standing.html:3
 #: metabrainz/templates/supporters/bad-standing.html:6
@@ -3105,9 +4148,9 @@ msgid "Forgot your username"
 msgstr ""
 
 #: frontend/js/src/forms/ResetPassword.tsx:79
-#: frontend/js/src/forms/SignupCommercial.tsx:320
+#: frontend/js/src/forms/SignupCommercial.tsx:325
 #: frontend/js/src/forms/SignupNonCommercial.tsx:227
-#: frontend/js/src/forms/SignupUser.tsx:169
+#: frontend/js/src/forms/SignupUser.tsx:175
 #: metabrainz/templates/users/reauthenticate.html:3
 #: metabrainz/templates/users/reauthenticate.html:6
 msgid "Confirm Password"
@@ -3117,17 +4160,22 @@ msgstr ""
 msgid "Please re-enter your password to continue."
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:108
+#: frontend/js/src/ProfileDelete.tsx:110
 #: frontend/js/src/forms/DeleteApplication.tsx:53
 #: frontend/js/src/forms/OAuthPrompt.tsx:54
 #: frontend/js/src/forms/ProfileChangePassword.tsx:104
 #: frontend/js/src/forms/ProfileEdit.tsx:105
-#: metabrainz/templates/users/reauthenticate.html:23
+#: metabrainz/templates/users/reauthenticate.html:28
 msgid "Cancel"
 msgstr ""
 
-#: metabrainz/templates/users/reauthenticate.html:24
+#: metabrainz/templates/users/reauthenticate.html:29
 msgid "Continue"
+msgstr ""
+
+#: frontend/js/src/forms/utils.tsx:202
+#: metabrainz/templates/users/reauthenticate.html:40
+msgid "Password must not exceed 72 bytes."
 msgstr ""
 
 #: frontend/js/src/forms/ResetPassword.tsx:27
@@ -3135,38 +4183,38 @@ msgstr ""
 msgid "Reset your password"
 msgstr ""
 
-#: frontend/js/src/hooks/useEmailValidation.ts:41 metabrainz/user/forms.py:15
+#: frontend/js/src/hooks/useEmailValidation.ts:41 metabrainz/user/forms.py:16
 msgid "Registration from this email domain is not allowed."
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:50
 #: frontend/js/src/forms/LostPassword.tsx:45
-#: frontend/js/src/forms/SignupCommercial.tsx:270
+#: frontend/js/src/forms/SignupCommercial.tsx:275
 #: frontend/js/src/forms/SignupNonCommercial.tsx:175
-#: frontend/js/src/forms/SignupUser.tsx:114 metabrainz/user/forms.py:20
-#: metabrainz/user/forms.py:45 metabrainz/user/forms.py:62
+#: frontend/js/src/forms/SignupUser.tsx:120 metabrainz/user/forms.py:22
+#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:75
 msgid "Username"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:42
 #: frontend/js/src/forms/LostPassword.tsx:37
-#: frontend/js/src/forms/SignupCommercial.tsx:153
+#: frontend/js/src/forms/SignupCommercial.tsx:158
 #: frontend/js/src/forms/SignupNonCommercial.tsx:84
-#: frontend/js/src/forms/SignupUser.tsx:67 metabrainz/user/forms.py:21
-#: metabrainz/user/forms.py:45 metabrainz/user/forms.py:62
+#: frontend/js/src/forms/SignupUser.tsx:73 metabrainz/user/forms.py:26
+#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:75
 msgid "Username is required!"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:63
 #: frontend/js/src/forms/ResetPassword.tsx:72
-#: frontend/js/src/forms/SignupCommercial.tsx:308
+#: frontend/js/src/forms/SignupCommercial.tsx:313
 #: frontend/js/src/forms/SignupNonCommercial.tsx:214
-#: frontend/js/src/forms/SignupUser.tsx:157 metabrainz/user/forms.py:46
-#: metabrainz/user/forms.py:52
+#: frontend/js/src/forms/SignupUser.tsx:163 metabrainz/user/forms.py:53
+#: metabrainz/user/forms.py:62
 msgid "Password"
 msgstr ""
 
-#: frontend/js/src/forms/LoginUser.tsx:76 metabrainz/user/forms.py:47
+#: frontend/js/src/forms/LoginUser.tsx:76 metabrainz/user/forms.py:57
 msgid "Remember me"
 msgstr ""
 
@@ -3178,11 +4226,11 @@ msgstr ""
 msgid "Username contains invalid or invisible characters."
 msgstr ""
 
-#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:181
+#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:220
 msgid "Hide password"
 msgstr ""
 
-#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:181
+#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:220
 msgid "Show password"
 msgstr ""
 
@@ -3240,11 +4288,11 @@ msgstr ""
 msgid "Revoke access"
 msgstr ""
 
-#: frontend/js/src/OAuthError.tsx:17
+#: frontend/js/src/OAuthError.tsx:18
 msgid "OAuth2 Error"
 msgstr ""
 
-#: frontend/js/src/OAuthError.tsx:18
+#: frontend/js/src/OAuthError.tsx:19
 msgid "An error occurred during OAuth authentication process."
 msgstr ""
 
@@ -3274,8 +4322,8 @@ msgstr ""
 
 #: frontend/js/src/Profile.tsx:109
 msgid ""
-"Are you sure you want to generate new access token? Current token will be"
-" revoked!"
+"Are you sure you want to generate a new access token? The current token "
+"will be revoked!"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:118
@@ -3391,8 +4439,8 @@ msgid "Contact Information"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:310 frontend/js/src/forms/ProfileEdit.tsx:70
-#: frontend/js/src/forms/SignupCommercial.tsx:284
-#: frontend/js/src/forms/SignupCommercial.tsx:333
+#: frontend/js/src/forms/SignupCommercial.tsx:289
+#: frontend/js/src/forms/SignupCommercial.tsx:338
 #: frontend/js/src/forms/SignupNonCommercial.tsx:189
 #: frontend/js/src/forms/SignupNonCommercial.tsx:241
 msgid "Contact name"
@@ -3508,7 +4556,7 @@ msgstr ""
 msgid "Once you delete your account, there is no going back. Please be certain."
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:550 frontend/js/src/ProfileDelete.tsx:105
+#: frontend/js/src/Profile.tsx:550 frontend/js/src/ProfileDelete.tsx:107
 msgid "Delete My Account"
 msgstr ""
 
@@ -3520,39 +4568,39 @@ msgstr ""
 msgid "Need to delete your account?"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:574
+#: frontend/js/src/Profile.tsx:575
 msgid ""
 "Deletion of supporter accounts requires manual review. Please contact us "
-"at"
+"at <email />."
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:594
+#: frontend/js/src/Profile.tsx:599
 msgid "Security"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:626
+#: frontend/js/src/Profile.tsx:631
 msgid "MetaBrainz Applications"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:630
+#: frontend/js/src/Profile.tsx:635
 msgid ""
 "With your MetaBrainz account, you can access every project in the "
 "MetaBrainz family:"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:643
+#: frontend/js/src/Profile.tsx:648
 msgid "The open-source music encyclopedia"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:655
+#: frontend/js/src/Profile.tsx:660
 msgid "Track, visualise and share the music you listen to"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:667
+#: frontend/js/src/Profile.tsx:672
 msgid "The open-source book database"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:679
+#: frontend/js/src/Profile.tsx:684
 msgid "Creative Commons licensed reviews"
 msgstr ""
 
@@ -3575,7 +4623,7 @@ msgid "Permanently remove all your account information"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:64
-msgid "Revoke all your API tokens and access"
+msgid "Revoke all your tokens and access to the replication API"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:65
@@ -3587,14 +4635,16 @@ msgid "Log you out of all MetaBrainz services"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:70
-msgid "Your username will be reserved and cannot be reused."
+msgid ""
+"Your username will be reserved and cannot be reused without the "
+"intervention of an administrator."
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:82
+#: frontend/js/src/ProfileDelete.tsx:84
 msgid "To confirm, type your username '<username />' below:"
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:105
+#: frontend/js/src/ProfileDelete.tsx:107
 msgid "Deleting..."
 msgstr ""
 
@@ -3607,64 +4657,7 @@ msgstr "Profilmu"
 msgid "Close"
 msgstr ""
 
-#: frontend/js/src/forms/ConditionsModal.tsx:23
-msgid "Licensing"
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:25
-msgid ""
-"Any contributions you make to any MetaBrainz service will be released "
-"into the Public Domain and/or licensed under a Creative Commons by-nc-sa "
-"license. Furthermore, you give the MetaBrainz Foundation the right to "
-"license this data for commercial use."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:30
-msgid "Please read our <licenseLink>license page</licenseLink> for more details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:45
-msgid ""
-"MetaBrainz strongly believes in the privacy of its users. Any personal "
-"information you choose to provide will not be sold or shared with anyone "
-"else."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:50
-msgid ""
-"Please read our <privacyLink>privacy policy</privacyLink> for more "
-"details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:59
-msgid "GDPR compliance"
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:61
-msgid ""
-"You may remove your personal information from our services anytime by "
-"deleting your account."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:66
-msgid ""
-"Please read our <gdprLink>GDPR compliance statement</gdprLink> for more "
-"details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:78
-msgid ""
-"Creating an account on MetaBrainz will give you access to all of our "
-"projects, such as MusicBrainz, ListenBrainz, BookBrainz, and more."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:82
-msgid ""
-"We create a placeholder account for all the MetaBrainz projects when you "
-"sign up, and you are one log-in away from activating them."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:91
+#: frontend/js/src/forms/ConditionsModal.tsx:29
 msgid "Sounds good"
 msgstr ""
 
@@ -3753,8 +4746,8 @@ msgstr ""
 msgid "Forgot your password?"
 msgstr ""
 
-#: frontend/js/src/forms/LoginUser.tsx:109
-msgid "Don't have an account?"
+#: frontend/js/src/forms/LoginUser.tsx:110
+msgid "Don't have an account? <signupLink>Sign up</signupLink>"
 msgstr ""
 
 #: frontend/js/src/forms/LostPassword.tsx:38
@@ -3784,15 +4777,72 @@ msgstr ""
 msgid "Allow access"
 msgstr ""
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:71
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:10
+msgid "Licensing"
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:12
+msgid ""
+"Any contributions you make to any MetaBrainz service will be released "
+"into the Public Domain and/or licensed under a Creative Commons by-nc-sa "
+"license. Furthermore, you give the MetaBrainz Foundation the right to "
+"license this data for commercial use."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:17
+msgid "Please read our <licenseLink>license page</licenseLink> for more details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:34
+msgid ""
+"MetaBrainz strongly believes in the privacy of its users. Any personal "
+"information you choose to provide will not be sold or shared with anyone "
+"else."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:39
+msgid ""
+"Please read our <privacyLink>privacy policy</privacyLink> for more "
+"details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:50
+msgid "GDPR compliance"
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:52
+msgid ""
+"You may remove your personal information from our services anytime by "
+"deleting your account."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:57
+msgid ""
+"Please read our <gdprLink>GDPR compliance statement</gdprLink> for more "
+"details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:71
+msgid ""
+"Creating an account on MetaBrainz will give you access to all of our "
+"projects, such as MusicBrainz, ListenBrainz, BookBrainz, and more."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:75
+msgid ""
+"We create a placeholder account for all the MetaBrainz projects when you "
+"sign up, and you are one log-in away from activating them."
+msgstr ""
+
+#: frontend/js/src/forms/ProfileChangePassword.tsx:70
 msgid "Current Password"
 msgstr ""
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:80
+#: frontend/js/src/forms/ProfileChangePassword.tsx:79
 msgid "New Password"
 msgstr ""
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:89
+#: frontend/js/src/forms/ProfileChangePassword.tsx:88
 msgid "Confirm New Password"
 msgstr ""
 
@@ -3804,194 +4854,184 @@ msgstr ""
 msgid "Reset Password"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:38
-msgid "If you would like to support us with more than $"
+#: frontend/js/src/forms/SignupCommercial.tsx:40
+msgid ""
+"If you would like to support us with more than ${{minPledge}}, please "
+"enter the actual amount here:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:39
-msgid ", please enter the actual amount here:"
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:144
+#: frontend/js/src/forms/SignupCommercial.tsx:149
 #: frontend/js/src/forms/SignupNonCommercial.tsx:75
-#: frontend/js/src/forms/SignupUser.tsx:87
+#: frontend/js/src/forms/SignupUser.tsx:93
 msgid "Captcha is required!"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:179
+#: frontend/js/src/forms/SignupCommercial.tsx:184
 #: frontend/js/src/forms/SignupNonCommercial.tsx:110
 #: frontend/js/src/forms/SignupUser.tsx:46
 #, fuzzy
 msgid "Access all MetaBrainz projects"
 msgstr "Proyek MetaBrainz"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:182
+#: frontend/js/src/forms/SignupCommercial.tsx:187
 msgid "Note:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:184
+#: frontend/js/src/forms/SignupCommercial.tsx:189
 msgid ""
 "Signing up for any tier other than the <italic>Stealth startup</italic> "
 "tier will publicly list your company on this web site. However, we will "
 "not publish any of your private details."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:221
+#: frontend/js/src/forms/SignupCommercial.tsx:226
 #: frontend/js/src/forms/SignupNonCommercial.tsx:145
 #, fuzzy
 msgid "Account type"
 msgstr "Jenis akun"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:234
+#: frontend/js/src/forms/SignupCommercial.tsx:239
 msgid "Selected tier"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:242
-msgid "month and up"
+#: frontend/js/src/forms/SignupCommercial.tsx:247
+msgid "${{tierPrice}}/month and up"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:250
+#: frontend/js/src/forms/SignupCommercial.tsx:255
 msgid "Change account type or tier"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:261
+#: frontend/js/src/forms/SignupCommercial.tsx:266
 #: frontend/js/src/forms/SignupNonCommercial.tsx:166
 msgid "Your account:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:271
+#: frontend/js/src/forms/SignupCommercial.tsx:276
 #: frontend/js/src/forms/SignupNonCommercial.tsx:176
-#: frontend/js/src/forms/SignupUser.tsx:114
+#: frontend/js/src/forms/SignupUser.tsx:120
 msgid "(public)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:291
+#: frontend/js/src/forms/SignupCommercial.tsx:296
 #: frontend/js/src/forms/SignupNonCommercial.tsx:196
-#: frontend/js/src/forms/SignupUser.tsx:127
+#: frontend/js/src/forms/SignupUser.tsx:133
 msgid "E-mail address"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:295
+#: frontend/js/src/forms/SignupCommercial.tsx:300
 #: frontend/js/src/forms/SignupNonCommercial.tsx:200
-#: frontend/js/src/forms/SignupUser.tsx:131
+#: frontend/js/src/forms/SignupUser.tsx:137
 msgid "(checking...)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:314
+#: frontend/js/src/forms/SignupCommercial.tsx:319
 #: frontend/js/src/forms/SignupNonCommercial.tsx:220
-#: frontend/js/src/forms/SignupUser.tsx:163
+#: frontend/js/src/forms/SignupUser.tsx:169
 msgid "Must be at least 8 characters"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:348
+#: frontend/js/src/forms/SignupCommercial.tsx:353
 msgid ""
 "If you don't have an organization name, you probably want to become a "
 "supporter as a <nonCommercialLink>Non-commercial / "
 "Personal</nonCommercialLink> supporter."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:358
+#: frontend/js/src/forms/SignupCommercial.tsx:363
 msgid ""
 "If you don't have an organization name, you probably want to sign up as a"
 " <nonCommercialLink>Non-commercial / Personal</nonCommercialLink> user."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:378
+#: frontend/js/src/forms/SignupCommercial.tsx:383
 msgid ""
 "Please tell us a little about your company and whether you plan to use "
 "our <apiLink>API</apiLink> or to <hostLink>host your own copy</hostLink> "
 "of the data."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:404
+#: frontend/js/src/forms/SignupCommercial.tsx:408
 #, fuzzy
 msgid "Logo URL"
 msgstr "URL gambar logo"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:405
+#: frontend/js/src/forms/SignupCommercial.tsx:409
 msgid "(preferably in SVG format)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:408
+#: frontend/js/src/forms/SignupCommercial.tsx:412
 msgid ""
 "Image should be about 250 pixels wide on a white or transparent "
 "background. We will host it on our site."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:421
+#: frontend/js/src/forms/SignupCommercial.tsx:425
 msgid ""
 "URL to where developers can use your APIs using MusicBrainz IDs, if "
-"available.."
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:430
-msgid "Your project"
+"available."
 msgstr ""
 
 #: frontend/js/src/forms/SignupCommercial.tsx:434
+msgid "Your project"
+msgstr ""
+
+#: frontend/js/src/forms/SignupCommercial.tsx:438
 #: frontend/js/src/forms/SignupNonCommercial.tsx:261
 msgid "(max 150 characters)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:451
+#: frontend/js/src/forms/SignupCommercial.tsx:455
 msgid "Billing address"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:502
+#: frontend/js/src/forms/SignupCommercial.tsx:506
 msgid ""
 "I agree to support the MetaBrainz Foundation when my organization is able"
 " to do so."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:507
+#: frontend/js/src/forms/SignupCommercial.tsx:511
+#: frontend/js/src/forms/SignupNonCommercial.tsx:284
 msgid ""
-"I also agree that if I generate a Live Data Feed access token, that I "
-"treat my access token as a secret and will not share this token publicly "
-"or commit it to a source code repository."
+"I also agree that if I generate a Live Data Feed access token, then I "
+"will treat my access token as a secret and will not share this token "
+"publicly or commit it to a source code repository."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:515
+#: frontend/js/src/forms/SignupCommercial.tsx:519
 msgid ""
 "The following information will be shown publicly: organization name, "
 "logo, website and API URLs, data usage description."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:520
+#: frontend/js/src/forms/SignupCommercial.tsx:524
 msgid ""
 "We'll send you more details about payment process once your application "
 "is approved."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:552
+#: frontend/js/src/forms/SignupCommercial.tsx:556
 #: frontend/js/src/forms/SignupNonCommercial.tsx:316
-#: frontend/js/src/forms/SignupUser.tsx:224
+#: frontend/js/src/forms/SignupUser.tsx:230
 msgid "Validating..."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:564
+#: frontend/js/src/forms/SignupCommercial.tsx:568
 #: frontend/js/src/forms/SignupNonCommercial.tsx:329
 #, fuzzy
 msgid "Back to profile"
 msgstr "Profilmu"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:569
-#: frontend/js/src/forms/SignupNonCommercial.tsx:334
-msgid "Not a supporter?"
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:570
+#: frontend/js/src/forms/SignupCommercial.tsx:574
 #: frontend/js/src/forms/SignupNonCommercial.tsx:335
-msgid "Create a user account"
+msgid "Not a supporter? <signupLink>Create a user account</signupLink>"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:573
-#: frontend/js/src/forms/SignupNonCommercial.tsx:338
-#: frontend/js/src/forms/SignupUser.tsx:231
-msgid "Already have an account?"
-msgstr ""
-
-#: frontend/js/src/forms/SignupNonCommercial.tsx:107
-msgid "non-commercial"
+#: frontend/js/src/forms/SignupCommercial.tsx:583
+#: frontend/js/src/forms/SignupNonCommercial.tsx:344
+#: frontend/js/src/forms/SignupUser.tsx:238
+msgid "Already have an account? <loginLink>Sign in</loginLink>"
 msgstr ""
 
 #: frontend/js/src/forms/SignupNonCommercial.tsx:113
@@ -4019,46 +5059,40 @@ msgid ""
 "income per year) or personal uses only."
 msgstr ""
 
-#: frontend/js/src/forms/SignupNonCommercial.tsx:284
-msgid ""
-"I also agree that if I generate a Live Data Feed access token, then I "
-"will treat my access token as a secret and will not share this token "
-"publicly or commit it to a source code repository."
-msgstr ""
-
 #: frontend/js/src/forms/SignupUser.tsx:43
 msgid "Create your account"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:50
-msgid "Registration started by"
+#: frontend/js/src/forms/SignupUser.tsx:51
+msgid "Registration started by <client />"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:69
+#: frontend/js/src/forms/SignupUser.tsx:75
+#: frontend/js/src/hooks/useEmailValidation.ts:82
 msgid "Invalid email address."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:150
+#: frontend/js/src/forms/SignupUser.tsx:156
 msgid ""
 "This username and email were provided by the app that started "
 "registration. You can change them later from MetaBrainz settings."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:182
+#: frontend/js/src/forms/SignupUser.tsx:188
 msgid ""
 "I accept that my contributions will be released into the public domain or"
 " licensed for use."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:191
+#: frontend/js/src/forms/SignupUser.tsx:197
 msgid "We will never share your personal information."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:200
+#: frontend/js/src/forms/SignupUser.tsx:206
 msgid "Click here to read more"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:224
+#: frontend/js/src/forms/SignupUser.tsx:230
 msgid "Create account"
 msgstr ""
 
@@ -4068,10 +5102,6 @@ msgstr ""
 
 #: frontend/js/src/hooks/useEmailValidation.ts:47
 msgid "Email validation failed"
-msgstr ""
-
-#: frontend/js/src/hooks/useEmailValidation.ts:82
-msgid "Invalid email address"
 msgstr ""
 
 #~ msgid "You need to specify amount!"
@@ -5274,4 +6304,96 @@ msgstr ""
 
 #~ msgid "Privacy policy"
 #~ msgstr "Kebijakan Privasi"
+
+#~ msgid "You need to specify website of the organization."
+#~ msgstr "Anda perlu menentukan situs web organisasi."
+
+#~ msgid ""
+#~ "We are currently evaluating our overall"
+#~ " online advertising strategy. We are "
+#~ "evaluating advertising, traffic optimization,\n"
+#~ ""
+#~ "    search engine optimization and "
+#~ "software monitization technologies. If you "
+#~ "provide these professional services, please"
+#~ " provide a detailed\n"
+#~ "    deck of your comprehensive services"
+#~ " to the following email address. "
+#~ "<em>Please respect our other non-media"
+#~ " teams and do not contact us \n"
+#~ "    regarding these services on any "
+#~ "other of our email addresses. We "
+#~ "will disregard the entirety of your "
+#~ "submissions if you contact us any "
+#~ "other way!</em>"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Please come ask your questions at "
+#~ "our <a href=\"%(forums_url)s\">forums</a>! We "
+#~ "would love to\n"
+#~ "    answer any questions you may have."
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Due to the increased unreliability of"
+#~ " the US Postal Service we have "
+#~ "stopped accepting paper checks. Sorry!"
+#~ msgstr ""
+
+#~ msgid "Upgrade"
+#~ msgstr ""
+
+#~ msgid "Back to Profile"
+#~ msgstr "Profilmu"
+
+#~ msgid ""
+#~ "Deletion of supporter accounts requires "
+#~ "manual review. Please contact us at"
+#~ msgstr ""
+
+#~ msgid "Revoke all your API tokens and access"
+#~ msgstr ""
+
+#~ msgid "Your username will be reserved and cannot be reused."
+#~ msgstr ""
+
+#~ msgid "Don't have an account?"
+#~ msgstr ""
+
+#~ msgid "If you would like to support us with more than $"
+#~ msgstr ""
+
+#~ msgid ", please enter the actual amount here:"
+#~ msgstr ""
+
+#~ msgid "month and up"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "I also agree that if I generate"
+#~ " a Live Data Feed access token, "
+#~ "that I treat my access token as"
+#~ " a secret and will not share "
+#~ "this token publicly or commit it "
+#~ "to a source code repository."
+#~ msgstr ""
+
+#~ msgid "Not a supporter?"
+#~ msgstr ""
+
+#~ msgid "Create a user account"
+#~ msgstr ""
+
+#~ msgid "Already have an account?"
+#~ msgstr ""
+
+#~ msgid "non-commercial"
+#~ msgstr ""
+
+#~ msgid "Registration started by"
+#~ msgstr ""
+
+#~ msgid "Invalid email address"
+#~ msgstr ""
 

--- a/metabrainz/translations/it/LC_MESSAGES/messages.po
+++ b/metabrainz/translations/it/LC_MESSAGES/messages.po
@@ -9,178 +9,262 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-07-25 16:21+0200\n"
+"POT-Creation-Date: 2026-09-08 11:18+0200\n"
 "PO-Revision-Date: 2026-08-04 06:12+0000\n"
 "Last-Translator: \"salo.rock\" "
 "<salo.rock@users.noreply.translations.metabrainz.org>\n"
 "Language: it\n"
-"Language-Team: Italian <https://translations.metabrainz.org/projects/"
-"metabrainz/website/it/>\n"
-"Plural-Forms: nplurals=3; plural=(n == 1) ? 0 : ((n != 0 && n % 1000000 == "
-"0) ? 1 : 2);\n"
+"Language-Team: Italian "
+"<https://translations.metabrainz.org/projects/metabrainz/website/it/>\n"
+"Plural-Forms: nplurals=3; plural=(n == 1) ? 0 : ((n != 0 && n % 1000000 "
+"== 0) ? 1 : 2);\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.18.0\n"
-"X-Generator: Weblate 2026.8\n"
 
-#: metabrainz/index/forms.py:46
+#: metabrainz/errors.py:24
+msgid "Authorization was declined."
+msgstr ""
+
+#: metabrainz/errors.py:25
+msgid "The authorization request was invalid."
+msgstr ""
+
+#: metabrainz/errors.py:26
+msgid "The application could not be authenticated."
+msgstr ""
+
+#: metabrainz/errors.py:27
+msgid "This application is not allowed to request authorization."
+msgstr ""
+
+#: metabrainz/errors.py:28
+msgid "The application asked for a response type this server does not support."
+msgstr ""
+
+#: metabrainz/errors.py:29
+msgid "The permissions requested by the application are invalid."
+msgstr ""
+
+#: metabrainz/errors.py:30
+msgid "You need to sign in to continue."
+msgstr ""
+
+#: metabrainz/errors.py:31
+msgid "Your consent is required to continue."
+msgstr ""
+
+#: metabrainz/password.py:12
+#, python-format
+msgid "Password must not exceed %(max_bytes)s bytes."
+msgstr ""
+
+#: metabrainz/index/forms.py:48
 #, python-format
 msgid "'%(value)s' is not a valid choice for this field"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileEdit.tsx:27
-#: frontend/js/src/forms/SignupCommercial.tsx:154
+#: frontend/js/src/forms/SignupCommercial.tsx:159
 #: frontend/js/src/forms/SignupNonCommercial.tsx:85
-#: frontend/js/src/forms/SignupUser.tsx:70
-#: frontend/js/src/hooks/useEmailValidation.ts:78 metabrainz/index/forms.py:57
-#: metabrainz/user/forms.py:25 metabrainz/user/forms.py:57
-#: metabrainz/user/forms.py:63
+#: frontend/js/src/forms/SignupUser.tsx:76
+#: frontend/js/src/hooks/useEmailValidation.ts:78 metabrainz/index/forms.py:59
+#: metabrainz/user/forms.py:31 metabrainz/user/forms.py:70
+#: metabrainz/user/forms.py:76
 msgid "Email address is required!"
 msgstr "È necessario fornire un indirizzo email!"
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:34
-#: metabrainz/index/forms.py:63
+#: metabrainz/index/forms.py:65
 msgid "Current password is required!"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:43
 #: frontend/js/src/forms/ProfileChangePassword.tsx:37
 #: frontend/js/src/forms/ResetPassword.tsx:39
-#: frontend/js/src/forms/SignupCommercial.tsx:156
+#: frontend/js/src/forms/SignupCommercial.tsx:161
 #: frontend/js/src/forms/SignupNonCommercial.tsx:87
-#: frontend/js/src/forms/SignupUser.tsx:72 metabrainz/index/forms.py:66
-#: metabrainz/user/forms.py:29 metabrainz/user/forms.py:46
-#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:69
+#: frontend/js/src/forms/SignupUser.tsx:78 metabrainz/index/forms.py:69
+#: metabrainz/user/forms.py:35 metabrainz/user/forms.py:54
+#: metabrainz/user/forms.py:63 metabrainz/user/forms.py:82
 msgid "Password is required!"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:41
-#: frontend/js/src/forms/SignupCommercial.tsx:160
+#: frontend/js/src/forms/SignupCommercial.tsx:165
 #: frontend/js/src/forms/SignupNonCommercial.tsx:91
-#: frontend/js/src/forms/SignupUser.tsx:76 metabrainz/index/forms.py:70
-#: metabrainz/user/forms.py:33 metabrainz/user/forms.py:73
+#: frontend/js/src/forms/SignupUser.tsx:82 metabrainz/index/forms.py:74
+#: metabrainz/user/forms.py:40 metabrainz/user/forms.py:87
 msgid "Confirm Password is required!"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:46
 #: frontend/js/src/forms/ResetPassword.tsx:48
-#: frontend/js/src/forms/SignupCommercial.tsx:165
+#: frontend/js/src/forms/SignupCommercial.tsx:170
 #: frontend/js/src/forms/SignupNonCommercial.tsx:96
-#: frontend/js/src/forms/SignupUser.tsx:81 metabrainz/index/forms.py:72
-#: metabrainz/user/forms.py:35 metabrainz/user/forms.py:75
+#: frontend/js/src/forms/SignupUser.tsx:87 metabrainz/index/forms.py:76
+#: metabrainz/user/forms.py:42 metabrainz/user/forms.py:89
 msgid "Confirm Password should match password!"
 msgstr ""
 
 #: frontend/js/src/Applications.tsx:56 frontend/js/src/Applications.tsx:86
 #: frontend/js/src/Profile.tsx:272 frontend/js/src/Profile.tsx:482
-#: metabrainz/index/forms.py:78
+#: metabrainz/index/forms.py:82
 msgid "Name"
 msgstr "Nome"
 
-#: metabrainz/index/forms.py:79
+#: metabrainz/index/forms.py:83
 msgid "Contact name field is empty."
 msgstr "Il campo nome di contatto è vuoto."
 
-#: metabrainz/index/views.py:234
+#: metabrainz/index/views.py:251
 msgid "Profile updated successfully."
 msgstr ""
 
-#: metabrainz/index/views.py:261
+#: metabrainz/index/views.py:278
 msgid "Current password is incorrect."
 msgstr ""
 
-#: metabrainz/index/views.py:266
+#: metabrainz/index/views.py:283
 msgid "Password changed successfully."
 msgstr ""
 
-#: metabrainz/index/views.py:372
+#: metabrainz/index/views.py:389
 msgid "You have updated an application!"
 msgstr "Hai aggiornato un'applicazione!"
 
-#: metabrainz/index/views.py:424
+#: metabrainz/index/views.py:441
 msgid "You have deleted an application."
 msgstr "Hai eliminato un'applicazione."
 
-#: metabrainz/index/views.py:426
+#: metabrainz/index/views.py:443
 msgid "Failed to delete an application."
 msgstr ""
 
-#: metabrainz/index/views.py:449
+#: metabrainz/index/views.py:466
 msgid "Revoked tokens successfully!"
 msgstr ""
 
-#: metabrainz/index/views.py:478
+#: metabrainz/index/views.py:495
 msgid "Your account has been deleted."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:106 metabrainz/oauth/forms.py:58
+#: frontend/js/src/forms/CreateApplication.tsx:106 metabrainz/oauth/forms.py:57
 msgid "Application Name"
 msgstr "Nome dell'applicazione"
 
-#: metabrainz/oauth/forms.py:59
+#: metabrainz/oauth/forms.py:58
 msgid "Application name field is empty."
 msgstr "Il campo \"nome dell'applicazione\" è vuoto."
 
-#: frontend/js/src/forms/CreateApplication.tsx:60 metabrainz/oauth/forms.py:60
+#: frontend/js/src/forms/CreateApplication.tsx:60 metabrainz/oauth/forms.py:59
 msgid "Application name needs to be at least 3 characters long."
 msgstr "Il nome dell'applicazione deve contenere almeno 3 caratteri."
 
-#: frontend/js/src/forms/CreateApplication.tsx:64 metabrainz/oauth/forms.py:61
+#: frontend/js/src/forms/CreateApplication.tsx:64 metabrainz/oauth/forms.py:60
 msgid "Application name needs to be at most 64 characters long."
 msgstr "Il nome dell'applicazione deve contenere al massimo 64 caratteri."
 
-#: frontend/js/src/forms/CreateApplication.tsx:114 metabrainz/oauth/forms.py:63
+#: frontend/js/src/forms/CreateApplication.tsx:114 metabrainz/oauth/forms.py:62
 msgid "Description"
 msgstr "Descrizione"
 
-#: metabrainz/oauth/forms.py:64
+#: metabrainz/oauth/forms.py:63
 msgid "Client description field is empty."
 msgstr "Il campo \"descrizione client\" è vuoto."
 
-#: metabrainz/oauth/forms.py:65
+#: metabrainz/oauth/forms.py:64
 msgid "Client description needs to be at least 3 characters long."
 msgstr "La descrizione client deve contenere almeno 3 caratteri."
 
-#: metabrainz/oauth/forms.py:66
+#: metabrainz/oauth/forms.py:65
 msgid "Client description needs to be at most 512 characters long."
 msgstr "La descrizione client deve contenere al massimo 512 caratteri."
 
-#: frontend/js/src/forms/CreateApplication.tsx:122 metabrainz/oauth/forms.py:68
+#: frontend/js/src/forms/CreateApplication.tsx:122 metabrainz/oauth/forms.py:67
 msgid "Homepage"
 msgstr "Sito web"
 
-#: metabrainz/oauth/forms.py:69
+#: metabrainz/oauth/forms.py:68
 msgid "Homepage field is empty."
 msgstr "Il campo \"sito web\" è vuoto."
 
-#: metabrainz/oauth/forms.py:70
+#: metabrainz/oauth/forms.py:69
 msgid "Homepage is not a valid URI."
 msgstr "Il sito web non contiene un URI valido."
 
-#: metabrainz/oauth/forms.py:71
+#: metabrainz/oauth/forms.py:70
 msgid "Homepage URL must use http or https"
 msgstr "L'URL del sito web deve usare http o https"
 
-#: metabrainz/oauth/forms.py:73
+#: metabrainz/oauth/forms.py:72
 msgid "Authorization callback URL"
 msgstr "URL di callback dell'autorizzazione"
 
-#: metabrainz/oauth/forms.py:74
+#: metabrainz/oauth/forms.py:73
 msgid "Authorization callback URL field is empty."
 msgstr "Il campo \"URL di callback dell'autorizzazione\" è vuoto."
 
-#: metabrainz/oauth/forms.py:75
+#: metabrainz/oauth/forms.py:74
 msgid "Authorization callback URL is invalid."
 msgstr "L'URL di callback dell'autorizzazione non è valido."
 
-#: metabrainz/oauth/forms.py:76
+#: metabrainz/oauth/forms.py:75
 msgid "Authorization callback URL must use http or https."
 msgstr "L'URL di callback dell'autorizzazione deve usare http o https."
 
-#: metabrainz/oauth/forms.py:81 metabrainz/oauth/forms.py:85
+#: metabrainz/oauth/forms.py:80 metabrainz/oauth/forms.py:84
 msgid "Confirm"
 msgstr "Conferma"
+
+#: metabrainz/oauth/scopes.py:15
+msgid "View your public account information"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:16
+msgid "View your email address"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:17
+msgid "View and modify your private tags"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:18
+msgid "View and modify your private ratings"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:19
+msgid "View and modify your private collections"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:20
+msgid "Submit new ISRCs to the database"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:21
+msgid "Submit new barcodes to the database"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:22
+msgid "Sign you in and view your unique user id"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:23
+msgid "Submit listens to ListenBrainz."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:24
+msgid "Create and modify CritiqueBrainz reviews."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:25
+msgid "Submit and delete votes on CritiqueBrainz reviews."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:26
+msgid "Modify profile info and delete profile on CritiqueBrainz."
+msgstr ""
 
 #: metabrainz/payments/views.py:164
 msgid ""
@@ -189,16 +273,17 @@ msgid ""
 "donation appears in the list due to processing delays."
 msgstr ""
 "Grazie per aver fatto una donazione alla MetaBrainz Foundation. Il tuo "
-"sostegno è molto apprezzato! È possibile che ci voglia un po' di tempo prima "
-"che la tua donazione appaia nell'elenco a causa dei tempi di elaborazione."
+"sostegno è molto apprezzato! È possibile che ci voglia un po' di tempo "
+"prima che la tua donazione appaia nell'elenco a causa dei tempi di "
+"elaborazione."
 
 #: metabrainz/payments/views.py:171
 msgid ""
 "Thank you for making a payment to the MetaBrainz Foundation. Your support"
 " is greatly appreciated!"
 msgstr ""
-"Grazie per aver fatto un pagamento alla MetaBrainz Foundation. Apprezziamo "
-"molto il tuo sostegno!"
+"Grazie per aver fatto un pagamento alla MetaBrainz Foundation. "
+"Apprezziamo molto il tuo sostegno!"
 
 #: metabrainz/payments/views.py:182
 msgid ""
@@ -233,168 +318,175 @@ msgid "Requested annual report was not found."
 msgstr "Il rapporto annuale richiesto non è stato trovato."
 
 #: frontend/js/src/forms/ProfileEdit.tsx:30
-#: frontend/js/src/forms/SignupCommercial.tsx:139
+#: frontend/js/src/forms/SignupCommercial.tsx:144
 #: frontend/js/src/forms/SignupNonCommercial.tsx:70
-#: metabrainz/supporter/forms.py:13
+#: metabrainz/supporter/forms.py:15
 msgid "Contact name is required!"
 msgstr "È necessario fornire un nome di contatto!"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:437
+#: frontend/js/src/forms/SignupCommercial.tsx:441
 #: frontend/js/src/forms/SignupNonCommercial.tsx:264
-#: metabrainz/supporter/forms.py:15
+#: metabrainz/supporter/forms.py:17
 msgid ""
 "Can you please tell us more about the project in which you'd like to use "
 "our data? Do you plan to self host the data or use our APIs?"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:137
+#: frontend/js/src/forms/SignupCommercial.tsx:142
 #: frontend/js/src/forms/SignupNonCommercial.tsx:68
-#: metabrainz/supporter/forms.py:17
+#: metabrainz/supporter/forms.py:19
 msgid "Please, tell us how you (will) use our data."
 msgstr "Facci sapere come usi o userai i nostri dati."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:138
+#: frontend/js/src/forms/SignupCommercial.tsx:143
 #: frontend/js/src/forms/SignupNonCommercial.tsx:69
-#: metabrainz/supporter/forms.py:18
+#: metabrainz/supporter/forms.py:20
 msgid "Please, limit usage description to 500 characters."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:141
-#: frontend/js/src/forms/SignupCommercial.tsx:142
+#: frontend/js/src/forms/SignupCommercial.tsx:146
+#: frontend/js/src/forms/SignupCommercial.tsx:147
 #: frontend/js/src/forms/SignupNonCommercial.tsx:72
 #: frontend/js/src/forms/SignupNonCommercial.tsx:73
-#: frontend/js/src/forms/SignupUser.tsx:84
-#: frontend/js/src/forms/SignupUser.tsx:85 metabrainz/supporter/forms.py:21
-#: metabrainz/user/forms.py:38
+#: frontend/js/src/forms/SignupUser.tsx:90
+#: frontend/js/src/forms/SignupUser.tsx:91 metabrainz/supporter/forms.py:23
+#: metabrainz/user/forms.py:45
 msgid "You need to accept the agreement!"
 msgstr "È necessario accettare l'accordo!"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:342
-#: metabrainz/supporter/forms.py:27
+#: frontend/js/src/forms/SignupCommercial.tsx:347
+#: metabrainz/supporter/forms.py:29
 msgid "Organization name"
 msgstr "Nome dell'organizzazione"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:113
-#: metabrainz/supporter/forms.py:28
+#: frontend/js/src/forms/SignupCommercial.tsx:115
+#: metabrainz/supporter/forms.py:30
 msgid "You need to specify the name of your organization."
 msgstr "È necessario specificare il nome della tua organizzazione."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:373
-#: metabrainz/supporter/forms.py:30
+#: frontend/js/src/forms/SignupCommercial.tsx:378
+#: metabrainz/supporter/forms.py:32
 msgid "Organization description"
 msgstr "Descrizione organizzazione"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:116
-#: metabrainz/supporter/forms.py:31
+#: frontend/js/src/forms/SignupCommercial.tsx:118
+#: metabrainz/supporter/forms.py:33
 msgid "You need to provide description of your organization."
 msgstr "È necessario fornire una descrizione della tua organizzazione."
 
 #: frontend/js/src/Profile.tsx:278
-#: frontend/js/src/forms/SignupCommercial.tsx:396
-#: metabrainz/supporter/forms.py:34
+#: frontend/js/src/forms/SignupCommercial.tsx:401
+#: metabrainz/supporter/forms.py:36
 msgid "Website URL"
 msgstr "URL sito web"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:119
-#: metabrainz/supporter/forms.py:35
-msgid "You need to specify website of the organization."
-msgstr "È necessario specificare il sito web dell'organizzazione."
+#: frontend/js/src/forms/SignupCommercial.tsx:121
+#: frontend/js/src/forms/SignupCommercial.tsx:123
+#: metabrainz/supporter/forms.py:38 metabrainz/supporter/forms.py:42
+msgid "Website URL must be a valid URL."
+msgstr ""
 
-#: metabrainz/supporter/forms.py:37
+#: metabrainz/supporter/forms.py:45
 msgid "Logo image URL"
 msgstr "URL immagine logo"
 
 #: frontend/js/src/Profile.tsx:284
-#: frontend/js/src/forms/SignupCommercial.tsx:418
-#: metabrainz/supporter/forms.py:38
+#: frontend/js/src/forms/SignupCommercial.tsx:422
+#: metabrainz/supporter/forms.py:46
 msgid "API URL"
 msgstr "URL API"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:457
-#: metabrainz/supporter/forms.py:40
+#: frontend/js/src/forms/SignupCommercial.tsx:461
+#: metabrainz/supporter/forms.py:48
 msgid "Street"
 msgstr "Indirizzo"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:123
-#: metabrainz/supporter/forms.py:41
+#: frontend/js/src/forms/SignupCommercial.tsx:128
+#: metabrainz/supporter/forms.py:49
 msgid "You need to specify street."
 msgstr "È necessario specificare l'indirizzo."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:465
-#: metabrainz/supporter/forms.py:43
+#: frontend/js/src/forms/SignupCommercial.tsx:469
+#: metabrainz/supporter/forms.py:51
 msgid "City"
 msgstr "Comune"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:124
-#: metabrainz/supporter/forms.py:44
+#: frontend/js/src/forms/SignupCommercial.tsx:129
+#: metabrainz/supporter/forms.py:52
 msgid "You need to specify city."
 msgstr "È necessario specificare il comune."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:473
-#: metabrainz/supporter/forms.py:46
+#: frontend/js/src/forms/SignupCommercial.tsx:477
+#: metabrainz/supporter/forms.py:54
 msgid "State / Province"
 msgstr "Regione / Provincia"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:126
-#: metabrainz/supporter/forms.py:47
+#: frontend/js/src/forms/SignupCommercial.tsx:131
+#: metabrainz/supporter/forms.py:55
 msgid "You need to specify state/province."
 msgstr "È necessario specificare la regione/provincia."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:481
-#: metabrainz/supporter/forms.py:49
+#: frontend/js/src/forms/SignupCommercial.tsx:485
+#: metabrainz/supporter/forms.py:57
 msgid "Postcode"
 msgstr "Codice postale"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:128
-#: metabrainz/supporter/forms.py:50
+#: frontend/js/src/forms/SignupCommercial.tsx:133
+#: metabrainz/supporter/forms.py:58
 msgid "You need to specify postcode."
 msgstr "È necessario specificare il codice postale."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:489
-#: metabrainz/supporter/forms.py:52
+#: frontend/js/src/forms/SignupCommercial.tsx:493
+#: metabrainz/supporter/forms.py:60
 msgid "Country"
 msgstr "Stato"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:129
-#: metabrainz/supporter/forms.py:53
+#: frontend/js/src/forms/SignupCommercial.tsx:134
+#: metabrainz/supporter/forms.py:61
 msgid "You need to specify country."
 msgstr "È necessario specificare lo stato."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:132
-#: metabrainz/supporter/forms.py:64
+#: frontend/js/src/forms/SignupCommercial.tsx:137
+#: metabrainz/supporter/forms.py:72
 msgid ""
 "Custom amount must be more than threshold amount for selected tier or "
 "equal to it!"
 msgstr ""
-"L'importo personalizzato deve essere maggiore o uguale all'importo minimo "
-"per il livello selezionato!"
+"L'importo personalizzato deve essere maggiore o uguale all'importo minimo"
+" per il livello selezionato!"
 
-#: metabrainz/supporter/views.py:46 metabrainz/supporter/views.py:119
-#: metabrainz/supporter/views.py:220
+#: metabrainz/supporter/views.py:54
+msgid ""
+"The verification email could not be sent. Please request a new one from "
+"your profile."
+msgstr ""
+
+#: metabrainz/supporter/views.py:85 metabrainz/supporter/views.py:158
+#: metabrainz/supporter/views.py:260
 msgid "You are already a supporter."
 msgstr ""
 
-#: metabrainz/supporter/views.py:61
+#: metabrainz/supporter/views.py:100
 msgid "Can't find tier with a specified ID."
 msgstr "Non è stato possibile trovare un livello con l'ID fornito."
 
-#: metabrainz/supporter/views.py:127
+#: metabrainz/supporter/views.py:166
 msgid "You need to choose support tier before signing up!"
 msgstr "È necessario scegliere un livello sostenitore prima di registrarsi!"
 
-#: metabrainz/supporter/views.py:137
+#: metabrainz/supporter/views.py:176
 msgid "You need to choose existing tier before signing up!"
 msgstr "È necessario scegliere un livello esistente prima di registrarsi!"
 
-#: metabrainz/supporter/views.py:164
+#: metabrainz/supporter/views.py:204
 msgid ""
 "Thanks for becoming a supporter! Your application will be reviewed soon. "
 "We will send you updates via email."
 msgstr ""
-"Grazie per essere diventato un sostenitore! La tua richiesta sarà esaminata "
-"presto. Ti aggiorneremo via email."
+"Grazie per essere diventato un sostenitore! La tua richiesta sarà "
+"esaminata presto. Ti aggiorneremo via email."
 
-#: metabrainz/supporter/views.py:187
+#: metabrainz/supporter/views.py:228
 msgid ""
 "Thanks for signing up! Your application will be reviewed soon. We will "
 "send you updates via email."
@@ -402,15 +494,15 @@ msgstr ""
 "Grazie per esserti registrato! La tua richiesta sarà esaminata presto. Ti"
 " manderemo aggiornamenti per email."
 
-#: metabrainz/supporter/views.py:248
+#: metabrainz/supporter/views.py:288
 msgid "Thanks for becoming a supporter!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:274
+#: metabrainz/supporter/views.py:312
 msgid "Thanks for signing up! Please check your inbox to complete verification."
 msgstr ""
 
-#: metabrainz/supporter/views.py:302
+#: metabrainz/supporter/views.py:340
 msgid "Can't generate new token unless account is active."
 msgstr "Impossibile generare un nuovo token se l'account non è attivo."
 
@@ -444,7 +536,7 @@ msgstr "Negozio"
 msgid "Policies"
 msgstr ""
 
-#: metabrainz/templates/base.html:55 metabrainz/templates/index/gdpr.html:178
+#: metabrainz/templates/base.html:55
 #: metabrainz/templates/index/social-contract.html:3
 #: metabrainz/templates/index/social-contract.html:6
 #: metabrainz/templates/navbar.html:34
@@ -454,14 +546,15 @@ msgstr "Contratto sociale"
 #: metabrainz/templates/base.html:56
 #: metabrainz/templates/index/code-of-conduct.html:3
 #: metabrainz/templates/index/code-of-conduct.html:16
-#: metabrainz/templates/index/gdpr.html:181 metabrainz/templates/navbar.html:35
+#: metabrainz/templates/navbar.html:35
 msgid "Code of Conduct"
 msgstr "Codice di condotta"
 
+#: frontend/js/src/PrivacySummary.tsx:11
 #: frontend/js/src/forms/ConditionsModal.tsx:21
-#: metabrainz/templates/base.html:57 metabrainz/templates/index/gdpr.html:184
-#: metabrainz/templates/index/privacy.html:6
+#: metabrainz/templates/base.html:57 metabrainz/templates/index/privacy.html:6
 #: metabrainz/templates/navbar.html:36
+#: metabrainz/templates/users/privacy-summary.html:3
 msgid "Privacy Policy"
 msgstr "Informativa sulla privacy"
 
@@ -494,10 +587,7 @@ msgstr "Sponsor"
 msgid "Supporters"
 msgstr "Sostenitori"
 
-#: frontend/js/src/forms/LoginUser.tsx:103
-#: frontend/js/src/forms/SignupCommercial.tsx:574
-#: frontend/js/src/forms/SignupNonCommercial.tsx:339
-#: frontend/js/src/forms/SignupUser.tsx:232 metabrainz/templates/base.html:73
+#: frontend/js/src/forms/LoginUser.tsx:103 metabrainz/templates/base.html:73
 #: metabrainz/templates/navbar.html:66 metabrainz/templates/users/login.html:3
 msgid "Sign in"
 msgstr "Accedi"
@@ -519,26 +609,26 @@ msgid "Contact us"
 msgstr "Contattaci"
 
 #: metabrainz/templates/base.html:85
-#: metabrainz/templates/index/contact.html:105
+#: metabrainz/templates/index/contact.html:106
 msgid "Blog"
 msgstr "Blog"
 
-#: metabrainz/templates/base.html:86 metabrainz/templates/index/contact.html:90
+#: metabrainz/templates/base.html:86 metabrainz/templates/index/contact.html:91
 msgid "Chat"
 msgstr "Chat"
 
 #: metabrainz/templates/base.html:87
-#: metabrainz/templates/index/contact.html:106
+#: metabrainz/templates/index/contact.html:107
 msgid "Mastodon"
 msgstr "Mastodon"
 
 #: metabrainz/templates/base.html:88
-#: metabrainz/templates/index/contact.html:107
+#: metabrainz/templates/index/contact.html:108
 msgid "Bluesky"
 msgstr "Bluesky"
 
 #: metabrainz/templates/base.html:89
-#: metabrainz/templates/index/contact.html:108
+#: metabrainz/templates/index/contact.html:109
 msgid "Instagram"
 msgstr ""
 
@@ -594,15 +684,14 @@ msgstr "Rapporti finanziari"
 msgid "Donate"
 msgstr "Fai una donazione"
 
-#: frontend/js/src/forms/LoginUser.tsx:110
-#: frontend/js/src/forms/SignupCommercial.tsx:175
-#: frontend/js/src/forms/SignupCommercial.tsx:555
+#: frontend/js/src/forms/SignupCommercial.tsx:180
+#: frontend/js/src/forms/SignupCommercial.tsx:559
 #: frontend/js/src/forms/SignupNonCommercial.tsx:106
 #: frontend/js/src/forms/SignupNonCommercial.tsx:319
 #: metabrainz/templates/navbar.html:65
-#: metabrainz/templates/supporters/account-type.html:51
-#: metabrainz/templates/supporters/account-type.html:93
-#: metabrainz/templates/supporters/account-type.html:144
+#: metabrainz/templates/supporters/account-type.html:47
+#: metabrainz/templates/supporters/account-type.html:84
+#: metabrainz/templates/supporters/account-type.html:130
 #: metabrainz/templates/users/signup.html:3
 msgid "Sign up"
 msgstr "Registrati"
@@ -780,9 +869,9 @@ msgid ""
 "href=\"%(internet_ecosys_url)s\">Internet &amp; Digital Ecosystem "
 "Alliance</a>"
 msgstr ""
-"Direttore &amp; segretario Nick Ashton-Hart, direttore esecutivo della <a "
-"href=\"%(internet_ecosys_url)s\">Internet &amp; Digital Ecosystem Alliance</"
-"a>"
+"Direttore &amp; segretario Nick Ashton-Hart, direttore esecutivo della <a"
+" href=\"%(internet_ecosys_url)s\">Internet &amp; Digital Ecosystem "
+"Alliance</a>"
 
 #: metabrainz/templates/index/about.html:54
 #, python-format
@@ -795,8 +884,8 @@ msgid ""
 "Director <a href=\"%(matthew_url)s\">Matthew Hawn</a> of <a "
 "href=\"%(compass_url)s\">Compass, Map & Key</a>"
 msgstr ""
-"Direttore <a href=\"%(matthew_url)s\">Matthew Hawn</a> di <a href=\"%"
-"(compass_url)s\">Compass, Map & Key</a>"
+"Direttore <a href=\"%(matthew_url)s\">Matthew Hawn</a> di <a "
+"href=\"%(compass_url)s\">Compass, Map & Key</a>"
 
 #: metabrainz/templates/index/about.html:56
 #, python-format
@@ -813,8 +902,8 @@ msgid ""
 "Interim Executive Director <a href=\"%(reo_url)s\">Nicolás Tamargo</a> of"
 " the MetaBrainz Foundation"
 msgstr ""
-"Direttore esecutivo ad interim <a href=\"%(reo_url)s\">Nicolás Tamargo</a> "
-"della MetaBrainz Foundation"
+"Direttore esecutivo ad interim <a href=\"%(reo_url)s\">Nicolás "
+"Tamargo</a> della MetaBrainz Foundation"
 
 #: metabrainz/templates/index/about.html:58
 #, python-format
@@ -822,8 +911,8 @@ msgid ""
 "Director <a href=\"%(hazel_url)s\">Hazel Savage</a> of <a "
 "href=\"%(leeds_url)s\">Leeds Angels</a>"
 msgstr ""
-"Direttrice <a href=\"%(hazel_url)s\">Hazel Savage</a> di <a href=\"%"
-"(leeds_url)s\">Leeds Angels</a>"
+"Direttrice <a href=\"%(hazel_url)s\">Hazel Savage</a> di <a "
+"href=\"%(leeds_url)s\">Leeds Angels</a>"
 
 #: metabrainz/templates/index/about.html:62
 msgid "Advisor"
@@ -930,7 +1019,8 @@ msgstr "Ottimo!!"
 #: metabrainz/templates/index/bad-customers.html:54
 msgid "There are currently no not-so-favorite commercial data supporters!"
 msgstr ""
-"Al momento non ci sono sostenitori commerciali di dati non proprio preferiti!"
+"Al momento non ci sono sostenitori commerciali di dati non proprio "
+"preferiti!"
 
 #: metabrainz/templates/index/bad-customers.html:56
 msgid ""
@@ -946,8 +1036,430 @@ msgstr ""
 msgid "Introduction"
 msgstr ""
 
-#: metabrainz/templates/index/conflict-policy.html:55
+#: metabrainz/templates/index/conflict-policy.html:17
+msgid ""
+"Conflicts between people arise in open source projects constantly and the"
+" projects by the \n"
+"    MetaBrainz Foundation are no different. This policy aims to establish"
+" a clear and unambiguous \n"
+"    policy for reporting and addressing conflicts in our community. In "
+"this policy we aim to \n"
+"    establish a fair practice that balances the need for confidentiality "
+"and our desire for \n"
+"    transparency in our operations."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:25
+#, python-format
+msgid ""
+"Before you continue to read this policy, we encourage you to review our "
+"existing community policies \n"
+"    including our <a href=\"%(social_contract_url)s\">Social "
+"Contract</a>, \n"
+"    <a href=\"%(code_of_conduct_url)s\">the Code of Conduct</a>, \n"
+"    and our <a href=\"%(privacy_policy_url)s\">Privacy Policy</a>. These "
+"policies establish the norms and rules for \n"
+"    participation in our projects; these policies apply equally to the "
+"contractors of the MetaBrainz \n"
+"    Foundation and any participants in our projects."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:37
+msgid ""
+"This policy divides conflicts into two categories: Private and public. "
+"Private conflicts are conflicts \n"
+"    that involve *confidential* information regarding contributors, "
+"contractors or supporters. Otherwise, any conflicts \n"
+"    that do not involve confidential information are considered to be "
+"public conflicts. For instance, a \n"
+"    conflict between a contractor and the Executive Director (aka BDFL) "
+"that involves contractor pay is \n"
+"    considered a private conflict because pay rates are confidential "
+"information. A public conflict in edit \n"
+"    notes between two editors in our community does not involve "
+"confidential information and therefore should \n"
+"    be considered a public conflict."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:47
+msgid ""
+"When conflicts arise we aim to disclose as much information as possible "
+"about the conflict in a timely \n"
+"    fashion. When conflicts contain confidential matters we will aim to "
+"disclose as much information as \n"
+"    possible, while fully respecting the confidentiality of the people "
+"involved in the conflict. With any \n"
+"    private conflict we will aim to extract the relevant lessons for the "
+"team and community in an effort to \n"
+"    evolve our policies to prevent future conflicts. Should the involved "
+"parties disagree whether a conflict \n"
+"    is private or public, the question about the nature of the conflict "
+"will be presented for the next higher \n"
+"    level in the chain of command to decide. (e.g. if a community member "
+"and the community manager disagree on \n"
+"    a conflict being public or private, the Executive Director shall "
+"decide if the conflict is public or private)."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:58
 msgid "Reporting and Response"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:61
+msgid ""
+"We aim to not have conflict in our community, but we recognize that in "
+"reality conflicts will arise and we \n"
+"    must be prepared to address them in a fair manner. When conflicts "
+"arise, we prefer to have community or team \n"
+"    members resolve the conflicts among themselves, using our existing "
+"policies as guidelines for resolving the \n"
+"    conflict."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:69
+msgid ""
+"If you do not feel comfortable resolving a conflict on your own, you "
+"should feel free to report the conflict to \n"
+"    us. How you address the conflict depends on who is involved in the "
+"conflict and your comfort level. Please see \n"
+"    the detailed sections below on how and with whom to address your "
+"conflict. We aim to address conflicts as soon \n"
+"    as possible in an effort to prevent them from escalating "
+"unnecessarily."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:75
+msgid "Direct conflict resolution"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:78
+msgid ""
+"In direct conflict resolution, the involved parties will attempt to "
+"resolve the conflict themselves without \n"
+"   involving any MetaBrainz Foundation team member. You should aim to use"
+" direct resolution when the conflict does \n"
+"   not involve the violation of one of our policies or if the conflict is"
+" minor."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:84
+#, python-format
+msgid ""
+"For instance, if a user uses a rude tone, is disruptive or flagrantly "
+"ignores our project guidelines, we suggest \n"
+"    that you use direct conflict resolution to resolve the conflict. Some"
+" resources that might give you some suggestions \n"
+"    on how to go about resolving the conflict might be this <a "
+"href=\"%(conflict_resolution_primer_url)s\">\n"
+"    conflict resolution primer</a> and <a "
+"href=\"%(difficult_conversations_url)s\">how to\n"
+"    have difficult conversations at work</a>."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:93
+msgid "Informal reporting"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:96
+msgid ""
+"You may use informal reporting of a conflict if you aim to communicate a "
+"concern or incident without \n"
+"    seeking a corrective outcome. Informal reporting may also be an "
+"option if you have not been personally \n"
+"    victimized, but you’ve witnessed a violation of our policies or where"
+" you wish to maintain confidentiality \n"
+"    throughout the entire reporting process."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:103
+msgid ""
+"For editing in MusicBrainz you may informally report a user using the "
+"“Report this user for bad behavior” \n"
+"    link from the user’s profile. For reporting bad user behavior in "
+"other of our projects, please report them to our \n"
+"    community manager by mailing <span class=\"backemail\">gro.zniarbatem"
+"@reganam-ytinummoc</span> . For conflicts \n"
+"    that involve the community manager, report them by mailing <span "
+"class=\"backemail\">gro.zniarbatem@de</span> ."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:110
+msgid ""
+"Depending the the severity of the issue, repeated informal complaints may"
+" eventually require a formal response \n"
+"    from the MetaBrainz team. If an involved party requires anonymity, "
+"the conflict becomes a private conflict. If at \n"
+"    all possible minor issues should be resolved in a public forum in "
+"order for all people to witness and learn from \n"
+"    the issue at hand."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:116
+msgid "Formal complaint process"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:119
+msgid ""
+"All complaints about conflicts should be submitted via email. To whom a "
+"complaint should be mailed and who will \n"
+"    carry out the investigation will be described in the next section."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:124
+msgid "All complaint submissions to the Foundation should include the following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:128
+msgid ""
+"Contact info, if it is different than the email used to submit the "
+"conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:129
+msgid "Who was involved in the conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:130
+msgid "Where and when the incident happened"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:131
+msgid ""
+"A description of what happened -- ideally with links (e.g. chatlogs, edit"
+" notes) that outlines what \n"
+"         happened so that the persons evaluating the conflict may "
+"understand the issue at hand"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:133
+msgid ""
+"Any related pieces of information that provide more context on the "
+"conflict (e.g. links, screenshots)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:134
+msgid "An indication if this conflict is ongoing or not"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:139
+msgid "The investigation that follows aims to determine:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:143
+msgid "The nature and severity of the incident"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:144
+msgid ""
+"Whether or not the incident is considered a violation of MetaBrainz’ "
+"conduct policies or core values"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:145
+msgid ""
+"The amount of harm experienced by the person who submitted the complaint "
+"and the broader MetaBrainz community \n"
+"         as a result of the incident"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:147
+msgid ""
+"Whether there have been prior complaints against the individual or "
+"individuals reported"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:148
+msgid "Whether the incident is ongoing"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:152
+msgid ""
+"The following potential forms of resolution may apply to any team members"
+" involved in the conflict:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:155
+#: metabrainz/templates/index/conflict-policy.html:168
+msgid "Nothing (if it has been found no violation occurred)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:156
+msgid "Creating a plan to improve the performance"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:157
+msgid "Creating a negative performance evaluation"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:158
+msgid "Mediation, an intervention by a third party to resolve the conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:159
+msgid "Suspension or forced leave"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:160
+msgid "Termination of contract"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:164
+msgid ""
+"The following potential forms of resolution may apply to non team members"
+" involved in the conflict:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:169
+msgid "A reprimand, either public or private"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:170
+msgid "Suspension of the users’ account"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:171
+msgid "Deletion of the users’ account"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:172
+msgid ""
+"Removal of user privileges (e.g. if an auto editor commits a serious "
+"offence, they may lose their auto editor status)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:175
+msgid "Filing a complaint"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:178
+msgid ""
+"NOTE: For complaints not about MetaBrainz staff, please see the "
+"<em>Informal reporting</em> section above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:182
+msgid ""
+"If the complaint does not involve the Executive Director (ED), do the "
+"following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:186
+msgid ""
+"If team member has directly violated conduct policies or engaged in "
+"otherwise harmful behavior, a formal complaint should be filed."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:187
+msgid ""
+"Mail <span class=\"backemail\">gro.zniarbatem@de</span> and include the "
+"complaint information outlined above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:188
+msgid ""
+"You should expect a response within a working day acknowledging the "
+"complaint."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:189
+msgid ""
+"The complaint will be investigated by the ED, member(s) of the board of "
+"directors or a neutral third party."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:190
+msgid ""
+"Once the investigation has been completed, the ED, with the support of "
+"others involved in the investigation will respond. The \n"
+"        ED will respond to incidents no later than 7 working days after a"
+" complaint has been filed with either a resolution or an \n"
+"        explanation of why the process must be extended."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:196
+msgid "If a complaint involves the Executive Director, do the following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:200
+msgid ""
+"If the Executive Director has directly violated conduct policies or "
+"engaged in otherwise harmful behavior, \n"
+"        a formal complaint should be filed with the board of directors."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:202
+msgid ""
+"Mail <span class=\"backemail\">gro.zniarbatem@noituloser-tcilfnoc</span> "
+"and include the complaint information outlined above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:203
+msgid ""
+"You should get a response within 5 working days acknowledging the "
+"complaint."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:204
+msgid ""
+"The complaint will be investigated by the member(s) of the board of "
+"directors, the community manager, a neutral \n"
+"        third party or a combination thereof."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:206
+msgid ""
+"Once the investigation has been completed, the board, with the support of"
+" others involved in the investigation \n"
+"        will respond. The board will aim to respond to incidents no later"
+" than 15 working days after a complaint has been filed \n"
+"        with either a resolution or an explanation of why the process "
+"must be extended."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:211
+msgid "Confidentiality"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:214
+msgid ""
+"Confidentiality is an important aspect of conflict resolution and all of "
+"the conflicts brought to the attention of the foundation \n"
+"    will be evaluated with confidentiality in mind and acted upon "
+"accordingly."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:219
+msgid ""
+"We work hard to make all of the actions of the foundation as transparent "
+"and open as possible. In cases where we cannot \n"
+"    disclose all aspects of a conflict we will disclose that a conflict "
+"is or has occurred and we will attempt to disclose the \n"
+"    appropriate amount of information about the conflict while balancing "
+"the need for confidentiality and our desire to learn \n"
+"    from conflicts so that we as a foundation and community can learn "
+"from these conflicts and improve our policies to avoid the \n"
+"    conflicts in the future."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:227
+msgid ""
+"Any breaches of confidentiality will be treated as severe breaches of our"
+" conduct policies."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:230
+msgid "Retaliation"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:233
+msgid ""
+"We will not allow retaliation for any contractor or volunteer that files "
+"a complaint or is involved in an investigation. If you \n"
+"    believe that you are being treated negatively because of your "
+"involvement in a complaint please report this complaint directly \n"
+"    to the ED at <span class=\"backemail\">gro.zniarbatem@de</span> or "
+"the board at \n"
+"    <span class=\"backemail\">gro.zniarbatem@noituloser-tcilfnoc</span>."
 msgstr ""
 
 #: metabrainz/templates/index/contact.html:3
@@ -974,8 +1486,8 @@ msgstr ""
 "aspetteresti?\n"
 "Puoi segnalare i problemi sul nostro <a href=\"%(bug_tracker_url)s\">bug "
 "tracker</a> o contattarci su IRC o via email.\n"
-"I nostri contatti sono qui sotto. Ricordati di includere dettagli su cosa è "
-"successo, cosa ti aspettavi succedesse\n"
+"I nostri contatti sono qui sotto. Ricordati di includere dettagli su cosa"
+" è successo, cosa ti aspettavi succedesse\n"
 "e l'URL delle pagine interessate."
 
 #: metabrainz/templates/index/contact.html:16
@@ -1055,7 +1567,7 @@ msgstr ""
 msgid ""
 "We are currently evaluating our overall online advertising strategy. We "
 "are evaluating advertising, traffic optimization,\n"
-"    search engine optimization and software monitization technologies. If"
+"    search engine optimization and software monetization technologies. If"
 " you provide these professional services, please provide a detailed\n"
 "    deck of your comprehensive services to the following email address. "
 "<em>Please respect our other non-media teams and do not contact us \n"
@@ -1135,14 +1647,11 @@ msgstr "Forum"
 #, python-format
 msgid ""
 "Please come ask your questions at our <a "
-"href=\"%(forums_url)s\">forums</a>! We would love to\n"
-"    answer any questions you may have."
+"href=\"%(forums_url)s\">forums</a>!\n"
+"    The community and the team will be more than happy to help you."
 msgstr ""
-"Vieni a porre le tue domande sui nostri <a "
-"href=\"%(forums_url)s\">forum</a>! Saremo lieti di rispondere a qualsiasi"
-" domanda tu possa avere."
 
-#: metabrainz/templates/index/contact.html:92
+#: metabrainz/templates/index/contact.html:93
 #, python-format
 msgid ""
 "The MetaBrainz/MusicBrainz/ListenBrainz team and community hang out\n"
@@ -1152,15 +1661,15 @@ msgid ""
 "    <a href=\"%(chatlogs_url)s\">chat log archives</a>."
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:101
+#: metabrainz/templates/index/contact.html:102
 msgid "Social media"
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:103
+#: metabrainz/templates/index/contact.html:104
 msgid "You can follow us on these social channels:"
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:112
+#: metabrainz/templates/index/contact.html:113
 msgid "Mailing address"
 msgstr "Indirizzo postale"
 
@@ -1173,33 +1682,349 @@ msgstr ""
 msgid "GDPR Compliance Statement"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:37
+#: metabrainz/templates/index/gdpr.html:10
+msgid ""
+"The General Data Protection Regulation is a complex EU regulation that "
+"stipulates many points for protecting private data of\n"
+"    users on the Internet. Even though this is an EU regulation, it has a"
+" worldwide impact due to the nature of the Internet.\n"
+"    The MetaBrainz Foundation with its collection of projects is also "
+"affected by this regulation. We’ve been learning and adapting\n"
+"    our sites to be compliant with the GDPR – sadly this regulation isn’t"
+" entirely black and white and there is an incredible\n"
+"    amount of room left for interpretation of these rules."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:17
+msgid ""
+"The good news is that this regulation is roughly in line with our "
+"established practices: We’ve always held private information\n"
+"    in a high regard and applied the sort of rules to ourselves as we "
+"wish to have our own private data treated. Luckily, this\n"
+"    makes our compliance effort considerably easier. We’ve made two "
+"significant changes to how we treat your data and also adopted\n"
+"    terminology as used in the GDPR in order to use the same languages "
+"that many other sites are now adopting. Please keep reading\n"
+"    to find out the exact details of what we are doing to comply."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:24
+#, python-format
+msgid ""
+"However, we do ask for your compassion and help in our process of "
+"complying with the GDPR. As we already mentioned, the GDPR is\n"
+"    a complex set of rules that are not fully clarified yet. We’ve taken "
+"action on the steps that are clear to us and we’re following\n"
+"    ongoing conversations on points that are in gray zones or unclear to "
+"us. We’ve made our best initial effort on compliance and\n"
+"    promise to keep working on it as the picture becomes more clear. If "
+"you believe that we could improve our compliance, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a> and let us know what we "
+"can do to improve. It would also help us if you\n"
+"    could provide concrete discussion or examples to help us understand "
+"and take action on your suggestion."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:33
+msgid ""
+"Finally, below are the key sections of the GDPR as we understand them and"
+" how they affect your data in our ecosystem. Where\n"
+"    possible, we provide links for deeper understanding, links for you to"
+" examine our relevant code and links to tickets to follow\n"
+"    the process of improving our compliance."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:38
 msgid "Right to be forgotten"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:77
+#: metabrainz/templates/index/gdpr.html:41
+msgid ""
+"Summary: <i>Provide the user with the ability to remove their private "
+"data from our services</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:44
+msgid ""
+"The most important aspect of the right to be forgotten is the ability to "
+"delete your account. Once you request for us to delete\n"
+"    your account, we will remove any personally identifying information "
+"you may have provided us from your account (name, email\n"
+"    address, gender, biography, URL, etc.). The visible name on your "
+"account will be changed to “Deleted User #####” and effectively\n"
+"    the account will no longer be identifiable as your account."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:50
+msgid ""
+"However, given the nature of our projects where we work on collaborative "
+"databases, your contributions that are not personally\n"
+"    identifying are valuable assets to our database and these "
+"contributions will not be removed from our databases. But we will\n"
+"    ensure that these contributions no longer contain personally "
+"identifying data."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:55
+#, python-format
+msgid ""
+"Our process of automatically deleting your accounts across the MetaBrainz"
+" ecosystem is not complete yet (see below for a set of\n"
+"    tickets where you can track our progress). If you would like to "
+"delete your accounts in the MetaBrainz ecosystem or mark a\n"
+"    donation that is currently public as a private donation, please <a "
+"href=\"%(contact_url)s\">contact us</a>\n"
+"    and we will address your request as soon as possible."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:62
+#: metabrainz/templates/index/gdpr.html:182
+msgid "Links:"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:66
+#, python-format
+msgid ""
+"<a href=\"%(editor_deletion_doc_url)s\">How we delete accounts\n"
+"       in MusicBrainz</a> (warning, geek content ahead!)"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:70
+msgid ""
+"Implement sitewide user account deletion in\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/MBS-9680\">MusicBrainz</a>,"
+"\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/AB-337\">AcousticBrainz</a>,"
+"\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/BB-260\">BookBrainz</a>,\n"
+"         <a href=\"https://tickets.metabrainz.org/browse/MEB-103\">the "
+"MetaBrainz Site</a>,\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/LB-354\">ListenBrainz</a>, "
+"and\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/CB-307\">CritiqueBrainz</a>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:80
 msgid "Restriction of processing"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:110
+#: metabrainz/templates/index/gdpr.html:83
+msgid ""
+"Summary: <i>To allow the user to control how their personally identifying"
+" data is being used.</i>"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:86
+msgid ""
+"Except for the ListenBrainz and AcousticBrainz projects, we do not "
+"process personally identifying data. Any personally\n"
+"    identifying data that our projects store is for the purpose of being "
+"able to contact you about your contributions to our database\n"
+"    (email address) or for voluntarily showing information about you to "
+"other users (biography, homepage, location, etc)."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:91
+#, python-format
+msgid ""
+"The ListenBrainz project differs in that the Listens (metadata about what"
+" music you have listened to) are stored on our servers\n"
+"    and <a href=\"%(listenbrainz_data_url)s\">made available to the "
+"public</a>. We believe Listens to be personally identifying\n"
+"    data and furthermore, we have goals of creating open source "
+"recommendation engines with this data, which involves processing the\n"
+"    user’s data. These two points are fundamental goals of the "
+"ListenBrainz project and we do not see a reasonable way to reach another"
+"\n"
+"    compromise position."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:99
+msgid ""
+"Because of this, we are going to require users to either acknowledge that"
+" we may process their Listen data or alternatively to\n"
+"    delete their account, including all of their Listens. Please note "
+"that if you decide to delete your ListenBrainz account, it may\n"
+"    take up to two weeks for all of your listens to no longer be included"
+" in our efforts to build a recommendation engine."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:104
+msgid ""
+"We have always made it clear that the data in ListenBrainz was to be "
+"public and that we plan to build new tools with your data, so\n"
+"    this should not come as a surprise to our users."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:108
+msgid ""
+"The AcousticBrainz project does not track who submits data to the "
+"database. If you create an account and use our data creation\n"
+"    tools (e.g. create a dataset or participate in a challenge) then we "
+"link your participation and the things that you create to\n"
+"    your account. If you choose to delete your account then we keep the "
+"non personally identifying data that you create, but anonymize\n"
+"    it so that it cannot be linked back to you."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:114
 msgid "Right to data portability / exporting your data"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:150
+#: metabrainz/templates/index/gdpr.html:117
+msgid ""
+"Summary: <i>You have the right to access/download the data we store about"
+" you</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:120
+msgid ""
+"Except for the ListenBrainz and AcousticBrainz projects, we do not store "
+"personally identifying data beyond the\n"
+"    information that is available in your public profile on each of our "
+"projects. Since this data is plainly available in your\n"
+"    profile we do not provide a means for you to export this data."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:125
+msgid "There are the following exceptions to this:"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:129
+msgid ""
+"<b>IP addresses</b>: If you visit one of our sites the IP address of your"
+" computer is stored in our web logs for 7 days\n"
+"        before our servers automatically delete them. This data is almost"
+" never used by anyone: the only time we look at the\n"
+"        IP addresses is if our sites are adversely impacted by the "
+"actions of some unknown users. In that case, we may investigate\n"
+"        the logs to identify the IP address that needs to be blocked in "
+"order to restore the stability of our service.\n"
+"        This data is not available to anyone but the contractors of the "
+"MetaBrainz Foundation and is not available to download\n"
+"        to anyone at all."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:137
+#, python-format
+msgid ""
+"<b>ListenBrainz Listen data</b>: Users may <a "
+"href=\"%(listenbrainz_export_url)s\">export their ListenBrainz Listen\n"
+"        data</a> directly from the site. The user Listen data is also "
+"included in the <a href=\"%(listenbrainz_data_url)s\">ListenBrainz\n"
+"        data dumps</a> that are available for public download."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:146
+msgid ""
+"All of the non personally identifying data, such as your metadata "
+"contributions, are publicly visible, available for download\n"
+"    and available via the project APIs. For details about this data, "
+"downloads and APIs please check the documentation for the\n"
+"    respective projects you are interested in."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:151
+#, python-format
+msgid ""
+"Anyone wishing to get a list of financial donations they have made to the"
+" MetaBrainz Foundation, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a> and provide your "
+"MusicBrainz editor name so that we can look up\n"
+"    your donations."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:157
 msgid "Right to rectification"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:165
+#: metabrainz/templates/index/gdpr.html:160
+msgid "Summary: <i>You have the right to correct your data</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:163
+msgid ""
+"All of our projects allow their users to update their personally "
+"identifying information in their profiles. Furthermore, most\n"
+"    of our projects allow the editing of their own metadata "
+"contributions. If you find that some of your data is incorrect, please\n"
+"    feel free to edit the data since we provide the tools to do so."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:168
+#, python-format
+msgid ""
+"If anyone who has made a financial donation to the MetaBrainz Foundation "
+"would like to make their donation private, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:173
 msgid "Right to be informed"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:188
+#: metabrainz/templates/index/gdpr.html:175
+msgid ""
+"Summary: <i>You have the right to be informed about how we use your data "
+"in plain English</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:178
+msgid ""
+"Our privacy policy, as well as other policies, have always been written "
+"by humans for human consumption. We abhor legalese and\n"
+"    not speaking in direct terms."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:186
+msgid "Social contract"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:189
+msgid "Code of conduct"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:192
+msgid "Privacy policy"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:196
 msgid "Right to access"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:198
-#: metabrainz/templates/index/privacy.html:166
+#: metabrainz/templates/index/gdpr.html:199
+msgid ""
+"Summary: <i>You have the right to access the data that we collect about "
+"you</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:202
+msgid ""
+"All of our projects make all of the data we collect on your behalf, "
+"privately identifying or not, available to you. The\n"
+"    only exception to this are the IP addresses we store for 7 days – see"
+" above for details."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:206
+#: metabrainz/templates/index/privacy.html:168
 msgid "Privacy/GDPR Representative"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:209
+#, python-format
+msgid ""
+"If you have any questions about our privacy policy, please <a "
+"href=\"%(contact_url)s\">contact us</a>. To report\n"
+"   any privacy problems, violations or leaks, our GDPR representative is "
+"our Interim Executive Director Nicolás Tamargo and for\n"
+"   privacy issues contact him at <strong><a "
+"href=\"mailto:gdpr@metabrainz.org\">gdpr@metabrainz.org</a></strong>."
 msgstr ""
 
 #: metabrainz/templates/index/index.html:6
@@ -1214,8 +2039,8 @@ msgid ""
 "Creative\n"
 "        Commons licenses."
 msgstr ""
-"La MetaBrainz Foundation è una non-profit che crede nell'accesso libero e "
-"aperto ai dati.\n"
+"La MetaBrainz Foundation è una non-profit che crede nell'accesso libero e"
+" aperto ai dati.\n"
 "È stata creata per costruire database mantenuti dalla comunità\n"
 "e renderli disponibili nel dominio pubblico\n"
 "o sotto licenze Creative Commons."
@@ -1236,17 +2061,18 @@ msgid ""
 "        that our data can be as comprehensive as possible."
 msgstr ""
 "I nostri dati sono raccolti perlopiù da volontari\n"
-"e verificati attraverso una revisione paritaria per assicurarne la coerenza "
-"e correttezza.\n"
-"Tutti gli <a href=\"%(account_type_url)s\">usi non commerciali</a> di questi "
-"dati sono liberi,\n"
+"e verificati attraverso una revisione paritaria per assicurarne la "
+"coerenza e correttezza.\n"
+"Tutti gli <a href=\"%(account_type_url)s\">usi non commerciali</a> di "
+"questi dati sono liberi,\n"
 "ma ai <a href=\"%(account_type_url)s\">sostenitori commerciali</a> è "
 "richiesto\n"
-"di <a href=\"%(account_type_url)s\">sostenerci</a> per aiutare a finanziare "
-"il progetto.\n"
+"di <a href=\"%(account_type_url)s\">sostenerci</a> per aiutare a "
+"finanziare il progetto.\n"
 "Incoraggiamo tutti gli utenti a contribuire al processo di raccolta dei "
 "dati\n"
-"in modo da assicurare che i nostri dati siano quanto più completi possibile."
+"in modo da assicurare che i nostri dati siano quanto più completi "
+"possibile."
 
 #: metabrainz/templates/index/index.html:38
 msgid ""
@@ -1280,8 +2106,8 @@ msgstr "Un registro aperto di abitudini di ascolto degli utenti"
 #: metabrainz/templates/index/index.html:73
 msgid "A repository for Creative Commons licensed music and book reviews"
 msgstr ""
-"Un repository di recensioni musicali e letterarie rilasciate sotto licenza "
-"Creative Commons"
+"Un repository di recensioni musicali e letterarie rilasciate sotto "
+"licenza Creative Commons"
 
 #: metabrainz/templates/index/index.html:81
 msgid "A repository of music cover art that is freely and easily accessible"
@@ -1311,14 +2137,15 @@ msgid ""
 "supporters</a>\n"
 "        who make use of our data sets."
 msgstr ""
-"La MetaBrainz Foundation crede nelle <a href=\"%(financial_reports_url)s\">"
-"finanze trasparenti</a>\n"
-"ed è sostenuta da <a href=\"%(donations_url)s\">donazioni di utenti finali</"
-"a>\n"
-"e da diversi <a href=\"%(sponsors_url)s\">sponsor</a> che forniscono fondi\n"
+"La MetaBrainz Foundation crede nelle <a "
+"href=\"%(financial_reports_url)s\">finanze trasparenti</a>\n"
+"ed è sostenuta da <a href=\"%(donations_url)s\">donazioni di utenti "
+"finali</a>\n"
+"e da diversi <a href=\"%(sponsors_url)s\">sponsor</a> che forniscono "
+"fondi\n"
 "per aiutare la fondazione a raggiungere i suoi obiettivi.\n"
-"La fondazione dispone anche di <a href=\"%(supporters_url)s\">sostenitori "
-"commerciali</a>\n"
+"La fondazione dispone anche di <a href=\"%(supporters_url)s\">sostenitori"
+" commerciali</a>\n"
 "che utilizzano i nostri data set."
 
 #: metabrainz/templates/index/index.html:133
@@ -1344,7 +2171,7 @@ msgstr ""
 "Per ottenere maggiori informazioni sulla fondazione,\n"
 "visita la pagina <a href=\"%(about_url)s\">Chi siamo</a>."
 
-#: frontend/js/src/forms/ConditionsModal.tsx:43
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:32
 #: metabrainz/templates/index/privacy.html:3
 msgid "Privacy"
 msgstr "Privacy"
@@ -1352,6 +2179,44 @@ msgstr "Privacy"
 #: metabrainz/templates/index/privacy.html:8
 msgid "Summary"
 msgstr "In sintesi"
+
+#: metabrainz/templates/index/privacy.html:12
+msgid ""
+"You do not have to provide any personal data to be able to browse the "
+"contents of the databases published by MetaBrainz."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:15
+msgid ""
+"You do not have to provide any personally-identifying information if you "
+"choose not to."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:18
+msgid ""
+"We will never reveal your email address on MetaBrainz controlled web "
+"sites."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:22
+msgid ""
+"In order to get maximum value out of the MetaBrainz projects, you may "
+"want to create an account and log in. \n"
+"    Doing so grants you the ability to: edit the databases, contribute "
+"your own data, communicate with other users, and keep track \n"
+"    of recently released music from artists in your MusicBrainz "
+"collection. If you choose to create an account then the minimum we \n"
+"    ask is that you: choose a unique username and password, use a web "
+"browser that accepts \"session\" cookies, and provide a verified \n"
+"    email address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:29
+msgid ""
+"If you do not create an account (or are not logged in) you will not have "
+"access to the above listed features, however, you will \n"
+"    still have full access to browse and examine the databases."
+msgstr ""
 
 #: metabrainz/templates/index/privacy.html:33
 msgid "Applicable to all users"
@@ -1361,39 +2226,197 @@ msgstr ""
 msgid "Cookies"
 msgstr ""
 
+#: metabrainz/templates/index/privacy.html:37
+msgid "We use two cookies that contain sensitive information:"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:42
+msgid ""
+"<b>remember_login</b>: If you choose the \"Log in permanently\" option "
+"when logging in to one of our sites; the cookie will be used to \n"
+"      remember your login details."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:46
+msgid ""
+"<b>musicbrainz_server_session, session, or connect.sid</b>: If you are "
+"logged into one of our sites, your current session ID is stored in this "
+"cookie."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:51
+msgid ""
+"We may store dynamic preference information in other cookies, but these "
+"do not contain any sensitive information."
+msgstr ""
+
 #: metabrainz/templates/index/privacy.html:54
 msgid "Web and FTP access logs"
 msgstr "Registri di accesso web e FTP"
+
+#: metabrainz/templates/index/privacy.html:57
+msgid ""
+"In a practice similar to other web sites (and APIs) we keep logs of all "
+"web requests made against our servers. These logs include: your IP\n"
+"    address, your browser's (or API client's) \"User-Agent\" string, and "
+"which page (or API endpoint) you requested with which parameters. "
+"Aggregate information about web and FTP traffic is\n"
+"    made available to the public via our site usage pages."
+msgstr ""
 
 #: metabrainz/templates/index/privacy.html:62
 msgid "Third-Party content"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:92
+#: metabrainz/templates/index/privacy.html:64
+msgid ""
+"Our projects' web pages may load some third-party content. Some, but "
+"possibly not all sites are listed below:"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:69
+#, python-format
+msgid ""
+"Cover art and other images: These are provided by the various cover art "
+"sites that have given MusicBrainz permission to do so and our own \n"
+"      <a href=\"%(caa_url)s\">Cover Art Archive</a>. This means that the "
+"relevant site will know (if they want to) your IP \n"
+"      address, User-Agent string, etc., and which MusicBrainz web page "
+"you were visiting (the one which included the cover art image)."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:75
+msgid ""
+"AcoustID: Our fingerprints tab loads fingerprint information from "
+"acoustid.org."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:78
+msgid ""
+"MTCaptcha: Our account creation page loads third party content in order "
+"to prevent spammers from creating accounts."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:83
+msgid ""
+"<i>The above information assumes that you are using \"normal\" web "
+"browser settings, whereby images are always loaded and HTTP referrer \n"
+"    information is always sent.</i>"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:88
+msgid ""
+"It is impractical to constantly modify this privacy policy when "
+"MetaBrainz projects change which third party content they utilize. We "
+"will \n"
+"    aim to use common sense, respect to our community and community "
+"review when adding more content from third party sites. We will also \n"
+"    periodically review our policy to ensure that it remains current."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:93
 msgid "Applicable to account holders"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:94
+#: metabrainz/templates/index/privacy.html:95
 msgid "Account creation"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:108
+#: metabrainz/templates/index/privacy.html:97
+msgid ""
+"When creating an account with a MetaBrainz project you need to pick a "
+"unique username and choose a password, the username you pick is the \n"
+"    only name associated with your account and will be what other "
+"MetaBrainz users know you as. You may optionally also tell us other \n"
+"    information about yourself that will be displayed to other MetaBrainz"
+" users and the public."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:103
+msgid ""
+"Additionally, in order to edit the databases you will need to provide a "
+"confirmed email address. This email address will be held in \n"
+"    confidence, the only method of revealing your email address to "
+"another user is if you choose to send a message to another \n"
+"    user and enable the option to \"reveal my email address\". Changing "
+"the email address stored with your account will require you to \n"
+"    verify the new address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:109
 msgid "Edits and Notes"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:114
+#: metabrainz/templates/index/privacy.html:111
+msgid ""
+"If you make any changes to a MetaBrainz project database, such as adding "
+"any data, the details of those changes will be visible to \n"
+"    other logged-in users and the change will be associated with your "
+"username."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:115
 msgid "Subscriptions on MusicBrainz"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:131
+#: metabrainz/templates/index/privacy.html:117
+msgid ""
+"As a logged-in user you can subscribe to one or more artists, labels, "
+"collections or other editors. The act of subscribing causes \n"
+"    any edits made to (or by in the case of another editor) those "
+"entities to be emailed to you. By default, other users can see your \n"
+"    list of subscriptions, however, you can opt out of this by editing "
+"the appropriate preference."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:123
+msgid ""
+"This does not provide \"perfect\" privacy though, in some cases it will "
+"be possible to infer information about the contents of your \n"
+"    subscription list even though you have disallowed others from viewing"
+" that list directly. This imperfection arises because various \n"
+"    parts of the system behave differently depending on whether or not an"
+" entity has any subscribers; also, the number of users \n"
+"    subscribed to each artist is available via the artist pages. In the "
+"most extreme (possibly contrived) example, imagine that all \n"
+"    users have their subscriptions set to \"public\", except for exactly "
+"one user whose list is \"private\". In that case, any discrepancy \n"
+"    for a given artist between the shown list of subscribers and the "
+"total number of subscribers must be down to that one user. Thus, \n"
+"    you can infer what artists are on that user's list."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:132
 msgid "Third-party sites"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:145
+#: metabrainz/templates/index/privacy.html:134
+#, python-format
+msgid ""
+"Our code reviews are done on GitHub, which is not under the control of "
+"MetaBrainz. Participating in code reviews or other\n"
+"    tasks carried out on GitHub are subject to <a "
+"href=\"%(github_url)s\">GitHub's privacy policy</a>."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:140
+#, python-format
+msgid ""
+"Our translations platform is provided and hosted by Weblate, which has a "
+"data processing agreement with MetaBrainz.\n"
+"    Participating in translations is subject to <a "
+"href=\"%(weblate_url)s\">dedicated legal terms</a>.\n"
+"    Any translations you make will be submitted to our Git repositories "
+"and publicly associated with your username;\n"
+"    if you so choose, you can also publicly associate them with your own "
+"verified email address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:147
 msgid "MetaBrainz donors"
 msgstr "Donatori MetaBrainz"
 
-#: metabrainz/templates/index/privacy.html:147
+#: metabrainz/templates/index/privacy.html:149
 msgid ""
 "When you make a donation to the MetaBrainz Foundation, we are legally\n"
 "    required to collect your personal information and keep it in our "
@@ -1407,10 +2430,10 @@ msgstr ""
 "a raccogliere le tue informazioni personali e archiviarle nei nostri "
 "registri\n"
 "in caso di controlli da parte dell'Internal Revenue Service.\n"
-"Non comunicheremo le tue informazioni personali a nessun altro, in nessun "
-"caso."
+"Non comunicheremo le tue informazioni personali a nessun altro, in nessun"
+" caso."
 
-#: metabrainz/templates/index/privacy.html:153
+#: metabrainz/templates/index/privacy.html:155
 msgid ""
 "We believe in transparent finances, which means that we list all "
 "donations\n"
@@ -1424,11 +2447,34 @@ msgstr ""
 "Elencheremo solo il tuo nome e l'importo della donazione, a meno che tu "
 "non scelga di essere anonimo durante il processo di donazione."
 
-#: metabrainz/templates/index/privacy.html:158
+#: metabrainz/templates/index/privacy.html:160
 msgid "Exceptions"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:598
+#: metabrainz/templates/index/privacy.html:162
+msgid ""
+"<i><b>Please note</b>: Reasonable exceptions may apply to the above "
+"policy, for example to comply with applicable laws.\n"
+"    Also, members of the MetaBrainz team and other personnel contracted "
+"to provide services to MetaBrainz may have access to\n"
+"    our infrastructure and could therefore view any information contained"
+" therein. However all personnel are contractually bound\n"
+"    by non-disclosure clauses which prevent them from making any such "
+"information available to others."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:171
+#, python-format
+msgid ""
+"If you have any questions about our GDPR statement, please <a "
+"href=\"%(contact_url)s\">contact us</a>. To report\n"
+"   any privacy problems, violations or leaks, our GDPR representative is "
+"our Interim Executive Director Nicolás Tamargo and for\n"
+"   privacy issues contact him at <strong><a "
+"href=\"mailto:gdpr@metabrainz.org\">gdpr@metabrainz.org</a></strong>."
+msgstr ""
+
+#: frontend/js/src/Profile.tsx:603
 #: frontend/js/src/forms/ProfileChangePassword.tsx:22
 #: frontend/js/src/forms/ProfileChangePassword.tsx:111
 #: metabrainz/templates/index/profile-change-password.html:3
@@ -1506,10 +2552,10 @@ msgid ""
 "            providing a platform created for the sole purpose of Creative"
 " Commons licensed reviews."
 msgstr ""
-"<a href=\"%(cb_url)s\">CritiqueBrainz</a> colma la distanza tra i critici "
-"musicali e letterari e i dati grezzi\n"
-"fornendo una piattaforma creata al solo fine di ospitare recensioni sotto "
-"licenza Creative Commons."
+"<a href=\"%(cb_url)s\">CritiqueBrainz</a> colma la distanza tra i critici"
+" musicali e letterari e i dati grezzi\n"
+"fornendo una piattaforma creata al solo fine di ospitare recensioni sotto"
+" licenza Creative Commons."
 
 #: metabrainz/templates/index/projects.html:78
 msgid "BookBrainz"
@@ -1583,8 +2629,8 @@ msgid ""
 "used for AcousticBrainz and is still being\n"
 "            used in ListenBrainz."
 msgstr ""
-"<a href=\"%(messybrainz_url)s\">MessyBrainz</a> identifica metadati grezzi "
-"e, dove possibile,\n"
+"<a href=\"%(messybrainz_url)s\">MessyBrainz</a> identifica metadati "
+"grezzi e, dove possibile,\n"
 "li collega a identificatori stabili di MusicBrainz.\n"
 "MessyBrainz era utilizzato per AcousticBrainz ed è ancora utilizzato per "
 "ListenBrainz."
@@ -1601,8 +2647,8 @@ msgid ""
 "operate."
 msgstr ""
 "La MetaBrainz Foundation vuole esprimere un enorme ringraziamento\n"
-"a tutti i suoi sponsor e partner per il loro sostegno al funzionamento di "
-"MusicBrainz."
+"a tutti i suoi sponsor e partner per il loro sostegno al funzionamento di"
+" MusicBrainz."
 
 #: metabrainz/templates/index/sponsors.html:13
 msgid ""
@@ -1648,8 +2694,8 @@ msgid ""
 "a few individuals\n"
 "    and companies who have made a big difference for us."
 msgstr ""
-"In passato tante persone ci hanno sostenuto in modi molto diversi: dandoci "
-"accesso a conferenze,\n"
+"In passato tante persone ci hanno sostenuto in modi molto diversi: "
+"dandoci accesso a conferenze,\n"
 "facendosi carico delle spese di viaggio, fornendoci grandi donazioni "
 "personali e innumerevoli pasti.\n"
 "Sono ormai troppi per elencarli tutti, ma vogliamo comunque sottolineare "
@@ -1685,13 +2731,13 @@ msgstr ""
 "donandoci più di <b>500,000 $</b> nel corso degli anni.\n"
 "Richard Jones, noto per <a href=\"%(last_fm_url)s\">Last.fm</a>, ci ha "
 "donato <b>50,000 $</b> nel 2010.\n"
-"<a href=\"%(oracle_url)s\">Sun Microsystems</a> &amp; Paul Lamere ci hanno "
-"donato un server per il database\n"
-"e <a href=\"%(oreilly_url)s\">O'Reilly Media</a> ha dato 500 $ a MusicBrainz "
-"per aprire un conto corrente per il progetto\n"
+"<a href=\"%(oracle_url)s\">Sun Microsystems</a> &amp; Paul Lamere ci "
+"hanno donato un server per il database\n"
+"e <a href=\"%(oreilly_url)s\">O'Reilly Media</a> ha dato 500 $ a "
+"MusicBrainz per aprire un conto corrente per il progetto\n"
 "prima ancora che la MetaBrainz Foundation esistesse.\n"
-"<a href=\"%(ed_url)s\">Ed Cavazos</a> ci fornisce periodicamente consulenza "
-"legale a titolo gratuito\n"
+"<a href=\"%(ed_url)s\">Ed Cavazos</a> ci fornisce periodicamente "
+"consulenza legale a titolo gratuito\n"
 "per le questioni di proprietà intellettuale con cui MetaBrainz ha "
 "occasionalmente a che fare.\n"
 "<a href=\"%(dan_url)s\">Dan Appleman</a> ci dà periodicamente una mano a "
@@ -1730,10 +2776,10 @@ msgid ""
 "working on MusicBrainz, the open music encyclopedia,\n"
 "          and fell in love with Open Source software."
 msgstr ""
-"Robert era il fondatore e capo geek di <a href=\"%(mb_url)s\">MusicBrainz</"
-"a> e della MetaBrainz Foundation,\n"
-"l'organizzazione non-profit creata per proteggere e sostenere MusicBrainz. "
-"Dopo aver studiato ingegneria informatica\n"
+"Robert era il fondatore e capo geek di <a "
+"href=\"%(mb_url)s\">MusicBrainz</a> e della MetaBrainz Foundation,\n"
+"l'organizzazione non-profit creata per proteggere e sostenere "
+"MusicBrainz. Dopo aver studiato ingegneria informatica\n"
 "al Cal Poly, San Luis Obispo, si è unito a Xing Technology dirigendo i "
 "progetti MP3, quindi ha lavorato nel team FreeAmp di EMusic\n"
 "durante il boom delle dot-com. Durante il periodo a EMusic ha iniziato a "
@@ -1748,13 +2794,18 @@ msgid ""
 "          <a href=\"%(pr_url)s\">Party Robotics</a> where he co-created "
 "Bartendro the open source cocktail robot."
 msgstr ""
-"Robert era un hacker hardware appassionato e ha creato progetti artistici "
-"per il Burning Man e il Nowhere. Ha co-fondato <a href=\"%(pr_url)s\">Party "
-"Robotics</a>, con cui ha co-creato Bartendro, il robot per cocktail open "
-"source."
+"Robert era un hacker hardware appassionato e ha creato progetti artistici"
+" per il Burning Man e il Nowhere. Ha co-fondato <a "
+"href=\"%(pr_url)s\">Party Robotics</a>, con cui ha co-creato Bartendro, "
+"il robot per cocktail open source."
 
 #: metabrainz/templates/index/team.html:26
 msgid "He lives on in our hearts and in open source."
+msgstr ""
+
+#: metabrainz/templates/index/team.html:29
+#: metabrainz/templates/index/team.html:315
+msgid "you’re welcome to try"
 msgstr ""
 
 #: metabrainz/templates/index/team.html:39
@@ -1762,8 +2813,8 @@ msgid ""
 "<span class=\"name\">Michael Wiencek</span> &mdash; Senior Software "
 "Engineer"
 msgstr ""
-"<span class=\"name\">Michael Wiencek</span> &mdash; ingegnere del software "
-"senior"
+"<span class=\"name\">Michael Wiencek</span> &mdash; ingegnere del "
+"software senior"
 
 #: metabrainz/templates/index/team.html:41
 msgid ""
@@ -1791,8 +2842,8 @@ msgid ""
 "<span class=\"name\">Nicolás Tamargo</span> &mdash; Style Leader/Customer"
 " Support/Community Manager/Software Engineer"
 msgstr ""
-"<span class=\"name\">Nicolás Tamargo</span> &mdash; Style Leader/Supporto "
-"clienti/Community manager/Ingegnere del software"
+"<span class=\"name\">Nicolás Tamargo</span> &mdash; Style Leader/Supporto"
+" clienti/Community manager/Ingegnere del software"
 
 #: metabrainz/templates/index/team.html:59
 #, python-format
@@ -2151,12 +3202,12 @@ msgid ""
 "      US taxpayer."
 msgstr ""
 "Se pensi che i nostri progetti possano essere utili, prendi in "
-"considerazione l'idea di fare una donazione alla MetaBrainz Foundation, che "
-"è un'<a href=\"%(wikipedia_non_profit_url)s\">impresa non-profit esentasse "
-"501(c)(3)</a> con sede in California.\n"
+"considerazione l'idea di fare una donazione alla MetaBrainz Foundation, "
+"che è un'<a href=\"%(wikipedia_non_profit_url)s\">impresa non-profit "
+"esentasse 501(c)(3)</a> con sede in California.\n"
 "Tutte le tue donazioni saranno deducibili fiscalmente; riceverai una "
-"ricevuta che potrai usare per dedurre la tua donazione dalle tasse se sei un "
-"contribuente americano."
+"ricevuta che potrai usare per dedurre la tua donazione dalle tasse se sei"
+" un contribuente americano."
 
 #: metabrainz/templates/payments/donate.html:18
 msgid ""
@@ -2166,10 +3217,10 @@ msgid ""
 "office, and paying a minimal\n"
 "      salary for MetaBrainz employees."
 msgstr ""
-"Le tue donazioni saranno utilizzate per il funzionamento dei progetti della "
-"MetaBrainz Foundation.\n"
-"Questo comprende il pagamento delle spese correnti come hosting, hardware, "
-"il mantenimento di un piccolo ufficio\n"
+"Le tue donazioni saranno utilizzate per il funzionamento dei progetti "
+"della MetaBrainz Foundation.\n"
+"Questo comprende il pagamento delle spese correnti come hosting, "
+"hardware, il mantenimento di un piccolo ufficio\n"
 "e il pagamento di un salario modesto agli impiegati di MetaBrainz."
 
 #: metabrainz/templates/payments/donate.html:23
@@ -2241,8 +3292,7 @@ msgstr "Vorrei che questa donazione fosse anonima"
 
 #: metabrainz/templates/payments/donate.html:92
 msgid "Your name and username won't appear in the donors list"
-msgstr ""
-"Il tuo nome e il tuo nome utente non compariranno nell'elenco dei donatori"
+msgstr "Il tuo nome e il tuo nome utente non compariranno nell'elenco dei donatori"
 
 #: metabrainz/templates/payments/donate.html:100
 msgid "Donate with Credit Card"
@@ -2267,7 +3317,8 @@ msgstr ""
 "Le informazioni personali fornite alla MetaBrainz Foundation\n"
 "durante il processo di donazione non saranno condivise con nessuno.\n"
 "Per maggiori informazioni, dai un'occhiata\n"
-"alla nostra <a href=\"%(privacy_policy_url)s\">informativa sulla privacy</a>."
+"alla nostra <a href=\"%(privacy_policy_url)s\">informativa sulla "
+"privacy</a>."
 
 #: metabrainz/templates/payments/donate.html:129
 #, python-format
@@ -2307,8 +3358,8 @@ msgid ""
 "Please indicate your name and use the word "
 "<em>%(donation_fixed_string)s</em> in the description field."
 msgstr ""
-"Indica il tuo nome e utilizza la parola <em>%(donation_fixed_string)s</em> "
-"nel campo descrizione."
+"Indica il tuo nome e utilizza la parola "
+"<em>%(donation_fixed_string)s</em> nel campo descrizione."
 
 #: metabrainz/templates/payments/donate.html:145
 msgid "US Check"
@@ -2316,8 +3367,10 @@ msgstr "Assegno (USA)"
 
 #: metabrainz/templates/payments/donate.html:146
 msgid ""
-"Due to the increased unreliability of the US Postal Service we have "
-"stopped accepting paper checks. Sorry!"
+"Due to the increased unreliability of the US Postal Service and the "
+"relatively large fees involved, we ask you to only send a paper check if "
+"it is the only possible option. Due to the fees, we will not cash checks "
+"for less than $25."
 msgstr ""
 
 #: metabrainz/templates/payments/donate.html:241
@@ -2391,8 +3444,8 @@ msgid ""
 msgstr ""
 "<b>Fai attenzione!</b> Questa è una versione di sviluppo del sito.\n"
 "NON utilizzare le credenziali autentiche della tua carta di credito!\n"
-"Se vuoi inviarci un pagamento, visita <a href=\"%(mb_url)s\">metabrainz.org</"
-"a>."
+"Se vuoi inviarci un pagamento, visita <a "
+"href=\"%(mb_url)s\">metabrainz.org</a>."
 
 #: metabrainz/templates/payments/payment.html:17
 msgid "Organization:"
@@ -2410,8 +3463,8 @@ msgid ""
 "          before you do."
 msgstr ""
 "Se desideri effettuare un pagamento particolarmente grande,\n"
-"contattaci all'indirizzo <a href=\"%(mail_link)s\">payments@metabrainz.org</"
-"a>\n"
+"contattaci all'indirizzo <a "
+"href=\"%(mail_link)s\">payments@metabrainz.org</a>\n"
 "prima di farlo."
 
 #: metabrainz/templates/payments/payment.html:52
@@ -2440,7 +3493,8 @@ msgstr ""
 "Le informazioni personali fornite alla MetaBrainz Foundation\n"
 "durante il processo di pagamento non saranno condivise con nessuno.\n"
 "Per maggiori informazioni, dai un'occhiata\n"
-"alla nostra <a href=\"%(privacy_policy_url)s\">informativa sulla privacy</a>."
+"alla nostra <a href=\"%(privacy_policy_url)s\">informativa sulla "
+"privacy</a>."
 
 #: metabrainz/templates/payments/payment.html:93
 #, python-format
@@ -2472,8 +3526,8 @@ msgstr ""
 "<b>Questa pagina serve alle organizzazioni che sostengono la MetaBrainz "
 "Foundation per trasmetterci pagamenti!</b>\n"
 "I pagamenti effettuati qui non saranno considerati come donazioni.\n"
-"Se invece vuoi fare una donazione, visita la <a href=\"%(donate_url)s\">"
-"pagina di donazione</a>."
+"Se invece vuoi fare una donazione, visita la <a "
+"href=\"%(donate_url)s\">pagina di donazione</a>."
 
 #: metabrainz/templates/payments/payment_base.html:16
 msgid ""
@@ -2483,10 +3537,10 @@ msgid ""
 "office, and paying a minimal\n"
 "      salary for MetaBrainz employees."
 msgstr ""
-"I tuoi pagamenti saranno utilizzati per il funzionamento dei progetti della "
-"MetaBrainz Foundation.\n"
-"Questo comprende il pagamento delle spese correnti come hosting, hardware, "
-"il mantenimento di un piccolo ufficio\n"
+"I tuoi pagamenti saranno utilizzati per il funzionamento dei progetti "
+"della MetaBrainz Foundation.\n"
+"Questo comprende il pagamento delle spese correnti come hosting, "
+"hardware, il mantenimento di un piccolo ufficio\n"
 "e il pagamento di un salario modesto agli impiegati di MetaBrainz."
 
 #: metabrainz/templates/payments/payment_base.html:21
@@ -2555,15 +3609,16 @@ msgid ""
 "    donations, we believe that our contributors have the right to see how"
 " the non-profit manages its finances."
 msgstr ""
-"La MetaBrainz Foundation pratica una politica di <i>finanze trasparenti</i>, "
-"secondo la quale le finanze della non-profit sono liberamente accessibili su "
-"questo sito web.\n"
-"Questa filosofia finanziaria permette ai contributori monetari di MetaBrainz "
-"e ai contributori di informazioni di MusicBrainz di vedere come la non-"
-"profit spende le donazioni e i diritti di licenza raccolti.\n"
-"Siccome MusicBrainz è stato costruito da volontari e MetaBrainz è in parte "
-"sostenuta da donazioni di volontari, crediamo che i nostri collaboratori "
-"abbiano il diritto di vedere come la non-profit gestisce le sue finanze."
+"La MetaBrainz Foundation pratica una politica di <i>finanze "
+"trasparenti</i>, secondo la quale le finanze della non-profit sono "
+"liberamente accessibili su questo sito web.\n"
+"Questa filosofia finanziaria permette ai contributori monetari di "
+"MetaBrainz e ai contributori di informazioni di MusicBrainz di vedere "
+"come la non-profit spende le donazioni e i diritti di licenza raccolti.\n"
+"Siccome MusicBrainz è stato costruito da volontari e MetaBrainz è in "
+"parte sostenuta da donazioni di volontari, crediamo che i nostri "
+"collaboratori abbiano il diritto di vedere come la non-profit gestisce le"
+" sue finanze."
 
 #: metabrainz/templates/reports/financial_reports/index.html:17
 msgid ""
@@ -3252,8 +4307,8 @@ msgid "Monthly balance sheets"
 msgstr "Bilanci mensili"
 
 #: frontend/js/src/Profile.tsx:520
-#: frontend/js/src/forms/SignupCommercial.tsx:175
-#: frontend/js/src/forms/SignupCommercial.tsx:554
+#: frontend/js/src/forms/SignupCommercial.tsx:180
+#: frontend/js/src/forms/SignupCommercial.tsx:558
 #: frontend/js/src/forms/SignupNonCommercial.tsx:106
 #: frontend/js/src/forms/SignupNonCommercial.tsx:318
 #: metabrainz/templates/supporters/account-type.html:3
@@ -3274,6 +4329,7 @@ msgid "Non-commercial / Personal"
 msgstr "Non commerciale / Personale"
 
 #: frontend/js/src/Profile.tsx:235
+#: frontend/js/src/forms/SignupNonCommercial.tsx:107
 #: frontend/js/src/forms/SignupNonCommercial.tsx:151
 #: metabrainz/templates/supporters/account-type.html:42
 msgid "Non-commercial"
@@ -3287,47 +4343,41 @@ msgstr ""
 msgid "Personal or university assignment user."
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:48
-#: metabrainz/templates/supporters/account-type.html:90
-#: metabrainz/templates/supporters/account-type.html:141
-msgid "Upgrade"
-msgstr ""
-
 #: frontend/js/src/Profile.tsx:235
-#: frontend/js/src/forms/SignupCommercial.tsx:176
-#: frontend/js/src/forms/SignupCommercial.tsx:228
-#: metabrainz/templates/supporters/account-type.html:61
+#: frontend/js/src/forms/SignupCommercial.tsx:181
+#: frontend/js/src/forms/SignupCommercial.tsx:233
+#: metabrainz/templates/supporters/account-type.html:56
 msgid "Commercial"
 msgstr "Commerciale"
 
-#: metabrainz/templates/supporters/account-type.html:83
-#: metabrainz/templates/supporters/account-type.html:135
+#: metabrainz/templates/supporters/account-type.html:78
+#: metabrainz/templates/supporters/account-type.html:125
 #, python-format
 msgid "$%(tier_price)s/month and up"
 msgstr "%(tier_price)s o più $/mese"
 
-#: metabrainz/templates/supporters/account-type.html:87
-#: metabrainz/templates/supporters/account-type.html:138
+#: metabrainz/templates/supporters/account-type.html:82
+#: metabrainz/templates/supporters/account-type.html:128
 msgid "More info"
 msgstr "Maggiori informazioni"
 
-#: metabrainz/templates/supporters/account-type.html:104
+#: metabrainz/templates/supporters/account-type.html:94
 msgid "View all tiers"
 msgstr "Visualizza tutti i livelli"
 
-#: metabrainz/templates/supporters/account-type.html:112
+#: metabrainz/templates/supporters/account-type.html:102
 msgid "Some of our Unicorn members"
 msgstr "Alcuni dei nostri membri Unicorno"
 
-#: metabrainz/templates/supporters/account-type.html:123
+#: metabrainz/templates/supporters/account-type.html:113
 msgid "See all our supporters"
 msgstr "Visualizza tutti i nostri sostenitori"
 
-#: metabrainz/templates/supporters/account-type.html:151
+#: metabrainz/templates/supporters/account-type.html:136
 msgid "View featured tiers"
 msgstr "Visualizza i livelli in vetrina"
 
-#: metabrainz/templates/supporters/account-type.html:158
+#: metabrainz/templates/supporters/account-type.html:143
 #, python-format
 msgid ""
 "If you are not sure which tier to pick, please\n"
@@ -3335,10 +4385,6 @@ msgid ""
 msgstr ""
 "Se non sei sicuro su quale livello scegliere, <a "
 "href=\"%(contact_url)s\">contattaci</a>."
-
-#: metabrainz/templates/supporters/account-type.html:166
-msgid "Back to Profile"
-msgstr "Ritorna al profilo"
 
 #: metabrainz/templates/supporters/bad-standing.html:3
 #: metabrainz/templates/supporters/bad-standing.html:6
@@ -3375,14 +4421,14 @@ msgstr ""
 "Le seguenti organizzazioni usano i dataset pubblicati da MetaBrainz\n"
 "e ci sostengono finanziariamente o attraverso qualche altro accordo "
 "reciproco.\n"
-"Ci sono anche organizzazioni che usano i nostri dati ma hanno esplicitamente "
-"rifiutato di sostenerci.\n"
-"Ci potrebbero anche essere altre organizzazioni che usano i nostri dati di "
-"cui non siamo ancora a conoscenza.\n"
-"Se sei a conoscenza di una società che usa i nostri dati, <a href=\"%"
-"(contact_url)s\">contattaci</a>.\n"
-"Se vuoi registrare la tua società come sostenitrice, visita la <a href=\"%"
-"(signup_form)s\">pagina di registrazione</a>."
+"Ci sono anche organizzazioni che usano i nostri dati ma hanno "
+"esplicitamente rifiutato di sostenerci.\n"
+"Ci potrebbero anche essere altre organizzazioni che usano i nostri dati "
+"di cui non siamo ancora a conoscenza.\n"
+"Se sei a conoscenza di una società che usa i nostri dati, <a "
+"href=\"%(contact_url)s\">contattaci</a>.\n"
+"Se vuoi registrare la tua società come sostenitrice, visita la <a "
+"href=\"%(signup_form)s\">pagina di registrazione</a>."
 
 #: metabrainz/templates/supporters/supporters-list.html:26
 #: metabrainz/templates/supporters/tier.html:3
@@ -3413,9 +4459,9 @@ msgid "Forgot your username"
 msgstr ""
 
 #: frontend/js/src/forms/ResetPassword.tsx:79
-#: frontend/js/src/forms/SignupCommercial.tsx:320
+#: frontend/js/src/forms/SignupCommercial.tsx:325
 #: frontend/js/src/forms/SignupNonCommercial.tsx:227
-#: frontend/js/src/forms/SignupUser.tsx:169
+#: frontend/js/src/forms/SignupUser.tsx:175
 #: metabrainz/templates/users/reauthenticate.html:3
 #: metabrainz/templates/users/reauthenticate.html:6
 msgid "Confirm Password"
@@ -3425,17 +4471,22 @@ msgstr ""
 msgid "Please re-enter your password to continue."
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:108
+#: frontend/js/src/ProfileDelete.tsx:110
 #: frontend/js/src/forms/DeleteApplication.tsx:53
 #: frontend/js/src/forms/OAuthPrompt.tsx:54
 #: frontend/js/src/forms/ProfileChangePassword.tsx:104
 #: frontend/js/src/forms/ProfileEdit.tsx:105
-#: metabrainz/templates/users/reauthenticate.html:23
+#: metabrainz/templates/users/reauthenticate.html:28
 msgid "Cancel"
 msgstr ""
 
-#: metabrainz/templates/users/reauthenticate.html:24
+#: metabrainz/templates/users/reauthenticate.html:29
 msgid "Continue"
+msgstr ""
+
+#: frontend/js/src/forms/utils.tsx:202
+#: metabrainz/templates/users/reauthenticate.html:40
+msgid "Password must not exceed 72 bytes."
 msgstr ""
 
 #: frontend/js/src/forms/ResetPassword.tsx:27
@@ -3443,38 +4494,38 @@ msgstr ""
 msgid "Reset your password"
 msgstr ""
 
-#: frontend/js/src/hooks/useEmailValidation.ts:41 metabrainz/user/forms.py:15
+#: frontend/js/src/hooks/useEmailValidation.ts:41 metabrainz/user/forms.py:16
 msgid "Registration from this email domain is not allowed."
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:50
 #: frontend/js/src/forms/LostPassword.tsx:45
-#: frontend/js/src/forms/SignupCommercial.tsx:270
+#: frontend/js/src/forms/SignupCommercial.tsx:275
 #: frontend/js/src/forms/SignupNonCommercial.tsx:175
-#: frontend/js/src/forms/SignupUser.tsx:114 metabrainz/user/forms.py:20
-#: metabrainz/user/forms.py:45 metabrainz/user/forms.py:62
+#: frontend/js/src/forms/SignupUser.tsx:120 metabrainz/user/forms.py:22
+#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:75
 msgid "Username"
 msgstr "Nome utente"
 
 #: frontend/js/src/forms/LoginUser.tsx:42
 #: frontend/js/src/forms/LostPassword.tsx:37
-#: frontend/js/src/forms/SignupCommercial.tsx:153
+#: frontend/js/src/forms/SignupCommercial.tsx:158
 #: frontend/js/src/forms/SignupNonCommercial.tsx:84
-#: frontend/js/src/forms/SignupUser.tsx:67 metabrainz/user/forms.py:21
-#: metabrainz/user/forms.py:45 metabrainz/user/forms.py:62
+#: frontend/js/src/forms/SignupUser.tsx:73 metabrainz/user/forms.py:26
+#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:75
 msgid "Username is required!"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:63
 #: frontend/js/src/forms/ResetPassword.tsx:72
-#: frontend/js/src/forms/SignupCommercial.tsx:308
+#: frontend/js/src/forms/SignupCommercial.tsx:313
 #: frontend/js/src/forms/SignupNonCommercial.tsx:214
-#: frontend/js/src/forms/SignupUser.tsx:157 metabrainz/user/forms.py:46
-#: metabrainz/user/forms.py:52
+#: frontend/js/src/forms/SignupUser.tsx:163 metabrainz/user/forms.py:53
+#: metabrainz/user/forms.py:62
 msgid "Password"
 msgstr "Password"
 
-#: frontend/js/src/forms/LoginUser.tsx:76 metabrainz/user/forms.py:47
+#: frontend/js/src/forms/LoginUser.tsx:76 metabrainz/user/forms.py:57
 msgid "Remember me"
 msgstr ""
 
@@ -3486,11 +4537,11 @@ msgstr ""
 msgid "Username contains invalid or invisible characters."
 msgstr ""
 
-#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:181
+#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:220
 msgid "Hide password"
 msgstr ""
 
-#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:181
+#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:220
 msgid "Show password"
 msgstr ""
 
@@ -3547,11 +4598,11 @@ msgstr "Accesso"
 msgid "Revoke access"
 msgstr "Revoca accesso"
 
-#: frontend/js/src/OAuthError.tsx:17
+#: frontend/js/src/OAuthError.tsx:18
 msgid "OAuth2 Error"
 msgstr ""
 
-#: frontend/js/src/OAuthError.tsx:18
+#: frontend/js/src/OAuthError.tsx:19
 msgid "An error occurred during OAuth authentication process."
 msgstr ""
 
@@ -3581,8 +4632,8 @@ msgstr ""
 
 #: frontend/js/src/Profile.tsx:109
 msgid ""
-"Are you sure you want to generate new access token? Current token will be"
-" revoked!"
+"Are you sure you want to generate a new access token? The current token "
+"will be revoked!"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:118
@@ -3697,8 +4748,8 @@ msgid "Contact Information"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:310 frontend/js/src/forms/ProfileEdit.tsx:70
-#: frontend/js/src/forms/SignupCommercial.tsx:284
-#: frontend/js/src/forms/SignupCommercial.tsx:333
+#: frontend/js/src/forms/SignupCommercial.tsx:289
+#: frontend/js/src/forms/SignupCommercial.tsx:338
 #: frontend/js/src/forms/SignupNonCommercial.tsx:189
 #: frontend/js/src/forms/SignupNonCommercial.tsx:241
 msgid "Contact name"
@@ -3813,7 +4864,7 @@ msgstr ""
 msgid "Once you delete your account, there is no going back. Please be certain."
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:550 frontend/js/src/ProfileDelete.tsx:105
+#: frontend/js/src/Profile.tsx:550 frontend/js/src/ProfileDelete.tsx:107
 msgid "Delete My Account"
 msgstr ""
 
@@ -3825,39 +4876,39 @@ msgstr ""
 msgid "Need to delete your account?"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:574
+#: frontend/js/src/Profile.tsx:575
 msgid ""
 "Deletion of supporter accounts requires manual review. Please contact us "
-"at"
+"at <email />."
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:594
+#: frontend/js/src/Profile.tsx:599
 msgid "Security"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:626
+#: frontend/js/src/Profile.tsx:631
 msgid "MetaBrainz Applications"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:630
+#: frontend/js/src/Profile.tsx:635
 msgid ""
 "With your MetaBrainz account, you can access every project in the "
 "MetaBrainz family:"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:643
+#: frontend/js/src/Profile.tsx:648
 msgid "The open-source music encyclopedia"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:655
+#: frontend/js/src/Profile.tsx:660
 msgid "Track, visualise and share the music you listen to"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:667
+#: frontend/js/src/Profile.tsx:672
 msgid "The open-source book database"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:679
+#: frontend/js/src/Profile.tsx:684
 msgid "Creative Commons licensed reviews"
 msgstr ""
 
@@ -3880,7 +4931,7 @@ msgid "Permanently remove all your account information"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:64
-msgid "Revoke all your API tokens and access"
+msgid "Revoke all your tokens and access to the replication API"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:65
@@ -3892,14 +4943,16 @@ msgid "Log you out of all MetaBrainz services"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:70
-msgid "Your username will be reserved and cannot be reused."
+msgid ""
+"Your username will be reserved and cannot be reused without the "
+"intervention of an administrator."
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:82
+#: frontend/js/src/ProfileDelete.tsx:84
 msgid "To confirm, type your username '<username />' below:"
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:105
+#: frontend/js/src/ProfileDelete.tsx:107
 msgid "Deleting..."
 msgstr ""
 
@@ -3911,64 +4964,7 @@ msgstr "Profilo"
 msgid "Close"
 msgstr ""
 
-#: frontend/js/src/forms/ConditionsModal.tsx:23
-msgid "Licensing"
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:25
-msgid ""
-"Any contributions you make to any MetaBrainz service will be released "
-"into the Public Domain and/or licensed under a Creative Commons by-nc-sa "
-"license. Furthermore, you give the MetaBrainz Foundation the right to "
-"license this data for commercial use."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:30
-msgid "Please read our <licenseLink>license page</licenseLink> for more details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:45
-msgid ""
-"MetaBrainz strongly believes in the privacy of its users. Any personal "
-"information you choose to provide will not be sold or shared with anyone "
-"else."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:50
-msgid ""
-"Please read our <privacyLink>privacy policy</privacyLink> for more "
-"details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:59
-msgid "GDPR compliance"
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:61
-msgid ""
-"You may remove your personal information from our services anytime by "
-"deleting your account."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:66
-msgid ""
-"Please read our <gdprLink>GDPR compliance statement</gdprLink> for more "
-"details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:78
-msgid ""
-"Creating an account on MetaBrainz will give you access to all of our "
-"projects, such as MusicBrainz, ListenBrainz, BookBrainz, and more."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:82
-msgid ""
-"We create a placeholder account for all the MetaBrainz projects when you "
-"sign up, and you are one log-in away from activating them."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:91
+#: frontend/js/src/forms/ConditionsModal.tsx:29
 msgid "Sounds good"
 msgstr ""
 
@@ -4054,8 +5050,8 @@ msgstr ""
 msgid "Forgot your password?"
 msgstr ""
 
-#: frontend/js/src/forms/LoginUser.tsx:109
-msgid "Don't have an account?"
+#: frontend/js/src/forms/LoginUser.tsx:110
+msgid "Don't have an account? <signupLink>Sign up</signupLink>"
 msgstr ""
 
 #: frontend/js/src/forms/LostPassword.tsx:38
@@ -4084,15 +5080,72 @@ msgstr ""
 msgid "Allow access"
 msgstr "Permetti l'accesso"
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:71
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:10
+msgid "Licensing"
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:12
+msgid ""
+"Any contributions you make to any MetaBrainz service will be released "
+"into the Public Domain and/or licensed under a Creative Commons by-nc-sa "
+"license. Furthermore, you give the MetaBrainz Foundation the right to "
+"license this data for commercial use."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:17
+msgid "Please read our <licenseLink>license page</licenseLink> for more details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:34
+msgid ""
+"MetaBrainz strongly believes in the privacy of its users. Any personal "
+"information you choose to provide will not be sold or shared with anyone "
+"else."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:39
+msgid ""
+"Please read our <privacyLink>privacy policy</privacyLink> for more "
+"details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:50
+msgid "GDPR compliance"
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:52
+msgid ""
+"You may remove your personal information from our services anytime by "
+"deleting your account."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:57
+msgid ""
+"Please read our <gdprLink>GDPR compliance statement</gdprLink> for more "
+"details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:71
+msgid ""
+"Creating an account on MetaBrainz will give you access to all of our "
+"projects, such as MusicBrainz, ListenBrainz, BookBrainz, and more."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:75
+msgid ""
+"We create a placeholder account for all the MetaBrainz projects when you "
+"sign up, and you are one log-in away from activating them."
+msgstr ""
+
+#: frontend/js/src/forms/ProfileChangePassword.tsx:70
 msgid "Current Password"
 msgstr ""
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:80
+#: frontend/js/src/forms/ProfileChangePassword.tsx:79
 msgid "New Password"
 msgstr ""
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:89
+#: frontend/js/src/forms/ProfileChangePassword.tsx:88
 msgid "Confirm New Password"
 msgstr ""
 
@@ -4104,191 +5157,181 @@ msgstr ""
 msgid "Reset Password"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:38
-msgid "If you would like to support us with more than $"
+#: frontend/js/src/forms/SignupCommercial.tsx:40
+msgid ""
+"If you would like to support us with more than ${{minPledge}}, please "
+"enter the actual amount here:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:39
-msgid ", please enter the actual amount here:"
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:144
+#: frontend/js/src/forms/SignupCommercial.tsx:149
 #: frontend/js/src/forms/SignupNonCommercial.tsx:75
-#: frontend/js/src/forms/SignupUser.tsx:87
+#: frontend/js/src/forms/SignupUser.tsx:93
 msgid "Captcha is required!"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:179
+#: frontend/js/src/forms/SignupCommercial.tsx:184
 #: frontend/js/src/forms/SignupNonCommercial.tsx:110
 #: frontend/js/src/forms/SignupUser.tsx:46
 msgid "Access all MetaBrainz projects"
 msgstr "Accedi a tutti i progetti di MetaBrainz"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:182
+#: frontend/js/src/forms/SignupCommercial.tsx:187
 msgid "Note:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:184
+#: frontend/js/src/forms/SignupCommercial.tsx:189
 msgid ""
 "Signing up for any tier other than the <italic>Stealth startup</italic> "
 "tier will publicly list your company on this web site. However, we will "
 "not publish any of your private details."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:221
+#: frontend/js/src/forms/SignupCommercial.tsx:226
 #: frontend/js/src/forms/SignupNonCommercial.tsx:145
 msgid "Account type"
 msgstr "Tipo di account"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:234
+#: frontend/js/src/forms/SignupCommercial.tsx:239
 msgid "Selected tier"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:242
-msgid "month and up"
+#: frontend/js/src/forms/SignupCommercial.tsx:247
+msgid "${{tierPrice}}/month and up"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:250
+#: frontend/js/src/forms/SignupCommercial.tsx:255
 msgid "Change account type or tier"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:261
+#: frontend/js/src/forms/SignupCommercial.tsx:266
 #: frontend/js/src/forms/SignupNonCommercial.tsx:166
 msgid "Your account:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:271
+#: frontend/js/src/forms/SignupCommercial.tsx:276
 #: frontend/js/src/forms/SignupNonCommercial.tsx:176
-#: frontend/js/src/forms/SignupUser.tsx:114
+#: frontend/js/src/forms/SignupUser.tsx:120
 msgid "(public)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:291
+#: frontend/js/src/forms/SignupCommercial.tsx:296
 #: frontend/js/src/forms/SignupNonCommercial.tsx:196
-#: frontend/js/src/forms/SignupUser.tsx:127
+#: frontend/js/src/forms/SignupUser.tsx:133
 msgid "E-mail address"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:295
+#: frontend/js/src/forms/SignupCommercial.tsx:300
 #: frontend/js/src/forms/SignupNonCommercial.tsx:200
-#: frontend/js/src/forms/SignupUser.tsx:131
+#: frontend/js/src/forms/SignupUser.tsx:137
 msgid "(checking...)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:314
+#: frontend/js/src/forms/SignupCommercial.tsx:319
 #: frontend/js/src/forms/SignupNonCommercial.tsx:220
-#: frontend/js/src/forms/SignupUser.tsx:163
+#: frontend/js/src/forms/SignupUser.tsx:169
 msgid "Must be at least 8 characters"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:348
+#: frontend/js/src/forms/SignupCommercial.tsx:353
 msgid ""
 "If you don't have an organization name, you probably want to become a "
 "supporter as a <nonCommercialLink>Non-commercial / "
 "Personal</nonCommercialLink> supporter."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:358
+#: frontend/js/src/forms/SignupCommercial.tsx:363
 msgid ""
 "If you don't have an organization name, you probably want to sign up as a"
 " <nonCommercialLink>Non-commercial / Personal</nonCommercialLink> user."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:378
+#: frontend/js/src/forms/SignupCommercial.tsx:383
 msgid ""
 "Please tell us a little about your company and whether you plan to use "
 "our <apiLink>API</apiLink> or to <hostLink>host your own copy</hostLink> "
 "of the data."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:404
+#: frontend/js/src/forms/SignupCommercial.tsx:408
 msgid "Logo URL"
 msgstr "URL del logo"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:405
+#: frontend/js/src/forms/SignupCommercial.tsx:409
 msgid "(preferably in SVG format)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:408
+#: frontend/js/src/forms/SignupCommercial.tsx:412
 msgid ""
 "Image should be about 250 pixels wide on a white or transparent "
 "background. We will host it on our site."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:421
+#: frontend/js/src/forms/SignupCommercial.tsx:425
 msgid ""
 "URL to where developers can use your APIs using MusicBrainz IDs, if "
-"available.."
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:430
-msgid "Your project"
+"available."
 msgstr ""
 
 #: frontend/js/src/forms/SignupCommercial.tsx:434
+msgid "Your project"
+msgstr ""
+
+#: frontend/js/src/forms/SignupCommercial.tsx:438
 #: frontend/js/src/forms/SignupNonCommercial.tsx:261
 msgid "(max 150 characters)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:451
+#: frontend/js/src/forms/SignupCommercial.tsx:455
 msgid "Billing address"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:502
+#: frontend/js/src/forms/SignupCommercial.tsx:506
 msgid ""
 "I agree to support the MetaBrainz Foundation when my organization is able"
 " to do so."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:507
+#: frontend/js/src/forms/SignupCommercial.tsx:511
+#: frontend/js/src/forms/SignupNonCommercial.tsx:284
 msgid ""
-"I also agree that if I generate a Live Data Feed access token, that I "
-"treat my access token as a secret and will not share this token publicly "
-"or commit it to a source code repository."
+"I also agree that if I generate a Live Data Feed access token, then I "
+"will treat my access token as a secret and will not share this token "
+"publicly or commit it to a source code repository."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:515
+#: frontend/js/src/forms/SignupCommercial.tsx:519
 msgid ""
 "The following information will be shown publicly: organization name, "
 "logo, website and API URLs, data usage description."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:520
+#: frontend/js/src/forms/SignupCommercial.tsx:524
 msgid ""
 "We'll send you more details about payment process once your application "
 "is approved."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:552
+#: frontend/js/src/forms/SignupCommercial.tsx:556
 #: frontend/js/src/forms/SignupNonCommercial.tsx:316
-#: frontend/js/src/forms/SignupUser.tsx:224
+#: frontend/js/src/forms/SignupUser.tsx:230
 msgid "Validating..."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:564
+#: frontend/js/src/forms/SignupCommercial.tsx:568
 #: frontend/js/src/forms/SignupNonCommercial.tsx:329
 msgid "Back to profile"
 msgstr "Ritorna al profilo"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:569
-#: frontend/js/src/forms/SignupNonCommercial.tsx:334
-msgid "Not a supporter?"
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:570
+#: frontend/js/src/forms/SignupCommercial.tsx:574
 #: frontend/js/src/forms/SignupNonCommercial.tsx:335
-msgid "Create a user account"
+msgid "Not a supporter? <signupLink>Create a user account</signupLink>"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:573
-#: frontend/js/src/forms/SignupNonCommercial.tsx:338
-#: frontend/js/src/forms/SignupUser.tsx:231
-msgid "Already have an account?"
+#: frontend/js/src/forms/SignupCommercial.tsx:583
+#: frontend/js/src/forms/SignupNonCommercial.tsx:344
+#: frontend/js/src/forms/SignupUser.tsx:238
+msgid "Already have an account? <loginLink>Sign in</loginLink>"
 msgstr ""
-
-#: frontend/js/src/forms/SignupNonCommercial.tsx:107
-msgid "non-commercial"
-msgstr "non commerciale"
 
 #: frontend/js/src/forms/SignupNonCommercial.tsx:113
 msgid ""
@@ -4315,46 +5358,40 @@ msgid ""
 "income per year) or personal uses only."
 msgstr ""
 
-#: frontend/js/src/forms/SignupNonCommercial.tsx:284
-msgid ""
-"I also agree that if I generate a Live Data Feed access token, then I "
-"will treat my access token as a secret and will not share this token "
-"publicly or commit it to a source code repository."
-msgstr ""
-
 #: frontend/js/src/forms/SignupUser.tsx:43
 msgid "Create your account"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:50
-msgid "Registration started by"
+#: frontend/js/src/forms/SignupUser.tsx:51
+msgid "Registration started by <client />"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:69
+#: frontend/js/src/forms/SignupUser.tsx:75
+#: frontend/js/src/hooks/useEmailValidation.ts:82
 msgid "Invalid email address."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:150
+#: frontend/js/src/forms/SignupUser.tsx:156
 msgid ""
 "This username and email were provided by the app that started "
 "registration. You can change them later from MetaBrainz settings."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:182
+#: frontend/js/src/forms/SignupUser.tsx:188
 msgid ""
 "I accept that my contributions will be released into the public domain or"
 " licensed for use."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:191
+#: frontend/js/src/forms/SignupUser.tsx:197
 msgid "We will never share your personal information."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:200
+#: frontend/js/src/forms/SignupUser.tsx:206
 msgid "Click here to read more"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:224
+#: frontend/js/src/forms/SignupUser.tsx:230
 msgid "Create account"
 msgstr ""
 
@@ -4364,10 +5401,6 @@ msgstr ""
 
 #: frontend/js/src/hooks/useEmailValidation.ts:47
 msgid "Email validation failed"
-msgstr ""
-
-#: frontend/js/src/hooks/useEmailValidation.ts:82
-msgid "Invalid email address"
 msgstr ""
 
 #~ msgid "You need to specify amount!"
@@ -5270,9 +6303,6 @@ msgstr ""
 #~ " new access token? Current token will"
 #~ " be revoked!"
 #~ msgstr ""
-#~ "Sei sicuro di voler generare un "
-#~ "nuovo token di accesso? Il token "
-#~ "attuale sarà revocato!"
 
 #~ msgid "Sign up <small>Commercial</small>"
 #~ msgstr "Registrati come utente <small>commerciale</small>"
@@ -5332,10 +6362,6 @@ msgstr ""
 #~ "your APIs using MusicBrainz IDs, if "
 #~ "available.."
 #~ msgstr ""
-#~ "L'URL con cui gli sviluppatori possono"
-#~ " utilizzare le tue API che si "
-#~ "avvalgono degli ID MusicBrainz, se "
-#~ "disponibile."
 
 #~ msgid "(max 150 characters)"
 #~ msgstr "(massimo 150 caratteri)"
@@ -5666,3 +6692,100 @@ msgstr ""
 
 #~ msgid "Privacy policy"
 #~ msgstr "Informazioni sulla privacy"
+
+#~ msgid "You need to specify website of the organization."
+#~ msgstr "È necessario specificare il sito web dell'organizzazione."
+
+#~ msgid ""
+#~ "We are currently evaluating our overall"
+#~ " online advertising strategy. We are "
+#~ "evaluating advertising, traffic optimization,\n"
+#~ ""
+#~ "    search engine optimization and "
+#~ "software monitization technologies. If you "
+#~ "provide these professional services, please"
+#~ " provide a detailed\n"
+#~ "    deck of your comprehensive services"
+#~ " to the following email address. "
+#~ "<em>Please respect our other non-media"
+#~ " teams and do not contact us \n"
+#~ "    regarding these services on any "
+#~ "other of our email addresses. We "
+#~ "will disregard the entirety of your "
+#~ "submissions if you contact us any "
+#~ "other way!</em>"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Please come ask your questions at "
+#~ "our <a href=\"%(forums_url)s\">forums</a>! We "
+#~ "would love to\n"
+#~ "    answer any questions you may have."
+#~ msgstr ""
+#~ "Vieni a porre le tue domande sui"
+#~ " nostri <a href=\"%(forums_url)s\">forum</a>! "
+#~ "Saremo lieti di rispondere a qualsiasi"
+#~ " domanda tu possa avere."
+
+#~ msgid ""
+#~ "Due to the increased unreliability of"
+#~ " the US Postal Service we have "
+#~ "stopped accepting paper checks. Sorry!"
+#~ msgstr ""
+
+#~ msgid "Upgrade"
+#~ msgstr ""
+
+#~ msgid "Back to Profile"
+#~ msgstr "Ritorna al profilo"
+
+#~ msgid ""
+#~ "Deletion of supporter accounts requires "
+#~ "manual review. Please contact us at"
+#~ msgstr ""
+
+#~ msgid "Revoke all your API tokens and access"
+#~ msgstr ""
+
+#~ msgid "Your username will be reserved and cannot be reused."
+#~ msgstr ""
+
+#~ msgid "Don't have an account?"
+#~ msgstr ""
+
+#~ msgid "If you would like to support us with more than $"
+#~ msgstr ""
+
+#~ msgid ", please enter the actual amount here:"
+#~ msgstr ""
+
+#~ msgid "month and up"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "I also agree that if I generate"
+#~ " a Live Data Feed access token, "
+#~ "that I treat my access token as"
+#~ " a secret and will not share "
+#~ "this token publicly or commit it "
+#~ "to a source code repository."
+#~ msgstr ""
+
+#~ msgid "Not a supporter?"
+#~ msgstr ""
+
+#~ msgid "Create a user account"
+#~ msgstr ""
+
+#~ msgid "Already have an account?"
+#~ msgstr ""
+
+#~ msgid "non-commercial"
+#~ msgstr "non commerciale"
+
+#~ msgid "Registration started by"
+#~ msgstr ""
+
+#~ msgid "Invalid email address"
+#~ msgstr ""
+

--- a/metabrainz/translations/ja/LC_MESSAGES/messages.po
+++ b/metabrainz/translations/ja/LC_MESSAGES/messages.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-07-25 16:21+0200\n"
+"POT-Creation-Date: 2026-09-08 11:18+0200\n"
 "PO-Revision-Date: 2026-07-07 18:12+0000\n"
 "Last-Translator: Weblate Translation Memory <noreply-mt-weblate-"
 "translation-memory@weblate.org>\n"
@@ -25,163 +25,248 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.18.0\n"
 
-#: metabrainz/index/forms.py:46
+#: metabrainz/errors.py:24
+msgid "Authorization was declined."
+msgstr ""
+
+#: metabrainz/errors.py:25
+msgid "The authorization request was invalid."
+msgstr ""
+
+#: metabrainz/errors.py:26
+msgid "The application could not be authenticated."
+msgstr ""
+
+#: metabrainz/errors.py:27
+msgid "This application is not allowed to request authorization."
+msgstr ""
+
+#: metabrainz/errors.py:28
+msgid "The application asked for a response type this server does not support."
+msgstr ""
+
+#: metabrainz/errors.py:29
+msgid "The permissions requested by the application are invalid."
+msgstr ""
+
+#: metabrainz/errors.py:30
+msgid "You need to sign in to continue."
+msgstr ""
+
+#: metabrainz/errors.py:31
+msgid "Your consent is required to continue."
+msgstr ""
+
+#: metabrainz/password.py:12
+#, python-format
+msgid "Password must not exceed %(max_bytes)s bytes."
+msgstr ""
+
+#: metabrainz/index/forms.py:48
 #, python-format
 msgid "'%(value)s' is not a valid choice for this field"
 msgstr "'%(value)s'はこのフィールドで選択可能な値ではありません"
 
 #: frontend/js/src/forms/ProfileEdit.tsx:27
-#: frontend/js/src/forms/SignupCommercial.tsx:154
+#: frontend/js/src/forms/SignupCommercial.tsx:159
 #: frontend/js/src/forms/SignupNonCommercial.tsx:85
-#: frontend/js/src/forms/SignupUser.tsx:70
-#: frontend/js/src/hooks/useEmailValidation.ts:78 metabrainz/index/forms.py:57
-#: metabrainz/user/forms.py:25 metabrainz/user/forms.py:57
-#: metabrainz/user/forms.py:63
+#: frontend/js/src/forms/SignupUser.tsx:76
+#: frontend/js/src/hooks/useEmailValidation.ts:78 metabrainz/index/forms.py:59
+#: metabrainz/user/forms.py:31 metabrainz/user/forms.py:70
+#: metabrainz/user/forms.py:76
 msgid "Email address is required!"
 msgstr "メールアドレスの入力は必須です！"
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:34
-#: metabrainz/index/forms.py:63
+#: metabrainz/index/forms.py:65
 msgid "Current password is required!"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:43
 #: frontend/js/src/forms/ProfileChangePassword.tsx:37
 #: frontend/js/src/forms/ResetPassword.tsx:39
-#: frontend/js/src/forms/SignupCommercial.tsx:156
+#: frontend/js/src/forms/SignupCommercial.tsx:161
 #: frontend/js/src/forms/SignupNonCommercial.tsx:87
-#: frontend/js/src/forms/SignupUser.tsx:72 metabrainz/index/forms.py:66
-#: metabrainz/user/forms.py:29 metabrainz/user/forms.py:46
-#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:69
+#: frontend/js/src/forms/SignupUser.tsx:78 metabrainz/index/forms.py:69
+#: metabrainz/user/forms.py:35 metabrainz/user/forms.py:54
+#: metabrainz/user/forms.py:63 metabrainz/user/forms.py:82
 msgid "Password is required!"
 msgstr "パスワードが必要です！"
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:41
-#: frontend/js/src/forms/SignupCommercial.tsx:160
+#: frontend/js/src/forms/SignupCommercial.tsx:165
 #: frontend/js/src/forms/SignupNonCommercial.tsx:91
-#: frontend/js/src/forms/SignupUser.tsx:76 metabrainz/index/forms.py:70
-#: metabrainz/user/forms.py:33 metabrainz/user/forms.py:73
+#: frontend/js/src/forms/SignupUser.tsx:82 metabrainz/index/forms.py:74
+#: metabrainz/user/forms.py:40 metabrainz/user/forms.py:87
 msgid "Confirm Password is required!"
 msgstr "「パスワードの確認」が必要です！"
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:46
 #: frontend/js/src/forms/ResetPassword.tsx:48
-#: frontend/js/src/forms/SignupCommercial.tsx:165
+#: frontend/js/src/forms/SignupCommercial.tsx:170
 #: frontend/js/src/forms/SignupNonCommercial.tsx:96
-#: frontend/js/src/forms/SignupUser.tsx:81 metabrainz/index/forms.py:72
-#: metabrainz/user/forms.py:35 metabrainz/user/forms.py:75
+#: frontend/js/src/forms/SignupUser.tsx:87 metabrainz/index/forms.py:76
+#: metabrainz/user/forms.py:42 metabrainz/user/forms.py:89
 msgid "Confirm Password should match password!"
 msgstr "「パスワードの確認」とパスワード欄は一致している必要があります！"
 
 #: frontend/js/src/Applications.tsx:56 frontend/js/src/Applications.tsx:86
 #: frontend/js/src/Profile.tsx:272 frontend/js/src/Profile.tsx:482
-#: metabrainz/index/forms.py:78
+#: metabrainz/index/forms.py:82
 msgid "Name"
 msgstr "名前"
 
-#: metabrainz/index/forms.py:79
+#: metabrainz/index/forms.py:83
 msgid "Contact name field is empty."
 msgstr "連絡先欄が空欄です。"
 
-#: metabrainz/index/views.py:234
+#: metabrainz/index/views.py:251
 msgid "Profile updated successfully."
 msgstr "プロフィールの更新に成功しました。"
 
-#: metabrainz/index/views.py:261
+#: metabrainz/index/views.py:278
 msgid "Current password is incorrect."
 msgstr ""
 
-#: metabrainz/index/views.py:266
+#: metabrainz/index/views.py:283
 msgid "Password changed successfully."
 msgstr ""
 
-#: metabrainz/index/views.py:372
+#: metabrainz/index/views.py:389
 msgid "You have updated an application!"
 msgstr "アプリケーションを更新しました！"
 
-#: metabrainz/index/views.py:424
+#: metabrainz/index/views.py:441
 msgid "You have deleted an application."
 msgstr "アプリケーションを削除しました。"
 
-#: metabrainz/index/views.py:426
+#: metabrainz/index/views.py:443
 msgid "Failed to delete an application."
 msgstr "アプリケーションの削除に失敗しました。"
 
-#: metabrainz/index/views.py:449
+#: metabrainz/index/views.py:466
 msgid "Revoked tokens successfully!"
 msgstr "トークンの無効化に成功しました！"
 
-#: metabrainz/index/views.py:478
+#: metabrainz/index/views.py:495
 msgid "Your account has been deleted."
 msgstr "アカウントが削除されました。"
 
-#: frontend/js/src/forms/CreateApplication.tsx:106 metabrainz/oauth/forms.py:58
+#: frontend/js/src/forms/CreateApplication.tsx:106 metabrainz/oauth/forms.py:57
 msgid "Application Name"
 msgstr "アプリケーション名"
 
-#: metabrainz/oauth/forms.py:59
+#: metabrainz/oauth/forms.py:58
 msgid "Application name field is empty."
 msgstr "アプリケーション名欄が空です。"
 
-#: frontend/js/src/forms/CreateApplication.tsx:60 metabrainz/oauth/forms.py:60
+#: frontend/js/src/forms/CreateApplication.tsx:60 metabrainz/oauth/forms.py:59
 msgid "Application name needs to be at least 3 characters long."
 msgstr "アプリケーション名は3文字以上である必要があります。"
 
-#: frontend/js/src/forms/CreateApplication.tsx:64 metabrainz/oauth/forms.py:61
+#: frontend/js/src/forms/CreateApplication.tsx:64 metabrainz/oauth/forms.py:60
 msgid "Application name needs to be at most 64 characters long."
 msgstr "アプリケーション名は、最大64文字までです。"
 
-#: frontend/js/src/forms/CreateApplication.tsx:114 metabrainz/oauth/forms.py:63
+#: frontend/js/src/forms/CreateApplication.tsx:114 metabrainz/oauth/forms.py:62
 msgid "Description"
 msgstr "説明"
 
-#: metabrainz/oauth/forms.py:64
+#: metabrainz/oauth/forms.py:63
 msgid "Client description field is empty."
 msgstr "「クライアントの説明」欄が空欄です。"
 
-#: metabrainz/oauth/forms.py:65
+#: metabrainz/oauth/forms.py:64
 msgid "Client description needs to be at least 3 characters long."
 msgstr "クライアントの説明は、3文字以上である必要があります。"
 
-#: metabrainz/oauth/forms.py:66
+#: metabrainz/oauth/forms.py:65
 msgid "Client description needs to be at most 512 characters long."
 msgstr "クライアントの説明は、最大512文字までです。"
 
-#: frontend/js/src/forms/CreateApplication.tsx:122 metabrainz/oauth/forms.py:68
+#: frontend/js/src/forms/CreateApplication.tsx:122 metabrainz/oauth/forms.py:67
 msgid "Homepage"
 msgstr "ホームページ"
 
-#: metabrainz/oauth/forms.py:69
+#: metabrainz/oauth/forms.py:68
 msgid "Homepage field is empty."
 msgstr "ホームページ欄が空欄です。"
 
-#: metabrainz/oauth/forms.py:70
+#: metabrainz/oauth/forms.py:69
 msgid "Homepage is not a valid URI."
 msgstr "ホームページは有効なURIではありません。"
 
-#: metabrainz/oauth/forms.py:71
+#: metabrainz/oauth/forms.py:70
 msgid "Homepage URL must use http or https"
 msgstr "ホームページのURLには「http」または「https」を使用する必要があります"
 
-#: metabrainz/oauth/forms.py:73
+#: metabrainz/oauth/forms.py:72
 msgid "Authorization callback URL"
 msgstr "認証コールバックURL"
 
-#: metabrainz/oauth/forms.py:74
+#: metabrainz/oauth/forms.py:73
 msgid "Authorization callback URL field is empty."
 msgstr "「認証コールバックURL」欄が空欄です。"
 
-#: metabrainz/oauth/forms.py:75
+#: metabrainz/oauth/forms.py:74
 msgid "Authorization callback URL is invalid."
 msgstr "認証コールバックURLが無効です。"
 
-#: metabrainz/oauth/forms.py:76
+#: metabrainz/oauth/forms.py:75
 msgid "Authorization callback URL must use http or https."
 msgstr "認証コールバックURLには、http または https を使用する必要があります。"
 
-#: metabrainz/oauth/forms.py:81 metabrainz/oauth/forms.py:85
+#: metabrainz/oauth/forms.py:80 metabrainz/oauth/forms.py:84
 msgid "Confirm"
 msgstr "確認"
+
+#: metabrainz/oauth/scopes.py:15
+msgid "View your public account information"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:16
+msgid "View your email address"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:17
+msgid "View and modify your private tags"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:18
+msgid "View and modify your private ratings"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:19
+msgid "View and modify your private collections"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:20
+msgid "Submit new ISRCs to the database"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:21
+msgid "Submit new barcodes to the database"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:22
+msgid "Sign you in and view your unique user id"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:23
+msgid "Submit listens to ListenBrainz."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:24
+msgid "Create and modify CritiqueBrainz reviews."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:25
+msgid "Submit and delete votes on CritiqueBrainz reviews."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:26
+msgid "Modify profile info and delete profile on CritiqueBrainz."
+msgstr ""
 
 #: metabrainz/payments/views.py:164
 msgid ""
@@ -225,178 +310,185 @@ msgid "Requested annual report was not found."
 msgstr "ご指定の年次レポートが見つかりませんでした。"
 
 #: frontend/js/src/forms/ProfileEdit.tsx:30
-#: frontend/js/src/forms/SignupCommercial.tsx:139
+#: frontend/js/src/forms/SignupCommercial.tsx:144
 #: frontend/js/src/forms/SignupNonCommercial.tsx:70
-#: metabrainz/supporter/forms.py:13
+#: metabrainz/supporter/forms.py:15
 msgid "Contact name is required!"
 msgstr "連絡先の入力は必須です！"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:437
+#: frontend/js/src/forms/SignupCommercial.tsx:441
 #: frontend/js/src/forms/SignupNonCommercial.tsx:264
-#: metabrainz/supporter/forms.py:15
+#: metabrainz/supporter/forms.py:17
 msgid ""
 "Can you please tell us more about the project in which you'd like to use "
 "our data? Do you plan to self host the data or use our APIs?"
 msgstr "当サービスのデータを活用したいとお考えのプロジェクトについて、詳しく教えていただけますか？データをご自身でホストする予定ですか、それとも当サービスのAPIをご利用になる予定ですか？"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:137
+#: frontend/js/src/forms/SignupCommercial.tsx:142
 #: frontend/js/src/forms/SignupNonCommercial.tsx:68
-#: metabrainz/supporter/forms.py:17
+#: metabrainz/supporter/forms.py:19
 msgid "Please, tell us how you (will) use our data."
 msgstr "当サービスのデータをどのように（今後）ご利用になるか、お知らせください。"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:138
+#: frontend/js/src/forms/SignupCommercial.tsx:143
 #: frontend/js/src/forms/SignupNonCommercial.tsx:69
-#: metabrainz/supporter/forms.py:18
+#: metabrainz/supporter/forms.py:20
 msgid "Please, limit usage description to 500 characters."
 msgstr "使用方法の説明は500文字以内に収めてください。"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:141
-#: frontend/js/src/forms/SignupCommercial.tsx:142
+#: frontend/js/src/forms/SignupCommercial.tsx:146
+#: frontend/js/src/forms/SignupCommercial.tsx:147
 #: frontend/js/src/forms/SignupNonCommercial.tsx:72
 #: frontend/js/src/forms/SignupNonCommercial.tsx:73
-#: frontend/js/src/forms/SignupUser.tsx:84
-#: frontend/js/src/forms/SignupUser.tsx:85 metabrainz/supporter/forms.py:21
-#: metabrainz/user/forms.py:38
+#: frontend/js/src/forms/SignupUser.tsx:90
+#: frontend/js/src/forms/SignupUser.tsx:91 metabrainz/supporter/forms.py:23
+#: metabrainz/user/forms.py:45
 msgid "You need to accept the agreement!"
 msgstr "利用規約に同意する必要があります！"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:342
-#: metabrainz/supporter/forms.py:27
+#: frontend/js/src/forms/SignupCommercial.tsx:347
+#: metabrainz/supporter/forms.py:29
 msgid "Organization name"
 msgstr "組織名"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:113
-#: metabrainz/supporter/forms.py:28
+#: frontend/js/src/forms/SignupCommercial.tsx:115
+#: metabrainz/supporter/forms.py:30
 msgid "You need to specify the name of your organization."
 msgstr "所属組織名を入力する必要があります。"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:373
-#: metabrainz/supporter/forms.py:30
+#: frontend/js/src/forms/SignupCommercial.tsx:378
+#: metabrainz/supporter/forms.py:32
 msgid "Organization description"
 msgstr "組織概要"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:116
-#: metabrainz/supporter/forms.py:31
+#: frontend/js/src/forms/SignupCommercial.tsx:118
+#: metabrainz/supporter/forms.py:33
 msgid "You need to provide description of your organization."
 msgstr "貴組織の概要をご記入ください。"
 
 #: frontend/js/src/Profile.tsx:278
-#: frontend/js/src/forms/SignupCommercial.tsx:396
-#: metabrainz/supporter/forms.py:34
+#: frontend/js/src/forms/SignupCommercial.tsx:401
+#: metabrainz/supporter/forms.py:36
 msgid "Website URL"
 msgstr "ウェブサイトURL"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:119
-#: metabrainz/supporter/forms.py:35
-msgid "You need to specify website of the organization."
-msgstr "組織のウェブサイトを入力する必要があります。"
+#: frontend/js/src/forms/SignupCommercial.tsx:121
+#: frontend/js/src/forms/SignupCommercial.tsx:123
+#: metabrainz/supporter/forms.py:38 metabrainz/supporter/forms.py:42
+msgid "Website URL must be a valid URL."
+msgstr ""
 
-#: metabrainz/supporter/forms.py:37
+#: metabrainz/supporter/forms.py:45
 msgid "Logo image URL"
 msgstr "ロゴ画像URL"
 
 #: frontend/js/src/Profile.tsx:284
-#: frontend/js/src/forms/SignupCommercial.tsx:418
-#: metabrainz/supporter/forms.py:38
+#: frontend/js/src/forms/SignupCommercial.tsx:422
+#: metabrainz/supporter/forms.py:46
 msgid "API URL"
 msgstr "API URL"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:457
-#: metabrainz/supporter/forms.py:40
+#: frontend/js/src/forms/SignupCommercial.tsx:461
+#: metabrainz/supporter/forms.py:48
 msgid "Street"
 msgstr "番地"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:123
-#: metabrainz/supporter/forms.py:41
+#: frontend/js/src/forms/SignupCommercial.tsx:128
+#: metabrainz/supporter/forms.py:49
 msgid "You need to specify street."
 msgstr "番地を入力する必要があります。"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:465
-#: metabrainz/supporter/forms.py:43
+#: frontend/js/src/forms/SignupCommercial.tsx:469
+#: metabrainz/supporter/forms.py:51
 msgid "City"
 msgstr "市"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:124
-#: metabrainz/supporter/forms.py:44
+#: frontend/js/src/forms/SignupCommercial.tsx:129
+#: metabrainz/supporter/forms.py:52
 msgid "You need to specify city."
 msgstr "市区町村を入力する必要があります。"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:473
-#: metabrainz/supporter/forms.py:46
+#: frontend/js/src/forms/SignupCommercial.tsx:477
+#: metabrainz/supporter/forms.py:54
 msgid "State / Province"
 msgstr "州/県"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:126
-#: metabrainz/supporter/forms.py:47
+#: frontend/js/src/forms/SignupCommercial.tsx:131
+#: metabrainz/supporter/forms.py:55
 msgid "You need to specify state/province."
 msgstr "市/県を入力する必要があります。"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:481
-#: metabrainz/supporter/forms.py:49
+#: frontend/js/src/forms/SignupCommercial.tsx:485
+#: metabrainz/supporter/forms.py:57
 msgid "Postcode"
 msgstr "郵便番号"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:128
-#: metabrainz/supporter/forms.py:50
+#: frontend/js/src/forms/SignupCommercial.tsx:133
+#: metabrainz/supporter/forms.py:58
 msgid "You need to specify postcode."
 msgstr "郵便番号を入力する必要があります。"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:489
-#: metabrainz/supporter/forms.py:52
+#: frontend/js/src/forms/SignupCommercial.tsx:493
+#: metabrainz/supporter/forms.py:60
 msgid "Country"
 msgstr "国"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:129
-#: metabrainz/supporter/forms.py:53
+#: frontend/js/src/forms/SignupCommercial.tsx:134
+#: metabrainz/supporter/forms.py:61
 msgid "You need to specify country."
 msgstr "国を入力する必要があります。"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:132
-#: metabrainz/supporter/forms.py:64
+#: frontend/js/src/forms/SignupCommercial.tsx:137
+#: metabrainz/supporter/forms.py:72
 msgid ""
 "Custom amount must be more than threshold amount for selected tier or "
 "equal to it!"
 msgstr "カスタム金額は、選択したティアの閾値金額以上でなければなりません！"
 
-#: metabrainz/supporter/views.py:46 metabrainz/supporter/views.py:119
-#: metabrainz/supporter/views.py:220
+#: metabrainz/supporter/views.py:54
+msgid ""
+"The verification email could not be sent. Please request a new one from "
+"your profile."
+msgstr ""
+
+#: metabrainz/supporter/views.py:85 metabrainz/supporter/views.py:158
+#: metabrainz/supporter/views.py:260
 msgid "You are already a supporter."
 msgstr "あなたはすでにサポーターです。"
 
-#: metabrainz/supporter/views.py:61
+#: metabrainz/supporter/views.py:100
 msgid "Can't find tier with a specified ID."
 msgstr "指定されたIDを持つティアが見つかりません。"
 
-#: metabrainz/supporter/views.py:127
+#: metabrainz/supporter/views.py:166
 msgid "You need to choose support tier before signing up!"
 msgstr "登録する前に、サポートティアを選択する必要があります！"
 
-#: metabrainz/supporter/views.py:137
+#: metabrainz/supporter/views.py:176
 msgid "You need to choose existing tier before signing up!"
 msgstr "登録する前に、既存のティアを選択する必要があります！"
 
-#: metabrainz/supporter/views.py:164
+#: metabrainz/supporter/views.py:204
 msgid ""
 "Thanks for becoming a supporter! Your application will be reviewed soon. "
 "We will send you updates via email."
 msgstr "サポーターになっていただき、ありがとうございます！お申し込み内容はまもなく審査されます。進捗状況については、メールでお知らせいたします。"
 
-#: metabrainz/supporter/views.py:187
+#: metabrainz/supporter/views.py:228
 msgid ""
 "Thanks for signing up! Your application will be reviewed soon. We will "
 "send you updates via email."
 msgstr "ご登録ありがとうございます！お申し込み内容はまもなく審査されます。進捗状況については、メールにてお知らせいたします。"
 
-#: metabrainz/supporter/views.py:248
+#: metabrainz/supporter/views.py:288
 msgid "Thanks for becoming a supporter!"
 msgstr "サポーターになっていただき、ありがとうございます！"
 
-#: metabrainz/supporter/views.py:274
+#: metabrainz/supporter/views.py:312
 msgid "Thanks for signing up! Please check your inbox to complete verification."
 msgstr "ご登録ありがとうございます！確認手続きを完了するため、受信トレイをご確認ください。"
 
-#: metabrainz/supporter/views.py:302
+#: metabrainz/supporter/views.py:340
 msgid "Can't generate new token unless account is active."
 msgstr "アカウントが有効でない限り、新しいトークンを生成することはできません。"
 
@@ -430,7 +522,7 @@ msgstr "ショップ"
 msgid "Policies"
 msgstr "ポリシー"
 
-#: metabrainz/templates/base.html:55 metabrainz/templates/index/gdpr.html:178
+#: metabrainz/templates/base.html:55
 #: metabrainz/templates/index/social-contract.html:3
 #: metabrainz/templates/index/social-contract.html:6
 #: metabrainz/templates/navbar.html:34
@@ -440,14 +532,15 @@ msgstr "社会契約"
 #: metabrainz/templates/base.html:56
 #: metabrainz/templates/index/code-of-conduct.html:3
 #: metabrainz/templates/index/code-of-conduct.html:16
-#: metabrainz/templates/index/gdpr.html:181 metabrainz/templates/navbar.html:35
+#: metabrainz/templates/navbar.html:35
 msgid "Code of Conduct"
 msgstr "行動規範"
 
+#: frontend/js/src/PrivacySummary.tsx:11
 #: frontend/js/src/forms/ConditionsModal.tsx:21
-#: metabrainz/templates/base.html:57 metabrainz/templates/index/gdpr.html:184
-#: metabrainz/templates/index/privacy.html:6
+#: metabrainz/templates/base.html:57 metabrainz/templates/index/privacy.html:6
 #: metabrainz/templates/navbar.html:36
+#: metabrainz/templates/users/privacy-summary.html:3
 msgid "Privacy Policy"
 msgstr "プライバシーポリシー"
 
@@ -480,10 +573,7 @@ msgstr "スポンサー"
 msgid "Supporters"
 msgstr "サポーター"
 
-#: frontend/js/src/forms/LoginUser.tsx:103
-#: frontend/js/src/forms/SignupCommercial.tsx:574
-#: frontend/js/src/forms/SignupNonCommercial.tsx:339
-#: frontend/js/src/forms/SignupUser.tsx:232 metabrainz/templates/base.html:73
+#: frontend/js/src/forms/LoginUser.tsx:103 metabrainz/templates/base.html:73
 #: metabrainz/templates/navbar.html:66 metabrainz/templates/users/login.html:3
 msgid "Sign in"
 msgstr "サインイン"
@@ -505,26 +595,26 @@ msgid "Contact us"
 msgstr "お問い合わせ"
 
 #: metabrainz/templates/base.html:85
-#: metabrainz/templates/index/contact.html:105
+#: metabrainz/templates/index/contact.html:106
 msgid "Blog"
 msgstr "ブログ"
 
-#: metabrainz/templates/base.html:86 metabrainz/templates/index/contact.html:90
+#: metabrainz/templates/base.html:86 metabrainz/templates/index/contact.html:91
 msgid "Chat"
 msgstr "チャット"
 
 #: metabrainz/templates/base.html:87
-#: metabrainz/templates/index/contact.html:106
+#: metabrainz/templates/index/contact.html:107
 msgid "Mastodon"
 msgstr "Mastodon"
 
 #: metabrainz/templates/base.html:88
-#: metabrainz/templates/index/contact.html:107
+#: metabrainz/templates/index/contact.html:108
 msgid "Bluesky"
 msgstr "Bluesky"
 
 #: metabrainz/templates/base.html:89
-#: metabrainz/templates/index/contact.html:108
+#: metabrainz/templates/index/contact.html:109
 msgid "Instagram"
 msgstr "Instagram"
 
@@ -582,15 +672,14 @@ msgstr "財務レポート"
 msgid "Donate"
 msgstr "寄付"
 
-#: frontend/js/src/forms/LoginUser.tsx:110
-#: frontend/js/src/forms/SignupCommercial.tsx:175
-#: frontend/js/src/forms/SignupCommercial.tsx:555
+#: frontend/js/src/forms/SignupCommercial.tsx:180
+#: frontend/js/src/forms/SignupCommercial.tsx:559
 #: frontend/js/src/forms/SignupNonCommercial.tsx:106
 #: frontend/js/src/forms/SignupNonCommercial.tsx:319
 #: metabrainz/templates/navbar.html:65
-#: metabrainz/templates/supporters/account-type.html:51
-#: metabrainz/templates/supporters/account-type.html:93
-#: metabrainz/templates/supporters/account-type.html:144
+#: metabrainz/templates/supporters/account-type.html:47
+#: metabrainz/templates/supporters/account-type.html:84
+#: metabrainz/templates/supporters/account-type.html:130
 #: metabrainz/templates/users/signup.html:3
 msgid "Sign up"
 msgstr "サインアップ"
@@ -954,9 +1043,431 @@ msgstr ""
 msgid "Introduction"
 msgstr "イントロダクション"
 
-#: metabrainz/templates/index/conflict-policy.html:55
+#: metabrainz/templates/index/conflict-policy.html:17
+msgid ""
+"Conflicts between people arise in open source projects constantly and the"
+" projects by the \n"
+"    MetaBrainz Foundation are no different. This policy aims to establish"
+" a clear and unambiguous \n"
+"    policy for reporting and addressing conflicts in our community. In "
+"this policy we aim to \n"
+"    establish a fair practice that balances the need for confidentiality "
+"and our desire for \n"
+"    transparency in our operations."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:25
+#, python-format
+msgid ""
+"Before you continue to read this policy, we encourage you to review our "
+"existing community policies \n"
+"    including our <a href=\"%(social_contract_url)s\">Social "
+"Contract</a>, \n"
+"    <a href=\"%(code_of_conduct_url)s\">the Code of Conduct</a>, \n"
+"    and our <a href=\"%(privacy_policy_url)s\">Privacy Policy</a>. These "
+"policies establish the norms and rules for \n"
+"    participation in our projects; these policies apply equally to the "
+"contractors of the MetaBrainz \n"
+"    Foundation and any participants in our projects."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:37
+msgid ""
+"This policy divides conflicts into two categories: Private and public. "
+"Private conflicts are conflicts \n"
+"    that involve *confidential* information regarding contributors, "
+"contractors or supporters. Otherwise, any conflicts \n"
+"    that do not involve confidential information are considered to be "
+"public conflicts. For instance, a \n"
+"    conflict between a contractor and the Executive Director (aka BDFL) "
+"that involves contractor pay is \n"
+"    considered a private conflict because pay rates are confidential "
+"information. A public conflict in edit \n"
+"    notes between two editors in our community does not involve "
+"confidential information and therefore should \n"
+"    be considered a public conflict."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:47
+msgid ""
+"When conflicts arise we aim to disclose as much information as possible "
+"about the conflict in a timely \n"
+"    fashion. When conflicts contain confidential matters we will aim to "
+"disclose as much information as \n"
+"    possible, while fully respecting the confidentiality of the people "
+"involved in the conflict. With any \n"
+"    private conflict we will aim to extract the relevant lessons for the "
+"team and community in an effort to \n"
+"    evolve our policies to prevent future conflicts. Should the involved "
+"parties disagree whether a conflict \n"
+"    is private or public, the question about the nature of the conflict "
+"will be presented for the next higher \n"
+"    level in the chain of command to decide. (e.g. if a community member "
+"and the community manager disagree on \n"
+"    a conflict being public or private, the Executive Director shall "
+"decide if the conflict is public or private)."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:58
 msgid "Reporting and Response"
 msgstr "報告と返答"
+
+#: metabrainz/templates/index/conflict-policy.html:61
+msgid ""
+"We aim to not have conflict in our community, but we recognize that in "
+"reality conflicts will arise and we \n"
+"    must be prepared to address them in a fair manner. When conflicts "
+"arise, we prefer to have community or team \n"
+"    members resolve the conflicts among themselves, using our existing "
+"policies as guidelines for resolving the \n"
+"    conflict."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:69
+msgid ""
+"If you do not feel comfortable resolving a conflict on your own, you "
+"should feel free to report the conflict to \n"
+"    us. How you address the conflict depends on who is involved in the "
+"conflict and your comfort level. Please see \n"
+"    the detailed sections below on how and with whom to address your "
+"conflict. We aim to address conflicts as soon \n"
+"    as possible in an effort to prevent them from escalating "
+"unnecessarily."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:75
+msgid "Direct conflict resolution"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:78
+msgid ""
+"In direct conflict resolution, the involved parties will attempt to "
+"resolve the conflict themselves without \n"
+"   involving any MetaBrainz Foundation team member. You should aim to use"
+" direct resolution when the conflict does \n"
+"   not involve the violation of one of our policies or if the conflict is"
+" minor."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:84
+#, python-format
+msgid ""
+"For instance, if a user uses a rude tone, is disruptive or flagrantly "
+"ignores our project guidelines, we suggest \n"
+"    that you use direct conflict resolution to resolve the conflict. Some"
+" resources that might give you some suggestions \n"
+"    on how to go about resolving the conflict might be this <a "
+"href=\"%(conflict_resolution_primer_url)s\">\n"
+"    conflict resolution primer</a> and <a "
+"href=\"%(difficult_conversations_url)s\">how to\n"
+"    have difficult conversations at work</a>."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:93
+msgid "Informal reporting"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:96
+msgid ""
+"You may use informal reporting of a conflict if you aim to communicate a "
+"concern or incident without \n"
+"    seeking a corrective outcome. Informal reporting may also be an "
+"option if you have not been personally \n"
+"    victimized, but you’ve witnessed a violation of our policies or where"
+" you wish to maintain confidentiality \n"
+"    throughout the entire reporting process."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:103
+msgid ""
+"For editing in MusicBrainz you may informally report a user using the "
+"“Report this user for bad behavior” \n"
+"    link from the user’s profile. For reporting bad user behavior in "
+"other of our projects, please report them to our \n"
+"    community manager by mailing <span class=\"backemail\">gro.zniarbatem"
+"@reganam-ytinummoc</span> . For conflicts \n"
+"    that involve the community manager, report them by mailing <span "
+"class=\"backemail\">gro.zniarbatem@de</span> ."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:110
+msgid ""
+"Depending the the severity of the issue, repeated informal complaints may"
+" eventually require a formal response \n"
+"    from the MetaBrainz team. If an involved party requires anonymity, "
+"the conflict becomes a private conflict. If at \n"
+"    all possible minor issues should be resolved in a public forum in "
+"order for all people to witness and learn from \n"
+"    the issue at hand."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:116
+msgid "Formal complaint process"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:119
+msgid ""
+"All complaints about conflicts should be submitted via email. To whom a "
+"complaint should be mailed and who will \n"
+"    carry out the investigation will be described in the next section."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:124
+msgid "All complaint submissions to the Foundation should include the following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:128
+msgid ""
+"Contact info, if it is different than the email used to submit the "
+"conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:129
+msgid "Who was involved in the conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:130
+msgid "Where and when the incident happened"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:131
+msgid ""
+"A description of what happened -- ideally with links (e.g. chatlogs, edit"
+" notes) that outlines what \n"
+"         happened so that the persons evaluating the conflict may "
+"understand the issue at hand"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:133
+msgid ""
+"Any related pieces of information that provide more context on the "
+"conflict (e.g. links, screenshots)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:134
+msgid "An indication if this conflict is ongoing or not"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:139
+msgid "The investigation that follows aims to determine:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:143
+msgid "The nature and severity of the incident"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:144
+msgid ""
+"Whether or not the incident is considered a violation of MetaBrainz’ "
+"conduct policies or core values"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:145
+msgid ""
+"The amount of harm experienced by the person who submitted the complaint "
+"and the broader MetaBrainz community \n"
+"         as a result of the incident"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:147
+msgid ""
+"Whether there have been prior complaints against the individual or "
+"individuals reported"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:148
+msgid "Whether the incident is ongoing"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:152
+msgid ""
+"The following potential forms of resolution may apply to any team members"
+" involved in the conflict:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:155
+#: metabrainz/templates/index/conflict-policy.html:168
+msgid "Nothing (if it has been found no violation occurred)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:156
+msgid "Creating a plan to improve the performance"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:157
+msgid "Creating a negative performance evaluation"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:158
+msgid "Mediation, an intervention by a third party to resolve the conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:159
+msgid "Suspension or forced leave"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:160
+msgid "Termination of contract"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:164
+msgid ""
+"The following potential forms of resolution may apply to non team members"
+" involved in the conflict:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:169
+msgid "A reprimand, either public or private"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:170
+msgid "Suspension of the users’ account"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:171
+msgid "Deletion of the users’ account"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:172
+msgid ""
+"Removal of user privileges (e.g. if an auto editor commits a serious "
+"offence, they may lose their auto editor status)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:175
+msgid "Filing a complaint"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:178
+msgid ""
+"NOTE: For complaints not about MetaBrainz staff, please see the "
+"<em>Informal reporting</em> section above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:182
+msgid ""
+"If the complaint does not involve the Executive Director (ED), do the "
+"following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:186
+msgid ""
+"If team member has directly violated conduct policies or engaged in "
+"otherwise harmful behavior, a formal complaint should be filed."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:187
+msgid ""
+"Mail <span class=\"backemail\">gro.zniarbatem@de</span> and include the "
+"complaint information outlined above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:188
+msgid ""
+"You should expect a response within a working day acknowledging the "
+"complaint."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:189
+msgid ""
+"The complaint will be investigated by the ED, member(s) of the board of "
+"directors or a neutral third party."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:190
+msgid ""
+"Once the investigation has been completed, the ED, with the support of "
+"others involved in the investigation will respond. The \n"
+"        ED will respond to incidents no later than 7 working days after a"
+" complaint has been filed with either a resolution or an \n"
+"        explanation of why the process must be extended."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:196
+msgid "If a complaint involves the Executive Director, do the following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:200
+msgid ""
+"If the Executive Director has directly violated conduct policies or "
+"engaged in otherwise harmful behavior, \n"
+"        a formal complaint should be filed with the board of directors."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:202
+msgid ""
+"Mail <span class=\"backemail\">gro.zniarbatem@noituloser-tcilfnoc</span> "
+"and include the complaint information outlined above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:203
+msgid ""
+"You should get a response within 5 working days acknowledging the "
+"complaint."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:204
+msgid ""
+"The complaint will be investigated by the member(s) of the board of "
+"directors, the community manager, a neutral \n"
+"        third party or a combination thereof."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:206
+msgid ""
+"Once the investigation has been completed, the board, with the support of"
+" others involved in the investigation \n"
+"        will respond. The board will aim to respond to incidents no later"
+" than 15 working days after a complaint has been filed \n"
+"        with either a resolution or an explanation of why the process "
+"must be extended."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:211
+msgid "Confidentiality"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:214
+msgid ""
+"Confidentiality is an important aspect of conflict resolution and all of "
+"the conflicts brought to the attention of the foundation \n"
+"    will be evaluated with confidentiality in mind and acted upon "
+"accordingly."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:219
+msgid ""
+"We work hard to make all of the actions of the foundation as transparent "
+"and open as possible. In cases where we cannot \n"
+"    disclose all aspects of a conflict we will disclose that a conflict "
+"is or has occurred and we will attempt to disclose the \n"
+"    appropriate amount of information about the conflict while balancing "
+"the need for confidentiality and our desire to learn \n"
+"    from conflicts so that we as a foundation and community can learn "
+"from these conflicts and improve our policies to avoid the \n"
+"    conflicts in the future."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:227
+msgid ""
+"Any breaches of confidentiality will be treated as severe breaches of our"
+" conduct policies."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:230
+msgid "Retaliation"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:233
+msgid ""
+"We will not allow retaliation for any contractor or volunteer that files "
+"a complaint or is involved in an investigation. If you \n"
+"    believe that you are being treated negatively because of your "
+"involvement in a complaint please report this complaint directly \n"
+"    to the ED at <span class=\"backemail\">gro.zniarbatem@de</span> or "
+"the board at \n"
+"    <span class=\"backemail\">gro.zniarbatem@noituloser-tcilfnoc</span>."
+msgstr ""
 
 #: metabrainz/templates/index/contact.html:3
 #: metabrainz/templates/index/contact.html:6
@@ -1055,7 +1566,7 @@ msgstr "広告リクエスト"
 msgid ""
 "We are currently evaluating our overall online advertising strategy. We "
 "are evaluating advertising, traffic optimization,\n"
-"    search engine optimization and software monitization technologies. If"
+"    search engine optimization and software monetization technologies. If"
 " you provide these professional services, please provide a detailed\n"
 "    deck of your comprehensive services to the following email address. "
 "<em>Please respect our other non-media teams and do not contact us \n"
@@ -1063,11 +1574,6 @@ msgid ""
 " disregard the entirety of your submissions if you contact us any other "
 "way!</em>"
 msgstr ""
-"現在、当社はオンライン広告戦略全体の見直しを行っています。広告、トラフィック最適化、検索エンジン最適化（SEO）、\n"
-"およびソフトウェアの収益化技術について評価を進めています。\n"
-"これらの専門サービスを提供されている場合は、包括的なサービス内容の詳細な資料を以下のメールアドレスまでお送りください。<em>当社のメディア部門以外のチームへの配慮をお願いいたします。"
-"\n"
-"これらのサービスに関して、当社の他のメールアドレスへご連絡いただくことはご遠慮ください。他の方法でご連絡いただいた場合、お送りいただいた資料はすべて無視させていただきます！</em>"
 
 #: metabrainz/templates/index/contact.html:52
 #, python-format
@@ -1139,13 +1645,11 @@ msgstr "フォーラム"
 #, python-format
 msgid ""
 "Please come ask your questions at our <a "
-"href=\"%(forums_url)s\">forums</a>! We would love to\n"
-"    answer any questions you may have."
+"href=\"%(forums_url)s\">forums</a>!\n"
+"    The community and the team will be more than happy to help you."
 msgstr ""
-"ぜひ、当サイトの <a href=\"%(forums_url)s\">フォーラム</a> までご質問をお寄せください！\n"
-"皆様からのご質問には、喜んでお答えいたします。"
 
-#: metabrainz/templates/index/contact.html:92
+#: metabrainz/templates/index/contact.html:93
 #, python-format
 msgid ""
 "The MetaBrainz/MusicBrainz/ListenBrainz team and community hang out\n"
@@ -1160,15 +1664,15 @@ msgstr ""
 "にアクセスして、チャットに参加してください。\n"
 "また、<a href=\"%(chatlogs_url)s\">チャットログのアーカイブ</a>を閲覧することもできます。"
 
-#: metabrainz/templates/index/contact.html:101
+#: metabrainz/templates/index/contact.html:102
 msgid "Social media"
 msgstr "ソーシャルメディア"
 
-#: metabrainz/templates/index/contact.html:103
+#: metabrainz/templates/index/contact.html:104
 msgid "You can follow us on these social channels:"
 msgstr "以下のソーシャルメディアで当アカウントをフォローいただけます："
 
-#: metabrainz/templates/index/contact.html:112
+#: metabrainz/templates/index/contact.html:113
 msgid "Mailing address"
 msgstr "郵送先住所"
 
@@ -1181,34 +1685,350 @@ msgstr "MetaBrainzデータセット"
 msgid "GDPR Compliance Statement"
 msgstr "GDPR準拠に関する声明"
 
-#: metabrainz/templates/index/gdpr.html:37
+#: metabrainz/templates/index/gdpr.html:10
+msgid ""
+"The General Data Protection Regulation is a complex EU regulation that "
+"stipulates many points for protecting private data of\n"
+"    users on the Internet. Even though this is an EU regulation, it has a"
+" worldwide impact due to the nature of the Internet.\n"
+"    The MetaBrainz Foundation with its collection of projects is also "
+"affected by this regulation. We’ve been learning and adapting\n"
+"    our sites to be compliant with the GDPR – sadly this regulation isn’t"
+" entirely black and white and there is an incredible\n"
+"    amount of room left for interpretation of these rules."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:17
+msgid ""
+"The good news is that this regulation is roughly in line with our "
+"established practices: We’ve always held private information\n"
+"    in a high regard and applied the sort of rules to ourselves as we "
+"wish to have our own private data treated. Luckily, this\n"
+"    makes our compliance effort considerably easier. We’ve made two "
+"significant changes to how we treat your data and also adopted\n"
+"    terminology as used in the GDPR in order to use the same languages "
+"that many other sites are now adopting. Please keep reading\n"
+"    to find out the exact details of what we are doing to comply."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:24
+#, python-format
+msgid ""
+"However, we do ask for your compassion and help in our process of "
+"complying with the GDPR. As we already mentioned, the GDPR is\n"
+"    a complex set of rules that are not fully clarified yet. We’ve taken "
+"action on the steps that are clear to us and we’re following\n"
+"    ongoing conversations on points that are in gray zones or unclear to "
+"us. We’ve made our best initial effort on compliance and\n"
+"    promise to keep working on it as the picture becomes more clear. If "
+"you believe that we could improve our compliance, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a> and let us know what we "
+"can do to improve. It would also help us if you\n"
+"    could provide concrete discussion or examples to help us understand "
+"and take action on your suggestion."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:33
+msgid ""
+"Finally, below are the key sections of the GDPR as we understand them and"
+" how they affect your data in our ecosystem. Where\n"
+"    possible, we provide links for deeper understanding, links for you to"
+" examine our relevant code and links to tickets to follow\n"
+"    the process of improving our compliance."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:38
 msgid "Right to be forgotten"
 msgstr "忘れられる権利"
 
-#: metabrainz/templates/index/gdpr.html:77
+#: metabrainz/templates/index/gdpr.html:41
+msgid ""
+"Summary: <i>Provide the user with the ability to remove their private "
+"data from our services</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:44
+msgid ""
+"The most important aspect of the right to be forgotten is the ability to "
+"delete your account. Once you request for us to delete\n"
+"    your account, we will remove any personally identifying information "
+"you may have provided us from your account (name, email\n"
+"    address, gender, biography, URL, etc.). The visible name on your "
+"account will be changed to “Deleted User #####” and effectively\n"
+"    the account will no longer be identifiable as your account."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:50
+msgid ""
+"However, given the nature of our projects where we work on collaborative "
+"databases, your contributions that are not personally\n"
+"    identifying are valuable assets to our database and these "
+"contributions will not be removed from our databases. But we will\n"
+"    ensure that these contributions no longer contain personally "
+"identifying data."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:55
+#, python-format
+msgid ""
+"Our process of automatically deleting your accounts across the MetaBrainz"
+" ecosystem is not complete yet (see below for a set of\n"
+"    tickets where you can track our progress). If you would like to "
+"delete your accounts in the MetaBrainz ecosystem or mark a\n"
+"    donation that is currently public as a private donation, please <a "
+"href=\"%(contact_url)s\">contact us</a>\n"
+"    and we will address your request as soon as possible."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:62
+#: metabrainz/templates/index/gdpr.html:182
+msgid "Links:"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:66
+#, python-format
+msgid ""
+"<a href=\"%(editor_deletion_doc_url)s\">How we delete accounts\n"
+"       in MusicBrainz</a> (warning, geek content ahead!)"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:70
+msgid ""
+"Implement sitewide user account deletion in\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/MBS-9680\">MusicBrainz</a>,"
+"\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/AB-337\">AcousticBrainz</a>,"
+"\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/BB-260\">BookBrainz</a>,\n"
+"         <a href=\"https://tickets.metabrainz.org/browse/MEB-103\">the "
+"MetaBrainz Site</a>,\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/LB-354\">ListenBrainz</a>, "
+"and\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/CB-307\">CritiqueBrainz</a>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:80
 msgid "Restriction of processing"
 msgstr "処理の制限"
 
-#: metabrainz/templates/index/gdpr.html:110
+#: metabrainz/templates/index/gdpr.html:83
+msgid ""
+"Summary: <i>To allow the user to control how their personally identifying"
+" data is being used.</i>"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:86
+msgid ""
+"Except for the ListenBrainz and AcousticBrainz projects, we do not "
+"process personally identifying data. Any personally\n"
+"    identifying data that our projects store is for the purpose of being "
+"able to contact you about your contributions to our database\n"
+"    (email address) or for voluntarily showing information about you to "
+"other users (biography, homepage, location, etc)."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:91
+#, python-format
+msgid ""
+"The ListenBrainz project differs in that the Listens (metadata about what"
+" music you have listened to) are stored on our servers\n"
+"    and <a href=\"%(listenbrainz_data_url)s\">made available to the "
+"public</a>. We believe Listens to be personally identifying\n"
+"    data and furthermore, we have goals of creating open source "
+"recommendation engines with this data, which involves processing the\n"
+"    user’s data. These two points are fundamental goals of the "
+"ListenBrainz project and we do not see a reasonable way to reach another"
+"\n"
+"    compromise position."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:99
+msgid ""
+"Because of this, we are going to require users to either acknowledge that"
+" we may process their Listen data or alternatively to\n"
+"    delete their account, including all of their Listens. Please note "
+"that if you decide to delete your ListenBrainz account, it may\n"
+"    take up to two weeks for all of your listens to no longer be included"
+" in our efforts to build a recommendation engine."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:104
+msgid ""
+"We have always made it clear that the data in ListenBrainz was to be "
+"public and that we plan to build new tools with your data, so\n"
+"    this should not come as a surprise to our users."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:108
+msgid ""
+"The AcousticBrainz project does not track who submits data to the "
+"database. If you create an account and use our data creation\n"
+"    tools (e.g. create a dataset or participate in a challenge) then we "
+"link your participation and the things that you create to\n"
+"    your account. If you choose to delete your account then we keep the "
+"non personally identifying data that you create, but anonymize\n"
+"    it so that it cannot be linked back to you."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:114
 msgid "Right to data portability / exporting your data"
 msgstr "データのポータビリティに関する権利 / データのエクスポート"
 
-#: metabrainz/templates/index/gdpr.html:150
+#: metabrainz/templates/index/gdpr.html:117
+msgid ""
+"Summary: <i>You have the right to access/download the data we store about"
+" you</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:120
+msgid ""
+"Except for the ListenBrainz and AcousticBrainz projects, we do not store "
+"personally identifying data beyond the\n"
+"    information that is available in your public profile on each of our "
+"projects. Since this data is plainly available in your\n"
+"    profile we do not provide a means for you to export this data."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:125
+msgid "There are the following exceptions to this:"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:129
+msgid ""
+"<b>IP addresses</b>: If you visit one of our sites the IP address of your"
+" computer is stored in our web logs for 7 days\n"
+"        before our servers automatically delete them. This data is almost"
+" never used by anyone: the only time we look at the\n"
+"        IP addresses is if our sites are adversely impacted by the "
+"actions of some unknown users. In that case, we may investigate\n"
+"        the logs to identify the IP address that needs to be blocked in "
+"order to restore the stability of our service.\n"
+"        This data is not available to anyone but the contractors of the "
+"MetaBrainz Foundation and is not available to download\n"
+"        to anyone at all."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:137
+#, python-format
+msgid ""
+"<b>ListenBrainz Listen data</b>: Users may <a "
+"href=\"%(listenbrainz_export_url)s\">export their ListenBrainz Listen\n"
+"        data</a> directly from the site. The user Listen data is also "
+"included in the <a href=\"%(listenbrainz_data_url)s\">ListenBrainz\n"
+"        data dumps</a> that are available for public download."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:146
+msgid ""
+"All of the non personally identifying data, such as your metadata "
+"contributions, are publicly visible, available for download\n"
+"    and available via the project APIs. For details about this data, "
+"downloads and APIs please check the documentation for the\n"
+"    respective projects you are interested in."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:151
+#, python-format
+msgid ""
+"Anyone wishing to get a list of financial donations they have made to the"
+" MetaBrainz Foundation, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a> and provide your "
+"MusicBrainz editor name so that we can look up\n"
+"    your donations."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:157
 msgid "Right to rectification"
 msgstr "訂正権"
 
-#: metabrainz/templates/index/gdpr.html:165
+#: metabrainz/templates/index/gdpr.html:160
+msgid "Summary: <i>You have the right to correct your data</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:163
+msgid ""
+"All of our projects allow their users to update their personally "
+"identifying information in their profiles. Furthermore, most\n"
+"    of our projects allow the editing of their own metadata "
+"contributions. If you find that some of your data is incorrect, please\n"
+"    feel free to edit the data since we provide the tools to do so."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:168
+#, python-format
+msgid ""
+"If anyone who has made a financial donation to the MetaBrainz Foundation "
+"would like to make their donation private, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:173
 msgid "Right to be informed"
 msgstr "情報提供を受ける権利"
 
-#: metabrainz/templates/index/gdpr.html:188
+#: metabrainz/templates/index/gdpr.html:175
+msgid ""
+"Summary: <i>You have the right to be informed about how we use your data "
+"in plain English</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:178
+msgid ""
+"Our privacy policy, as well as other policies, have always been written "
+"by humans for human consumption. We abhor legalese and\n"
+"    not speaking in direct terms."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:186
+msgid "Social contract"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:189
+msgid "Code of conduct"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:192
+msgid "Privacy policy"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:196
 msgid "Right to access"
 msgstr "アクセスする権利"
 
-#: metabrainz/templates/index/gdpr.html:198
-#: metabrainz/templates/index/privacy.html:166
+#: metabrainz/templates/index/gdpr.html:199
+msgid ""
+"Summary: <i>You have the right to access the data that we collect about "
+"you</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:202
+msgid ""
+"All of our projects make all of the data we collect on your behalf, "
+"privately identifying or not, available to you. The\n"
+"    only exception to this are the IP addresses we store for 7 days – see"
+" above for details."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:206
+#: metabrainz/templates/index/privacy.html:168
 msgid "Privacy/GDPR Representative"
 msgstr "プライバシー/GDPR担当責任者"
+
+#: metabrainz/templates/index/gdpr.html:209
+#, python-format
+msgid ""
+"If you have any questions about our privacy policy, please <a "
+"href=\"%(contact_url)s\">contact us</a>. To report\n"
+"   any privacy problems, violations or leaks, our GDPR representative is "
+"our Interim Executive Director Nicolás Tamargo and for\n"
+"   privacy issues contact him at <strong><a "
+"href=\"mailto:gdpr@metabrainz.org\">gdpr@metabrainz.org</a></strong>."
+msgstr ""
 
 #: metabrainz/templates/index/index.html:6
 msgid "Welcome to MetaBrainz!"
@@ -1336,7 +2156,7 @@ msgstr ""
 "この財団に関する詳細については、\n"
 "<a href=\"%(about_url)s\">概要</a>ページをご覧ください。"
 
-#: frontend/js/src/forms/ConditionsModal.tsx:43
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:32
 #: metabrainz/templates/index/privacy.html:3
 msgid "Privacy"
 msgstr "プライバシー"
@@ -1344,6 +2164,44 @@ msgstr "プライバシー"
 #: metabrainz/templates/index/privacy.html:8
 msgid "Summary"
 msgstr "概要"
+
+#: metabrainz/templates/index/privacy.html:12
+msgid ""
+"You do not have to provide any personal data to be able to browse the "
+"contents of the databases published by MetaBrainz."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:15
+msgid ""
+"You do not have to provide any personally-identifying information if you "
+"choose not to."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:18
+msgid ""
+"We will never reveal your email address on MetaBrainz controlled web "
+"sites."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:22
+msgid ""
+"In order to get maximum value out of the MetaBrainz projects, you may "
+"want to create an account and log in. \n"
+"    Doing so grants you the ability to: edit the databases, contribute "
+"your own data, communicate with other users, and keep track \n"
+"    of recently released music from artists in your MusicBrainz "
+"collection. If you choose to create an account then the minimum we \n"
+"    ask is that you: choose a unique username and password, use a web "
+"browser that accepts \"session\" cookies, and provide a verified \n"
+"    email address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:29
+msgid ""
+"If you do not create an account (or are not logged in) you will not have "
+"access to the above listed features, however, you will \n"
+"    still have full access to browse and examine the databases."
+msgstr ""
 
 #: metabrainz/templates/index/privacy.html:33
 msgid "Applicable to all users"
@@ -1353,39 +2211,197 @@ msgstr ""
 msgid "Cookies"
 msgstr "クッキー"
 
+#: metabrainz/templates/index/privacy.html:37
+msgid "We use two cookies that contain sensitive information:"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:42
+msgid ""
+"<b>remember_login</b>: If you choose the \"Log in permanently\" option "
+"when logging in to one of our sites; the cookie will be used to \n"
+"      remember your login details."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:46
+msgid ""
+"<b>musicbrainz_server_session, session, or connect.sid</b>: If you are "
+"logged into one of our sites, your current session ID is stored in this "
+"cookie."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:51
+msgid ""
+"We may store dynamic preference information in other cookies, but these "
+"do not contain any sensitive information."
+msgstr ""
+
 #: metabrainz/templates/index/privacy.html:54
 msgid "Web and FTP access logs"
 msgstr "WebとFTPのアクセスログ"
+
+#: metabrainz/templates/index/privacy.html:57
+msgid ""
+"In a practice similar to other web sites (and APIs) we keep logs of all "
+"web requests made against our servers. These logs include: your IP\n"
+"    address, your browser's (or API client's) \"User-Agent\" string, and "
+"which page (or API endpoint) you requested with which parameters. "
+"Aggregate information about web and FTP traffic is\n"
+"    made available to the public via our site usage pages."
+msgstr ""
 
 #: metabrainz/templates/index/privacy.html:62
 msgid "Third-Party content"
 msgstr "第三者によるコンテンツ"
 
-#: metabrainz/templates/index/privacy.html:92
+#: metabrainz/templates/index/privacy.html:64
+msgid ""
+"Our projects' web pages may load some third-party content. Some, but "
+"possibly not all sites are listed below:"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:69
+#, python-format
+msgid ""
+"Cover art and other images: These are provided by the various cover art "
+"sites that have given MusicBrainz permission to do so and our own \n"
+"      <a href=\"%(caa_url)s\">Cover Art Archive</a>. This means that the "
+"relevant site will know (if they want to) your IP \n"
+"      address, User-Agent string, etc., and which MusicBrainz web page "
+"you were visiting (the one which included the cover art image)."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:75
+msgid ""
+"AcoustID: Our fingerprints tab loads fingerprint information from "
+"acoustid.org."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:78
+msgid ""
+"MTCaptcha: Our account creation page loads third party content in order "
+"to prevent spammers from creating accounts."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:83
+msgid ""
+"<i>The above information assumes that you are using \"normal\" web "
+"browser settings, whereby images are always loaded and HTTP referrer \n"
+"    information is always sent.</i>"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:88
+msgid ""
+"It is impractical to constantly modify this privacy policy when "
+"MetaBrainz projects change which third party content they utilize. We "
+"will \n"
+"    aim to use common sense, respect to our community and community "
+"review when adding more content from third party sites. We will also \n"
+"    periodically review our policy to ensure that it remains current."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:93
 msgid "Applicable to account holders"
 msgstr "アカウント保有者が対象となります"
 
-#: metabrainz/templates/index/privacy.html:94
+#: metabrainz/templates/index/privacy.html:95
 msgid "Account creation"
 msgstr "アカウント作成"
 
-#: metabrainz/templates/index/privacy.html:108
+#: metabrainz/templates/index/privacy.html:97
+msgid ""
+"When creating an account with a MetaBrainz project you need to pick a "
+"unique username and choose a password, the username you pick is the \n"
+"    only name associated with your account and will be what other "
+"MetaBrainz users know you as. You may optionally also tell us other \n"
+"    information about yourself that will be displayed to other MetaBrainz"
+" users and the public."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:103
+msgid ""
+"Additionally, in order to edit the databases you will need to provide a "
+"confirmed email address. This email address will be held in \n"
+"    confidence, the only method of revealing your email address to "
+"another user is if you choose to send a message to another \n"
+"    user and enable the option to \"reveal my email address\". Changing "
+"the email address stored with your account will require you to \n"
+"    verify the new address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:109
 msgid "Edits and Notes"
 msgstr "編集と議論"
 
-#: metabrainz/templates/index/privacy.html:114
+#: metabrainz/templates/index/privacy.html:111
+msgid ""
+"If you make any changes to a MetaBrainz project database, such as adding "
+"any data, the details of those changes will be visible to \n"
+"    other logged-in users and the change will be associated with your "
+"username."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:115
 msgid "Subscriptions on MusicBrainz"
 msgstr "MusicBrainzの購読"
 
-#: metabrainz/templates/index/privacy.html:131
+#: metabrainz/templates/index/privacy.html:117
+msgid ""
+"As a logged-in user you can subscribe to one or more artists, labels, "
+"collections or other editors. The act of subscribing causes \n"
+"    any edits made to (or by in the case of another editor) those "
+"entities to be emailed to you. By default, other users can see your \n"
+"    list of subscriptions, however, you can opt out of this by editing "
+"the appropriate preference."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:123
+msgid ""
+"This does not provide \"perfect\" privacy though, in some cases it will "
+"be possible to infer information about the contents of your \n"
+"    subscription list even though you have disallowed others from viewing"
+" that list directly. This imperfection arises because various \n"
+"    parts of the system behave differently depending on whether or not an"
+" entity has any subscribers; also, the number of users \n"
+"    subscribed to each artist is available via the artist pages. In the "
+"most extreme (possibly contrived) example, imagine that all \n"
+"    users have their subscriptions set to \"public\", except for exactly "
+"one user whose list is \"private\". In that case, any discrepancy \n"
+"    for a given artist between the shown list of subscribers and the "
+"total number of subscribers must be down to that one user. Thus, \n"
+"    you can infer what artists are on that user's list."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:132
 msgid "Third-party sites"
 msgstr "サードパーティ・サイト"
 
-#: metabrainz/templates/index/privacy.html:145
+#: metabrainz/templates/index/privacy.html:134
+#, python-format
+msgid ""
+"Our code reviews are done on GitHub, which is not under the control of "
+"MetaBrainz. Participating in code reviews or other\n"
+"    tasks carried out on GitHub are subject to <a "
+"href=\"%(github_url)s\">GitHub's privacy policy</a>."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:140
+#, python-format
+msgid ""
+"Our translations platform is provided and hosted by Weblate, which has a "
+"data processing agreement with MetaBrainz.\n"
+"    Participating in translations is subject to <a "
+"href=\"%(weblate_url)s\">dedicated legal terms</a>.\n"
+"    Any translations you make will be submitted to our Git repositories "
+"and publicly associated with your username;\n"
+"    if you so choose, you can also publicly associate them with your own "
+"verified email address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:147
 msgid "MetaBrainz donors"
 msgstr "MetaBrainzの寄付者"
 
-#: metabrainz/templates/index/privacy.html:147
+#: metabrainz/templates/index/privacy.html:149
 msgid ""
 "When you make a donation to the MetaBrainz Foundation, we are legally\n"
 "    required to collect your personal information and keep it in our "
@@ -1399,7 +2415,7 @@ msgstr ""
 "法律に基づき、寄付者の個人情報を収集し、記録として保管する義務があります。\n"
 "当財団は、いかなる場合においても、寄付者の個人情報を第三者に開示することはありません。"
 
-#: metabrainz/templates/index/privacy.html:153
+#: metabrainz/templates/index/privacy.html:155
 msgid ""
 "We believe in transparent finances, which means that we list all "
 "donations\n"
@@ -1412,11 +2428,34 @@ msgstr ""
 "寄付手続きの際に匿名を選択された場合を除き、\n"
 "掲載されるのはお名前と寄付金額のみとなります。"
 
-#: metabrainz/templates/index/privacy.html:158
+#: metabrainz/templates/index/privacy.html:160
 msgid "Exceptions"
 msgstr "例外"
 
-#: frontend/js/src/Profile.tsx:598
+#: metabrainz/templates/index/privacy.html:162
+msgid ""
+"<i><b>Please note</b>: Reasonable exceptions may apply to the above "
+"policy, for example to comply with applicable laws.\n"
+"    Also, members of the MetaBrainz team and other personnel contracted "
+"to provide services to MetaBrainz may have access to\n"
+"    our infrastructure and could therefore view any information contained"
+" therein. However all personnel are contractually bound\n"
+"    by non-disclosure clauses which prevent them from making any such "
+"information available to others."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:171
+#, python-format
+msgid ""
+"If you have any questions about our GDPR statement, please <a "
+"href=\"%(contact_url)s\">contact us</a>. To report\n"
+"   any privacy problems, violations or leaks, our GDPR representative is "
+"our Interim Executive Director Nicolás Tamargo and for\n"
+"   privacy issues contact him at <strong><a "
+"href=\"mailto:gdpr@metabrainz.org\">gdpr@metabrainz.org</a></strong>."
+msgstr ""
+
+#: frontend/js/src/Profile.tsx:603
 #: frontend/js/src/forms/ProfileChangePassword.tsx:22
 #: frontend/js/src/forms/ProfileChangePassword.tsx:111
 #: metabrainz/templates/index/profile-change-password.html:3
@@ -1729,6 +2768,11 @@ msgstr ""
 #: metabrainz/templates/index/team.html:26
 msgid "He lives on in our hearts and in open source."
 msgstr "彼は私たちの心の中、そしてオープンソースの中で、今も生き続けています。"
+
+#: metabrainz/templates/index/team.html:29
+#: metabrainz/templates/index/team.html:315
+msgid "you’re welcome to try"
+msgstr ""
 
 #: metabrainz/templates/index/team.html:39
 msgid ""
@@ -2345,9 +3389,11 @@ msgstr "米国小切手"
 
 #: metabrainz/templates/payments/donate.html:146
 msgid ""
-"Due to the increased unreliability of the US Postal Service we have "
-"stopped accepting paper checks. Sorry!"
-msgstr "米国郵政公社のサービスがますます不安定になっているため、紙の小切手の受け付けを中止いたしました。ゴメンね！"
+"Due to the increased unreliability of the US Postal Service and the "
+"relatively large fees involved, we ask you to only send a paper check if "
+"it is the only possible option. Due to the fees, we will not cash checks "
+"for less than $25."
+msgstr ""
 
 #: metabrainz/templates/payments/donate.html:241
 msgid ""
@@ -3261,8 +4307,8 @@ msgid "Monthly balance sheets"
 msgstr "月次貸借対照表"
 
 #: frontend/js/src/Profile.tsx:520
-#: frontend/js/src/forms/SignupCommercial.tsx:175
-#: frontend/js/src/forms/SignupCommercial.tsx:554
+#: frontend/js/src/forms/SignupCommercial.tsx:180
+#: frontend/js/src/forms/SignupCommercial.tsx:558
 #: frontend/js/src/forms/SignupNonCommercial.tsx:106
 #: frontend/js/src/forms/SignupNonCommercial.tsx:318
 #: metabrainz/templates/supporters/account-type.html:3
@@ -3283,6 +4329,7 @@ msgid "Non-commercial / Personal"
 msgstr "非営利/個人"
 
 #: frontend/js/src/Profile.tsx:235
+#: frontend/js/src/forms/SignupNonCommercial.tsx:107
 #: frontend/js/src/forms/SignupNonCommercial.tsx:151
 #: metabrainz/templates/supporters/account-type.html:42
 msgid "Non-commercial"
@@ -3296,47 +4343,41 @@ msgstr "$0.00/月～"
 msgid "Personal or university assignment user."
 msgstr "個人または大学ユーザー。"
 
-#: metabrainz/templates/supporters/account-type.html:48
-#: metabrainz/templates/supporters/account-type.html:90
-#: metabrainz/templates/supporters/account-type.html:141
-msgid "Upgrade"
-msgstr "アップグレード"
-
 #: frontend/js/src/Profile.tsx:235
-#: frontend/js/src/forms/SignupCommercial.tsx:176
-#: frontend/js/src/forms/SignupCommercial.tsx:228
-#: metabrainz/templates/supporters/account-type.html:61
+#: frontend/js/src/forms/SignupCommercial.tsx:181
+#: frontend/js/src/forms/SignupCommercial.tsx:233
+#: metabrainz/templates/supporters/account-type.html:56
 msgid "Commercial"
 msgstr "営利"
 
-#: metabrainz/templates/supporters/account-type.html:83
-#: metabrainz/templates/supporters/account-type.html:135
+#: metabrainz/templates/supporters/account-type.html:78
+#: metabrainz/templates/supporters/account-type.html:125
 #, python-format
 msgid "$%(tier_price)s/month and up"
 msgstr "$%(tier_price)s/月～"
 
-#: metabrainz/templates/supporters/account-type.html:87
-#: metabrainz/templates/supporters/account-type.html:138
+#: metabrainz/templates/supporters/account-type.html:82
+#: metabrainz/templates/supporters/account-type.html:128
 msgid "More info"
 msgstr "もっと見る"
 
-#: metabrainz/templates/supporters/account-type.html:104
+#: metabrainz/templates/supporters/account-type.html:94
 msgid "View all tiers"
 msgstr "全プランを見る"
 
-#: metabrainz/templates/supporters/account-type.html:112
+#: metabrainz/templates/supporters/account-type.html:102
 msgid "Some of our Unicorn members"
 msgstr "物珍しいメンバーの一部"
 
-#: metabrainz/templates/supporters/account-type.html:123
+#: metabrainz/templates/supporters/account-type.html:113
 msgid "See all our supporters"
 msgstr "すべての支援者を見る"
 
-#: metabrainz/templates/supporters/account-type.html:151
+#: metabrainz/templates/supporters/account-type.html:136
 msgid "View featured tiers"
 msgstr "注目のプランを見る"
 
-#: metabrainz/templates/supporters/account-type.html:158
+#: metabrainz/templates/supporters/account-type.html:143
 #, python-format
 msgid ""
 "If you are not sure which tier to pick, please\n"
@@ -3344,10 +4385,6 @@ msgid ""
 msgstr ""
 "どのプランを選べばよいか迷っている場合は、\n"
 "<a href=\"%(contact_url)s\">お問い合わせ</a>ください。"
-
-#: metabrainz/templates/supporters/account-type.html:166
-msgid "Back to Profile"
-msgstr "プロフィールに戻る"
 
 #: metabrainz/templates/supporters/bad-standing.html:3
 #: metabrainz/templates/supporters/bad-standing.html:6
@@ -3419,9 +4456,9 @@ msgid "Forgot your username"
 msgstr "ユーザー名を忘れてしまいました"
 
 #: frontend/js/src/forms/ResetPassword.tsx:79
-#: frontend/js/src/forms/SignupCommercial.tsx:320
+#: frontend/js/src/forms/SignupCommercial.tsx:325
 #: frontend/js/src/forms/SignupNonCommercial.tsx:227
-#: frontend/js/src/forms/SignupUser.tsx:169
+#: frontend/js/src/forms/SignupUser.tsx:175
 #: metabrainz/templates/users/reauthenticate.html:3
 #: metabrainz/templates/users/reauthenticate.html:6
 msgid "Confirm Password"
@@ -3431,17 +4468,22 @@ msgstr ""
 msgid "Please re-enter your password to continue."
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:108
+#: frontend/js/src/ProfileDelete.tsx:110
 #: frontend/js/src/forms/DeleteApplication.tsx:53
 #: frontend/js/src/forms/OAuthPrompt.tsx:54
 #: frontend/js/src/forms/ProfileChangePassword.tsx:104
 #: frontend/js/src/forms/ProfileEdit.tsx:105
-#: metabrainz/templates/users/reauthenticate.html:23
+#: metabrainz/templates/users/reauthenticate.html:28
 msgid "Cancel"
 msgstr ""
 
-#: metabrainz/templates/users/reauthenticate.html:24
+#: metabrainz/templates/users/reauthenticate.html:29
 msgid "Continue"
+msgstr ""
+
+#: frontend/js/src/forms/utils.tsx:202
+#: metabrainz/templates/users/reauthenticate.html:40
+msgid "Password must not exceed 72 bytes."
 msgstr ""
 
 #: frontend/js/src/forms/ResetPassword.tsx:27
@@ -3449,38 +4491,38 @@ msgstr ""
 msgid "Reset your password"
 msgstr "パスワードをリセット"
 
-#: frontend/js/src/hooks/useEmailValidation.ts:41 metabrainz/user/forms.py:15
+#: frontend/js/src/hooks/useEmailValidation.ts:41 metabrainz/user/forms.py:16
 msgid "Registration from this email domain is not allowed."
 msgstr "このメールアドレスのドメインからの登録は許可されていません。"
 
 #: frontend/js/src/forms/LoginUser.tsx:50
 #: frontend/js/src/forms/LostPassword.tsx:45
-#: frontend/js/src/forms/SignupCommercial.tsx:270
+#: frontend/js/src/forms/SignupCommercial.tsx:275
 #: frontend/js/src/forms/SignupNonCommercial.tsx:175
-#: frontend/js/src/forms/SignupUser.tsx:114 metabrainz/user/forms.py:20
-#: metabrainz/user/forms.py:45 metabrainz/user/forms.py:62
+#: frontend/js/src/forms/SignupUser.tsx:120 metabrainz/user/forms.py:22
+#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:75
 msgid "Username"
 msgstr "ユーザー名"
 
 #: frontend/js/src/forms/LoginUser.tsx:42
 #: frontend/js/src/forms/LostPassword.tsx:37
-#: frontend/js/src/forms/SignupCommercial.tsx:153
+#: frontend/js/src/forms/SignupCommercial.tsx:158
 #: frontend/js/src/forms/SignupNonCommercial.tsx:84
-#: frontend/js/src/forms/SignupUser.tsx:67 metabrainz/user/forms.py:21
-#: metabrainz/user/forms.py:45 metabrainz/user/forms.py:62
+#: frontend/js/src/forms/SignupUser.tsx:73 metabrainz/user/forms.py:26
+#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:75
 msgid "Username is required!"
 msgstr "ユーザー名が必要です！"
 
 #: frontend/js/src/forms/LoginUser.tsx:63
 #: frontend/js/src/forms/ResetPassword.tsx:72
-#: frontend/js/src/forms/SignupCommercial.tsx:308
+#: frontend/js/src/forms/SignupCommercial.tsx:313
 #: frontend/js/src/forms/SignupNonCommercial.tsx:214
-#: frontend/js/src/forms/SignupUser.tsx:157 metabrainz/user/forms.py:46
-#: metabrainz/user/forms.py:52
+#: frontend/js/src/forms/SignupUser.tsx:163 metabrainz/user/forms.py:53
+#: metabrainz/user/forms.py:62
 msgid "Password"
 msgstr "パスワード"
 
-#: frontend/js/src/forms/LoginUser.tsx:76 metabrainz/user/forms.py:47
+#: frontend/js/src/forms/LoginUser.tsx:76 metabrainz/user/forms.py:57
 msgid "Remember me"
 msgstr "ログイン情報を記憶"
 
@@ -3492,11 +4534,11 @@ msgstr "不正なユーザー名です。"
 msgid "Username contains invalid or invisible characters."
 msgstr "ユーザー名に、不正または不可視な文字が使われています。"
 
-#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:181
+#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:220
 msgid "Hide password"
 msgstr "パスワードを隠す"
 
-#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:181
+#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:220
 msgid "Show password"
 msgstr "パスワードを表示"
 
@@ -3553,12 +4595,12 @@ msgstr "アクセス"
 msgid "Revoke access"
 msgstr "アクセスを無効化"
 
-#: frontend/js/src/OAuthError.tsx:17
+#: frontend/js/src/OAuthError.tsx:18
 #, fuzzy
 msgid "OAuth2 Error"
 msgstr "OAuthエラー"
 
-#: frontend/js/src/OAuthError.tsx:18
+#: frontend/js/src/OAuthError.tsx:19
 msgid "An error occurred during OAuth authentication process."
 msgstr ""
 
@@ -3588,8 +4630,8 @@ msgstr ""
 
 #: frontend/js/src/Profile.tsx:109
 msgid ""
-"Are you sure you want to generate new access token? Current token will be"
-" revoked!"
+"Are you sure you want to generate a new access token? The current token "
+"will be revoked!"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:118
@@ -3704,8 +4746,8 @@ msgid "Contact Information"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:310 frontend/js/src/forms/ProfileEdit.tsx:70
-#: frontend/js/src/forms/SignupCommercial.tsx:284
-#: frontend/js/src/forms/SignupCommercial.tsx:333
+#: frontend/js/src/forms/SignupCommercial.tsx:289
+#: frontend/js/src/forms/SignupCommercial.tsx:338
 #: frontend/js/src/forms/SignupNonCommercial.tsx:189
 #: frontend/js/src/forms/SignupNonCommercial.tsx:241
 msgid "Contact name"
@@ -3820,7 +4862,7 @@ msgstr ""
 msgid "Once you delete your account, there is no going back. Please be certain."
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:550 frontend/js/src/ProfileDelete.tsx:105
+#: frontend/js/src/Profile.tsx:550 frontend/js/src/ProfileDelete.tsx:107
 #, fuzzy
 msgid "Delete My Account"
 msgstr "アカウント削除"
@@ -3834,39 +4876,39 @@ msgstr ""
 msgid "Need to delete your account?"
 msgstr "アカウント削除"
 
-#: frontend/js/src/Profile.tsx:574
+#: frontend/js/src/Profile.tsx:575
 msgid ""
 "Deletion of supporter accounts requires manual review. Please contact us "
-"at"
+"at <email />."
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:594
+#: frontend/js/src/Profile.tsx:599
 msgid "Security"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:626
+#: frontend/js/src/Profile.tsx:631
 msgid "MetaBrainz Applications"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:630
+#: frontend/js/src/Profile.tsx:635
 msgid ""
 "With your MetaBrainz account, you can access every project in the "
 "MetaBrainz family:"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:643
+#: frontend/js/src/Profile.tsx:648
 msgid "The open-source music encyclopedia"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:655
+#: frontend/js/src/Profile.tsx:660
 msgid "Track, visualise and share the music you listen to"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:667
+#: frontend/js/src/Profile.tsx:672
 msgid "The open-source book database"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:679
+#: frontend/js/src/Profile.tsx:684
 msgid "Creative Commons licensed reviews"
 msgstr ""
 
@@ -3889,7 +4931,7 @@ msgid "Permanently remove all your account information"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:64
-msgid "Revoke all your API tokens and access"
+msgid "Revoke all your tokens and access to the replication API"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:65
@@ -3901,14 +4943,16 @@ msgid "Log you out of all MetaBrainz services"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:70
-msgid "Your username will be reserved and cannot be reused."
+msgid ""
+"Your username will be reserved and cannot be reused without the "
+"intervention of an administrator."
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:82
+#: frontend/js/src/ProfileDelete.tsx:84
 msgid "To confirm, type your username '<username />' below:"
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:105
+#: frontend/js/src/ProfileDelete.tsx:107
 msgid "Deleting..."
 msgstr ""
 
@@ -3921,65 +4965,7 @@ msgstr "プロフィール"
 msgid "Close"
 msgstr ""
 
-#: frontend/js/src/forms/ConditionsModal.tsx:23
-msgid "Licensing"
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:25
-msgid ""
-"Any contributions you make to any MetaBrainz service will be released "
-"into the Public Domain and/or licensed under a Creative Commons by-nc-sa "
-"license. Furthermore, you give the MetaBrainz Foundation the right to "
-"license this data for commercial use."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:30
-msgid "Please read our <licenseLink>license page</licenseLink> for more details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:45
-msgid ""
-"MetaBrainz strongly believes in the privacy of its users. Any personal "
-"information you choose to provide will not be sold or shared with anyone "
-"else."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:50
-msgid ""
-"Please read our <privacyLink>privacy policy</privacyLink> for more "
-"details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:59
-#, fuzzy
-msgid "GDPR compliance"
-msgstr "GDPRコンプライアンス"
-
-#: frontend/js/src/forms/ConditionsModal.tsx:61
-msgid ""
-"You may remove your personal information from our services anytime by "
-"deleting your account."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:66
-msgid ""
-"Please read our <gdprLink>GDPR compliance statement</gdprLink> for more "
-"details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:78
-msgid ""
-"Creating an account on MetaBrainz will give you access to all of our "
-"projects, such as MusicBrainz, ListenBrainz, BookBrainz, and more."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:82
-msgid ""
-"We create a placeholder account for all the MetaBrainz projects when you "
-"sign up, and you are one log-in away from activating them."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:91
+#: frontend/js/src/forms/ConditionsModal.tsx:29
 msgid "Sounds good"
 msgstr ""
 
@@ -4073,8 +5059,8 @@ msgstr "ユーザー名を忘れてしまいました"
 msgid "Forgot your password?"
 msgstr "パスワードを忘れてしまいました"
 
-#: frontend/js/src/forms/LoginUser.tsx:109
-msgid "Don't have an account?"
+#: frontend/js/src/forms/LoginUser.tsx:110
+msgid "Don't have an account? <signupLink>Sign up</signupLink>"
 msgstr ""
 
 #: frontend/js/src/forms/LostPassword.tsx:38
@@ -4105,15 +5091,73 @@ msgstr ""
 msgid "Allow access"
 msgstr "アクセス"
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:71
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:10
+msgid "Licensing"
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:12
+msgid ""
+"Any contributions you make to any MetaBrainz service will be released "
+"into the Public Domain and/or licensed under a Creative Commons by-nc-sa "
+"license. Furthermore, you give the MetaBrainz Foundation the right to "
+"license this data for commercial use."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:17
+msgid "Please read our <licenseLink>license page</licenseLink> for more details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:34
+msgid ""
+"MetaBrainz strongly believes in the privacy of its users. Any personal "
+"information you choose to provide will not be sold or shared with anyone "
+"else."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:39
+msgid ""
+"Please read our <privacyLink>privacy policy</privacyLink> for more "
+"details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:50
+#, fuzzy
+msgid "GDPR compliance"
+msgstr "GDPRコンプライアンス"
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:52
+msgid ""
+"You may remove your personal information from our services anytime by "
+"deleting your account."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:57
+msgid ""
+"Please read our <gdprLink>GDPR compliance statement</gdprLink> for more "
+"details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:71
+msgid ""
+"Creating an account on MetaBrainz will give you access to all of our "
+"projects, such as MusicBrainz, ListenBrainz, BookBrainz, and more."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:75
+msgid ""
+"We create a placeholder account for all the MetaBrainz projects when you "
+"sign up, and you are one log-in away from activating them."
+msgstr ""
+
+#: frontend/js/src/forms/ProfileChangePassword.tsx:70
 msgid "Current Password"
 msgstr ""
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:80
+#: frontend/js/src/forms/ProfileChangePassword.tsx:79
 msgid "New Password"
 msgstr ""
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:89
+#: frontend/js/src/forms/ProfileChangePassword.tsx:88
 msgid "Confirm New Password"
 msgstr ""
 
@@ -4126,195 +5170,184 @@ msgstr ""
 msgid "Reset Password"
 msgstr "パスワードをリセット"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:38
-msgid "If you would like to support us with more than $"
+#: frontend/js/src/forms/SignupCommercial.tsx:40
+msgid ""
+"If you would like to support us with more than ${{minPledge}}, please "
+"enter the actual amount here:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:39
-msgid ", please enter the actual amount here:"
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:144
+#: frontend/js/src/forms/SignupCommercial.tsx:149
 #: frontend/js/src/forms/SignupNonCommercial.tsx:75
-#: frontend/js/src/forms/SignupUser.tsx:87
+#: frontend/js/src/forms/SignupUser.tsx:93
 msgid "Captcha is required!"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:179
+#: frontend/js/src/forms/SignupCommercial.tsx:184
 #: frontend/js/src/forms/SignupNonCommercial.tsx:110
 #: frontend/js/src/forms/SignupUser.tsx:46
 #, fuzzy
 msgid "Access all MetaBrainz projects"
 msgstr "MetaBrainzプロジェクト"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:182
+#: frontend/js/src/forms/SignupCommercial.tsx:187
 msgid "Note:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:184
+#: frontend/js/src/forms/SignupCommercial.tsx:189
 msgid ""
 "Signing up for any tier other than the <italic>Stealth startup</italic> "
 "tier will publicly list your company on this web site. However, we will "
 "not publish any of your private details."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:221
+#: frontend/js/src/forms/SignupCommercial.tsx:226
 #: frontend/js/src/forms/SignupNonCommercial.tsx:145
 msgid "Account type"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:234
+#: frontend/js/src/forms/SignupCommercial.tsx:239
 msgid "Selected tier"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:242
-msgid "month and up"
+#: frontend/js/src/forms/SignupCommercial.tsx:247
+msgid "${{tierPrice}}/month and up"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:250
+#: frontend/js/src/forms/SignupCommercial.tsx:255
 msgid "Change account type or tier"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:261
+#: frontend/js/src/forms/SignupCommercial.tsx:266
 #: frontend/js/src/forms/SignupNonCommercial.tsx:166
 msgid "Your account:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:271
+#: frontend/js/src/forms/SignupCommercial.tsx:276
 #: frontend/js/src/forms/SignupNonCommercial.tsx:176
-#: frontend/js/src/forms/SignupUser.tsx:114
+#: frontend/js/src/forms/SignupUser.tsx:120
 msgid "(public)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:291
+#: frontend/js/src/forms/SignupCommercial.tsx:296
 #: frontend/js/src/forms/SignupNonCommercial.tsx:196
-#: frontend/js/src/forms/SignupUser.tsx:127
+#: frontend/js/src/forms/SignupUser.tsx:133
 msgid "E-mail address"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:295
+#: frontend/js/src/forms/SignupCommercial.tsx:300
 #: frontend/js/src/forms/SignupNonCommercial.tsx:200
-#: frontend/js/src/forms/SignupUser.tsx:131
+#: frontend/js/src/forms/SignupUser.tsx:137
 msgid "(checking...)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:314
+#: frontend/js/src/forms/SignupCommercial.tsx:319
 #: frontend/js/src/forms/SignupNonCommercial.tsx:220
-#: frontend/js/src/forms/SignupUser.tsx:163
+#: frontend/js/src/forms/SignupUser.tsx:169
 msgid "Must be at least 8 characters"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:348
+#: frontend/js/src/forms/SignupCommercial.tsx:353
 msgid ""
 "If you don't have an organization name, you probably want to become a "
 "supporter as a <nonCommercialLink>Non-commercial / "
 "Personal</nonCommercialLink> supporter."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:358
+#: frontend/js/src/forms/SignupCommercial.tsx:363
 msgid ""
 "If you don't have an organization name, you probably want to sign up as a"
 " <nonCommercialLink>Non-commercial / Personal</nonCommercialLink> user."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:378
+#: frontend/js/src/forms/SignupCommercial.tsx:383
 msgid ""
 "Please tell us a little about your company and whether you plan to use "
 "our <apiLink>API</apiLink> or to <hostLink>host your own copy</hostLink> "
 "of the data."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:404
+#: frontend/js/src/forms/SignupCommercial.tsx:408
 #, fuzzy
 msgid "Logo URL"
 msgstr "ロゴ画像URL"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:405
+#: frontend/js/src/forms/SignupCommercial.tsx:409
 msgid "(preferably in SVG format)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:408
+#: frontend/js/src/forms/SignupCommercial.tsx:412
 msgid ""
 "Image should be about 250 pixels wide on a white or transparent "
 "background. We will host it on our site."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:421
+#: frontend/js/src/forms/SignupCommercial.tsx:425
 msgid ""
 "URL to where developers can use your APIs using MusicBrainz IDs, if "
-"available.."
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:430
-msgid "Your project"
+"available."
 msgstr ""
 
 #: frontend/js/src/forms/SignupCommercial.tsx:434
+msgid "Your project"
+msgstr ""
+
+#: frontend/js/src/forms/SignupCommercial.tsx:438
 #: frontend/js/src/forms/SignupNonCommercial.tsx:261
 msgid "(max 150 characters)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:451
+#: frontend/js/src/forms/SignupCommercial.tsx:455
 msgid "Billing address"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:502
+#: frontend/js/src/forms/SignupCommercial.tsx:506
 msgid ""
 "I agree to support the MetaBrainz Foundation when my organization is able"
 " to do so."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:507
+#: frontend/js/src/forms/SignupCommercial.tsx:511
+#: frontend/js/src/forms/SignupNonCommercial.tsx:284
 msgid ""
-"I also agree that if I generate a Live Data Feed access token, that I "
-"treat my access token as a secret and will not share this token publicly "
-"or commit it to a source code repository."
+"I also agree that if I generate a Live Data Feed access token, then I "
+"will treat my access token as a secret and will not share this token "
+"publicly or commit it to a source code repository."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:515
+#: frontend/js/src/forms/SignupCommercial.tsx:519
 msgid ""
 "The following information will be shown publicly: organization name, "
 "logo, website and API URLs, data usage description."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:520
+#: frontend/js/src/forms/SignupCommercial.tsx:524
 msgid ""
 "We'll send you more details about payment process once your application "
 "is approved."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:552
+#: frontend/js/src/forms/SignupCommercial.tsx:556
 #: frontend/js/src/forms/SignupNonCommercial.tsx:316
-#: frontend/js/src/forms/SignupUser.tsx:224
+#: frontend/js/src/forms/SignupUser.tsx:230
 msgid "Validating..."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:564
+#: frontend/js/src/forms/SignupCommercial.tsx:568
 #: frontend/js/src/forms/SignupNonCommercial.tsx:329
 #, fuzzy
 msgid "Back to profile"
 msgstr "プロフィールに戻る"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:569
-#: frontend/js/src/forms/SignupNonCommercial.tsx:334
-msgid "Not a supporter?"
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:570
+#: frontend/js/src/forms/SignupCommercial.tsx:574
 #: frontend/js/src/forms/SignupNonCommercial.tsx:335
-msgid "Create a user account"
+msgid "Not a supporter? <signupLink>Create a user account</signupLink>"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:573
-#: frontend/js/src/forms/SignupNonCommercial.tsx:338
-#: frontend/js/src/forms/SignupUser.tsx:231
-msgid "Already have an account?"
+#: frontend/js/src/forms/SignupCommercial.tsx:583
+#: frontend/js/src/forms/SignupNonCommercial.tsx:344
+#: frontend/js/src/forms/SignupUser.tsx:238
+msgid "Already have an account? <loginLink>Sign in</loginLink>"
 msgstr ""
-
-#: frontend/js/src/forms/SignupNonCommercial.tsx:107
-#, fuzzy
-msgid "non-commercial"
-msgstr "非営利"
 
 #: frontend/js/src/forms/SignupNonCommercial.tsx:113
 msgid ""
@@ -4341,46 +5374,40 @@ msgid ""
 "income per year) or personal uses only."
 msgstr ""
 
-#: frontend/js/src/forms/SignupNonCommercial.tsx:284
-msgid ""
-"I also agree that if I generate a Live Data Feed access token, then I "
-"will treat my access token as a secret and will not share this token "
-"publicly or commit it to a source code repository."
-msgstr ""
-
 #: frontend/js/src/forms/SignupUser.tsx:43
 msgid "Create your account"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:50
-msgid "Registration started by"
+#: frontend/js/src/forms/SignupUser.tsx:51
+msgid "Registration started by <client />"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:69
+#: frontend/js/src/forms/SignupUser.tsx:75
+#: frontend/js/src/hooks/useEmailValidation.ts:82
 msgid "Invalid email address."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:150
+#: frontend/js/src/forms/SignupUser.tsx:156
 msgid ""
 "This username and email were provided by the app that started "
 "registration. You can change them later from MetaBrainz settings."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:182
+#: frontend/js/src/forms/SignupUser.tsx:188
 msgid ""
 "I accept that my contributions will be released into the public domain or"
 " licensed for use."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:191
+#: frontend/js/src/forms/SignupUser.tsx:197
 msgid "We will never share your personal information."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:200
+#: frontend/js/src/forms/SignupUser.tsx:206
 msgid "Click here to read more"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:224
+#: frontend/js/src/forms/SignupUser.tsx:230
 msgid "Create account"
 msgstr ""
 
@@ -4390,10 +5417,6 @@ msgstr ""
 
 #: frontend/js/src/hooks/useEmailValidation.ts:47
 msgid "Email validation failed"
-msgstr ""
-
-#: frontend/js/src/hooks/useEmailValidation.ts:82
-msgid "Invalid email address"
 msgstr ""
 
 #~ msgid "You need to specify amount!"
@@ -5591,4 +6614,103 @@ msgstr ""
 
 #~ msgid "Privacy policy"
 #~ msgstr "プライバシーポリシー"
+
+#~ msgid "You need to specify website of the organization."
+#~ msgstr "組織のウェブサイトを入力する必要があります。"
+
+#~ msgid ""
+#~ "We are currently evaluating our overall"
+#~ " online advertising strategy. We are "
+#~ "evaluating advertising, traffic optimization,\n"
+#~ ""
+#~ "    search engine optimization and "
+#~ "software monitization technologies. If you "
+#~ "provide these professional services, please"
+#~ " provide a detailed\n"
+#~ "    deck of your comprehensive services"
+#~ " to the following email address. "
+#~ "<em>Please respect our other non-media"
+#~ " teams and do not contact us \n"
+#~ "    regarding these services on any "
+#~ "other of our email addresses. We "
+#~ "will disregard the entirety of your "
+#~ "submissions if you contact us any "
+#~ "other way!</em>"
+#~ msgstr ""
+#~ "現在、当社はオンライン広告戦略全体の見直しを行っています。広告、トラフィック最適化、検索エンジン最適化（SEO）、\n"
+#~ "およびソフトウェアの収益化技術について評価を進めています。\n"
+#~ "これらの専門サービスを提供されている場合は、包括的なサービス内容の詳細な資料を以下のメールアドレスまでお送りください。<em>当社のメディア部門以外のチームへの配慮をお願いいたします。"
+#~ "\n"
+#~ "これらのサービスに関して、当社の他のメールアドレスへご連絡いただくことはご遠慮ください。他の方法でご連絡いただいた場合、お送りいただいた資料はすべて無視させていただきます！</em>"
+
+#~ msgid ""
+#~ "Please come ask your questions at "
+#~ "our <a href=\"%(forums_url)s\">forums</a>! We "
+#~ "would love to\n"
+#~ "    answer any questions you may have."
+#~ msgstr ""
+#~ "ぜひ、当サイトの <a href=\"%(forums_url)s\">フォーラム</a> までご質問をお寄せください！\n"
+#~ "皆様からのご質問には、喜んでお答えいたします。"
+
+#~ msgid ""
+#~ "Due to the increased unreliability of"
+#~ " the US Postal Service we have "
+#~ "stopped accepting paper checks. Sorry!"
+#~ msgstr "米国郵政公社のサービスがますます不安定になっているため、紙の小切手の受け付けを中止いたしました。ゴメンね！"
+
+#~ msgid "Upgrade"
+#~ msgstr "アップグレード"
+
+#~ msgid "Back to Profile"
+#~ msgstr "プロフィールに戻る"
+
+#~ msgid ""
+#~ "Deletion of supporter accounts requires "
+#~ "manual review. Please contact us at"
+#~ msgstr ""
+
+#~ msgid "Revoke all your API tokens and access"
+#~ msgstr ""
+
+#~ msgid "Your username will be reserved and cannot be reused."
+#~ msgstr ""
+
+#~ msgid "Don't have an account?"
+#~ msgstr ""
+
+#~ msgid "If you would like to support us with more than $"
+#~ msgstr ""
+
+#~ msgid ", please enter the actual amount here:"
+#~ msgstr ""
+
+#~ msgid "month and up"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "I also agree that if I generate"
+#~ " a Live Data Feed access token, "
+#~ "that I treat my access token as"
+#~ " a secret and will not share "
+#~ "this token publicly or commit it "
+#~ "to a source code repository."
+#~ msgstr ""
+
+#~ msgid "Not a supporter?"
+#~ msgstr ""
+
+#~ msgid "Create a user account"
+#~ msgstr ""
+
+#~ msgid "Already have an account?"
+#~ msgstr ""
+
+#~ msgid "non-commercial"
+#~ msgstr "非営利"
+
+#~ msgid "Registration started by"
+#~ msgstr ""
+
+#~ msgid "Invalid email address"
+#~ msgstr ""
 

--- a/metabrainz/translations/lt/LC_MESSAGES/messages.po
+++ b/metabrainz/translations/lt/LC_MESSAGES/messages.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-07-25 16:21+0200\n"
+"POT-Creation-Date: 2026-09-08 11:18+0200\n"
 "PO-Revision-Date: 2026-06-12 00:54+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: lt\n"
@@ -23,163 +23,248 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.18.0\n"
 
-#: metabrainz/index/forms.py:46
+#: metabrainz/errors.py:24
+msgid "Authorization was declined."
+msgstr ""
+
+#: metabrainz/errors.py:25
+msgid "The authorization request was invalid."
+msgstr ""
+
+#: metabrainz/errors.py:26
+msgid "The application could not be authenticated."
+msgstr ""
+
+#: metabrainz/errors.py:27
+msgid "This application is not allowed to request authorization."
+msgstr ""
+
+#: metabrainz/errors.py:28
+msgid "The application asked for a response type this server does not support."
+msgstr ""
+
+#: metabrainz/errors.py:29
+msgid "The permissions requested by the application are invalid."
+msgstr ""
+
+#: metabrainz/errors.py:30
+msgid "You need to sign in to continue."
+msgstr ""
+
+#: metabrainz/errors.py:31
+msgid "Your consent is required to continue."
+msgstr ""
+
+#: metabrainz/password.py:12
+#, python-format
+msgid "Password must not exceed %(max_bytes)s bytes."
+msgstr ""
+
+#: metabrainz/index/forms.py:48
 #, python-format
 msgid "'%(value)s' is not a valid choice for this field"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileEdit.tsx:27
-#: frontend/js/src/forms/SignupCommercial.tsx:154
+#: frontend/js/src/forms/SignupCommercial.tsx:159
 #: frontend/js/src/forms/SignupNonCommercial.tsx:85
-#: frontend/js/src/forms/SignupUser.tsx:70
-#: frontend/js/src/hooks/useEmailValidation.ts:78 metabrainz/index/forms.py:57
-#: metabrainz/user/forms.py:25 metabrainz/user/forms.py:57
-#: metabrainz/user/forms.py:63
+#: frontend/js/src/forms/SignupUser.tsx:76
+#: frontend/js/src/hooks/useEmailValidation.ts:78 metabrainz/index/forms.py:59
+#: metabrainz/user/forms.py:31 metabrainz/user/forms.py:70
+#: metabrainz/user/forms.py:76
 msgid "Email address is required!"
 msgstr "El. pašto adresas – būtinas!"
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:34
-#: metabrainz/index/forms.py:63
+#: metabrainz/index/forms.py:65
 msgid "Current password is required!"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:43
 #: frontend/js/src/forms/ProfileChangePassword.tsx:37
 #: frontend/js/src/forms/ResetPassword.tsx:39
-#: frontend/js/src/forms/SignupCommercial.tsx:156
+#: frontend/js/src/forms/SignupCommercial.tsx:161
 #: frontend/js/src/forms/SignupNonCommercial.tsx:87
-#: frontend/js/src/forms/SignupUser.tsx:72 metabrainz/index/forms.py:66
-#: metabrainz/user/forms.py:29 metabrainz/user/forms.py:46
-#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:69
+#: frontend/js/src/forms/SignupUser.tsx:78 metabrainz/index/forms.py:69
+#: metabrainz/user/forms.py:35 metabrainz/user/forms.py:54
+#: metabrainz/user/forms.py:63 metabrainz/user/forms.py:82
 msgid "Password is required!"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:41
-#: frontend/js/src/forms/SignupCommercial.tsx:160
+#: frontend/js/src/forms/SignupCommercial.tsx:165
 #: frontend/js/src/forms/SignupNonCommercial.tsx:91
-#: frontend/js/src/forms/SignupUser.tsx:76 metabrainz/index/forms.py:70
-#: metabrainz/user/forms.py:33 metabrainz/user/forms.py:73
+#: frontend/js/src/forms/SignupUser.tsx:82 metabrainz/index/forms.py:74
+#: metabrainz/user/forms.py:40 metabrainz/user/forms.py:87
 msgid "Confirm Password is required!"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:46
 #: frontend/js/src/forms/ResetPassword.tsx:48
-#: frontend/js/src/forms/SignupCommercial.tsx:165
+#: frontend/js/src/forms/SignupCommercial.tsx:170
 #: frontend/js/src/forms/SignupNonCommercial.tsx:96
-#: frontend/js/src/forms/SignupUser.tsx:81 metabrainz/index/forms.py:72
-#: metabrainz/user/forms.py:35 metabrainz/user/forms.py:75
+#: frontend/js/src/forms/SignupUser.tsx:87 metabrainz/index/forms.py:76
+#: metabrainz/user/forms.py:42 metabrainz/user/forms.py:89
 msgid "Confirm Password should match password!"
 msgstr ""
 
 #: frontend/js/src/Applications.tsx:56 frontend/js/src/Applications.tsx:86
 #: frontend/js/src/Profile.tsx:272 frontend/js/src/Profile.tsx:482
-#: metabrainz/index/forms.py:78
+#: metabrainz/index/forms.py:82
 msgid "Name"
 msgstr "Pavadinimas"
 
-#: metabrainz/index/forms.py:79
+#: metabrainz/index/forms.py:83
 msgid "Contact name field is empty."
 msgstr "Kontakto vardo laukas yra tuščias."
 
-#: metabrainz/index/views.py:234
+#: metabrainz/index/views.py:251
 msgid "Profile updated successfully."
 msgstr ""
 
-#: metabrainz/index/views.py:261
+#: metabrainz/index/views.py:278
 msgid "Current password is incorrect."
 msgstr ""
 
-#: metabrainz/index/views.py:266
+#: metabrainz/index/views.py:283
 msgid "Password changed successfully."
 msgstr ""
 
-#: metabrainz/index/views.py:372
+#: metabrainz/index/views.py:389
 msgid "You have updated an application!"
 msgstr ""
 
-#: metabrainz/index/views.py:424
+#: metabrainz/index/views.py:441
 msgid "You have deleted an application."
 msgstr ""
 
-#: metabrainz/index/views.py:426
+#: metabrainz/index/views.py:443
 msgid "Failed to delete an application."
 msgstr ""
 
-#: metabrainz/index/views.py:449
+#: metabrainz/index/views.py:466
 msgid "Revoked tokens successfully!"
 msgstr ""
 
-#: metabrainz/index/views.py:478
+#: metabrainz/index/views.py:495
 msgid "Your account has been deleted."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:106 metabrainz/oauth/forms.py:58
+#: frontend/js/src/forms/CreateApplication.tsx:106 metabrainz/oauth/forms.py:57
 msgid "Application Name"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:59
+#: metabrainz/oauth/forms.py:58
 msgid "Application name field is empty."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:60 metabrainz/oauth/forms.py:60
+#: frontend/js/src/forms/CreateApplication.tsx:60 metabrainz/oauth/forms.py:59
 msgid "Application name needs to be at least 3 characters long."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:64 metabrainz/oauth/forms.py:61
+#: frontend/js/src/forms/CreateApplication.tsx:64 metabrainz/oauth/forms.py:60
 msgid "Application name needs to be at most 64 characters long."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:114 metabrainz/oauth/forms.py:63
+#: frontend/js/src/forms/CreateApplication.tsx:114 metabrainz/oauth/forms.py:62
 #, fuzzy
 msgid "Description"
 msgstr "Organizacijos aprašymas"
 
-#: metabrainz/oauth/forms.py:64
+#: metabrainz/oauth/forms.py:63
 msgid "Client description field is empty."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:65
+#: metabrainz/oauth/forms.py:64
 msgid "Client description needs to be at least 3 characters long."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:66
+#: metabrainz/oauth/forms.py:65
 msgid "Client description needs to be at most 512 characters long."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:122 metabrainz/oauth/forms.py:68
+#: frontend/js/src/forms/CreateApplication.tsx:122 metabrainz/oauth/forms.py:67
 msgid "Homepage"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:69
+#: metabrainz/oauth/forms.py:68
 msgid "Homepage field is empty."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:70
+#: metabrainz/oauth/forms.py:69
 msgid "Homepage is not a valid URI."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:71
+#: metabrainz/oauth/forms.py:70
 msgid "Homepage URL must use http or https"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:73
+#: metabrainz/oauth/forms.py:72
 msgid "Authorization callback URL"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:74
+#: metabrainz/oauth/forms.py:73
 msgid "Authorization callback URL field is empty."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:75
+#: metabrainz/oauth/forms.py:74
 msgid "Authorization callback URL is invalid."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:76
+#: metabrainz/oauth/forms.py:75
 msgid "Authorization callback URL must use http or https."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:81 metabrainz/oauth/forms.py:85
+#: metabrainz/oauth/forms.py:80 metabrainz/oauth/forms.py:84
 msgid "Confirm"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:15
+msgid "View your public account information"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:16
+msgid "View your email address"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:17
+msgid "View and modify your private tags"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:18
+msgid "View and modify your private ratings"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:19
+msgid "View and modify your private collections"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:20
+msgid "Submit new ISRCs to the database"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:21
+msgid "Submit new barcodes to the database"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:22
+msgid "Sign you in and view your unique user id"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:23
+msgid "Submit listens to ListenBrainz."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:24
+msgid "Create and modify CritiqueBrainz reviews."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:25
+msgid "Submit and delete votes on CritiqueBrainz reviews."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:26
+msgid "Modify profile info and delete profile on CritiqueBrainz."
 msgstr ""
 
 #: metabrainz/payments/views.py:164
@@ -233,135 +318,136 @@ msgid "Requested annual report was not found."
 msgstr "Prašoma metinė ataskaita nebuvo rasta."
 
 #: frontend/js/src/forms/ProfileEdit.tsx:30
-#: frontend/js/src/forms/SignupCommercial.tsx:139
+#: frontend/js/src/forms/SignupCommercial.tsx:144
 #: frontend/js/src/forms/SignupNonCommercial.tsx:70
-#: metabrainz/supporter/forms.py:13
+#: metabrainz/supporter/forms.py:15
 msgid "Contact name is required!"
 msgstr "Būtinas kontaktinis vardas!"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:437
+#: frontend/js/src/forms/SignupCommercial.tsx:441
 #: frontend/js/src/forms/SignupNonCommercial.tsx:264
-#: metabrainz/supporter/forms.py:15
+#: metabrainz/supporter/forms.py:17
 msgid ""
 "Can you please tell us more about the project in which you'd like to use "
 "our data? Do you plan to self host the data or use our APIs?"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:137
+#: frontend/js/src/forms/SignupCommercial.tsx:142
 #: frontend/js/src/forms/SignupNonCommercial.tsx:68
-#: metabrainz/supporter/forms.py:17
+#: metabrainz/supporter/forms.py:19
 msgid "Please, tell us how you (will) use our data."
 msgstr "Prašome, papasakokite mums, kaip jūs (ketinate) naudosite mūsų duomenis."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:138
+#: frontend/js/src/forms/SignupCommercial.tsx:143
 #: frontend/js/src/forms/SignupNonCommercial.tsx:69
-#: metabrainz/supporter/forms.py:18
+#: metabrainz/supporter/forms.py:20
 msgid "Please, limit usage description to 500 characters."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:141
-#: frontend/js/src/forms/SignupCommercial.tsx:142
+#: frontend/js/src/forms/SignupCommercial.tsx:146
+#: frontend/js/src/forms/SignupCommercial.tsx:147
 #: frontend/js/src/forms/SignupNonCommercial.tsx:72
 #: frontend/js/src/forms/SignupNonCommercial.tsx:73
-#: frontend/js/src/forms/SignupUser.tsx:84
-#: frontend/js/src/forms/SignupUser.tsx:85 metabrainz/supporter/forms.py:21
-#: metabrainz/user/forms.py:38
+#: frontend/js/src/forms/SignupUser.tsx:90
+#: frontend/js/src/forms/SignupUser.tsx:91 metabrainz/supporter/forms.py:23
+#: metabrainz/user/forms.py:45
 msgid "You need to accept the agreement!"
 msgstr "Turite sutikti su susitarimu!"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:342
-#: metabrainz/supporter/forms.py:27
+#: frontend/js/src/forms/SignupCommercial.tsx:347
+#: metabrainz/supporter/forms.py:29
 msgid "Organization name"
 msgstr "Organizacijos pavadinimas"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:113
-#: metabrainz/supporter/forms.py:28
+#: frontend/js/src/forms/SignupCommercial.tsx:115
+#: metabrainz/supporter/forms.py:30
 msgid "You need to specify the name of your organization."
 msgstr "Turite nurodyti savo organizacijos pavadinimą."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:373
-#: metabrainz/supporter/forms.py:30
+#: frontend/js/src/forms/SignupCommercial.tsx:378
+#: metabrainz/supporter/forms.py:32
 msgid "Organization description"
 msgstr "Organizacijos aprašymas"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:116
-#: metabrainz/supporter/forms.py:31
+#: frontend/js/src/forms/SignupCommercial.tsx:118
+#: metabrainz/supporter/forms.py:33
 msgid "You need to provide description of your organization."
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:278
-#: frontend/js/src/forms/SignupCommercial.tsx:396
-#: metabrainz/supporter/forms.py:34
+#: frontend/js/src/forms/SignupCommercial.tsx:401
+#: metabrainz/supporter/forms.py:36
 msgid "Website URL"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:119
-#: metabrainz/supporter/forms.py:35
-msgid "You need to specify website of the organization."
+#: frontend/js/src/forms/SignupCommercial.tsx:121
+#: frontend/js/src/forms/SignupCommercial.tsx:123
+#: metabrainz/supporter/forms.py:38 metabrainz/supporter/forms.py:42
+msgid "Website URL must be a valid URL."
 msgstr ""
 
-#: metabrainz/supporter/forms.py:37
+#: metabrainz/supporter/forms.py:45
 msgid "Logo image URL"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:284
-#: frontend/js/src/forms/SignupCommercial.tsx:418
-#: metabrainz/supporter/forms.py:38
+#: frontend/js/src/forms/SignupCommercial.tsx:422
+#: metabrainz/supporter/forms.py:46
 msgid "API URL"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:457
-#: metabrainz/supporter/forms.py:40
+#: frontend/js/src/forms/SignupCommercial.tsx:461
+#: metabrainz/supporter/forms.py:48
 msgid "Street"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:123
-#: metabrainz/supporter/forms.py:41
+#: frontend/js/src/forms/SignupCommercial.tsx:128
+#: metabrainz/supporter/forms.py:49
 msgid "You need to specify street."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:465
-#: metabrainz/supporter/forms.py:43
+#: frontend/js/src/forms/SignupCommercial.tsx:469
+#: metabrainz/supporter/forms.py:51
 msgid "City"
 msgstr "Miestas"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:124
-#: metabrainz/supporter/forms.py:44
+#: frontend/js/src/forms/SignupCommercial.tsx:129
+#: metabrainz/supporter/forms.py:52
 msgid "You need to specify city."
 msgstr "Jūs turite nurodyti miestą."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:473
-#: metabrainz/supporter/forms.py:46
+#: frontend/js/src/forms/SignupCommercial.tsx:477
+#: metabrainz/supporter/forms.py:54
 msgid "State / Province"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:126
-#: metabrainz/supporter/forms.py:47
+#: frontend/js/src/forms/SignupCommercial.tsx:131
+#: metabrainz/supporter/forms.py:55
 msgid "You need to specify state/province."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:481
-#: metabrainz/supporter/forms.py:49
+#: frontend/js/src/forms/SignupCommercial.tsx:485
+#: metabrainz/supporter/forms.py:57
 msgid "Postcode"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:128
-#: metabrainz/supporter/forms.py:50
+#: frontend/js/src/forms/SignupCommercial.tsx:133
+#: metabrainz/supporter/forms.py:58
 msgid "You need to specify postcode."
 msgstr "Reikia nurodyti pašto kodą."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:489
-#: metabrainz/supporter/forms.py:52
+#: frontend/js/src/forms/SignupCommercial.tsx:493
+#: metabrainz/supporter/forms.py:60
 msgid "Country"
 msgstr "Šalis"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:129
-#: metabrainz/supporter/forms.py:53
+#: frontend/js/src/forms/SignupCommercial.tsx:134
+#: metabrainz/supporter/forms.py:61
 msgid "You need to specify country."
 msgstr "Turite nurodyti šalį."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:132
-#: metabrainz/supporter/forms.py:64
+#: frontend/js/src/forms/SignupCommercial.tsx:137
+#: metabrainz/supporter/forms.py:72
 #, fuzzy
 msgid ""
 "Custom amount must be more than threshold amount for selected tier or "
@@ -370,24 +456,30 @@ msgstr ""
 "Pasirinkta suma turi būti didesnė už pasirinktos pakopos ribinę sumą arba"
 " jai lygi!"
 
-#: metabrainz/supporter/views.py:46 metabrainz/supporter/views.py:119
-#: metabrainz/supporter/views.py:220
+#: metabrainz/supporter/views.py:54
+msgid ""
+"The verification email could not be sent. Please request a new one from "
+"your profile."
+msgstr ""
+
+#: metabrainz/supporter/views.py:85 metabrainz/supporter/views.py:158
+#: metabrainz/supporter/views.py:260
 msgid "You are already a supporter."
 msgstr ""
 
-#: metabrainz/supporter/views.py:61
+#: metabrainz/supporter/views.py:100
 msgid "Can't find tier with a specified ID."
 msgstr "Negalima rasti lygio su nurodytu ID."
 
-#: metabrainz/supporter/views.py:127
+#: metabrainz/supporter/views.py:166
 msgid "You need to choose support tier before signing up!"
 msgstr "Prieš užsiregistruodami turite pasirinkti palaikymo lygį!"
 
-#: metabrainz/supporter/views.py:137
+#: metabrainz/supporter/views.py:176
 msgid "You need to choose existing tier before signing up!"
 msgstr "Prieš užsiregistruodami turite pasirinkti esamą lygį!"
 
-#: metabrainz/supporter/views.py:164
+#: metabrainz/supporter/views.py:204
 #, fuzzy
 msgid ""
 "Thanks for becoming a supporter! Your application will be reviewed soon. "
@@ -396,7 +488,7 @@ msgstr ""
 "Ačiū, kad užsiregistravote! Jūsų paraiška netrukus bus peržiūrėta. "
 "Naujienas jums atsiųsime el. paštu."
 
-#: metabrainz/supporter/views.py:187
+#: metabrainz/supporter/views.py:228
 msgid ""
 "Thanks for signing up! Your application will be reviewed soon. We will "
 "send you updates via email."
@@ -404,15 +496,15 @@ msgstr ""
 "Ačiū, kad užsiregistravote! Jūsų paraiška netrukus bus peržiūrėta. "
 "Naujienas jums atsiųsime el. paštu."
 
-#: metabrainz/supporter/views.py:248
+#: metabrainz/supporter/views.py:288
 msgid "Thanks for becoming a supporter!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:274
+#: metabrainz/supporter/views.py:312
 msgid "Thanks for signing up! Please check your inbox to complete verification."
 msgstr ""
 
-#: metabrainz/supporter/views.py:302
+#: metabrainz/supporter/views.py:340
 msgid "Can't generate new token unless account is active."
 msgstr "Negalima sugeneruoti naujo prieigos rakto, nebent paskyra yra aktyvi."
 
@@ -446,7 +538,7 @@ msgstr ""
 msgid "Policies"
 msgstr ""
 
-#: metabrainz/templates/base.html:55 metabrainz/templates/index/gdpr.html:178
+#: metabrainz/templates/base.html:55
 #: metabrainz/templates/index/social-contract.html:3
 #: metabrainz/templates/index/social-contract.html:6
 #: metabrainz/templates/navbar.html:34
@@ -456,14 +548,15 @@ msgstr ""
 #: metabrainz/templates/base.html:56
 #: metabrainz/templates/index/code-of-conduct.html:3
 #: metabrainz/templates/index/code-of-conduct.html:16
-#: metabrainz/templates/index/gdpr.html:181 metabrainz/templates/navbar.html:35
+#: metabrainz/templates/navbar.html:35
 msgid "Code of Conduct"
 msgstr ""
 
+#: frontend/js/src/PrivacySummary.tsx:11
 #: frontend/js/src/forms/ConditionsModal.tsx:21
-#: metabrainz/templates/base.html:57 metabrainz/templates/index/gdpr.html:184
-#: metabrainz/templates/index/privacy.html:6
+#: metabrainz/templates/base.html:57 metabrainz/templates/index/privacy.html:6
 #: metabrainz/templates/navbar.html:36
+#: metabrainz/templates/users/privacy-summary.html:3
 msgid "Privacy Policy"
 msgstr "Privatumo politika"
 
@@ -497,10 +590,7 @@ msgstr "Rėmėjai"
 msgid "Supporters"
 msgstr "Palaikytojai"
 
-#: frontend/js/src/forms/LoginUser.tsx:103
-#: frontend/js/src/forms/SignupCommercial.tsx:574
-#: frontend/js/src/forms/SignupNonCommercial.tsx:339
-#: frontend/js/src/forms/SignupUser.tsx:232 metabrainz/templates/base.html:73
+#: frontend/js/src/forms/LoginUser.tsx:103 metabrainz/templates/base.html:73
 #: metabrainz/templates/navbar.html:66 metabrainz/templates/users/login.html:3
 msgid "Sign in"
 msgstr "Prisijungti"
@@ -522,26 +612,26 @@ msgid "Contact us"
 msgstr "Susisiekti su mumis"
 
 #: metabrainz/templates/base.html:85
-#: metabrainz/templates/index/contact.html:105
+#: metabrainz/templates/index/contact.html:106
 msgid "Blog"
 msgstr "Tinklaraštis"
 
-#: metabrainz/templates/base.html:86 metabrainz/templates/index/contact.html:90
+#: metabrainz/templates/base.html:86 metabrainz/templates/index/contact.html:91
 msgid "Chat"
 msgstr ""
 
 #: metabrainz/templates/base.html:87
-#: metabrainz/templates/index/contact.html:106
+#: metabrainz/templates/index/contact.html:107
 msgid "Mastodon"
 msgstr ""
 
 #: metabrainz/templates/base.html:88
-#: metabrainz/templates/index/contact.html:107
+#: metabrainz/templates/index/contact.html:108
 msgid "Bluesky"
 msgstr ""
 
 #: metabrainz/templates/base.html:89
-#: metabrainz/templates/index/contact.html:108
+#: metabrainz/templates/index/contact.html:109
 msgid "Instagram"
 msgstr ""
 
@@ -600,15 +690,14 @@ msgstr "Finansų ataskaitos"
 msgid "Donate"
 msgstr "Aukoti"
 
-#: frontend/js/src/forms/LoginUser.tsx:110
-#: frontend/js/src/forms/SignupCommercial.tsx:175
-#: frontend/js/src/forms/SignupCommercial.tsx:555
+#: frontend/js/src/forms/SignupCommercial.tsx:180
+#: frontend/js/src/forms/SignupCommercial.tsx:559
 #: frontend/js/src/forms/SignupNonCommercial.tsx:106
 #: frontend/js/src/forms/SignupNonCommercial.tsx:319
 #: metabrainz/templates/navbar.html:65
-#: metabrainz/templates/supporters/account-type.html:51
-#: metabrainz/templates/supporters/account-type.html:93
-#: metabrainz/templates/supporters/account-type.html:144
+#: metabrainz/templates/supporters/account-type.html:47
+#: metabrainz/templates/supporters/account-type.html:84
+#: metabrainz/templates/supporters/account-type.html:130
 #: metabrainz/templates/users/signup.html:3
 msgid "Sign up"
 msgstr "Registruotis"
@@ -957,8 +1046,430 @@ msgstr ""
 msgid "Introduction"
 msgstr ""
 
-#: metabrainz/templates/index/conflict-policy.html:55
+#: metabrainz/templates/index/conflict-policy.html:17
+msgid ""
+"Conflicts between people arise in open source projects constantly and the"
+" projects by the \n"
+"    MetaBrainz Foundation are no different. This policy aims to establish"
+" a clear and unambiguous \n"
+"    policy for reporting and addressing conflicts in our community. In "
+"this policy we aim to \n"
+"    establish a fair practice that balances the need for confidentiality "
+"and our desire for \n"
+"    transparency in our operations."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:25
+#, python-format
+msgid ""
+"Before you continue to read this policy, we encourage you to review our "
+"existing community policies \n"
+"    including our <a href=\"%(social_contract_url)s\">Social "
+"Contract</a>, \n"
+"    <a href=\"%(code_of_conduct_url)s\">the Code of Conduct</a>, \n"
+"    and our <a href=\"%(privacy_policy_url)s\">Privacy Policy</a>. These "
+"policies establish the norms and rules for \n"
+"    participation in our projects; these policies apply equally to the "
+"contractors of the MetaBrainz \n"
+"    Foundation and any participants in our projects."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:37
+msgid ""
+"This policy divides conflicts into two categories: Private and public. "
+"Private conflicts are conflicts \n"
+"    that involve *confidential* information regarding contributors, "
+"contractors or supporters. Otherwise, any conflicts \n"
+"    that do not involve confidential information are considered to be "
+"public conflicts. For instance, a \n"
+"    conflict between a contractor and the Executive Director (aka BDFL) "
+"that involves contractor pay is \n"
+"    considered a private conflict because pay rates are confidential "
+"information. A public conflict in edit \n"
+"    notes between two editors in our community does not involve "
+"confidential information and therefore should \n"
+"    be considered a public conflict."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:47
+msgid ""
+"When conflicts arise we aim to disclose as much information as possible "
+"about the conflict in a timely \n"
+"    fashion. When conflicts contain confidential matters we will aim to "
+"disclose as much information as \n"
+"    possible, while fully respecting the confidentiality of the people "
+"involved in the conflict. With any \n"
+"    private conflict we will aim to extract the relevant lessons for the "
+"team and community in an effort to \n"
+"    evolve our policies to prevent future conflicts. Should the involved "
+"parties disagree whether a conflict \n"
+"    is private or public, the question about the nature of the conflict "
+"will be presented for the next higher \n"
+"    level in the chain of command to decide. (e.g. if a community member "
+"and the community manager disagree on \n"
+"    a conflict being public or private, the Executive Director shall "
+"decide if the conflict is public or private)."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:58
 msgid "Reporting and Response"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:61
+msgid ""
+"We aim to not have conflict in our community, but we recognize that in "
+"reality conflicts will arise and we \n"
+"    must be prepared to address them in a fair manner. When conflicts "
+"arise, we prefer to have community or team \n"
+"    members resolve the conflicts among themselves, using our existing "
+"policies as guidelines for resolving the \n"
+"    conflict."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:69
+msgid ""
+"If you do not feel comfortable resolving a conflict on your own, you "
+"should feel free to report the conflict to \n"
+"    us. How you address the conflict depends on who is involved in the "
+"conflict and your comfort level. Please see \n"
+"    the detailed sections below on how and with whom to address your "
+"conflict. We aim to address conflicts as soon \n"
+"    as possible in an effort to prevent them from escalating "
+"unnecessarily."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:75
+msgid "Direct conflict resolution"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:78
+msgid ""
+"In direct conflict resolution, the involved parties will attempt to "
+"resolve the conflict themselves without \n"
+"   involving any MetaBrainz Foundation team member. You should aim to use"
+" direct resolution when the conflict does \n"
+"   not involve the violation of one of our policies or if the conflict is"
+" minor."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:84
+#, python-format
+msgid ""
+"For instance, if a user uses a rude tone, is disruptive or flagrantly "
+"ignores our project guidelines, we suggest \n"
+"    that you use direct conflict resolution to resolve the conflict. Some"
+" resources that might give you some suggestions \n"
+"    on how to go about resolving the conflict might be this <a "
+"href=\"%(conflict_resolution_primer_url)s\">\n"
+"    conflict resolution primer</a> and <a "
+"href=\"%(difficult_conversations_url)s\">how to\n"
+"    have difficult conversations at work</a>."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:93
+msgid "Informal reporting"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:96
+msgid ""
+"You may use informal reporting of a conflict if you aim to communicate a "
+"concern or incident without \n"
+"    seeking a corrective outcome. Informal reporting may also be an "
+"option if you have not been personally \n"
+"    victimized, but you’ve witnessed a violation of our policies or where"
+" you wish to maintain confidentiality \n"
+"    throughout the entire reporting process."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:103
+msgid ""
+"For editing in MusicBrainz you may informally report a user using the "
+"“Report this user for bad behavior” \n"
+"    link from the user’s profile. For reporting bad user behavior in "
+"other of our projects, please report them to our \n"
+"    community manager by mailing <span class=\"backemail\">gro.zniarbatem"
+"@reganam-ytinummoc</span> . For conflicts \n"
+"    that involve the community manager, report them by mailing <span "
+"class=\"backemail\">gro.zniarbatem@de</span> ."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:110
+msgid ""
+"Depending the the severity of the issue, repeated informal complaints may"
+" eventually require a formal response \n"
+"    from the MetaBrainz team. If an involved party requires anonymity, "
+"the conflict becomes a private conflict. If at \n"
+"    all possible minor issues should be resolved in a public forum in "
+"order for all people to witness and learn from \n"
+"    the issue at hand."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:116
+msgid "Formal complaint process"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:119
+msgid ""
+"All complaints about conflicts should be submitted via email. To whom a "
+"complaint should be mailed and who will \n"
+"    carry out the investigation will be described in the next section."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:124
+msgid "All complaint submissions to the Foundation should include the following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:128
+msgid ""
+"Contact info, if it is different than the email used to submit the "
+"conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:129
+msgid "Who was involved in the conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:130
+msgid "Where and when the incident happened"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:131
+msgid ""
+"A description of what happened -- ideally with links (e.g. chatlogs, edit"
+" notes) that outlines what \n"
+"         happened so that the persons evaluating the conflict may "
+"understand the issue at hand"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:133
+msgid ""
+"Any related pieces of information that provide more context on the "
+"conflict (e.g. links, screenshots)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:134
+msgid "An indication if this conflict is ongoing or not"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:139
+msgid "The investigation that follows aims to determine:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:143
+msgid "The nature and severity of the incident"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:144
+msgid ""
+"Whether or not the incident is considered a violation of MetaBrainz’ "
+"conduct policies or core values"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:145
+msgid ""
+"The amount of harm experienced by the person who submitted the complaint "
+"and the broader MetaBrainz community \n"
+"         as a result of the incident"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:147
+msgid ""
+"Whether there have been prior complaints against the individual or "
+"individuals reported"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:148
+msgid "Whether the incident is ongoing"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:152
+msgid ""
+"The following potential forms of resolution may apply to any team members"
+" involved in the conflict:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:155
+#: metabrainz/templates/index/conflict-policy.html:168
+msgid "Nothing (if it has been found no violation occurred)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:156
+msgid "Creating a plan to improve the performance"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:157
+msgid "Creating a negative performance evaluation"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:158
+msgid "Mediation, an intervention by a third party to resolve the conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:159
+msgid "Suspension or forced leave"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:160
+msgid "Termination of contract"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:164
+msgid ""
+"The following potential forms of resolution may apply to non team members"
+" involved in the conflict:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:169
+msgid "A reprimand, either public or private"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:170
+msgid "Suspension of the users’ account"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:171
+msgid "Deletion of the users’ account"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:172
+msgid ""
+"Removal of user privileges (e.g. if an auto editor commits a serious "
+"offence, they may lose their auto editor status)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:175
+msgid "Filing a complaint"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:178
+msgid ""
+"NOTE: For complaints not about MetaBrainz staff, please see the "
+"<em>Informal reporting</em> section above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:182
+msgid ""
+"If the complaint does not involve the Executive Director (ED), do the "
+"following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:186
+msgid ""
+"If team member has directly violated conduct policies or engaged in "
+"otherwise harmful behavior, a formal complaint should be filed."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:187
+msgid ""
+"Mail <span class=\"backemail\">gro.zniarbatem@de</span> and include the "
+"complaint information outlined above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:188
+msgid ""
+"You should expect a response within a working day acknowledging the "
+"complaint."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:189
+msgid ""
+"The complaint will be investigated by the ED, member(s) of the board of "
+"directors or a neutral third party."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:190
+msgid ""
+"Once the investigation has been completed, the ED, with the support of "
+"others involved in the investigation will respond. The \n"
+"        ED will respond to incidents no later than 7 working days after a"
+" complaint has been filed with either a resolution or an \n"
+"        explanation of why the process must be extended."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:196
+msgid "If a complaint involves the Executive Director, do the following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:200
+msgid ""
+"If the Executive Director has directly violated conduct policies or "
+"engaged in otherwise harmful behavior, \n"
+"        a formal complaint should be filed with the board of directors."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:202
+msgid ""
+"Mail <span class=\"backemail\">gro.zniarbatem@noituloser-tcilfnoc</span> "
+"and include the complaint information outlined above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:203
+msgid ""
+"You should get a response within 5 working days acknowledging the "
+"complaint."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:204
+msgid ""
+"The complaint will be investigated by the member(s) of the board of "
+"directors, the community manager, a neutral \n"
+"        third party or a combination thereof."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:206
+msgid ""
+"Once the investigation has been completed, the board, with the support of"
+" others involved in the investigation \n"
+"        will respond. The board will aim to respond to incidents no later"
+" than 15 working days after a complaint has been filed \n"
+"        with either a resolution or an explanation of why the process "
+"must be extended."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:211
+msgid "Confidentiality"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:214
+msgid ""
+"Confidentiality is an important aspect of conflict resolution and all of "
+"the conflicts brought to the attention of the foundation \n"
+"    will be evaluated with confidentiality in mind and acted upon "
+"accordingly."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:219
+msgid ""
+"We work hard to make all of the actions of the foundation as transparent "
+"and open as possible. In cases where we cannot \n"
+"    disclose all aspects of a conflict we will disclose that a conflict "
+"is or has occurred and we will attempt to disclose the \n"
+"    appropriate amount of information about the conflict while balancing "
+"the need for confidentiality and our desire to learn \n"
+"    from conflicts so that we as a foundation and community can learn "
+"from these conflicts and improve our policies to avoid the \n"
+"    conflicts in the future."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:227
+msgid ""
+"Any breaches of confidentiality will be treated as severe breaches of our"
+" conduct policies."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:230
+msgid "Retaliation"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:233
+msgid ""
+"We will not allow retaliation for any contractor or volunteer that files "
+"a complaint or is involved in an investigation. If you \n"
+"    believe that you are being treated negatively because of your "
+"involvement in a complaint please report this complaint directly \n"
+"    to the ED at <span class=\"backemail\">gro.zniarbatem@de</span> or "
+"the board at \n"
+"    <span class=\"backemail\">gro.zniarbatem@noituloser-tcilfnoc</span>."
 msgstr ""
 
 #: metabrainz/templates/index/contact.html:3
@@ -1070,7 +1581,7 @@ msgstr ""
 msgid ""
 "We are currently evaluating our overall online advertising strategy. We "
 "are evaluating advertising, traffic optimization,\n"
-"    search engine optimization and software monitization technologies. If"
+"    search engine optimization and software monetization technologies. If"
 " you provide these professional services, please provide a detailed\n"
 "    deck of your comprehensive services to the following email address. "
 "<em>Please respect our other non-media teams and do not contact us \n"
@@ -1150,14 +1661,11 @@ msgstr "Forumai"
 #, python-format
 msgid ""
 "Please come ask your questions at our <a "
-"href=\"%(forums_url)s\">forums</a>! We would love to\n"
-"    answer any questions you may have."
+"href=\"%(forums_url)s\">forums</a>!\n"
+"    The community and the team will be more than happy to help you."
 msgstr ""
-"Užduokite savo klausimus mūsų <a href=\"%(forums_url)s\">forumuose</a>! "
-"Mes mielai norėtume\n"
-"    atsakyti į klausimus, kurių jums gali kilti."
 
-#: metabrainz/templates/index/contact.html:92
+#: metabrainz/templates/index/contact.html:93
 #, python-format
 msgid ""
 "The MetaBrainz/MusicBrainz/ListenBrainz team and community hang out\n"
@@ -1167,15 +1675,15 @@ msgid ""
 "    <a href=\"%(chatlogs_url)s\">chat log archives</a>."
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:101
+#: metabrainz/templates/index/contact.html:102
 msgid "Social media"
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:103
+#: metabrainz/templates/index/contact.html:104
 msgid "You can follow us on these social channels:"
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:112
+#: metabrainz/templates/index/contact.html:113
 msgid "Mailing address"
 msgstr "Pašto adresas"
 
@@ -1188,33 +1696,349 @@ msgstr ""
 msgid "GDPR Compliance Statement"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:37
+#: metabrainz/templates/index/gdpr.html:10
+msgid ""
+"The General Data Protection Regulation is a complex EU regulation that "
+"stipulates many points for protecting private data of\n"
+"    users on the Internet. Even though this is an EU regulation, it has a"
+" worldwide impact due to the nature of the Internet.\n"
+"    The MetaBrainz Foundation with its collection of projects is also "
+"affected by this regulation. We’ve been learning and adapting\n"
+"    our sites to be compliant with the GDPR – sadly this regulation isn’t"
+" entirely black and white and there is an incredible\n"
+"    amount of room left for interpretation of these rules."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:17
+msgid ""
+"The good news is that this regulation is roughly in line with our "
+"established practices: We’ve always held private information\n"
+"    in a high regard and applied the sort of rules to ourselves as we "
+"wish to have our own private data treated. Luckily, this\n"
+"    makes our compliance effort considerably easier. We’ve made two "
+"significant changes to how we treat your data and also adopted\n"
+"    terminology as used in the GDPR in order to use the same languages "
+"that many other sites are now adopting. Please keep reading\n"
+"    to find out the exact details of what we are doing to comply."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:24
+#, python-format
+msgid ""
+"However, we do ask for your compassion and help in our process of "
+"complying with the GDPR. As we already mentioned, the GDPR is\n"
+"    a complex set of rules that are not fully clarified yet. We’ve taken "
+"action on the steps that are clear to us and we’re following\n"
+"    ongoing conversations on points that are in gray zones or unclear to "
+"us. We’ve made our best initial effort on compliance and\n"
+"    promise to keep working on it as the picture becomes more clear. If "
+"you believe that we could improve our compliance, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a> and let us know what we "
+"can do to improve. It would also help us if you\n"
+"    could provide concrete discussion or examples to help us understand "
+"and take action on your suggestion."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:33
+msgid ""
+"Finally, below are the key sections of the GDPR as we understand them and"
+" how they affect your data in our ecosystem. Where\n"
+"    possible, we provide links for deeper understanding, links for you to"
+" examine our relevant code and links to tickets to follow\n"
+"    the process of improving our compliance."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:38
 msgid "Right to be forgotten"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:77
+#: metabrainz/templates/index/gdpr.html:41
+msgid ""
+"Summary: <i>Provide the user with the ability to remove their private "
+"data from our services</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:44
+msgid ""
+"The most important aspect of the right to be forgotten is the ability to "
+"delete your account. Once you request for us to delete\n"
+"    your account, we will remove any personally identifying information "
+"you may have provided us from your account (name, email\n"
+"    address, gender, biography, URL, etc.). The visible name on your "
+"account will be changed to “Deleted User #####” and effectively\n"
+"    the account will no longer be identifiable as your account."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:50
+msgid ""
+"However, given the nature of our projects where we work on collaborative "
+"databases, your contributions that are not personally\n"
+"    identifying are valuable assets to our database and these "
+"contributions will not be removed from our databases. But we will\n"
+"    ensure that these contributions no longer contain personally "
+"identifying data."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:55
+#, python-format
+msgid ""
+"Our process of automatically deleting your accounts across the MetaBrainz"
+" ecosystem is not complete yet (see below for a set of\n"
+"    tickets where you can track our progress). If you would like to "
+"delete your accounts in the MetaBrainz ecosystem or mark a\n"
+"    donation that is currently public as a private donation, please <a "
+"href=\"%(contact_url)s\">contact us</a>\n"
+"    and we will address your request as soon as possible."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:62
+#: metabrainz/templates/index/gdpr.html:182
+msgid "Links:"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:66
+#, python-format
+msgid ""
+"<a href=\"%(editor_deletion_doc_url)s\">How we delete accounts\n"
+"       in MusicBrainz</a> (warning, geek content ahead!)"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:70
+msgid ""
+"Implement sitewide user account deletion in\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/MBS-9680\">MusicBrainz</a>,"
+"\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/AB-337\">AcousticBrainz</a>,"
+"\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/BB-260\">BookBrainz</a>,\n"
+"         <a href=\"https://tickets.metabrainz.org/browse/MEB-103\">the "
+"MetaBrainz Site</a>,\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/LB-354\">ListenBrainz</a>, "
+"and\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/CB-307\">CritiqueBrainz</a>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:80
 msgid "Restriction of processing"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:110
+#: metabrainz/templates/index/gdpr.html:83
+msgid ""
+"Summary: <i>To allow the user to control how their personally identifying"
+" data is being used.</i>"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:86
+msgid ""
+"Except for the ListenBrainz and AcousticBrainz projects, we do not "
+"process personally identifying data. Any personally\n"
+"    identifying data that our projects store is for the purpose of being "
+"able to contact you about your contributions to our database\n"
+"    (email address) or for voluntarily showing information about you to "
+"other users (biography, homepage, location, etc)."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:91
+#, python-format
+msgid ""
+"The ListenBrainz project differs in that the Listens (metadata about what"
+" music you have listened to) are stored on our servers\n"
+"    and <a href=\"%(listenbrainz_data_url)s\">made available to the "
+"public</a>. We believe Listens to be personally identifying\n"
+"    data and furthermore, we have goals of creating open source "
+"recommendation engines with this data, which involves processing the\n"
+"    user’s data. These two points are fundamental goals of the "
+"ListenBrainz project and we do not see a reasonable way to reach another"
+"\n"
+"    compromise position."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:99
+msgid ""
+"Because of this, we are going to require users to either acknowledge that"
+" we may process their Listen data or alternatively to\n"
+"    delete their account, including all of their Listens. Please note "
+"that if you decide to delete your ListenBrainz account, it may\n"
+"    take up to two weeks for all of your listens to no longer be included"
+" in our efforts to build a recommendation engine."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:104
+msgid ""
+"We have always made it clear that the data in ListenBrainz was to be "
+"public and that we plan to build new tools with your data, so\n"
+"    this should not come as a surprise to our users."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:108
+msgid ""
+"The AcousticBrainz project does not track who submits data to the "
+"database. If you create an account and use our data creation\n"
+"    tools (e.g. create a dataset or participate in a challenge) then we "
+"link your participation and the things that you create to\n"
+"    your account. If you choose to delete your account then we keep the "
+"non personally identifying data that you create, but anonymize\n"
+"    it so that it cannot be linked back to you."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:114
 msgid "Right to data portability / exporting your data"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:150
+#: metabrainz/templates/index/gdpr.html:117
+msgid ""
+"Summary: <i>You have the right to access/download the data we store about"
+" you</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:120
+msgid ""
+"Except for the ListenBrainz and AcousticBrainz projects, we do not store "
+"personally identifying data beyond the\n"
+"    information that is available in your public profile on each of our "
+"projects. Since this data is plainly available in your\n"
+"    profile we do not provide a means for you to export this data."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:125
+msgid "There are the following exceptions to this:"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:129
+msgid ""
+"<b>IP addresses</b>: If you visit one of our sites the IP address of your"
+" computer is stored in our web logs for 7 days\n"
+"        before our servers automatically delete them. This data is almost"
+" never used by anyone: the only time we look at the\n"
+"        IP addresses is if our sites are adversely impacted by the "
+"actions of some unknown users. In that case, we may investigate\n"
+"        the logs to identify the IP address that needs to be blocked in "
+"order to restore the stability of our service.\n"
+"        This data is not available to anyone but the contractors of the "
+"MetaBrainz Foundation and is not available to download\n"
+"        to anyone at all."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:137
+#, python-format
+msgid ""
+"<b>ListenBrainz Listen data</b>: Users may <a "
+"href=\"%(listenbrainz_export_url)s\">export their ListenBrainz Listen\n"
+"        data</a> directly from the site. The user Listen data is also "
+"included in the <a href=\"%(listenbrainz_data_url)s\">ListenBrainz\n"
+"        data dumps</a> that are available for public download."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:146
+msgid ""
+"All of the non personally identifying data, such as your metadata "
+"contributions, are publicly visible, available for download\n"
+"    and available via the project APIs. For details about this data, "
+"downloads and APIs please check the documentation for the\n"
+"    respective projects you are interested in."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:151
+#, python-format
+msgid ""
+"Anyone wishing to get a list of financial donations they have made to the"
+" MetaBrainz Foundation, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a> and provide your "
+"MusicBrainz editor name so that we can look up\n"
+"    your donations."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:157
 msgid "Right to rectification"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:165
+#: metabrainz/templates/index/gdpr.html:160
+msgid "Summary: <i>You have the right to correct your data</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:163
+msgid ""
+"All of our projects allow their users to update their personally "
+"identifying information in their profiles. Furthermore, most\n"
+"    of our projects allow the editing of their own metadata "
+"contributions. If you find that some of your data is incorrect, please\n"
+"    feel free to edit the data since we provide the tools to do so."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:168
+#, python-format
+msgid ""
+"If anyone who has made a financial donation to the MetaBrainz Foundation "
+"would like to make their donation private, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:173
 msgid "Right to be informed"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:188
+#: metabrainz/templates/index/gdpr.html:175
+msgid ""
+"Summary: <i>You have the right to be informed about how we use your data "
+"in plain English</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:178
+msgid ""
+"Our privacy policy, as well as other policies, have always been written "
+"by humans for human consumption. We abhor legalese and\n"
+"    not speaking in direct terms."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:186
+msgid "Social contract"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:189
+msgid "Code of conduct"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:192
+msgid "Privacy policy"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:196
 msgid "Right to access"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:198
-#: metabrainz/templates/index/privacy.html:166
+#: metabrainz/templates/index/gdpr.html:199
+msgid ""
+"Summary: <i>You have the right to access the data that we collect about "
+"you</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:202
+msgid ""
+"All of our projects make all of the data we collect on your behalf, "
+"privately identifying or not, available to you. The\n"
+"    only exception to this are the IP addresses we store for 7 days – see"
+" above for details."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:206
+#: metabrainz/templates/index/privacy.html:168
 msgid "Privacy/GDPR Representative"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:209
+#, python-format
+msgid ""
+"If you have any questions about our privacy policy, please <a "
+"href=\"%(contact_url)s\">contact us</a>. To report\n"
+"   any privacy problems, violations or leaks, our GDPR representative is "
+"our Interim Executive Director Nicolás Tamargo and for\n"
+"   privacy issues contact him at <strong><a "
+"href=\"mailto:gdpr@metabrainz.org\">gdpr@metabrainz.org</a></strong>."
 msgstr ""
 
 #: metabrainz/templates/index/index.html:6
@@ -1361,7 +2185,7 @@ msgstr ""
 "Norėdami gauti daugiau informacijos apie fondą, eikite į\n"
 "      <a href=\"%(about_url)s\">apie</a> puslapį."
 
-#: frontend/js/src/forms/ConditionsModal.tsx:43
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:32
 #: metabrainz/templates/index/privacy.html:3
 msgid "Privacy"
 msgstr "Privatumas"
@@ -1369,6 +2193,44 @@ msgstr "Privatumas"
 #: metabrainz/templates/index/privacy.html:8
 msgid "Summary"
 msgstr "Santrauka"
+
+#: metabrainz/templates/index/privacy.html:12
+msgid ""
+"You do not have to provide any personal data to be able to browse the "
+"contents of the databases published by MetaBrainz."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:15
+msgid ""
+"You do not have to provide any personally-identifying information if you "
+"choose not to."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:18
+msgid ""
+"We will never reveal your email address on MetaBrainz controlled web "
+"sites."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:22
+msgid ""
+"In order to get maximum value out of the MetaBrainz projects, you may "
+"want to create an account and log in. \n"
+"    Doing so grants you the ability to: edit the databases, contribute "
+"your own data, communicate with other users, and keep track \n"
+"    of recently released music from artists in your MusicBrainz "
+"collection. If you choose to create an account then the minimum we \n"
+"    ask is that you: choose a unique username and password, use a web "
+"browser that accepts \"session\" cookies, and provide a verified \n"
+"    email address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:29
+msgid ""
+"If you do not create an account (or are not logged in) you will not have "
+"access to the above listed features, however, you will \n"
+"    still have full access to browse and examine the databases."
+msgstr ""
 
 #: metabrainz/templates/index/privacy.html:33
 msgid "Applicable to all users"
@@ -1378,40 +2240,198 @@ msgstr ""
 msgid "Cookies"
 msgstr ""
 
+#: metabrainz/templates/index/privacy.html:37
+msgid "We use two cookies that contain sensitive information:"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:42
+msgid ""
+"<b>remember_login</b>: If you choose the \"Log in permanently\" option "
+"when logging in to one of our sites; the cookie will be used to \n"
+"      remember your login details."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:46
+msgid ""
+"<b>musicbrainz_server_session, session, or connect.sid</b>: If you are "
+"logged into one of our sites, your current session ID is stored in this "
+"cookie."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:51
+msgid ""
+"We may store dynamic preference information in other cookies, but these "
+"do not contain any sensitive information."
+msgstr ""
+
 #: metabrainz/templates/index/privacy.html:54
 #, fuzzy
 msgid "Web and FTP access logs"
 msgstr "Žiniatinklio ir FTP prieigos žurnalai (visi naudotojai)"
 
+#: metabrainz/templates/index/privacy.html:57
+msgid ""
+"In a practice similar to other web sites (and APIs) we keep logs of all "
+"web requests made against our servers. These logs include: your IP\n"
+"    address, your browser's (or API client's) \"User-Agent\" string, and "
+"which page (or API endpoint) you requested with which parameters. "
+"Aggregate information about web and FTP traffic is\n"
+"    made available to the public via our site usage pages."
+msgstr ""
+
 #: metabrainz/templates/index/privacy.html:62
 msgid "Third-Party content"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:92
+#: metabrainz/templates/index/privacy.html:64
+msgid ""
+"Our projects' web pages may load some third-party content. Some, but "
+"possibly not all sites are listed below:"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:69
+#, python-format
+msgid ""
+"Cover art and other images: These are provided by the various cover art "
+"sites that have given MusicBrainz permission to do so and our own \n"
+"      <a href=\"%(caa_url)s\">Cover Art Archive</a>. This means that the "
+"relevant site will know (if they want to) your IP \n"
+"      address, User-Agent string, etc., and which MusicBrainz web page "
+"you were visiting (the one which included the cover art image)."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:75
+msgid ""
+"AcoustID: Our fingerprints tab loads fingerprint information from "
+"acoustid.org."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:78
+msgid ""
+"MTCaptcha: Our account creation page loads third party content in order "
+"to prevent spammers from creating accounts."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:83
+msgid ""
+"<i>The above information assumes that you are using \"normal\" web "
+"browser settings, whereby images are always loaded and HTTP referrer \n"
+"    information is always sent.</i>"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:88
+msgid ""
+"It is impractical to constantly modify this privacy policy when "
+"MetaBrainz projects change which third party content they utilize. We "
+"will \n"
+"    aim to use common sense, respect to our community and community "
+"review when adding more content from third party sites. We will also \n"
+"    periodically review our policy to ensure that it remains current."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:93
 msgid "Applicable to account holders"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:94
+#: metabrainz/templates/index/privacy.html:95
 msgid "Account creation"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:108
+#: metabrainz/templates/index/privacy.html:97
+msgid ""
+"When creating an account with a MetaBrainz project you need to pick a "
+"unique username and choose a password, the username you pick is the \n"
+"    only name associated with your account and will be what other "
+"MetaBrainz users know you as. You may optionally also tell us other \n"
+"    information about yourself that will be displayed to other MetaBrainz"
+" users and the public."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:103
+msgid ""
+"Additionally, in order to edit the databases you will need to provide a "
+"confirmed email address. This email address will be held in \n"
+"    confidence, the only method of revealing your email address to "
+"another user is if you choose to send a message to another \n"
+"    user and enable the option to \"reveal my email address\". Changing "
+"the email address stored with your account will require you to \n"
+"    verify the new address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:109
 msgid "Edits and Notes"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:114
+#: metabrainz/templates/index/privacy.html:111
+msgid ""
+"If you make any changes to a MetaBrainz project database, such as adding "
+"any data, the details of those changes will be visible to \n"
+"    other logged-in users and the change will be associated with your "
+"username."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:115
 msgid "Subscriptions on MusicBrainz"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:131
+#: metabrainz/templates/index/privacy.html:117
+msgid ""
+"As a logged-in user you can subscribe to one or more artists, labels, "
+"collections or other editors. The act of subscribing causes \n"
+"    any edits made to (or by in the case of another editor) those "
+"entities to be emailed to you. By default, other users can see your \n"
+"    list of subscriptions, however, you can opt out of this by editing "
+"the appropriate preference."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:123
+msgid ""
+"This does not provide \"perfect\" privacy though, in some cases it will "
+"be possible to infer information about the contents of your \n"
+"    subscription list even though you have disallowed others from viewing"
+" that list directly. This imperfection arises because various \n"
+"    parts of the system behave differently depending on whether or not an"
+" entity has any subscribers; also, the number of users \n"
+"    subscribed to each artist is available via the artist pages. In the "
+"most extreme (possibly contrived) example, imagine that all \n"
+"    users have their subscriptions set to \"public\", except for exactly "
+"one user whose list is \"private\". In that case, any discrepancy \n"
+"    for a given artist between the shown list of subscribers and the "
+"total number of subscribers must be down to that one user. Thus, \n"
+"    you can infer what artists are on that user's list."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:132
 msgid "Third-party sites"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:145
+#: metabrainz/templates/index/privacy.html:134
+#, python-format
+msgid ""
+"Our code reviews are done on GitHub, which is not under the control of "
+"MetaBrainz. Participating in code reviews or other\n"
+"    tasks carried out on GitHub are subject to <a "
+"href=\"%(github_url)s\">GitHub's privacy policy</a>."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:140
+#, python-format
+msgid ""
+"Our translations platform is provided and hosted by Weblate, which has a "
+"data processing agreement with MetaBrainz.\n"
+"    Participating in translations is subject to <a "
+"href=\"%(weblate_url)s\">dedicated legal terms</a>.\n"
+"    Any translations you make will be submitted to our Git repositories "
+"and publicly associated with your username;\n"
+"    if you so choose, you can also publicly associate them with your own "
+"verified email address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:147
 msgid "MetaBrainz donors"
 msgstr "„MetaBrainz“ donorai"
 
-#: metabrainz/templates/index/privacy.html:147
+#: metabrainz/templates/index/privacy.html:149
 msgid ""
 "When you make a donation to the MetaBrainz Foundation, we are legally\n"
 "    required to collect your personal information and keep it in our "
@@ -1427,7 +2447,7 @@ msgstr ""
 "neatskleisime jūsų asmeninės\n"
 "    informacijos niekam kitam."
 
-#: metabrainz/templates/index/privacy.html:153
+#: metabrainz/templates/index/privacy.html:155
 msgid ""
 "We believe in transparent finances, which means that we list all "
 "donations\n"
@@ -1437,11 +2457,34 @@ msgid ""
 "process."
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:158
+#: metabrainz/templates/index/privacy.html:160
 msgid "Exceptions"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:598
+#: metabrainz/templates/index/privacy.html:162
+msgid ""
+"<i><b>Please note</b>: Reasonable exceptions may apply to the above "
+"policy, for example to comply with applicable laws.\n"
+"    Also, members of the MetaBrainz team and other personnel contracted "
+"to provide services to MetaBrainz may have access to\n"
+"    our infrastructure and could therefore view any information contained"
+" therein. However all personnel are contractually bound\n"
+"    by non-disclosure clauses which prevent them from making any such "
+"information available to others."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:171
+#, python-format
+msgid ""
+"If you have any questions about our GDPR statement, please <a "
+"href=\"%(contact_url)s\">contact us</a>. To report\n"
+"   any privacy problems, violations or leaks, our GDPR representative is "
+"our Interim Executive Director Nicolás Tamargo and for\n"
+"   privacy issues contact him at <strong><a "
+"href=\"mailto:gdpr@metabrainz.org\">gdpr@metabrainz.org</a></strong>."
+msgstr ""
+
+#: frontend/js/src/Profile.tsx:603
 #: frontend/js/src/forms/ProfileChangePassword.tsx:22
 #: frontend/js/src/forms/ProfileChangePassword.tsx:111
 #: metabrainz/templates/index/profile-change-password.html:3
@@ -1698,6 +2741,11 @@ msgstr ""
 
 #: metabrainz/templates/index/team.html:26
 msgid "He lives on in our hearts and in open source."
+msgstr ""
+
+#: metabrainz/templates/index/team.html:29
+#: metabrainz/templates/index/team.html:315
+msgid "you’re welcome to try"
 msgstr ""
 
 #: metabrainz/templates/index/team.html:39
@@ -2211,8 +3259,10 @@ msgstr "JAV čekis"
 
 #: metabrainz/templates/payments/donate.html:146
 msgid ""
-"Due to the increased unreliability of the US Postal Service we have "
-"stopped accepting paper checks. Sorry!"
+"Due to the increased unreliability of the US Postal Service and the "
+"relatively large fees involved, we ask you to only send a paper check if "
+"it is the only possible option. Due to the fees, we will not cash checks "
+"for less than $25."
 msgstr ""
 
 #: metabrainz/templates/payments/donate.html:241
@@ -3104,8 +4154,8 @@ msgid "Monthly balance sheets"
 msgstr "Mėnesio balanso ataskaitos"
 
 #: frontend/js/src/Profile.tsx:520
-#: frontend/js/src/forms/SignupCommercial.tsx:175
-#: frontend/js/src/forms/SignupCommercial.tsx:554
+#: frontend/js/src/forms/SignupCommercial.tsx:180
+#: frontend/js/src/forms/SignupCommercial.tsx:558
 #: frontend/js/src/forms/SignupNonCommercial.tsx:106
 #: frontend/js/src/forms/SignupNonCommercial.tsx:318
 #: metabrainz/templates/supporters/account-type.html:3
@@ -3127,6 +4177,7 @@ msgid "Non-commercial / Personal"
 msgstr "Nekomercinis / asmeninis"
 
 #: frontend/js/src/Profile.tsx:235
+#: frontend/js/src/forms/SignupNonCommercial.tsx:107
 #: frontend/js/src/forms/SignupNonCommercial.tsx:151
 #: metabrainz/templates/supporters/account-type.html:42
 msgid "Non-commercial"
@@ -3140,57 +4191,46 @@ msgstr ""
 msgid "Personal or university assignment user."
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:48
-#: metabrainz/templates/supporters/account-type.html:90
-#: metabrainz/templates/supporters/account-type.html:141
-msgid "Upgrade"
-msgstr ""
-
 #: frontend/js/src/Profile.tsx:235
-#: frontend/js/src/forms/SignupCommercial.tsx:176
-#: frontend/js/src/forms/SignupCommercial.tsx:228
-#: metabrainz/templates/supporters/account-type.html:61
+#: frontend/js/src/forms/SignupCommercial.tsx:181
+#: frontend/js/src/forms/SignupCommercial.tsx:233
+#: metabrainz/templates/supporters/account-type.html:56
 msgid "Commercial"
 msgstr "Komercinis"
 
-#: metabrainz/templates/supporters/account-type.html:83
-#: metabrainz/templates/supporters/account-type.html:135
+#: metabrainz/templates/supporters/account-type.html:78
+#: metabrainz/templates/supporters/account-type.html:125
 #, python-format
 msgid "$%(tier_price)s/month and up"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:87
-#: metabrainz/templates/supporters/account-type.html:138
+#: metabrainz/templates/supporters/account-type.html:82
+#: metabrainz/templates/supporters/account-type.html:128
 msgid "More info"
 msgstr "Daugiau informacijos"
 
-#: metabrainz/templates/supporters/account-type.html:104
+#: metabrainz/templates/supporters/account-type.html:94
 msgid "View all tiers"
 msgstr "Peržiūrėti visus lygius"
 
-#: metabrainz/templates/supporters/account-type.html:112
+#: metabrainz/templates/supporters/account-type.html:102
 msgid "Some of our Unicorn members"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:123
+#: metabrainz/templates/supporters/account-type.html:113
 msgid "See all our supporters"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:151
+#: metabrainz/templates/supporters/account-type.html:136
 msgid "View featured tiers"
 msgstr "Peržiūrėti rekomenduojamus lygius"
 
-#: metabrainz/templates/supporters/account-type.html:158
+#: metabrainz/templates/supporters/account-type.html:143
 #, python-format
 msgid ""
 "If you are not sure which tier to pick, please\n"
 "      <a href=\"%(contact_url)s\">contact us</a>."
 msgstr ""
-
-#: metabrainz/templates/supporters/account-type.html:166
-#, fuzzy
-msgid "Back to Profile"
-msgstr "Jūsų profilis"
 
 #: metabrainz/templates/supporters/bad-standing.html:3
 #: metabrainz/templates/supporters/bad-standing.html:6
@@ -3251,9 +4291,9 @@ msgid "Forgot your username"
 msgstr ""
 
 #: frontend/js/src/forms/ResetPassword.tsx:79
-#: frontend/js/src/forms/SignupCommercial.tsx:320
+#: frontend/js/src/forms/SignupCommercial.tsx:325
 #: frontend/js/src/forms/SignupNonCommercial.tsx:227
-#: frontend/js/src/forms/SignupUser.tsx:169
+#: frontend/js/src/forms/SignupUser.tsx:175
 #: metabrainz/templates/users/reauthenticate.html:3
 #: metabrainz/templates/users/reauthenticate.html:6
 msgid "Confirm Password"
@@ -3263,17 +4303,22 @@ msgstr ""
 msgid "Please re-enter your password to continue."
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:108
+#: frontend/js/src/ProfileDelete.tsx:110
 #: frontend/js/src/forms/DeleteApplication.tsx:53
 #: frontend/js/src/forms/OAuthPrompt.tsx:54
 #: frontend/js/src/forms/ProfileChangePassword.tsx:104
 #: frontend/js/src/forms/ProfileEdit.tsx:105
-#: metabrainz/templates/users/reauthenticate.html:23
+#: metabrainz/templates/users/reauthenticate.html:28
 msgid "Cancel"
 msgstr ""
 
-#: metabrainz/templates/users/reauthenticate.html:24
+#: metabrainz/templates/users/reauthenticate.html:29
 msgid "Continue"
+msgstr ""
+
+#: frontend/js/src/forms/utils.tsx:202
+#: metabrainz/templates/users/reauthenticate.html:40
+msgid "Password must not exceed 72 bytes."
 msgstr ""
 
 #: frontend/js/src/forms/ResetPassword.tsx:27
@@ -3281,38 +4326,38 @@ msgstr ""
 msgid "Reset your password"
 msgstr ""
 
-#: frontend/js/src/hooks/useEmailValidation.ts:41 metabrainz/user/forms.py:15
+#: frontend/js/src/hooks/useEmailValidation.ts:41 metabrainz/user/forms.py:16
 msgid "Registration from this email domain is not allowed."
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:50
 #: frontend/js/src/forms/LostPassword.tsx:45
-#: frontend/js/src/forms/SignupCommercial.tsx:270
+#: frontend/js/src/forms/SignupCommercial.tsx:275
 #: frontend/js/src/forms/SignupNonCommercial.tsx:175
-#: frontend/js/src/forms/SignupUser.tsx:114 metabrainz/user/forms.py:20
-#: metabrainz/user/forms.py:45 metabrainz/user/forms.py:62
+#: frontend/js/src/forms/SignupUser.tsx:120 metabrainz/user/forms.py:22
+#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:75
 msgid "Username"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:42
 #: frontend/js/src/forms/LostPassword.tsx:37
-#: frontend/js/src/forms/SignupCommercial.tsx:153
+#: frontend/js/src/forms/SignupCommercial.tsx:158
 #: frontend/js/src/forms/SignupNonCommercial.tsx:84
-#: frontend/js/src/forms/SignupUser.tsx:67 metabrainz/user/forms.py:21
-#: metabrainz/user/forms.py:45 metabrainz/user/forms.py:62
+#: frontend/js/src/forms/SignupUser.tsx:73 metabrainz/user/forms.py:26
+#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:75
 msgid "Username is required!"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:63
 #: frontend/js/src/forms/ResetPassword.tsx:72
-#: frontend/js/src/forms/SignupCommercial.tsx:308
+#: frontend/js/src/forms/SignupCommercial.tsx:313
 #: frontend/js/src/forms/SignupNonCommercial.tsx:214
-#: frontend/js/src/forms/SignupUser.tsx:157 metabrainz/user/forms.py:46
-#: metabrainz/user/forms.py:52
+#: frontend/js/src/forms/SignupUser.tsx:163 metabrainz/user/forms.py:53
+#: metabrainz/user/forms.py:62
 msgid "Password"
 msgstr ""
 
-#: frontend/js/src/forms/LoginUser.tsx:76 metabrainz/user/forms.py:47
+#: frontend/js/src/forms/LoginUser.tsx:76 metabrainz/user/forms.py:57
 msgid "Remember me"
 msgstr ""
 
@@ -3324,11 +4369,11 @@ msgstr ""
 msgid "Username contains invalid or invisible characters."
 msgstr ""
 
-#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:181
+#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:220
 msgid "Hide password"
 msgstr ""
 
-#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:181
+#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:220
 msgid "Show password"
 msgstr ""
 
@@ -3386,11 +4431,11 @@ msgstr ""
 msgid "Revoke access"
 msgstr ""
 
-#: frontend/js/src/OAuthError.tsx:17
+#: frontend/js/src/OAuthError.tsx:18
 msgid "OAuth2 Error"
 msgstr ""
 
-#: frontend/js/src/OAuthError.tsx:18
+#: frontend/js/src/OAuthError.tsx:19
 msgid "An error occurred during OAuth authentication process."
 msgstr ""
 
@@ -3420,8 +4465,8 @@ msgstr ""
 
 #: frontend/js/src/Profile.tsx:109
 msgid ""
-"Are you sure you want to generate new access token? Current token will be"
-" revoked!"
+"Are you sure you want to generate a new access token? The current token "
+"will be revoked!"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:118
@@ -3536,8 +4581,8 @@ msgid "Contact Information"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:310 frontend/js/src/forms/ProfileEdit.tsx:70
-#: frontend/js/src/forms/SignupCommercial.tsx:284
-#: frontend/js/src/forms/SignupCommercial.tsx:333
+#: frontend/js/src/forms/SignupCommercial.tsx:289
+#: frontend/js/src/forms/SignupCommercial.tsx:338
 #: frontend/js/src/forms/SignupNonCommercial.tsx:189
 #: frontend/js/src/forms/SignupNonCommercial.tsx:241
 msgid "Contact name"
@@ -3652,7 +4697,7 @@ msgstr ""
 msgid "Once you delete your account, there is no going back. Please be certain."
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:550 frontend/js/src/ProfileDelete.tsx:105
+#: frontend/js/src/Profile.tsx:550 frontend/js/src/ProfileDelete.tsx:107
 msgid "Delete My Account"
 msgstr ""
 
@@ -3664,39 +4709,39 @@ msgstr ""
 msgid "Need to delete your account?"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:574
+#: frontend/js/src/Profile.tsx:575
 msgid ""
 "Deletion of supporter accounts requires manual review. Please contact us "
-"at"
+"at <email />."
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:594
+#: frontend/js/src/Profile.tsx:599
 msgid "Security"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:626
+#: frontend/js/src/Profile.tsx:631
 msgid "MetaBrainz Applications"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:630
+#: frontend/js/src/Profile.tsx:635
 msgid ""
 "With your MetaBrainz account, you can access every project in the "
 "MetaBrainz family:"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:643
+#: frontend/js/src/Profile.tsx:648
 msgid "The open-source music encyclopedia"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:655
+#: frontend/js/src/Profile.tsx:660
 msgid "Track, visualise and share the music you listen to"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:667
+#: frontend/js/src/Profile.tsx:672
 msgid "The open-source book database"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:679
+#: frontend/js/src/Profile.tsx:684
 msgid "Creative Commons licensed reviews"
 msgstr ""
 
@@ -3719,7 +4764,7 @@ msgid "Permanently remove all your account information"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:64
-msgid "Revoke all your API tokens and access"
+msgid "Revoke all your tokens and access to the replication API"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:65
@@ -3731,14 +4776,16 @@ msgid "Log you out of all MetaBrainz services"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:70
-msgid "Your username will be reserved and cannot be reused."
+msgid ""
+"Your username will be reserved and cannot be reused without the "
+"intervention of an administrator."
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:82
+#: frontend/js/src/ProfileDelete.tsx:84
 msgid "To confirm, type your username '<username />' below:"
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:105
+#: frontend/js/src/ProfileDelete.tsx:107
 msgid "Deleting..."
 msgstr ""
 
@@ -3751,64 +4798,7 @@ msgstr "Jūsų profilis"
 msgid "Close"
 msgstr ""
 
-#: frontend/js/src/forms/ConditionsModal.tsx:23
-msgid "Licensing"
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:25
-msgid ""
-"Any contributions you make to any MetaBrainz service will be released "
-"into the Public Domain and/or licensed under a Creative Commons by-nc-sa "
-"license. Furthermore, you give the MetaBrainz Foundation the right to "
-"license this data for commercial use."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:30
-msgid "Please read our <licenseLink>license page</licenseLink> for more details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:45
-msgid ""
-"MetaBrainz strongly believes in the privacy of its users. Any personal "
-"information you choose to provide will not be sold or shared with anyone "
-"else."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:50
-msgid ""
-"Please read our <privacyLink>privacy policy</privacyLink> for more "
-"details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:59
-msgid "GDPR compliance"
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:61
-msgid ""
-"You may remove your personal information from our services anytime by "
-"deleting your account."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:66
-msgid ""
-"Please read our <gdprLink>GDPR compliance statement</gdprLink> for more "
-"details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:78
-msgid ""
-"Creating an account on MetaBrainz will give you access to all of our "
-"projects, such as MusicBrainz, ListenBrainz, BookBrainz, and more."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:82
-msgid ""
-"We create a placeholder account for all the MetaBrainz projects when you "
-"sign up, and you are one log-in away from activating them."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:91
+#: frontend/js/src/forms/ConditionsModal.tsx:29
 msgid "Sounds good"
 msgstr ""
 
@@ -3896,8 +4886,8 @@ msgstr ""
 msgid "Forgot your password?"
 msgstr ""
 
-#: frontend/js/src/forms/LoginUser.tsx:109
-msgid "Don't have an account?"
+#: frontend/js/src/forms/LoginUser.tsx:110
+msgid "Don't have an account? <signupLink>Sign up</signupLink>"
 msgstr ""
 
 #: frontend/js/src/forms/LostPassword.tsx:38
@@ -3928,15 +4918,72 @@ msgstr ""
 msgid "Allow access"
 msgstr "Leisti prieigą"
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:71
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:10
+msgid "Licensing"
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:12
+msgid ""
+"Any contributions you make to any MetaBrainz service will be released "
+"into the Public Domain and/or licensed under a Creative Commons by-nc-sa "
+"license. Furthermore, you give the MetaBrainz Foundation the right to "
+"license this data for commercial use."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:17
+msgid "Please read our <licenseLink>license page</licenseLink> for more details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:34
+msgid ""
+"MetaBrainz strongly believes in the privacy of its users. Any personal "
+"information you choose to provide will not be sold or shared with anyone "
+"else."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:39
+msgid ""
+"Please read our <privacyLink>privacy policy</privacyLink> for more "
+"details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:50
+msgid "GDPR compliance"
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:52
+msgid ""
+"You may remove your personal information from our services anytime by "
+"deleting your account."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:57
+msgid ""
+"Please read our <gdprLink>GDPR compliance statement</gdprLink> for more "
+"details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:71
+msgid ""
+"Creating an account on MetaBrainz will give you access to all of our "
+"projects, such as MusicBrainz, ListenBrainz, BookBrainz, and more."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:75
+msgid ""
+"We create a placeholder account for all the MetaBrainz projects when you "
+"sign up, and you are one log-in away from activating them."
+msgstr ""
+
+#: frontend/js/src/forms/ProfileChangePassword.tsx:70
 msgid "Current Password"
 msgstr ""
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:80
+#: frontend/js/src/forms/ProfileChangePassword.tsx:79
 msgid "New Password"
 msgstr ""
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:89
+#: frontend/js/src/forms/ProfileChangePassword.tsx:88
 msgid "Confirm New Password"
 msgstr ""
 
@@ -3948,195 +4995,184 @@ msgstr ""
 msgid "Reset Password"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:38
-msgid "If you would like to support us with more than $"
+#: frontend/js/src/forms/SignupCommercial.tsx:40
+msgid ""
+"If you would like to support us with more than ${{minPledge}}, please "
+"enter the actual amount here:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:39
-msgid ", please enter the actual amount here:"
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:144
+#: frontend/js/src/forms/SignupCommercial.tsx:149
 #: frontend/js/src/forms/SignupNonCommercial.tsx:75
-#: frontend/js/src/forms/SignupUser.tsx:87
+#: frontend/js/src/forms/SignupUser.tsx:93
 msgid "Captcha is required!"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:179
+#: frontend/js/src/forms/SignupCommercial.tsx:184
 #: frontend/js/src/forms/SignupNonCommercial.tsx:110
 #: frontend/js/src/forms/SignupUser.tsx:46
 #, fuzzy
 msgid "Access all MetaBrainz projects"
 msgstr "„MetaBrainz“ projektai"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:182
+#: frontend/js/src/forms/SignupCommercial.tsx:187
 msgid "Note:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:184
+#: frontend/js/src/forms/SignupCommercial.tsx:189
 msgid ""
 "Signing up for any tier other than the <italic>Stealth startup</italic> "
 "tier will publicly list your company on this web site. However, we will "
 "not publish any of your private details."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:221
+#: frontend/js/src/forms/SignupCommercial.tsx:226
 #: frontend/js/src/forms/SignupNonCommercial.tsx:145
 #, fuzzy
 msgid "Account type"
 msgstr "Paskyros tipas"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:234
+#: frontend/js/src/forms/SignupCommercial.tsx:239
 msgid "Selected tier"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:242
-msgid "month and up"
+#: frontend/js/src/forms/SignupCommercial.tsx:247
+msgid "${{tierPrice}}/month and up"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:250
+#: frontend/js/src/forms/SignupCommercial.tsx:255
 msgid "Change account type or tier"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:261
+#: frontend/js/src/forms/SignupCommercial.tsx:266
 #: frontend/js/src/forms/SignupNonCommercial.tsx:166
 msgid "Your account:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:271
+#: frontend/js/src/forms/SignupCommercial.tsx:276
 #: frontend/js/src/forms/SignupNonCommercial.tsx:176
-#: frontend/js/src/forms/SignupUser.tsx:114
+#: frontend/js/src/forms/SignupUser.tsx:120
 msgid "(public)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:291
+#: frontend/js/src/forms/SignupCommercial.tsx:296
 #: frontend/js/src/forms/SignupNonCommercial.tsx:196
-#: frontend/js/src/forms/SignupUser.tsx:127
+#: frontend/js/src/forms/SignupUser.tsx:133
 msgid "E-mail address"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:295
+#: frontend/js/src/forms/SignupCommercial.tsx:300
 #: frontend/js/src/forms/SignupNonCommercial.tsx:200
-#: frontend/js/src/forms/SignupUser.tsx:131
+#: frontend/js/src/forms/SignupUser.tsx:137
 msgid "(checking...)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:314
+#: frontend/js/src/forms/SignupCommercial.tsx:319
 #: frontend/js/src/forms/SignupNonCommercial.tsx:220
-#: frontend/js/src/forms/SignupUser.tsx:163
+#: frontend/js/src/forms/SignupUser.tsx:169
 msgid "Must be at least 8 characters"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:348
+#: frontend/js/src/forms/SignupCommercial.tsx:353
 msgid ""
 "If you don't have an organization name, you probably want to become a "
 "supporter as a <nonCommercialLink>Non-commercial / "
 "Personal</nonCommercialLink> supporter."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:358
+#: frontend/js/src/forms/SignupCommercial.tsx:363
 msgid ""
 "If you don't have an organization name, you probably want to sign up as a"
 " <nonCommercialLink>Non-commercial / Personal</nonCommercialLink> user."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:378
+#: frontend/js/src/forms/SignupCommercial.tsx:383
 msgid ""
 "Please tell us a little about your company and whether you plan to use "
 "our <apiLink>API</apiLink> or to <hostLink>host your own copy</hostLink> "
 "of the data."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:404
+#: frontend/js/src/forms/SignupCommercial.tsx:408
 msgid "Logo URL"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:405
+#: frontend/js/src/forms/SignupCommercial.tsx:409
 msgid "(preferably in SVG format)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:408
+#: frontend/js/src/forms/SignupCommercial.tsx:412
 msgid ""
 "Image should be about 250 pixels wide on a white or transparent "
 "background. We will host it on our site."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:421
+#: frontend/js/src/forms/SignupCommercial.tsx:425
 msgid ""
 "URL to where developers can use your APIs using MusicBrainz IDs, if "
-"available.."
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:430
-msgid "Your project"
+"available."
 msgstr ""
 
 #: frontend/js/src/forms/SignupCommercial.tsx:434
+msgid "Your project"
+msgstr ""
+
+#: frontend/js/src/forms/SignupCommercial.tsx:438
 #: frontend/js/src/forms/SignupNonCommercial.tsx:261
 msgid "(max 150 characters)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:451
+#: frontend/js/src/forms/SignupCommercial.tsx:455
 msgid "Billing address"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:502
+#: frontend/js/src/forms/SignupCommercial.tsx:506
 msgid ""
 "I agree to support the MetaBrainz Foundation when my organization is able"
 " to do so."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:507
+#: frontend/js/src/forms/SignupCommercial.tsx:511
+#: frontend/js/src/forms/SignupNonCommercial.tsx:284
 msgid ""
-"I also agree that if I generate a Live Data Feed access token, that I "
-"treat my access token as a secret and will not share this token publicly "
-"or commit it to a source code repository."
+"I also agree that if I generate a Live Data Feed access token, then I "
+"will treat my access token as a secret and will not share this token "
+"publicly or commit it to a source code repository."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:515
+#: frontend/js/src/forms/SignupCommercial.tsx:519
 msgid ""
 "The following information will be shown publicly: organization name, "
 "logo, website and API URLs, data usage description."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:520
+#: frontend/js/src/forms/SignupCommercial.tsx:524
 msgid ""
 "We'll send you more details about payment process once your application "
 "is approved."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:552
+#: frontend/js/src/forms/SignupCommercial.tsx:556
 #: frontend/js/src/forms/SignupNonCommercial.tsx:316
-#: frontend/js/src/forms/SignupUser.tsx:224
+#: frontend/js/src/forms/SignupUser.tsx:230
 msgid "Validating..."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:564
+#: frontend/js/src/forms/SignupCommercial.tsx:568
 #: frontend/js/src/forms/SignupNonCommercial.tsx:329
 #, fuzzy
 msgid "Back to profile"
 msgstr "Jūsų profilis"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:569
-#: frontend/js/src/forms/SignupNonCommercial.tsx:334
-msgid "Not a supporter?"
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:570
+#: frontend/js/src/forms/SignupCommercial.tsx:574
 #: frontend/js/src/forms/SignupNonCommercial.tsx:335
-msgid "Create a user account"
+msgid "Not a supporter? <signupLink>Create a user account</signupLink>"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:573
-#: frontend/js/src/forms/SignupNonCommercial.tsx:338
-#: frontend/js/src/forms/SignupUser.tsx:231
-msgid "Already have an account?"
+#: frontend/js/src/forms/SignupCommercial.tsx:583
+#: frontend/js/src/forms/SignupNonCommercial.tsx:344
+#: frontend/js/src/forms/SignupUser.tsx:238
+msgid "Already have an account? <loginLink>Sign in</loginLink>"
 msgstr ""
-
-#: frontend/js/src/forms/SignupNonCommercial.tsx:107
-#, fuzzy
-msgid "non-commercial"
-msgstr "Nekomercinis"
 
 #: frontend/js/src/forms/SignupNonCommercial.tsx:113
 msgid ""
@@ -4163,46 +5199,40 @@ msgid ""
 "income per year) or personal uses only."
 msgstr ""
 
-#: frontend/js/src/forms/SignupNonCommercial.tsx:284
-msgid ""
-"I also agree that if I generate a Live Data Feed access token, then I "
-"will treat my access token as a secret and will not share this token "
-"publicly or commit it to a source code repository."
-msgstr ""
-
 #: frontend/js/src/forms/SignupUser.tsx:43
 msgid "Create your account"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:50
-msgid "Registration started by"
+#: frontend/js/src/forms/SignupUser.tsx:51
+msgid "Registration started by <client />"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:69
+#: frontend/js/src/forms/SignupUser.tsx:75
+#: frontend/js/src/hooks/useEmailValidation.ts:82
 msgid "Invalid email address."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:150
+#: frontend/js/src/forms/SignupUser.tsx:156
 msgid ""
 "This username and email were provided by the app that started "
 "registration. You can change them later from MetaBrainz settings."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:182
+#: frontend/js/src/forms/SignupUser.tsx:188
 msgid ""
 "I accept that my contributions will be released into the public domain or"
 " licensed for use."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:191
+#: frontend/js/src/forms/SignupUser.tsx:197
 msgid "We will never share your personal information."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:200
+#: frontend/js/src/forms/SignupUser.tsx:206
 msgid "Click here to read more"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:224
+#: frontend/js/src/forms/SignupUser.tsx:230
 msgid "Create account"
 msgstr ""
 
@@ -4212,10 +5242,6 @@ msgstr ""
 
 #: frontend/js/src/hooks/useEmailValidation.ts:47
 msgid "Email validation failed"
-msgstr ""
-
-#: frontend/js/src/hooks/useEmailValidation.ts:82
-msgid "Invalid email address"
 msgstr ""
 
 #~ msgid "You need to specify amount!"
@@ -5438,4 +6464,100 @@ msgstr ""
 
 #~ msgid "Privacy policy"
 #~ msgstr "Privatumo politika"
+
+#~ msgid "You need to specify website of the organization."
+#~ msgstr ""
+
+#~ msgid ""
+#~ "We are currently evaluating our overall"
+#~ " online advertising strategy. We are "
+#~ "evaluating advertising, traffic optimization,\n"
+#~ ""
+#~ "    search engine optimization and "
+#~ "software monitization technologies. If you "
+#~ "provide these professional services, please"
+#~ " provide a detailed\n"
+#~ "    deck of your comprehensive services"
+#~ " to the following email address. "
+#~ "<em>Please respect our other non-media"
+#~ " teams and do not contact us \n"
+#~ "    regarding these services on any "
+#~ "other of our email addresses. We "
+#~ "will disregard the entirety of your "
+#~ "submissions if you contact us any "
+#~ "other way!</em>"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Please come ask your questions at "
+#~ "our <a href=\"%(forums_url)s\">forums</a>! We "
+#~ "would love to\n"
+#~ "    answer any questions you may have."
+#~ msgstr ""
+#~ "Užduokite savo klausimus mūsų <a "
+#~ "href=\"%(forums_url)s\">forumuose</a>! Mes mielai "
+#~ "norėtume\n"
+#~ "    atsakyti į klausimus, kurių jums gali kilti."
+
+#~ msgid ""
+#~ "Due to the increased unreliability of"
+#~ " the US Postal Service we have "
+#~ "stopped accepting paper checks. Sorry!"
+#~ msgstr ""
+
+#~ msgid "Upgrade"
+#~ msgstr ""
+
+#~ msgid "Back to Profile"
+#~ msgstr "Jūsų profilis"
+
+#~ msgid ""
+#~ "Deletion of supporter accounts requires "
+#~ "manual review. Please contact us at"
+#~ msgstr ""
+
+#~ msgid "Revoke all your API tokens and access"
+#~ msgstr ""
+
+#~ msgid "Your username will be reserved and cannot be reused."
+#~ msgstr ""
+
+#~ msgid "Don't have an account?"
+#~ msgstr ""
+
+#~ msgid "If you would like to support us with more than $"
+#~ msgstr ""
+
+#~ msgid ", please enter the actual amount here:"
+#~ msgstr ""
+
+#~ msgid "month and up"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "I also agree that if I generate"
+#~ " a Live Data Feed access token, "
+#~ "that I treat my access token as"
+#~ " a secret and will not share "
+#~ "this token publicly or commit it "
+#~ "to a source code repository."
+#~ msgstr ""
+
+#~ msgid "Not a supporter?"
+#~ msgstr ""
+
+#~ msgid "Create a user account"
+#~ msgstr ""
+
+#~ msgid "Already have an account?"
+#~ msgstr ""
+
+#~ msgid "non-commercial"
+#~ msgstr "Nekomercinis"
+
+#~ msgid "Registration started by"
+#~ msgstr ""
+
+#~ msgid "Invalid email address"
+#~ msgstr ""
 

--- a/metabrainz/translations/nb/LC_MESSAGES/messages.po
+++ b/metabrainz/translations/nb/LC_MESSAGES/messages.po
@@ -9,179 +9,264 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-07-25 16:21+0200\n"
+"POT-Creation-Date: 2026-09-08 11:18+0200\n"
 "PO-Revision-Date: 2026-08-01 22:12+0000\n"
 "Last-Translator: \"ApeKattQuest, MonkeyPython\" "
 "<monkeypython+inst@yepmail.net>\n"
 "Language: nb\n"
-"Language-Team: Norwegian Bokmål <https://translations.metabrainz.org/"
-"projects/metabrainz/website/nb_NO/>\n"
+"Language-Team: Norwegian Bokmål "
+"<https://translations.metabrainz.org/projects/metabrainz/website/nb_NO/>"
+"\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.18.0\n"
-"X-Generator: Weblate 2026.7.1\n"
 
-#: metabrainz/index/forms.py:46
+#: metabrainz/errors.py:24
+msgid "Authorization was declined."
+msgstr ""
+
+#: metabrainz/errors.py:25
+msgid "The authorization request was invalid."
+msgstr ""
+
+#: metabrainz/errors.py:26
+msgid "The application could not be authenticated."
+msgstr ""
+
+#: metabrainz/errors.py:27
+msgid "This application is not allowed to request authorization."
+msgstr ""
+
+#: metabrainz/errors.py:28
+msgid "The application asked for a response type this server does not support."
+msgstr ""
+
+#: metabrainz/errors.py:29
+msgid "The permissions requested by the application are invalid."
+msgstr ""
+
+#: metabrainz/errors.py:30
+msgid "You need to sign in to continue."
+msgstr ""
+
+#: metabrainz/errors.py:31
+msgid "Your consent is required to continue."
+msgstr ""
+
+#: metabrainz/password.py:12
+#, python-format
+msgid "Password must not exceed %(max_bytes)s bytes."
+msgstr ""
+
+#: metabrainz/index/forms.py:48
 #, python-format
 msgid "'%(value)s' is not a valid choice for this field"
 msgstr "«%(value)s» er ikke et gyldig valg for dette feltet"
 
 #: frontend/js/src/forms/ProfileEdit.tsx:27
-#: frontend/js/src/forms/SignupCommercial.tsx:154
+#: frontend/js/src/forms/SignupCommercial.tsx:159
 #: frontend/js/src/forms/SignupNonCommercial.tsx:85
-#: frontend/js/src/forms/SignupUser.tsx:70
-#: frontend/js/src/hooks/useEmailValidation.ts:78 metabrainz/index/forms.py:57
-#: metabrainz/user/forms.py:25 metabrainz/user/forms.py:57
-#: metabrainz/user/forms.py:63
+#: frontend/js/src/forms/SignupUser.tsx:76
+#: frontend/js/src/hooks/useEmailValidation.ts:78 metabrainz/index/forms.py:59
+#: metabrainz/user/forms.py:31 metabrainz/user/forms.py:70
+#: metabrainz/user/forms.py:76
 msgid "Email address is required!"
 msgstr "E-postadresse er påkrevd!"
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:34
-#: metabrainz/index/forms.py:63
+#: metabrainz/index/forms.py:65
 msgid "Current password is required!"
 msgstr "Forhenværende passord er påkrevd!"
 
 #: frontend/js/src/forms/LoginUser.tsx:43
 #: frontend/js/src/forms/ProfileChangePassword.tsx:37
 #: frontend/js/src/forms/ResetPassword.tsx:39
-#: frontend/js/src/forms/SignupCommercial.tsx:156
+#: frontend/js/src/forms/SignupCommercial.tsx:161
 #: frontend/js/src/forms/SignupNonCommercial.tsx:87
-#: frontend/js/src/forms/SignupUser.tsx:72 metabrainz/index/forms.py:66
-#: metabrainz/user/forms.py:29 metabrainz/user/forms.py:46
-#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:69
+#: frontend/js/src/forms/SignupUser.tsx:78 metabrainz/index/forms.py:69
+#: metabrainz/user/forms.py:35 metabrainz/user/forms.py:54
+#: metabrainz/user/forms.py:63 metabrainz/user/forms.py:82
 msgid "Password is required!"
 msgstr "Passord er påkrevd!"
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:41
-#: frontend/js/src/forms/SignupCommercial.tsx:160
+#: frontend/js/src/forms/SignupCommercial.tsx:165
 #: frontend/js/src/forms/SignupNonCommercial.tsx:91
-#: frontend/js/src/forms/SignupUser.tsx:76 metabrainz/index/forms.py:70
-#: metabrainz/user/forms.py:33 metabrainz/user/forms.py:73
+#: frontend/js/src/forms/SignupUser.tsx:82 metabrainz/index/forms.py:74
+#: metabrainz/user/forms.py:40 metabrainz/user/forms.py:87
 msgid "Confirm Password is required!"
 msgstr "Bekreftelsespassord er påkrevd!"
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:46
 #: frontend/js/src/forms/ResetPassword.tsx:48
-#: frontend/js/src/forms/SignupCommercial.tsx:165
+#: frontend/js/src/forms/SignupCommercial.tsx:170
 #: frontend/js/src/forms/SignupNonCommercial.tsx:96
-#: frontend/js/src/forms/SignupUser.tsx:81 metabrainz/index/forms.py:72
-#: metabrainz/user/forms.py:35 metabrainz/user/forms.py:75
+#: frontend/js/src/forms/SignupUser.tsx:87 metabrainz/index/forms.py:76
+#: metabrainz/user/forms.py:42 metabrainz/user/forms.py:89
 msgid "Confirm Password should match password!"
 msgstr "Bekreftelsespassordet må samsvare med passordet!"
 
 #: frontend/js/src/Applications.tsx:56 frontend/js/src/Applications.tsx:86
 #: frontend/js/src/Profile.tsx:272 frontend/js/src/Profile.tsx:482
-#: metabrainz/index/forms.py:78
+#: metabrainz/index/forms.py:82
 msgid "Name"
 msgstr "Navn"
 
-#: metabrainz/index/forms.py:79
+#: metabrainz/index/forms.py:83
 msgid "Contact name field is empty."
 msgstr "Kontaktnavnsfeltet er tomt."
 
-#: metabrainz/index/views.py:234
+#: metabrainz/index/views.py:251
 msgid "Profile updated successfully."
 msgstr "Profilen er oppdatert!"
 
-#: metabrainz/index/views.py:261
+#: metabrainz/index/views.py:278
 msgid "Current password is incorrect."
 msgstr "Nåværende passord er ikke gyldig."
 
-#: metabrainz/index/views.py:266
+#: metabrainz/index/views.py:283
 msgid "Password changed successfully."
 msgstr "Passord endret."
 
-#: metabrainz/index/views.py:372
+#: metabrainz/index/views.py:389
 msgid "You have updated an application!"
 msgstr "Søknaden er oppdatert!"
 
-#: metabrainz/index/views.py:424
+#: metabrainz/index/views.py:441
 msgid "You have deleted an application."
 msgstr "Søknaden er slettet."
 
-#: metabrainz/index/views.py:426
+#: metabrainz/index/views.py:443
 msgid "Failed to delete an application."
 msgstr "Kunne ikke slette søknad."
 
-#: metabrainz/index/views.py:449
+#: metabrainz/index/views.py:466
 msgid "Revoked tokens successfully!"
 msgstr "Pollettene ble annullert!"
 
-#: metabrainz/index/views.py:478
+#: metabrainz/index/views.py:495
 msgid "Your account has been deleted."
 msgstr "Brukerprofilen er slettet."
 
-#: frontend/js/src/forms/CreateApplication.tsx:106 metabrainz/oauth/forms.py:58
+#: frontend/js/src/forms/CreateApplication.tsx:106 metabrainz/oauth/forms.py:57
 msgid "Application Name"
 msgstr "Søknadsnavn"
 
-#: metabrainz/oauth/forms.py:59
+#: metabrainz/oauth/forms.py:58
 msgid "Application name field is empty."
 msgstr "Feltet for søknadsnavn tomt."
 
-#: frontend/js/src/forms/CreateApplication.tsx:60 metabrainz/oauth/forms.py:60
+#: frontend/js/src/forms/CreateApplication.tsx:60 metabrainz/oauth/forms.py:59
 msgid "Application name needs to be at least 3 characters long."
 msgstr "Søknadens navn må ha minst 3 tegn."
 
-#: frontend/js/src/forms/CreateApplication.tsx:64 metabrainz/oauth/forms.py:61
+#: frontend/js/src/forms/CreateApplication.tsx:64 metabrainz/oauth/forms.py:60
 msgid "Application name needs to be at most 64 characters long."
 msgstr "Søknadens navn kan bare ha maksimum 64 tegn."
 
-#: frontend/js/src/forms/CreateApplication.tsx:114 metabrainz/oauth/forms.py:63
+#: frontend/js/src/forms/CreateApplication.tsx:114 metabrainz/oauth/forms.py:62
 msgid "Description"
 msgstr "Organisasjonsbeskrivelse"
 
-#: metabrainz/oauth/forms.py:64
+#: metabrainz/oauth/forms.py:63
 msgid "Client description field is empty."
 msgstr "Klienttbeskrivelsen er tom."
 
-#: metabrainz/oauth/forms.py:65
+#: metabrainz/oauth/forms.py:64
 msgid "Client description needs to be at least 3 characters long."
 msgstr "Klientfbeskrivelsen må være på minst 3 tegn."
 
-#: metabrainz/oauth/forms.py:66
+#: metabrainz/oauth/forms.py:65
 msgid "Client description needs to be at most 512 characters long."
 msgstr "Klienttbeskrivelsen kan bare ha maksimum 512 tegn."
 
-#: frontend/js/src/forms/CreateApplication.tsx:122 metabrainz/oauth/forms.py:68
+#: frontend/js/src/forms/CreateApplication.tsx:122 metabrainz/oauth/forms.py:67
 msgid "Homepage"
 msgstr "Hjemmeside"
 
-#: metabrainz/oauth/forms.py:69
+#: metabrainz/oauth/forms.py:68
 msgid "Homepage field is empty."
 msgstr "Hjemmesidefeltet er tomt."
 
-#: metabrainz/oauth/forms.py:70
+#: metabrainz/oauth/forms.py:69
 msgid "Homepage is not a valid URI."
 msgstr "Hjemmesidefeltet har en ugyldig URI."
 
-#: metabrainz/oauth/forms.py:71
+#: metabrainz/oauth/forms.py:70
 msgid "Homepage URL must use http or https"
 msgstr "Hjemmesideadressen kan bare bruke http eller https"
 
-#: metabrainz/oauth/forms.py:73
+#: metabrainz/oauth/forms.py:72
 msgid "Authorization callback URL"
 msgstr "Adresse for tilbakekalling av autorisasjon"
 
-#: metabrainz/oauth/forms.py:74
+#: metabrainz/oauth/forms.py:73
 msgid "Authorization callback URL field is empty."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:75
+#: metabrainz/oauth/forms.py:74
 msgid "Authorization callback URL is invalid."
 msgstr "Autorisasjonstilbakekallingsadressen er ugyldig."
 
-#: metabrainz/oauth/forms.py:76
+#: metabrainz/oauth/forms.py:75
 msgid "Authorization callback URL must use http or https."
 msgstr ""
 "Adresse for tilbakekalling av autorisasjon kan bare bruke http eller "
 "https."
 
-#: metabrainz/oauth/forms.py:81 metabrainz/oauth/forms.py:85
+#: metabrainz/oauth/forms.py:80 metabrainz/oauth/forms.py:84
 msgid "Confirm"
 msgstr "Bekreft"
+
+#: metabrainz/oauth/scopes.py:15
+msgid "View your public account information"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:16
+msgid "View your email address"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:17
+msgid "View and modify your private tags"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:18
+msgid "View and modify your private ratings"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:19
+msgid "View and modify your private collections"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:20
+msgid "Submit new ISRCs to the database"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:21
+msgid "Submit new barcodes to the database"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:22
+msgid "Sign you in and view your unique user id"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:23
+msgid "Submit listens to ListenBrainz."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:24
+msgid "Create and modify CritiqueBrainz reviews."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:25
+msgid "Submit and delete votes on CritiqueBrainz reviews."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:26
+msgid "Modify profile info and delete profile on CritiqueBrainz."
+msgstr ""
 
 #: metabrainz/payments/views.py:164
 msgid ""
@@ -234,15 +319,15 @@ msgid "Requested annual report was not found."
 msgstr "Den forespurte årsrapporten ble ikke funnet."
 
 #: frontend/js/src/forms/ProfileEdit.tsx:30
-#: frontend/js/src/forms/SignupCommercial.tsx:139
+#: frontend/js/src/forms/SignupCommercial.tsx:144
 #: frontend/js/src/forms/SignupNonCommercial.tsx:70
-#: metabrainz/supporter/forms.py:13
+#: metabrainz/supporter/forms.py:15
 msgid "Contact name is required!"
 msgstr "Kontaktens navn er påkrevd!"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:437
+#: frontend/js/src/forms/SignupCommercial.tsx:441
 #: frontend/js/src/forms/SignupNonCommercial.tsx:264
-#: metabrainz/supporter/forms.py:15
+#: metabrainz/supporter/forms.py:17
 msgid ""
 "Can you please tell us more about the project in which you'd like to use "
 "our data? Do you plan to self host the data or use our APIs?"
@@ -250,121 +335,122 @@ msgstr ""
 "Fortell oss mer om prosjektet som skal bruke dataene våre. Skal det "
 "lagres på din egen server eller vil du bruke våre APIer?"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:137
+#: frontend/js/src/forms/SignupCommercial.tsx:142
 #: frontend/js/src/forms/SignupNonCommercial.tsx:68
-#: metabrainz/supporter/forms.py:17
+#: metabrainz/supporter/forms.py:19
 msgid "Please, tell us how you (will) use our data."
 msgstr "Fortell oss hvordan du bruker eller ønsker å bruke vår data."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:138
+#: frontend/js/src/forms/SignupCommercial.tsx:143
 #: frontend/js/src/forms/SignupNonCommercial.tsx:69
-#: metabrainz/supporter/forms.py:18
+#: metabrainz/supporter/forms.py:20
 msgid "Please, limit usage description to 500 characters."
 msgstr "Begrens bruksbeskrivelse til 500 tegn."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:141
-#: frontend/js/src/forms/SignupCommercial.tsx:142
+#: frontend/js/src/forms/SignupCommercial.tsx:146
+#: frontend/js/src/forms/SignupCommercial.tsx:147
 #: frontend/js/src/forms/SignupNonCommercial.tsx:72
 #: frontend/js/src/forms/SignupNonCommercial.tsx:73
-#: frontend/js/src/forms/SignupUser.tsx:84
-#: frontend/js/src/forms/SignupUser.tsx:85 metabrainz/supporter/forms.py:21
-#: metabrainz/user/forms.py:38
+#: frontend/js/src/forms/SignupUser.tsx:90
+#: frontend/js/src/forms/SignupUser.tsx:91 metabrainz/supporter/forms.py:23
+#: metabrainz/user/forms.py:45
 msgid "You need to accept the agreement!"
 msgstr "Du må godta avtalen!"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:342
-#: metabrainz/supporter/forms.py:27
+#: frontend/js/src/forms/SignupCommercial.tsx:347
+#: metabrainz/supporter/forms.py:29
 msgid "Organization name"
 msgstr "Organisasjonsnavn"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:113
-#: metabrainz/supporter/forms.py:28
+#: frontend/js/src/forms/SignupCommercial.tsx:115
+#: metabrainz/supporter/forms.py:30
 msgid "You need to specify the name of your organization."
 msgstr "Du må oppgi navnet på organisasjonen."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:373
-#: metabrainz/supporter/forms.py:30
+#: frontend/js/src/forms/SignupCommercial.tsx:378
+#: metabrainz/supporter/forms.py:32
 msgid "Organization description"
 msgstr "Beskrivelse av organisasjon"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:116
-#: metabrainz/supporter/forms.py:31
+#: frontend/js/src/forms/SignupCommercial.tsx:118
+#: metabrainz/supporter/forms.py:33
 msgid "You need to provide description of your organization."
 msgstr "Du må oppgi en beskrivelse av organisasjonen."
 
 #: frontend/js/src/Profile.tsx:278
-#: frontend/js/src/forms/SignupCommercial.tsx:396
-#: metabrainz/supporter/forms.py:34
+#: frontend/js/src/forms/SignupCommercial.tsx:401
+#: metabrainz/supporter/forms.py:36
 msgid "Website URL"
 msgstr "Nettsideadresse"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:119
-#: metabrainz/supporter/forms.py:35
-msgid "You need to specify website of the organization."
-msgstr "Du må oppgi nettsideadresse for organisasjonen."
+#: frontend/js/src/forms/SignupCommercial.tsx:121
+#: frontend/js/src/forms/SignupCommercial.tsx:123
+#: metabrainz/supporter/forms.py:38 metabrainz/supporter/forms.py:42
+msgid "Website URL must be a valid URL."
+msgstr ""
 
-#: metabrainz/supporter/forms.py:37
+#: metabrainz/supporter/forms.py:45
 msgid "Logo image URL"
 msgstr "Nettadresse for logo"
 
 #: frontend/js/src/Profile.tsx:284
-#: frontend/js/src/forms/SignupCommercial.tsx:418
-#: metabrainz/supporter/forms.py:38
+#: frontend/js/src/forms/SignupCommercial.tsx:422
+#: metabrainz/supporter/forms.py:46
 msgid "API URL"
 msgstr "API-nettadresse"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:457
-#: metabrainz/supporter/forms.py:40
+#: frontend/js/src/forms/SignupCommercial.tsx:461
+#: metabrainz/supporter/forms.py:48
 msgid "Street"
 msgstr "Gate"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:123
-#: metabrainz/supporter/forms.py:41
+#: frontend/js/src/forms/SignupCommercial.tsx:128
+#: metabrainz/supporter/forms.py:49
 msgid "You need to specify street."
 msgstr "Du må oppgi gateadresse."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:465
-#: metabrainz/supporter/forms.py:43
+#: frontend/js/src/forms/SignupCommercial.tsx:469
+#: metabrainz/supporter/forms.py:51
 msgid "City"
 msgstr "By"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:124
-#: metabrainz/supporter/forms.py:44
+#: frontend/js/src/forms/SignupCommercial.tsx:129
+#: metabrainz/supporter/forms.py:52
 msgid "You need to specify city."
 msgstr "Du må oppgi by."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:473
-#: metabrainz/supporter/forms.py:46
+#: frontend/js/src/forms/SignupCommercial.tsx:477
+#: metabrainz/supporter/forms.py:54
 msgid "State / Province"
 msgstr "Fylke"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:126
-#: metabrainz/supporter/forms.py:47
+#: frontend/js/src/forms/SignupCommercial.tsx:131
+#: metabrainz/supporter/forms.py:55
 msgid "You need to specify state/province."
 msgstr "Du må oppgi fylke/provins."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:481
-#: metabrainz/supporter/forms.py:49
+#: frontend/js/src/forms/SignupCommercial.tsx:485
+#: metabrainz/supporter/forms.py:57
 msgid "Postcode"
 msgstr "Postnummer"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:128
-#: metabrainz/supporter/forms.py:50
+#: frontend/js/src/forms/SignupCommercial.tsx:133
+#: metabrainz/supporter/forms.py:58
 msgid "You need to specify postcode."
 msgstr "Du må oppgi postnummer."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:489
-#: metabrainz/supporter/forms.py:52
+#: frontend/js/src/forms/SignupCommercial.tsx:493
+#: metabrainz/supporter/forms.py:60
 msgid "Country"
 msgstr "Land"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:129
-#: metabrainz/supporter/forms.py:53
+#: frontend/js/src/forms/SignupCommercial.tsx:134
+#: metabrainz/supporter/forms.py:61
 msgid "You need to specify country."
 msgstr "Du må oppgi land."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:132
-#: metabrainz/supporter/forms.py:64
+#: frontend/js/src/forms/SignupCommercial.tsx:137
+#: metabrainz/supporter/forms.py:72
 msgid ""
 "Custom amount must be more than threshold amount for selected tier or "
 "equal to it!"
@@ -372,24 +458,30 @@ msgstr ""
 "Egendefinert beløp må være høyere enn terskelen for valgt nivå eller lik "
 "det!"
 
-#: metabrainz/supporter/views.py:46 metabrainz/supporter/views.py:119
-#: metabrainz/supporter/views.py:220
+#: metabrainz/supporter/views.py:54
+msgid ""
+"The verification email could not be sent. Please request a new one from "
+"your profile."
+msgstr ""
+
+#: metabrainz/supporter/views.py:85 metabrainz/supporter/views.py:158
+#: metabrainz/supporter/views.py:260
 msgid "You are already a supporter."
 msgstr "Du er allerede en støttespiller."
 
-#: metabrainz/supporter/views.py:61
+#: metabrainz/supporter/views.py:100
 msgid "Can't find tier with a specified ID."
 msgstr "Kan ikke finne nivå med oppgitt ID."
 
-#: metabrainz/supporter/views.py:127
+#: metabrainz/supporter/views.py:166
 msgid "You need to choose support tier before signing up!"
 msgstr "Du må velge et støttenivå før du registrerer deg!"
 
-#: metabrainz/supporter/views.py:137
+#: metabrainz/supporter/views.py:176
 msgid "You need to choose existing tier before signing up!"
 msgstr "Du må velge et eksisterende nivå før du registrerer deg!"
 
-#: metabrainz/supporter/views.py:164
+#: metabrainz/supporter/views.py:204
 msgid ""
 "Thanks for becoming a supporter! Your application will be reviewed soon. "
 "We will send you updates via email."
@@ -397,7 +489,7 @@ msgstr ""
 "Takk for din støtte! Din søknad vil bli vurdert snart. Vi vil sende deg "
 "oppdateringer per e-post."
 
-#: metabrainz/supporter/views.py:187
+#: metabrainz/supporter/views.py:228
 msgid ""
 "Thanks for signing up! Your application will be reviewed soon. We will "
 "send you updates via email."
@@ -405,15 +497,15 @@ msgstr ""
 "Takk for din registrering! Din søknad vil bli vurdert snart. Vi vil sende"
 " deg oppdateringer per e-post."
 
-#: metabrainz/supporter/views.py:248
+#: metabrainz/supporter/views.py:288
 msgid "Thanks for becoming a supporter!"
 msgstr "Takk for din støtte!"
 
-#: metabrainz/supporter/views.py:274
+#: metabrainz/supporter/views.py:312
 msgid "Thanks for signing up! Please check your inbox to complete verification."
 msgstr "Takk for din registrering! Sjekk innboksen for å fullføre bekreftelsen."
 
-#: metabrainz/supporter/views.py:302
+#: metabrainz/supporter/views.py:340
 msgid "Can't generate new token unless account is active."
 msgstr "Kan ikke generere en ny pollett med mindre kontoen er aktiv."
 
@@ -447,7 +539,7 @@ msgstr "Butikk"
 msgid "Policies"
 msgstr "Retningslinjer"
 
-#: metabrainz/templates/base.html:55 metabrainz/templates/index/gdpr.html:178
+#: metabrainz/templates/base.html:55
 #: metabrainz/templates/index/social-contract.html:3
 #: metabrainz/templates/index/social-contract.html:6
 #: metabrainz/templates/navbar.html:34
@@ -457,14 +549,15 @@ msgstr "Samfunnspakt"
 #: metabrainz/templates/base.html:56
 #: metabrainz/templates/index/code-of-conduct.html:3
 #: metabrainz/templates/index/code-of-conduct.html:16
-#: metabrainz/templates/index/gdpr.html:181 metabrainz/templates/navbar.html:35
+#: metabrainz/templates/navbar.html:35
 msgid "Code of Conduct"
 msgstr "Retningslinjer for god oppførsel"
 
+#: frontend/js/src/PrivacySummary.tsx:11
 #: frontend/js/src/forms/ConditionsModal.tsx:21
-#: metabrainz/templates/base.html:57 metabrainz/templates/index/gdpr.html:184
-#: metabrainz/templates/index/privacy.html:6
+#: metabrainz/templates/base.html:57 metabrainz/templates/index/privacy.html:6
 #: metabrainz/templates/navbar.html:36
+#: metabrainz/templates/users/privacy-summary.html:3
 msgid "Privacy Policy"
 msgstr "Personvernerklæring"
 
@@ -497,10 +590,7 @@ msgstr "Sponsorer"
 msgid "Supporters"
 msgstr "Støttespillere"
 
-#: frontend/js/src/forms/LoginUser.tsx:103
-#: frontend/js/src/forms/SignupCommercial.tsx:574
-#: frontend/js/src/forms/SignupNonCommercial.tsx:339
-#: frontend/js/src/forms/SignupUser.tsx:232 metabrainz/templates/base.html:73
+#: frontend/js/src/forms/LoginUser.tsx:103 metabrainz/templates/base.html:73
 #: metabrainz/templates/navbar.html:66 metabrainz/templates/users/login.html:3
 msgid "Sign in"
 msgstr "Logg inn"
@@ -522,26 +612,26 @@ msgid "Contact us"
 msgstr "Kontakt oss"
 
 #: metabrainz/templates/base.html:85
-#: metabrainz/templates/index/contact.html:105
+#: metabrainz/templates/index/contact.html:106
 msgid "Blog"
 msgstr "Blogg"
 
-#: metabrainz/templates/base.html:86 metabrainz/templates/index/contact.html:90
+#: metabrainz/templates/base.html:86 metabrainz/templates/index/contact.html:91
 msgid "Chat"
 msgstr "Chat"
 
 #: metabrainz/templates/base.html:87
-#: metabrainz/templates/index/contact.html:106
+#: metabrainz/templates/index/contact.html:107
 msgid "Mastodon"
 msgstr "Mastodon"
 
 #: metabrainz/templates/base.html:88
-#: metabrainz/templates/index/contact.html:107
+#: metabrainz/templates/index/contact.html:108
 msgid "Bluesky"
 msgstr "Bluesky"
 
 #: metabrainz/templates/base.html:89
-#: metabrainz/templates/index/contact.html:108
+#: metabrainz/templates/index/contact.html:109
 msgid "Instagram"
 msgstr "Instagram"
 
@@ -597,15 +687,14 @@ msgstr "Finansrapporter"
 msgid "Donate"
 msgstr "Donére"
 
-#: frontend/js/src/forms/LoginUser.tsx:110
-#: frontend/js/src/forms/SignupCommercial.tsx:175
-#: frontend/js/src/forms/SignupCommercial.tsx:555
+#: frontend/js/src/forms/SignupCommercial.tsx:180
+#: frontend/js/src/forms/SignupCommercial.tsx:559
 #: frontend/js/src/forms/SignupNonCommercial.tsx:106
 #: frontend/js/src/forms/SignupNonCommercial.tsx:319
 #: metabrainz/templates/navbar.html:65
-#: metabrainz/templates/supporters/account-type.html:51
-#: metabrainz/templates/supporters/account-type.html:93
-#: metabrainz/templates/supporters/account-type.html:144
+#: metabrainz/templates/supporters/account-type.html:47
+#: metabrainz/templates/supporters/account-type.html:84
+#: metabrainz/templates/supporters/account-type.html:130
 #: metabrainz/templates/users/signup.html:3
 msgid "Sign up"
 msgstr "Registrering"
@@ -808,8 +897,8 @@ msgid ""
 "Director <a href=\"%(matthew_url)s\">Matthew Hawn</a> of <a "
 "href=\"%(compass_url)s\">Compass, Map & Key</a>"
 msgstr ""
-"Direktør <a href=\"%(matthew_url)s\">Matthew Hawn</a> i <a href=\"%"
-"(compass_url)s\">Compass, Map & Key</a>"
+"Direktør <a href=\"%(matthew_url)s\">Matthew Hawn</a> i <a "
+"href=\"%(compass_url)s\">Compass, Map & Key</a>"
 
 #: metabrainz/templates/index/about.html:56
 #, python-format
@@ -835,8 +924,8 @@ msgid ""
 "Director <a href=\"%(hazel_url)s\">Hazel Savage</a> of <a "
 "href=\"%(leeds_url)s\">Leeds Angels</a>"
 msgstr ""
-"Direktør <a href=\"%(hazel_url)s\">Hazel Savage</a> i <a href=\"%(leeds_url)"
-"s\">Leeds Angels</a>"
+"Direktør <a href=\"%(hazel_url)s\">Hazel Savage</a> i <a "
+"href=\"%(leeds_url)s\">Leeds Angels</a>"
 
 #: metabrainz/templates/index/about.html:62
 msgid "Advisor"
@@ -920,8 +1009,8 @@ msgid ""
 "them for support!\n"
 "      Please <a href=\"%(contact_url)s\">let us know</a>!"
 msgstr ""
-"Kjenner du til andre selskaper som bruker dataene våre? Vi vil gjerne vite "
-"om dem og spørre dem om støtte!\n"
+"Kjenner du til andre selskaper som bruker dataene våre? Vi vil gjerne "
+"vite om dem og spørre dem om støtte!\n"
 "      Send oss <a href=\"%(contact_url)s\">en melding</a>!"
 
 #: metabrainz/templates/index/bad-customers.html:53
@@ -949,9 +1038,431 @@ msgstr ""
 msgid "Introduction"
 msgstr "Introduksjon"
 
-#: metabrainz/templates/index/conflict-policy.html:55
+#: metabrainz/templates/index/conflict-policy.html:17
+msgid ""
+"Conflicts between people arise in open source projects constantly and the"
+" projects by the \n"
+"    MetaBrainz Foundation are no different. This policy aims to establish"
+" a clear and unambiguous \n"
+"    policy for reporting and addressing conflicts in our community. In "
+"this policy we aim to \n"
+"    establish a fair practice that balances the need for confidentiality "
+"and our desire for \n"
+"    transparency in our operations."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:25
+#, python-format
+msgid ""
+"Before you continue to read this policy, we encourage you to review our "
+"existing community policies \n"
+"    including our <a href=\"%(social_contract_url)s\">Social "
+"Contract</a>, \n"
+"    <a href=\"%(code_of_conduct_url)s\">the Code of Conduct</a>, \n"
+"    and our <a href=\"%(privacy_policy_url)s\">Privacy Policy</a>. These "
+"policies establish the norms and rules for \n"
+"    participation in our projects; these policies apply equally to the "
+"contractors of the MetaBrainz \n"
+"    Foundation and any participants in our projects."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:37
+msgid ""
+"This policy divides conflicts into two categories: Private and public. "
+"Private conflicts are conflicts \n"
+"    that involve *confidential* information regarding contributors, "
+"contractors or supporters. Otherwise, any conflicts \n"
+"    that do not involve confidential information are considered to be "
+"public conflicts. For instance, a \n"
+"    conflict between a contractor and the Executive Director (aka BDFL) "
+"that involves contractor pay is \n"
+"    considered a private conflict because pay rates are confidential "
+"information. A public conflict in edit \n"
+"    notes between two editors in our community does not involve "
+"confidential information and therefore should \n"
+"    be considered a public conflict."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:47
+msgid ""
+"When conflicts arise we aim to disclose as much information as possible "
+"about the conflict in a timely \n"
+"    fashion. When conflicts contain confidential matters we will aim to "
+"disclose as much information as \n"
+"    possible, while fully respecting the confidentiality of the people "
+"involved in the conflict. With any \n"
+"    private conflict we will aim to extract the relevant lessons for the "
+"team and community in an effort to \n"
+"    evolve our policies to prevent future conflicts. Should the involved "
+"parties disagree whether a conflict \n"
+"    is private or public, the question about the nature of the conflict "
+"will be presented for the next higher \n"
+"    level in the chain of command to decide. (e.g. if a community member "
+"and the community manager disagree on \n"
+"    a conflict being public or private, the Executive Director shall "
+"decide if the conflict is public or private)."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:58
 msgid "Reporting and Response"
 msgstr "Rapportering og respons"
+
+#: metabrainz/templates/index/conflict-policy.html:61
+msgid ""
+"We aim to not have conflict in our community, but we recognize that in "
+"reality conflicts will arise and we \n"
+"    must be prepared to address them in a fair manner. When conflicts "
+"arise, we prefer to have community or team \n"
+"    members resolve the conflicts among themselves, using our existing "
+"policies as guidelines for resolving the \n"
+"    conflict."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:69
+msgid ""
+"If you do not feel comfortable resolving a conflict on your own, you "
+"should feel free to report the conflict to \n"
+"    us. How you address the conflict depends on who is involved in the "
+"conflict and your comfort level. Please see \n"
+"    the detailed sections below on how and with whom to address your "
+"conflict. We aim to address conflicts as soon \n"
+"    as possible in an effort to prevent them from escalating "
+"unnecessarily."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:75
+msgid "Direct conflict resolution"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:78
+msgid ""
+"In direct conflict resolution, the involved parties will attempt to "
+"resolve the conflict themselves without \n"
+"   involving any MetaBrainz Foundation team member. You should aim to use"
+" direct resolution when the conflict does \n"
+"   not involve the violation of one of our policies or if the conflict is"
+" minor."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:84
+#, python-format
+msgid ""
+"For instance, if a user uses a rude tone, is disruptive or flagrantly "
+"ignores our project guidelines, we suggest \n"
+"    that you use direct conflict resolution to resolve the conflict. Some"
+" resources that might give you some suggestions \n"
+"    on how to go about resolving the conflict might be this <a "
+"href=\"%(conflict_resolution_primer_url)s\">\n"
+"    conflict resolution primer</a> and <a "
+"href=\"%(difficult_conversations_url)s\">how to\n"
+"    have difficult conversations at work</a>."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:93
+msgid "Informal reporting"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:96
+msgid ""
+"You may use informal reporting of a conflict if you aim to communicate a "
+"concern or incident without \n"
+"    seeking a corrective outcome. Informal reporting may also be an "
+"option if you have not been personally \n"
+"    victimized, but you’ve witnessed a violation of our policies or where"
+" you wish to maintain confidentiality \n"
+"    throughout the entire reporting process."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:103
+msgid ""
+"For editing in MusicBrainz you may informally report a user using the "
+"“Report this user for bad behavior” \n"
+"    link from the user’s profile. For reporting bad user behavior in "
+"other of our projects, please report them to our \n"
+"    community manager by mailing <span class=\"backemail\">gro.zniarbatem"
+"@reganam-ytinummoc</span> . For conflicts \n"
+"    that involve the community manager, report them by mailing <span "
+"class=\"backemail\">gro.zniarbatem@de</span> ."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:110
+msgid ""
+"Depending the the severity of the issue, repeated informal complaints may"
+" eventually require a formal response \n"
+"    from the MetaBrainz team. If an involved party requires anonymity, "
+"the conflict becomes a private conflict. If at \n"
+"    all possible minor issues should be resolved in a public forum in "
+"order for all people to witness and learn from \n"
+"    the issue at hand."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:116
+msgid "Formal complaint process"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:119
+msgid ""
+"All complaints about conflicts should be submitted via email. To whom a "
+"complaint should be mailed and who will \n"
+"    carry out the investigation will be described in the next section."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:124
+msgid "All complaint submissions to the Foundation should include the following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:128
+msgid ""
+"Contact info, if it is different than the email used to submit the "
+"conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:129
+msgid "Who was involved in the conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:130
+msgid "Where and when the incident happened"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:131
+msgid ""
+"A description of what happened -- ideally with links (e.g. chatlogs, edit"
+" notes) that outlines what \n"
+"         happened so that the persons evaluating the conflict may "
+"understand the issue at hand"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:133
+msgid ""
+"Any related pieces of information that provide more context on the "
+"conflict (e.g. links, screenshots)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:134
+msgid "An indication if this conflict is ongoing or not"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:139
+msgid "The investigation that follows aims to determine:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:143
+msgid "The nature and severity of the incident"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:144
+msgid ""
+"Whether or not the incident is considered a violation of MetaBrainz’ "
+"conduct policies or core values"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:145
+msgid ""
+"The amount of harm experienced by the person who submitted the complaint "
+"and the broader MetaBrainz community \n"
+"         as a result of the incident"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:147
+msgid ""
+"Whether there have been prior complaints against the individual or "
+"individuals reported"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:148
+msgid "Whether the incident is ongoing"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:152
+msgid ""
+"The following potential forms of resolution may apply to any team members"
+" involved in the conflict:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:155
+#: metabrainz/templates/index/conflict-policy.html:168
+msgid "Nothing (if it has been found no violation occurred)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:156
+msgid "Creating a plan to improve the performance"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:157
+msgid "Creating a negative performance evaluation"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:158
+msgid "Mediation, an intervention by a third party to resolve the conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:159
+msgid "Suspension or forced leave"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:160
+msgid "Termination of contract"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:164
+msgid ""
+"The following potential forms of resolution may apply to non team members"
+" involved in the conflict:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:169
+msgid "A reprimand, either public or private"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:170
+msgid "Suspension of the users’ account"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:171
+msgid "Deletion of the users’ account"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:172
+msgid ""
+"Removal of user privileges (e.g. if an auto editor commits a serious "
+"offence, they may lose their auto editor status)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:175
+msgid "Filing a complaint"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:178
+msgid ""
+"NOTE: For complaints not about MetaBrainz staff, please see the "
+"<em>Informal reporting</em> section above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:182
+msgid ""
+"If the complaint does not involve the Executive Director (ED), do the "
+"following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:186
+msgid ""
+"If team member has directly violated conduct policies or engaged in "
+"otherwise harmful behavior, a formal complaint should be filed."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:187
+msgid ""
+"Mail <span class=\"backemail\">gro.zniarbatem@de</span> and include the "
+"complaint information outlined above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:188
+msgid ""
+"You should expect a response within a working day acknowledging the "
+"complaint."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:189
+msgid ""
+"The complaint will be investigated by the ED, member(s) of the board of "
+"directors or a neutral third party."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:190
+msgid ""
+"Once the investigation has been completed, the ED, with the support of "
+"others involved in the investigation will respond. The \n"
+"        ED will respond to incidents no later than 7 working days after a"
+" complaint has been filed with either a resolution or an \n"
+"        explanation of why the process must be extended."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:196
+msgid "If a complaint involves the Executive Director, do the following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:200
+msgid ""
+"If the Executive Director has directly violated conduct policies or "
+"engaged in otherwise harmful behavior, \n"
+"        a formal complaint should be filed with the board of directors."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:202
+msgid ""
+"Mail <span class=\"backemail\">gro.zniarbatem@noituloser-tcilfnoc</span> "
+"and include the complaint information outlined above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:203
+msgid ""
+"You should get a response within 5 working days acknowledging the "
+"complaint."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:204
+msgid ""
+"The complaint will be investigated by the member(s) of the board of "
+"directors, the community manager, a neutral \n"
+"        third party or a combination thereof."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:206
+msgid ""
+"Once the investigation has been completed, the board, with the support of"
+" others involved in the investigation \n"
+"        will respond. The board will aim to respond to incidents no later"
+" than 15 working days after a complaint has been filed \n"
+"        with either a resolution or an explanation of why the process "
+"must be extended."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:211
+msgid "Confidentiality"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:214
+msgid ""
+"Confidentiality is an important aspect of conflict resolution and all of "
+"the conflicts brought to the attention of the foundation \n"
+"    will be evaluated with confidentiality in mind and acted upon "
+"accordingly."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:219
+msgid ""
+"We work hard to make all of the actions of the foundation as transparent "
+"and open as possible. In cases where we cannot \n"
+"    disclose all aspects of a conflict we will disclose that a conflict "
+"is or has occurred and we will attempt to disclose the \n"
+"    appropriate amount of information about the conflict while balancing "
+"the need for confidentiality and our desire to learn \n"
+"    from conflicts so that we as a foundation and community can learn "
+"from these conflicts and improve our policies to avoid the \n"
+"    conflicts in the future."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:227
+msgid ""
+"Any breaches of confidentiality will be treated as severe breaches of our"
+" conduct policies."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:230
+msgid "Retaliation"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:233
+msgid ""
+"We will not allow retaliation for any contractor or volunteer that files "
+"a complaint or is involved in an investigation. If you \n"
+"    believe that you are being treated negatively because of your "
+"involvement in a complaint please report this complaint directly \n"
+"    to the ED at <span class=\"backemail\">gro.zniarbatem@de</span> or "
+"the board at \n"
+"    <span class=\"backemail\">gro.zniarbatem@noituloser-tcilfnoc</span>."
+msgstr ""
 
 #: metabrainz/templates/index/contact.html:3
 #: metabrainz/templates/index/contact.html:6
@@ -1009,10 +1520,10 @@ msgid ""
 "    <a href=\"%(dr_policy_url)s\">data removal policy</a> for more "
 "information."
 msgstr ""
-"MusicBrainz verken redigerer eller fjerner faktaopplysninger på forespørsel. "
-"Vennligst les våre\n"
-"    <a href=\"%(dr_policy_url)s\">retningslinjer for fjerning av data</a> "
-"for mer informasjon."
+"MusicBrainz verken redigerer eller fjerner faktaopplysninger på "
+"forespørsel. Vennligst les våre\n"
+"    <a href=\"%(dr_policy_url)s\">retningslinjer for fjerning av data</a>"
+" for mer informasjon."
 
 #: metabrainz/templates/index/contact.html:30
 msgid "Copyright issues"
@@ -1042,7 +1553,7 @@ msgstr "Reklame forespørsler"
 msgid ""
 "We are currently evaluating our overall online advertising strategy. We "
 "are evaluating advertising, traffic optimization,\n"
-"    search engine optimization and software monitization technologies. If"
+"    search engine optimization and software monetization technologies. If"
 " you provide these professional services, please provide a detailed\n"
 "    deck of your comprehensive services to the following email address. "
 "<em>Please respect our other non-media teams and do not contact us \n"
@@ -1054,8 +1565,7 @@ msgstr ""
 #: metabrainz/templates/index/contact.html:52
 #, python-format
 msgid "Please submit your proposals before 17:00 PST on %(ad_deadline)s."
-msgstr ""
-"Vennligst send inn forslagene dine før kl. 17:00 PST den %(ad_deadline)s."
+msgstr "Vennligst send inn forslagene dine før kl. 17:00 PST den %(ad_deadline)s."
 
 #: metabrainz/templates/index/contact.html:54
 msgid "Contact details"
@@ -1071,8 +1581,8 @@ msgid ""
 "neither the music itself nor the\n"
 "        rights to license the music."
 msgstr ""
-"Vi kan ikke lisensiere musikken som finnes på MusicBrainz, siden vi verken "
-"har musikken, ei heller\n"
+"Vi kan ikke lisensiere musikken som finnes på MusicBrainz, siden vi "
+"verken har musikken, ei heller\n"
 "        rettighetene til å lisensiere den."
 
 #: metabrainz/templates/index/contact.html:60
@@ -1127,14 +1637,11 @@ msgstr "Forum"
 #, python-format
 msgid ""
 "Please come ask your questions at our <a "
-"href=\"%(forums_url)s\">forums</a>! We would love to\n"
-"    answer any questions you may have."
+"href=\"%(forums_url)s\">forums</a>!\n"
+"    The community and the team will be more than happy to help you."
 msgstr ""
-"Kom og still spørsmål på vårt <a href=\"%(forums_url)s\">forum</a>! Vi "
-"ser fram til å svare\n"
-"    på ethvert spørsmål du måtte ha."
 
-#: metabrainz/templates/index/contact.html:92
+#: metabrainz/templates/index/contact.html:93
 #, python-format
 msgid ""
 "The MetaBrainz/MusicBrainz/ListenBrainz team and community hang out\n"
@@ -1150,15 +1657,15 @@ msgstr ""
 "    siden og bli med i chatten. Du kan også bla gjennom\n"
 "    <a href=\"%(chatlogs_url)s\">chatloggarkivet</a>."
 
-#: metabrainz/templates/index/contact.html:101
+#: metabrainz/templates/index/contact.html:102
 msgid "Social media"
 msgstr "Sosiale medier"
 
-#: metabrainz/templates/index/contact.html:103
+#: metabrainz/templates/index/contact.html:104
 msgid "You can follow us on these social channels:"
 msgstr "Du kan følge oss på følgende sosiale medier:"
 
-#: metabrainz/templates/index/contact.html:112
+#: metabrainz/templates/index/contact.html:113
 msgid "Mailing address"
 msgstr "Postadresse"
 
@@ -1171,34 +1678,350 @@ msgstr "MetaBrainz-datasettene"
 msgid "GDPR Compliance Statement"
 msgstr "Erklæring av GDPR-krav"
 
-#: metabrainz/templates/index/gdpr.html:37
+#: metabrainz/templates/index/gdpr.html:10
+msgid ""
+"The General Data Protection Regulation is a complex EU regulation that "
+"stipulates many points for protecting private data of\n"
+"    users on the Internet. Even though this is an EU regulation, it has a"
+" worldwide impact due to the nature of the Internet.\n"
+"    The MetaBrainz Foundation with its collection of projects is also "
+"affected by this regulation. We’ve been learning and adapting\n"
+"    our sites to be compliant with the GDPR – sadly this regulation isn’t"
+" entirely black and white and there is an incredible\n"
+"    amount of room left for interpretation of these rules."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:17
+msgid ""
+"The good news is that this regulation is roughly in line with our "
+"established practices: We’ve always held private information\n"
+"    in a high regard and applied the sort of rules to ourselves as we "
+"wish to have our own private data treated. Luckily, this\n"
+"    makes our compliance effort considerably easier. We’ve made two "
+"significant changes to how we treat your data and also adopted\n"
+"    terminology as used in the GDPR in order to use the same languages "
+"that many other sites are now adopting. Please keep reading\n"
+"    to find out the exact details of what we are doing to comply."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:24
+#, python-format
+msgid ""
+"However, we do ask for your compassion and help in our process of "
+"complying with the GDPR. As we already mentioned, the GDPR is\n"
+"    a complex set of rules that are not fully clarified yet. We’ve taken "
+"action on the steps that are clear to us and we’re following\n"
+"    ongoing conversations on points that are in gray zones or unclear to "
+"us. We’ve made our best initial effort on compliance and\n"
+"    promise to keep working on it as the picture becomes more clear. If "
+"you believe that we could improve our compliance, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a> and let us know what we "
+"can do to improve. It would also help us if you\n"
+"    could provide concrete discussion or examples to help us understand "
+"and take action on your suggestion."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:33
+msgid ""
+"Finally, below are the key sections of the GDPR as we understand them and"
+" how they affect your data in our ecosystem. Where\n"
+"    possible, we provide links for deeper understanding, links for you to"
+" examine our relevant code and links to tickets to follow\n"
+"    the process of improving our compliance."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:38
 msgid "Right to be forgotten"
 msgstr "Rett til å bli glemt"
 
-#: metabrainz/templates/index/gdpr.html:77
+#: metabrainz/templates/index/gdpr.html:41
+msgid ""
+"Summary: <i>Provide the user with the ability to remove their private "
+"data from our services</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:44
+msgid ""
+"The most important aspect of the right to be forgotten is the ability to "
+"delete your account. Once you request for us to delete\n"
+"    your account, we will remove any personally identifying information "
+"you may have provided us from your account (name, email\n"
+"    address, gender, biography, URL, etc.). The visible name on your "
+"account will be changed to “Deleted User #####” and effectively\n"
+"    the account will no longer be identifiable as your account."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:50
+msgid ""
+"However, given the nature of our projects where we work on collaborative "
+"databases, your contributions that are not personally\n"
+"    identifying are valuable assets to our database and these "
+"contributions will not be removed from our databases. But we will\n"
+"    ensure that these contributions no longer contain personally "
+"identifying data."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:55
+#, python-format
+msgid ""
+"Our process of automatically deleting your accounts across the MetaBrainz"
+" ecosystem is not complete yet (see below for a set of\n"
+"    tickets where you can track our progress). If you would like to "
+"delete your accounts in the MetaBrainz ecosystem or mark a\n"
+"    donation that is currently public as a private donation, please <a "
+"href=\"%(contact_url)s\">contact us</a>\n"
+"    and we will address your request as soon as possible."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:62
+#: metabrainz/templates/index/gdpr.html:182
+msgid "Links:"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:66
+#, python-format
+msgid ""
+"<a href=\"%(editor_deletion_doc_url)s\">How we delete accounts\n"
+"       in MusicBrainz</a> (warning, geek content ahead!)"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:70
+msgid ""
+"Implement sitewide user account deletion in\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/MBS-9680\">MusicBrainz</a>,"
+"\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/AB-337\">AcousticBrainz</a>,"
+"\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/BB-260\">BookBrainz</a>,\n"
+"         <a href=\"https://tickets.metabrainz.org/browse/MEB-103\">the "
+"MetaBrainz Site</a>,\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/LB-354\">ListenBrainz</a>, "
+"and\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/CB-307\">CritiqueBrainz</a>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:80
 msgid "Restriction of processing"
 msgstr "Behandlingsrestriksjon"
 
-#: metabrainz/templates/index/gdpr.html:110
+#: metabrainz/templates/index/gdpr.html:83
+msgid ""
+"Summary: <i>To allow the user to control how their personally identifying"
+" data is being used.</i>"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:86
+msgid ""
+"Except for the ListenBrainz and AcousticBrainz projects, we do not "
+"process personally identifying data. Any personally\n"
+"    identifying data that our projects store is for the purpose of being "
+"able to contact you about your contributions to our database\n"
+"    (email address) or for voluntarily showing information about you to "
+"other users (biography, homepage, location, etc)."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:91
+#, python-format
+msgid ""
+"The ListenBrainz project differs in that the Listens (metadata about what"
+" music you have listened to) are stored on our servers\n"
+"    and <a href=\"%(listenbrainz_data_url)s\">made available to the "
+"public</a>. We believe Listens to be personally identifying\n"
+"    data and furthermore, we have goals of creating open source "
+"recommendation engines with this data, which involves processing the\n"
+"    user’s data. These two points are fundamental goals of the "
+"ListenBrainz project and we do not see a reasonable way to reach another"
+"\n"
+"    compromise position."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:99
+msgid ""
+"Because of this, we are going to require users to either acknowledge that"
+" we may process their Listen data or alternatively to\n"
+"    delete their account, including all of their Listens. Please note "
+"that if you decide to delete your ListenBrainz account, it may\n"
+"    take up to two weeks for all of your listens to no longer be included"
+" in our efforts to build a recommendation engine."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:104
+msgid ""
+"We have always made it clear that the data in ListenBrainz was to be "
+"public and that we plan to build new tools with your data, so\n"
+"    this should not come as a surprise to our users."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:108
+msgid ""
+"The AcousticBrainz project does not track who submits data to the "
+"database. If you create an account and use our data creation\n"
+"    tools (e.g. create a dataset or participate in a challenge) then we "
+"link your participation and the things that you create to\n"
+"    your account. If you choose to delete your account then we keep the "
+"non personally identifying data that you create, but anonymize\n"
+"    it so that it cannot be linked back to you."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:114
 msgid "Right to data portability / exporting your data"
 msgstr "Rett til dataoverføring / eksport av dataene dine"
 
-#: metabrainz/templates/index/gdpr.html:150
+#: metabrainz/templates/index/gdpr.html:117
+msgid ""
+"Summary: <i>You have the right to access/download the data we store about"
+" you</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:120
+msgid ""
+"Except for the ListenBrainz and AcousticBrainz projects, we do not store "
+"personally identifying data beyond the\n"
+"    information that is available in your public profile on each of our "
+"projects. Since this data is plainly available in your\n"
+"    profile we do not provide a means for you to export this data."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:125
+msgid "There are the following exceptions to this:"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:129
+msgid ""
+"<b>IP addresses</b>: If you visit one of our sites the IP address of your"
+" computer is stored in our web logs for 7 days\n"
+"        before our servers automatically delete them. This data is almost"
+" never used by anyone: the only time we look at the\n"
+"        IP addresses is if our sites are adversely impacted by the "
+"actions of some unknown users. In that case, we may investigate\n"
+"        the logs to identify the IP address that needs to be blocked in "
+"order to restore the stability of our service.\n"
+"        This data is not available to anyone but the contractors of the "
+"MetaBrainz Foundation and is not available to download\n"
+"        to anyone at all."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:137
+#, python-format
+msgid ""
+"<b>ListenBrainz Listen data</b>: Users may <a "
+"href=\"%(listenbrainz_export_url)s\">export their ListenBrainz Listen\n"
+"        data</a> directly from the site. The user Listen data is also "
+"included in the <a href=\"%(listenbrainz_data_url)s\">ListenBrainz\n"
+"        data dumps</a> that are available for public download."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:146
+msgid ""
+"All of the non personally identifying data, such as your metadata "
+"contributions, are publicly visible, available for download\n"
+"    and available via the project APIs. For details about this data, "
+"downloads and APIs please check the documentation for the\n"
+"    respective projects you are interested in."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:151
+#, python-format
+msgid ""
+"Anyone wishing to get a list of financial donations they have made to the"
+" MetaBrainz Foundation, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a> and provide your "
+"MusicBrainz editor name so that we can look up\n"
+"    your donations."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:157
 msgid "Right to rectification"
 msgstr "Rett til retting"
 
-#: metabrainz/templates/index/gdpr.html:165
+#: metabrainz/templates/index/gdpr.html:160
+msgid "Summary: <i>You have the right to correct your data</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:163
+msgid ""
+"All of our projects allow their users to update their personally "
+"identifying information in their profiles. Furthermore, most\n"
+"    of our projects allow the editing of their own metadata "
+"contributions. If you find that some of your data is incorrect, please\n"
+"    feel free to edit the data since we provide the tools to do so."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:168
+#, python-format
+msgid ""
+"If anyone who has made a financial donation to the MetaBrainz Foundation "
+"would like to make their donation private, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:173
 msgid "Right to be informed"
 msgstr "Retten til å bli informert"
 
-#: metabrainz/templates/index/gdpr.html:188
+#: metabrainz/templates/index/gdpr.html:175
+msgid ""
+"Summary: <i>You have the right to be informed about how we use your data "
+"in plain English</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:178
+msgid ""
+"Our privacy policy, as well as other policies, have always been written "
+"by humans for human consumption. We abhor legalese and\n"
+"    not speaking in direct terms."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:186
+msgid "Social contract"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:189
+msgid "Code of conduct"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:192
+msgid "Privacy policy"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:196
 msgid "Right to access"
 msgstr "Rett til tilgang"
 
-#: metabrainz/templates/index/gdpr.html:198
-#: metabrainz/templates/index/privacy.html:166
+#: metabrainz/templates/index/gdpr.html:199
+msgid ""
+"Summary: <i>You have the right to access the data that we collect about "
+"you</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:202
+msgid ""
+"All of our projects make all of the data we collect on your behalf, "
+"privately identifying or not, available to you. The\n"
+"    only exception to this are the IP addresses we store for 7 days – see"
+" above for details."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:206
+#: metabrainz/templates/index/privacy.html:168
 msgid "Privacy/GDPR Representative"
 msgstr "Personvern-/GDPR-representant"
+
+#: metabrainz/templates/index/gdpr.html:209
+#, python-format
+msgid ""
+"If you have any questions about our privacy policy, please <a "
+"href=\"%(contact_url)s\">contact us</a>. To report\n"
+"   any privacy problems, violations or leaks, our GDPR representative is "
+"our Interim Executive Director Nicolás Tamargo and for\n"
+"   privacy issues contact him at <strong><a "
+"href=\"mailto:gdpr@metabrainz.org\">gdpr@metabrainz.org</a></strong>."
+msgstr ""
 
 #: metabrainz/templates/index/index.html:6
 msgid "Welcome to MetaBrainz!"
@@ -1231,12 +2054,12 @@ msgstr ""
 "Våre data er hovedsakelig samlet inn av frivillige og blir verifisert\n"
 "        av fellesskapet for å sikre at informasjonen er gjennomført og "
 "riktig. All  \n"
-"        <a href=\"%(account_type_url)s\">ikke-kommersiell bruk</a> av disse "
-"dataene er gratis,\n"
+"        <a href=\"%(account_type_url)s\">ikke-kommersiell bruk</a> av "
+"disse dataene er gratis,\n"
 "        men vi ber <a href=\"%(account_type_url)s\">kommersielle "
 "støttespillere</a> om å\n"
-"        <a href=\"%(account_type_url)s\">støtte oss</a> for å bidra til å "
-"finansiere\n"
+"        <a href=\"%(account_type_url)s\">støtte oss</a> for å bidra til å"
+" finansiere\n"
 "        prosjektet. Vi oppfordrer alle brukere av data til å bidra til å "
 "samle inn informasjon, sånn\n"
 "        at dataene vi har er så altomfattende som mulig."
@@ -1322,7 +2145,7 @@ msgstr ""
 "For å få mer informasjon om stiftelsen, gå til\n"
 "      <a href=\"%(about_url)s\">Om oss</a> siden."
 
-#: frontend/js/src/forms/ConditionsModal.tsx:43
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:32
 #: metabrainz/templates/index/privacy.html:3
 msgid "Privacy"
 msgstr "Personvern"
@@ -1330,6 +2153,44 @@ msgstr "Personvern"
 #: metabrainz/templates/index/privacy.html:8
 msgid "Summary"
 msgstr "Sammendrag"
+
+#: metabrainz/templates/index/privacy.html:12
+msgid ""
+"You do not have to provide any personal data to be able to browse the "
+"contents of the databases published by MetaBrainz."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:15
+msgid ""
+"You do not have to provide any personally-identifying information if you "
+"choose not to."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:18
+msgid ""
+"We will never reveal your email address on MetaBrainz controlled web "
+"sites."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:22
+msgid ""
+"In order to get maximum value out of the MetaBrainz projects, you may "
+"want to create an account and log in. \n"
+"    Doing so grants you the ability to: edit the databases, contribute "
+"your own data, communicate with other users, and keep track \n"
+"    of recently released music from artists in your MusicBrainz "
+"collection. If you choose to create an account then the minimum we \n"
+"    ask is that you: choose a unique username and password, use a web "
+"browser that accepts \"session\" cookies, and provide a verified \n"
+"    email address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:29
+msgid ""
+"If you do not create an account (or are not logged in) you will not have "
+"access to the above listed features, however, you will \n"
+"    still have full access to browse and examine the databases."
+msgstr ""
 
 #: metabrainz/templates/index/privacy.html:33
 msgid "Applicable to all users"
@@ -1339,39 +2200,197 @@ msgstr "Gjelder for alle brukere"
 msgid "Cookies"
 msgstr "Informasjonskapsler"
 
+#: metabrainz/templates/index/privacy.html:37
+msgid "We use two cookies that contain sensitive information:"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:42
+msgid ""
+"<b>remember_login</b>: If you choose the \"Log in permanently\" option "
+"when logging in to one of our sites; the cookie will be used to \n"
+"      remember your login details."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:46
+msgid ""
+"<b>musicbrainz_server_session, session, or connect.sid</b>: If you are "
+"logged into one of our sites, your current session ID is stored in this "
+"cookie."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:51
+msgid ""
+"We may store dynamic preference information in other cookies, but these "
+"do not contain any sensitive information."
+msgstr ""
+
 #: metabrainz/templates/index/privacy.html:54
 msgid "Web and FTP access logs"
 msgstr "Nett- og FTP-tilgangslogger (alle brukere)"
+
+#: metabrainz/templates/index/privacy.html:57
+msgid ""
+"In a practice similar to other web sites (and APIs) we keep logs of all "
+"web requests made against our servers. These logs include: your IP\n"
+"    address, your browser's (or API client's) \"User-Agent\" string, and "
+"which page (or API endpoint) you requested with which parameters. "
+"Aggregate information about web and FTP traffic is\n"
+"    made available to the public via our site usage pages."
+msgstr ""
 
 #: metabrainz/templates/index/privacy.html:62
 msgid "Third-Party content"
 msgstr "Tredjepartsinnhold"
 
-#: metabrainz/templates/index/privacy.html:92
+#: metabrainz/templates/index/privacy.html:64
+msgid ""
+"Our projects' web pages may load some third-party content. Some, but "
+"possibly not all sites are listed below:"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:69
+#, python-format
+msgid ""
+"Cover art and other images: These are provided by the various cover art "
+"sites that have given MusicBrainz permission to do so and our own \n"
+"      <a href=\"%(caa_url)s\">Cover Art Archive</a>. This means that the "
+"relevant site will know (if they want to) your IP \n"
+"      address, User-Agent string, etc., and which MusicBrainz web page "
+"you were visiting (the one which included the cover art image)."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:75
+msgid ""
+"AcoustID: Our fingerprints tab loads fingerprint information from "
+"acoustid.org."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:78
+msgid ""
+"MTCaptcha: Our account creation page loads third party content in order "
+"to prevent spammers from creating accounts."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:83
+msgid ""
+"<i>The above information assumes that you are using \"normal\" web "
+"browser settings, whereby images are always loaded and HTTP referrer \n"
+"    information is always sent.</i>"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:88
+msgid ""
+"It is impractical to constantly modify this privacy policy when "
+"MetaBrainz projects change which third party content they utilize. We "
+"will \n"
+"    aim to use common sense, respect to our community and community "
+"review when adding more content from third party sites. We will also \n"
+"    periodically review our policy to ensure that it remains current."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:93
 msgid "Applicable to account holders"
 msgstr "Gjelder for kontoinnehavere"
 
-#: metabrainz/templates/index/privacy.html:94
+#: metabrainz/templates/index/privacy.html:95
 msgid "Account creation"
 msgstr "Brukerkontooppretting"
 
-#: metabrainz/templates/index/privacy.html:108
+#: metabrainz/templates/index/privacy.html:97
+msgid ""
+"When creating an account with a MetaBrainz project you need to pick a "
+"unique username and choose a password, the username you pick is the \n"
+"    only name associated with your account and will be what other "
+"MetaBrainz users know you as. You may optionally also tell us other \n"
+"    information about yourself that will be displayed to other MetaBrainz"
+" users and the public."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:103
+msgid ""
+"Additionally, in order to edit the databases you will need to provide a "
+"confirmed email address. This email address will be held in \n"
+"    confidence, the only method of revealing your email address to "
+"another user is if you choose to send a message to another \n"
+"    user and enable the option to \"reveal my email address\". Changing "
+"the email address stored with your account will require you to \n"
+"    verify the new address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:109
 msgid "Edits and Notes"
 msgstr "Endringer og Endringsnotat"
 
-#: metabrainz/templates/index/privacy.html:114
+#: metabrainz/templates/index/privacy.html:111
+msgid ""
+"If you make any changes to a MetaBrainz project database, such as adding "
+"any data, the details of those changes will be visible to \n"
+"    other logged-in users and the change will be associated with your "
+"username."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:115
 msgid "Subscriptions on MusicBrainz"
 msgstr "Abonnementer på MusicBrainz"
 
-#: metabrainz/templates/index/privacy.html:131
+#: metabrainz/templates/index/privacy.html:117
+msgid ""
+"As a logged-in user you can subscribe to one or more artists, labels, "
+"collections or other editors. The act of subscribing causes \n"
+"    any edits made to (or by in the case of another editor) those "
+"entities to be emailed to you. By default, other users can see your \n"
+"    list of subscriptions, however, you can opt out of this by editing "
+"the appropriate preference."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:123
+msgid ""
+"This does not provide \"perfect\" privacy though, in some cases it will "
+"be possible to infer information about the contents of your \n"
+"    subscription list even though you have disallowed others from viewing"
+" that list directly. This imperfection arises because various \n"
+"    parts of the system behave differently depending on whether or not an"
+" entity has any subscribers; also, the number of users \n"
+"    subscribed to each artist is available via the artist pages. In the "
+"most extreme (possibly contrived) example, imagine that all \n"
+"    users have their subscriptions set to \"public\", except for exactly "
+"one user whose list is \"private\". In that case, any discrepancy \n"
+"    for a given artist between the shown list of subscribers and the "
+"total number of subscribers must be down to that one user. Thus, \n"
+"    you can infer what artists are on that user's list."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:132
 msgid "Third-party sites"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:145
+#: metabrainz/templates/index/privacy.html:134
+#, python-format
+msgid ""
+"Our code reviews are done on GitHub, which is not under the control of "
+"MetaBrainz. Participating in code reviews or other\n"
+"    tasks carried out on GitHub are subject to <a "
+"href=\"%(github_url)s\">GitHub's privacy policy</a>."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:140
+#, python-format
+msgid ""
+"Our translations platform is provided and hosted by Weblate, which has a "
+"data processing agreement with MetaBrainz.\n"
+"    Participating in translations is subject to <a "
+"href=\"%(weblate_url)s\">dedicated legal terms</a>.\n"
+"    Any translations you make will be submitted to our Git repositories "
+"and publicly associated with your username;\n"
+"    if you so choose, you can also publicly associate them with your own "
+"verified email address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:147
 msgid "MetaBrainz donors"
 msgstr "MetaBrainz-donorer"
 
-#: metabrainz/templates/index/privacy.html:147
+#: metabrainz/templates/index/privacy.html:149
 msgid ""
 "When you make a donation to the MetaBrainz Foundation, we are legally\n"
 "    required to collect your personal information and keep it in our "
@@ -1381,7 +2400,7 @@ msgid ""
 "    information to anyone else, ever."
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:153
+#: metabrainz/templates/index/privacy.html:155
 msgid ""
 "We believe in transparent finances, which means that we list all "
 "donations\n"
@@ -1391,11 +2410,34 @@ msgid ""
 "process."
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:158
+#: metabrainz/templates/index/privacy.html:160
 msgid "Exceptions"
 msgstr "Unntak"
 
-#: frontend/js/src/Profile.tsx:598
+#: metabrainz/templates/index/privacy.html:162
+msgid ""
+"<i><b>Please note</b>: Reasonable exceptions may apply to the above "
+"policy, for example to comply with applicable laws.\n"
+"    Also, members of the MetaBrainz team and other personnel contracted "
+"to provide services to MetaBrainz may have access to\n"
+"    our infrastructure and could therefore view any information contained"
+" therein. However all personnel are contractually bound\n"
+"    by non-disclosure clauses which prevent them from making any such "
+"information available to others."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:171
+#, python-format
+msgid ""
+"If you have any questions about our GDPR statement, please <a "
+"href=\"%(contact_url)s\">contact us</a>. To report\n"
+"   any privacy problems, violations or leaks, our GDPR representative is "
+"our Interim Executive Director Nicolás Tamargo and for\n"
+"   privacy issues contact him at <strong><a "
+"href=\"mailto:gdpr@metabrainz.org\">gdpr@metabrainz.org</a></strong>."
+msgstr ""
+
+#: frontend/js/src/Profile.tsx:603
 #: frontend/js/src/forms/ProfileChangePassword.tsx:22
 #: frontend/js/src/forms/ProfileChangePassword.tsx:111
 #: metabrainz/templates/index/profile-change-password.html:3
@@ -1456,8 +2498,8 @@ msgid ""
 msgstr ""
 "<a href=\"%(caa_url)s\">Omslagsbildearkivet</a> er en database med "
 "omslagsbilder for\n"
-"            utgivelsene i MusicBrainz. Det er et samarbeidsprosjekt med <a "
-"href=\"%(archive_org_url)s\">Internet Archive</a>et."
+"            utgivelsene i MusicBrainz. Det er et samarbeidsprosjekt med "
+"<a href=\"%(archive_org_url)s\">Internet Archive</a>et."
 
 #: metabrainz/templates/index/projects.html:63
 msgid "CritiqueBrainz"
@@ -1533,8 +2575,8 @@ msgid ""
 msgstr ""
 "<a href=\"%(messybrainz_url)s\">MessyBrainz</a> identifiserer rotete "
 "metadata, og der det er mulig,\n"
-"            kobler dem til stabile MusicBrainz-identifikatorer. MessyBrainz "
-"ble brukt i AcousticBrainz og blir fortsatt\n"
+"            kobler dem til stabile MusicBrainz-identifikatorer. "
+"MessyBrainz ble brukt i AcousticBrainz og blir fortsatt\n"
 "            brukt i ListenBrainz."
 
 #: metabrainz/templates/index/shop.html:3
@@ -1549,7 +2591,8 @@ msgid ""
 "operate."
 msgstr ""
 "MetaBrainz-stiftelsen ønsker å rette en stor takk til alle \n"
-"    våre sponsorer og partnere for deres støtte med driften av MusicBrainz."
+"    våre sponsorer og partnere for deres støtte med driften av "
+"MusicBrainz."
 
 #: metabrainz/templates/index/sponsors.html:13
 msgid ""
@@ -1621,8 +2664,8 @@ msgid ""
 "Thanks to everyone who has helped make the MetaBrainz Foundation what it "
 "is today!"
 msgstr ""
-"Takk til alle som har bidratt til å gjøre MetaBrainz-stiftelsen til det den "
-"er i dag!"
+"Takk til alle som har bidratt til å gjøre MetaBrainz-stiftelsen til det "
+"den er i dag!"
 
 #: metabrainz/templates/index/team.html:6
 msgid "The MetaBrainz Team"
@@ -1659,12 +2702,16 @@ msgstr ""
 msgid "He lives on in our hearts and in open source."
 msgstr "Han lever videre i våre hjerter og i åpen kildekode."
 
+#: metabrainz/templates/index/team.html:29
+#: metabrainz/templates/index/team.html:315
+msgid "you’re welcome to try"
+msgstr ""
+
 #: metabrainz/templates/index/team.html:39
 msgid ""
 "<span class=\"name\">Michael Wiencek</span> &mdash; Senior Software "
 "Engineer"
-msgstr ""
-"<span class=\"name\">Michael Wiencek</span> – Senior programvareingeniør"
+msgstr "<span class=\"name\">Michael Wiencek</span> – Senior programvareingeniør"
 
 #: metabrainz/templates/index/team.html:41
 msgid ""
@@ -1683,8 +2730,8 @@ msgid ""
 "<span class=\"name\">Nicolás Tamargo</span> &mdash; Style Leader/Customer"
 " Support/Community Manager/Software Engineer"
 msgstr ""
-"<span class=\"name\">Nicolás Tamargo</span> – Stilleder/Kundesupport/"
-"Fellesskapssjef/Programvareingeniør"
+"<span class=\"name\">Nicolás Tamargo</span> – "
+"Stilleder/Kundesupport/Fellesskapssjef/Programvareingeniør"
 
 #: metabrainz/templates/index/team.html:59
 #, python-format
@@ -1773,16 +2820,16 @@ msgid ""
 "In his free time, Nicolas likes to go rock climbing, hence the nickname, "
 "and designing and building structures."
 msgstr ""
-"På fritiden liker Nicolas å klatre, derav kallenavnet, og å designe og bygge "
-"strukturer."
+"På fritiden liker Nicolas å klatre, derav kallenavnet, og å designe og "
+"bygge strukturer."
 
 #: metabrainz/templates/index/team.html:130
 msgid ""
 "Born in Canada and raised in France, Nicolas now lives in Barcelona, "
 "Spain."
 msgstr ""
-"Nicolas er født i Canada og oppvokst i Frankrike, og bor nå i Barcelona i "
-"Spania."
+"Nicolas er født i Canada og oppvokst i Frankrike, og bor nå i Barcelona i"
+" Spania."
 
 #: metabrainz/templates/index/team.html:146
 msgid ""
@@ -1790,8 +2837,9 @@ msgid ""
 "ListenBrainz/CritiqueBrainz/Android App Lead &amp; Junior Software "
 "Engineer"
 msgstr ""
-"<span class=\"name\">Kartik Ohri</span> – ListenBrainz/CritiqueBrainz/"
-"Android App leder og junior programvareingeniør"
+"<span class=\"name\">Kartik Ohri</span> – "
+"ListenBrainz/CritiqueBrainz/Android App leder og junior "
+"programvareingeniør"
 
 #: metabrainz/templates/index/team.html:148
 msgid ""
@@ -1846,8 +2894,8 @@ msgid ""
 "<span class=\"name\">Simon Hartman</span> &mdash; Design, UX Consultant &"
 " Social Media Jockey"
 msgstr ""
-"<span class=\"name\">Simon Hartman</span> – design, UX-konsulent og sosiale "
-"medier-jockey"
+"<span class=\"name\">Simon Hartman</span> – design, UX-konsulent og "
+"sosiale medier-jockey"
 
 #: metabrainz/templates/index/team.html:217
 msgid ""
@@ -1881,7 +2929,8 @@ msgstr "Frivillige prosjektledere"
 #: metabrainz/templates/index/team.html:259
 msgid "<span class=\"name\">Akshat Tiwari</span> &mdash; Junior Software Engineer"
 msgstr ""
-"<span class=\"name\">Akshat Tiwari</span> &mdash; Junior programvareingeniør"
+"<span class=\"name\">Akshat Tiwari</span> &mdash; Junior "
+"programvareingeniør"
 
 #: metabrainz/templates/index/team.html:261
 msgid ""
@@ -2000,8 +3049,7 @@ msgstr "Avbryte gjentakende betalinger"
 
 #: metabrainz/templates/payments/cancel_recurring.html:9
 msgid "If you want to cancel a recurring donation (payment) that you have set up:"
-msgstr ""
-"Hvis du vil avbryte en regelmessig donasjon (betaling) du har opprettet:"
+msgstr "Hvis du vil avbryte en regelmessig donasjon (betaling) du har opprettet:"
 
 #: metabrainz/templates/payments/cancel_recurring.html:14
 #, python-format
@@ -2053,8 +3101,8 @@ msgid ""
 "Where has my contribution gone? See our <a "
 "href=\"%(finance_reports_url)s\">transparent finances</a>."
 msgstr ""
-"Hvor har bidraget mitt blitt av? Se vår <a href=\"%(finance_reports_url)s\">"
-"transparente økonomi</a>."
+"Hvor har bidraget mitt blitt av? Se vår <a "
+"href=\"%(finance_reports_url)s\">transparente økonomi</a>."
 
 #: metabrainz/templates/payments/donate.html:24
 #, python-format
@@ -2062,7 +3110,8 @@ msgid ""
 "Who else is contributing? See our list of <a "
 "href=\"%(donors_url)s\">donors</a>."
 msgstr ""
-"Hvem andre bidrar? Se listen vår over <a href=\"%(donors_url)s\">givere</a>."
+"Hvem andre bidrar? Se listen vår over <a "
+"href=\"%(donors_url)s\">givere</a>."
 
 #: metabrainz/templates/payments/donate.html:28
 #, python-format
@@ -2073,8 +3122,8 @@ msgid ""
 "        donation, go to <a href=\"%(mb_url)s\">metabrainz.org</a>."
 msgstr ""
 "<b>Vær forsiktig!</b> Dette er en utviklingsversjon av nettstedet. IKKE\n"
-"        bruk dine ordentlige kredittkortopplysninger! Hvis du vil sende en "
-"ekte\n"
+"        bruk dine ordentlige kredittkortopplysninger! Hvis du vil sende "
+"en ekte\n"
 "        donasjon, gå til <a href=\"%(mb_url)s\">metabrainz.org</a>."
 
 #: metabrainz/templates/payments/donate.html:39
@@ -2112,8 +3161,7 @@ msgstr "Jeg ønsker å donere anonymt"
 
 #: metabrainz/templates/payments/donate.html:92
 msgid "Your name and username won't appear in the donors list"
-msgstr ""
-"Navnet og brukernavnet ditt vil ikke vises på listen over støttespillere"
+msgstr "Navnet og brukernavnet ditt vil ikke vises på listen over støttespillere"
 
 #: metabrainz/templates/payments/donate.html:100
 msgid "Donate with Credit Card"
@@ -2181,19 +3229,19 @@ msgstr "Amerikansk sjekk"
 
 #: metabrainz/templates/payments/donate.html:146
 msgid ""
-"Due to the increased unreliability of the US Postal Service we have "
-"stopped accepting paper checks. Sorry!"
+"Due to the increased unreliability of the US Postal Service and the "
+"relatively large fees involved, we ask you to only send a paper check if "
+"it is the only possible option. Due to the fees, we will not cash checks "
+"for less than $25."
 msgstr ""
-"På grunn av den økte upåliteligheten til det amerikanske postvesenet har vi "
-"sluttet å godta papirsjekker. Beklager!"
 
 #: metabrainz/templates/payments/donate.html:241
 msgid ""
 "Enter your MusicBrainz username to have Picard/MusicBrainz stop nagging "
 "you"
 msgstr ""
-"Skriv inn MusicBrainz-brukernavnet ditt for å få Picard/MusicBrainz til å "
-"slutte å mase på deg"
+"Skriv inn MusicBrainz-brukernavnet ditt for å få Picard/MusicBrainz til å"
+" slutte å mase på deg"
 
 #: metabrainz/templates/payments/donate.html:256
 msgid "MusicBrainz is currently unavailable."
@@ -2257,8 +3305,8 @@ msgid ""
 "      payment, go to <a href=\"%(mb_url)s\">metabrainz.org</a>."
 msgstr ""
 "<b>Vær forsiktig!</b> Dette er en utviklingsversjon av nettstedet. IKKE\n"
-"        bruk dine ordentlige kredittkortopplysninger! Hvis du vil sende en "
-"virkelig\n"
+"        bruk dine ordentlige kredittkortopplysninger! Hvis du vil sende "
+"en virkelig\n"
 "        betaling, gå til <a href=\"%(mb_url)s\">metabrainz.org</a>."
 
 #: metabrainz/templates/payments/payment.html:17
@@ -2344,8 +3392,8 @@ msgid ""
 "<p>Where has your contribution gone? See our <a "
 "href=\"%(financial_reports_url)s\">transparent finances</a>.</p>"
 msgstr ""
-"<p>Hvor har bidraget ditt blitt av? Se vår <a href=\"%(financial_reports_url)"
-"s\">gjennomsiktige økonomi</a>.</p>"
+"<p>Hvor har bidraget ditt blitt av? Se vår <a "
+"href=\"%(financial_reports_url)s\">gjennomsiktige økonomi</a>.</p>"
 
 #: metabrainz/templates/payments/payment_base.html:27
 msgid "Other ways to pay"
@@ -2364,8 +3412,8 @@ msgid ""
 "Please specify the invoice number(s) you are paying in the description "
 "field of the transfer."
 msgstr ""
-"Vennligst oppgi fakturanummeret/ene du betaler for i beskrivelsesfeltet for "
-"overføringen."
+"Vennligst oppgi fakturanummeret/ene du betaler for i beskrivelsesfeltet "
+"for overføringen."
 
 #: metabrainz/templates/payments/payment_selector.html:7
 msgid "Please, select a currency that you want to use for payment:"
@@ -2430,8 +3478,8 @@ msgid ""
 "We attempt to publish our balance sheets within the first week of the "
 "succeeding quarter, or as close to that as possible."
 msgstr ""
-"Vi forsøker å publisere balansene våre innen den første uka i det påfølgende "
-"kvartalet, eller så nært det som mulig."
+"Vi forsøker å publisere balansene våre innen den første uka i det "
+"påfølgende kvartalet, eller så nært det som mulig."
 
 #: metabrainz/templates/reports/financial_reports/index.html:36
 #: metabrainz/templates/reports/financial_reports/index.html:52
@@ -3084,8 +4132,8 @@ msgid "Monthly balance sheets"
 msgstr "Månedlige balanser"
 
 #: frontend/js/src/Profile.tsx:520
-#: frontend/js/src/forms/SignupCommercial.tsx:175
-#: frontend/js/src/forms/SignupCommercial.tsx:554
+#: frontend/js/src/forms/SignupCommercial.tsx:180
+#: frontend/js/src/forms/SignupCommercial.tsx:558
 #: frontend/js/src/forms/SignupNonCommercial.tsx:106
 #: frontend/js/src/forms/SignupNonCommercial.tsx:318
 #: metabrainz/templates/supporters/account-type.html:3
@@ -3106,6 +4154,7 @@ msgid "Non-commercial / Personal"
 msgstr "Ikke-kommersiell / personlig"
 
 #: frontend/js/src/Profile.tsx:235
+#: frontend/js/src/forms/SignupNonCommercial.tsx:107
 #: frontend/js/src/forms/SignupNonCommercial.tsx:151
 #: metabrainz/templates/supporters/account-type.html:42
 msgid "Non-commercial"
@@ -3119,47 +4168,41 @@ msgstr "0,00 kr per måned og oppover"
 msgid "Personal or university assignment user."
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:48
-#: metabrainz/templates/supporters/account-type.html:90
-#: metabrainz/templates/supporters/account-type.html:141
-msgid "Upgrade"
-msgstr "Oppgrader"
-
 #: frontend/js/src/Profile.tsx:235
-#: frontend/js/src/forms/SignupCommercial.tsx:176
-#: frontend/js/src/forms/SignupCommercial.tsx:228
-#: metabrainz/templates/supporters/account-type.html:61
+#: frontend/js/src/forms/SignupCommercial.tsx:181
+#: frontend/js/src/forms/SignupCommercial.tsx:233
+#: metabrainz/templates/supporters/account-type.html:56
 msgid "Commercial"
 msgstr "Kommersiell"
 
-#: metabrainz/templates/supporters/account-type.html:83
-#: metabrainz/templates/supporters/account-type.html:135
+#: metabrainz/templates/supporters/account-type.html:78
+#: metabrainz/templates/supporters/account-type.html:125
 #, python-format
 msgid "$%(tier_price)s/month and up"
 msgstr "$%(tier_price)s per måned og oppover"
 
-#: metabrainz/templates/supporters/account-type.html:87
-#: metabrainz/templates/supporters/account-type.html:138
+#: metabrainz/templates/supporters/account-type.html:82
+#: metabrainz/templates/supporters/account-type.html:128
 msgid "More info"
 msgstr "Mer info"
 
-#: metabrainz/templates/supporters/account-type.html:104
+#: metabrainz/templates/supporters/account-type.html:94
 msgid "View all tiers"
 msgstr "Vis alle nivåer"
 
-#: metabrainz/templates/supporters/account-type.html:112
+#: metabrainz/templates/supporters/account-type.html:102
 msgid "Some of our Unicorn members"
 msgstr "Noen av våre enhjørningsmedlemmer"
 
-#: metabrainz/templates/supporters/account-type.html:123
+#: metabrainz/templates/supporters/account-type.html:113
 msgid "See all our supporters"
 msgstr "Se alle våre støttespillere"
 
-#: metabrainz/templates/supporters/account-type.html:151
+#: metabrainz/templates/supporters/account-type.html:136
 msgid "View featured tiers"
 msgstr "Se utvalgte nivåer"
 
-#: metabrainz/templates/supporters/account-type.html:158
+#: metabrainz/templates/supporters/account-type.html:143
 #, python-format
 msgid ""
 "If you are not sure which tier to pick, please\n"
@@ -3167,10 +4210,6 @@ msgid ""
 msgstr ""
 "Hvis du er usikker på hvilket nivå du skal velge, vennligst\n"
 "      <a href=\"%(contact_url)s\">kontakt oss</a>."
-
-#: metabrainz/templates/supporters/account-type.html:166
-msgid "Back to Profile"
-msgstr "Tilbake til profil"
 
 #: metabrainz/templates/supporters/bad-standing.html:3
 #: metabrainz/templates/supporters/bad-standing.html:6
@@ -3231,9 +4270,9 @@ msgid "Forgot your username"
 msgstr "Glemt brukernavn"
 
 #: frontend/js/src/forms/ResetPassword.tsx:79
-#: frontend/js/src/forms/SignupCommercial.tsx:320
+#: frontend/js/src/forms/SignupCommercial.tsx:325
 #: frontend/js/src/forms/SignupNonCommercial.tsx:227
-#: frontend/js/src/forms/SignupUser.tsx:169
+#: frontend/js/src/forms/SignupUser.tsx:175
 #: metabrainz/templates/users/reauthenticate.html:3
 #: metabrainz/templates/users/reauthenticate.html:6
 msgid "Confirm Password"
@@ -3243,56 +4282,61 @@ msgstr "Bekreft passord"
 msgid "Please re-enter your password to continue."
 msgstr "Vennligst skriv inn passordet ditt på nytt for å fortsette."
 
-#: frontend/js/src/ProfileDelete.tsx:108
+#: frontend/js/src/ProfileDelete.tsx:110
 #: frontend/js/src/forms/DeleteApplication.tsx:53
 #: frontend/js/src/forms/OAuthPrompt.tsx:54
 #: frontend/js/src/forms/ProfileChangePassword.tsx:104
 #: frontend/js/src/forms/ProfileEdit.tsx:105
-#: metabrainz/templates/users/reauthenticate.html:23
+#: metabrainz/templates/users/reauthenticate.html:28
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: metabrainz/templates/users/reauthenticate.html:24
+#: metabrainz/templates/users/reauthenticate.html:29
 msgid "Continue"
 msgstr "Fortsett"
+
+#: frontend/js/src/forms/utils.tsx:202
+#: metabrainz/templates/users/reauthenticate.html:40
+msgid "Password must not exceed 72 bytes."
+msgstr ""
 
 #: frontend/js/src/forms/ResetPassword.tsx:27
 #: metabrainz/templates/users/reset-password.html:3
 msgid "Reset your password"
 msgstr "Tilbakestill passord"
 
-#: frontend/js/src/hooks/useEmailValidation.ts:41 metabrainz/user/forms.py:15
+#: frontend/js/src/hooks/useEmailValidation.ts:41 metabrainz/user/forms.py:16
 msgid "Registration from this email domain is not allowed."
 msgstr "Dette epostdomenet er ugyldig."
 
 #: frontend/js/src/forms/LoginUser.tsx:50
 #: frontend/js/src/forms/LostPassword.tsx:45
-#: frontend/js/src/forms/SignupCommercial.tsx:270
+#: frontend/js/src/forms/SignupCommercial.tsx:275
 #: frontend/js/src/forms/SignupNonCommercial.tsx:175
-#: frontend/js/src/forms/SignupUser.tsx:114 metabrainz/user/forms.py:20
-#: metabrainz/user/forms.py:45 metabrainz/user/forms.py:62
+#: frontend/js/src/forms/SignupUser.tsx:120 metabrainz/user/forms.py:22
+#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:75
 msgid "Username"
 msgstr "Brukernavn"
 
 #: frontend/js/src/forms/LoginUser.tsx:42
 #: frontend/js/src/forms/LostPassword.tsx:37
-#: frontend/js/src/forms/SignupCommercial.tsx:153
+#: frontend/js/src/forms/SignupCommercial.tsx:158
 #: frontend/js/src/forms/SignupNonCommercial.tsx:84
-#: frontend/js/src/forms/SignupUser.tsx:67 metabrainz/user/forms.py:21
-#: metabrainz/user/forms.py:45 metabrainz/user/forms.py:62
+#: frontend/js/src/forms/SignupUser.tsx:73 metabrainz/user/forms.py:26
+#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:75
 msgid "Username is required!"
 msgstr "Brukernavn er påkrevd!"
 
 #: frontend/js/src/forms/LoginUser.tsx:63
 #: frontend/js/src/forms/ResetPassword.tsx:72
-#: frontend/js/src/forms/SignupCommercial.tsx:308
+#: frontend/js/src/forms/SignupCommercial.tsx:313
 #: frontend/js/src/forms/SignupNonCommercial.tsx:214
-#: frontend/js/src/forms/SignupUser.tsx:157 metabrainz/user/forms.py:46
-#: metabrainz/user/forms.py:52
+#: frontend/js/src/forms/SignupUser.tsx:163 metabrainz/user/forms.py:53
+#: metabrainz/user/forms.py:62
 msgid "Password"
 msgstr "Passord"
 
-#: frontend/js/src/forms/LoginUser.tsx:76 metabrainz/user/forms.py:47
+#: frontend/js/src/forms/LoginUser.tsx:76 metabrainz/user/forms.py:57
 msgid "Remember me"
 msgstr "Husk meg"
 
@@ -3304,11 +4348,11 @@ msgstr "Brukernavn er ugyldig."
 msgid "Username contains invalid or invisible characters."
 msgstr "Brukernavnet innholder ugyldige tegn."
 
-#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:181
+#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:220
 msgid "Hide password"
 msgstr "Skjul passord"
 
-#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:181
+#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:220
 msgid "Show password"
 msgstr "Vis passord"
 
@@ -3365,11 +4409,11 @@ msgstr "Tilgang"
 msgid "Revoke access"
 msgstr "Opphev tilgang"
 
-#: frontend/js/src/OAuthError.tsx:17
+#: frontend/js/src/OAuthError.tsx:18
 msgid "OAuth2 Error"
 msgstr "OAuth2 feil"
 
-#: frontend/js/src/OAuthError.tsx:18
+#: frontend/js/src/OAuthError.tsx:19
 msgid "An error occurred during OAuth authentication process."
 msgstr "Det oppsto en feil under OAuth-autentiseringsprosessen."
 
@@ -3401,8 +4445,8 @@ msgstr ""
 
 #: frontend/js/src/Profile.tsx:109
 msgid ""
-"Are you sure you want to generate new access token? Current token will be"
-" revoked!"
+"Are you sure you want to generate a new access token? The current token "
+"will be revoked!"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:118
@@ -3512,15 +4556,16 @@ msgstr "Uspesifisert"
 #: frontend/js/src/Profile.tsx:293
 msgid "<contactLink>Contact us</contactLink> to update this information."
 msgstr ""
-"<contactLink>Kontakt oss</contactLink> for å oppdatere denne informasjonen."
+"<contactLink>Kontakt oss</contactLink> for å oppdatere denne "
+"informasjonen."
 
 #: frontend/js/src/Profile.tsx:306 frontend/js/src/Profile.tsx:478
 msgid "Contact Information"
 msgstr "Kontaktinformasjon"
 
 #: frontend/js/src/Profile.tsx:310 frontend/js/src/forms/ProfileEdit.tsx:70
-#: frontend/js/src/forms/SignupCommercial.tsx:284
-#: frontend/js/src/forms/SignupCommercial.tsx:333
+#: frontend/js/src/forms/SignupCommercial.tsx:289
+#: frontend/js/src/forms/SignupCommercial.tsx:338
 #: frontend/js/src/forms/SignupNonCommercial.tsx:189
 #: frontend/js/src/forms/SignupNonCommercial.tsx:241
 msgid "Contact name"
@@ -3577,8 +4622,7 @@ msgstr "Datanedlasting"
 
 #: frontend/js/src/Profile.tsx:402
 msgid "Thank you for registering with us -- we really appreciate it!"
-msgstr ""
-"Takk for at du registrerte deg hos oss – vi setter virkelig pris på det!"
+msgstr "Takk for at du registrerte deg hos oss – vi setter virkelig pris på det!"
 
 #: frontend/js/src/Profile.tsx:407
 msgid "Proceed to our download page to download datasets:"
@@ -3636,7 +4680,7 @@ msgstr "Faresone"
 msgid "Once you delete your account, there is no going back. Please be certain."
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:550 frontend/js/src/ProfileDelete.tsx:105
+#: frontend/js/src/Profile.tsx:550 frontend/js/src/ProfileDelete.tsx:107
 msgid "Delete My Account"
 msgstr "Slett brukerkontoen din"
 
@@ -3648,39 +4692,39 @@ msgstr "Sletting av brukerkonto"
 msgid "Need to delete your account?"
 msgstr "Trenger du å slette brukerkontoen?"
 
-#: frontend/js/src/Profile.tsx:574
+#: frontend/js/src/Profile.tsx:575
 msgid ""
 "Deletion of supporter accounts requires manual review. Please contact us "
-"at"
+"at <email />."
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:594
+#: frontend/js/src/Profile.tsx:599
 msgid "Security"
 msgstr "Sikkerhet"
 
-#: frontend/js/src/Profile.tsx:626
+#: frontend/js/src/Profile.tsx:631
 msgid "MetaBrainz Applications"
 msgstr "MetaBrainz søknader"
 
-#: frontend/js/src/Profile.tsx:630
+#: frontend/js/src/Profile.tsx:635
 msgid ""
 "With your MetaBrainz account, you can access every project in the "
 "MetaBrainz family:"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:643
+#: frontend/js/src/Profile.tsx:648
 msgid "The open-source music encyclopedia"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:655
+#: frontend/js/src/Profile.tsx:660
 msgid "Track, visualise and share the music you listen to"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:667
+#: frontend/js/src/Profile.tsx:672
 msgid "The open-source book database"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:679
+#: frontend/js/src/Profile.tsx:684
 msgid "Creative Commons licensed reviews"
 msgstr "Creative Commons-lisensierte anmeldelser"
 
@@ -3703,8 +4747,8 @@ msgid "Permanently remove all your account information"
 msgstr "Fjerne alt av informasjon i brukerkontoen permanent"
 
 #: frontend/js/src/ProfileDelete.tsx:64
-msgid "Revoke all your API tokens and access"
-msgstr "Oppheve alle API-polletter og tilgang"
+msgid "Revoke all your tokens and access to the replication API"
+msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:65
 msgid "Remove your supporter status (if applicable)"
@@ -3715,14 +4759,16 @@ msgid "Log you out of all MetaBrainz services"
 msgstr "Logge deg ut av alle MetaBrainz-tjenester"
 
 #: frontend/js/src/ProfileDelete.tsx:70
-msgid "Your username will be reserved and cannot be reused."
-msgstr "Brukernavnet ditt vil bli reservert og kan ikke brukes om igjen."
+msgid ""
+"Your username will be reserved and cannot be reused without the "
+"intervention of an administrator."
+msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:82
+#: frontend/js/src/ProfileDelete.tsx:84
 msgid "To confirm, type your username '<username />' below:"
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:105
+#: frontend/js/src/ProfileDelete.tsx:107
 msgid "Deleting..."
 msgstr "Sletter..."
 
@@ -3734,64 +4780,7 @@ msgstr "Profil"
 msgid "Close"
 msgstr "Lukk"
 
-#: frontend/js/src/forms/ConditionsModal.tsx:23
-msgid "Licensing"
-msgstr "Lisensiering"
-
-#: frontend/js/src/forms/ConditionsModal.tsx:25
-msgid ""
-"Any contributions you make to any MetaBrainz service will be released "
-"into the Public Domain and/or licensed under a Creative Commons by-nc-sa "
-"license. Furthermore, you give the MetaBrainz Foundation the right to "
-"license this data for commercial use."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:30
-msgid "Please read our <licenseLink>license page</licenseLink> for more details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:45
-msgid ""
-"MetaBrainz strongly believes in the privacy of its users. Any personal "
-"information you choose to provide will not be sold or shared with anyone "
-"else."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:50
-msgid ""
-"Please read our <privacyLink>privacy policy</privacyLink> for more "
-"details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:59
-msgid "GDPR compliance"
-msgstr "GDPR krav"
-
-#: frontend/js/src/forms/ConditionsModal.tsx:61
-msgid ""
-"You may remove your personal information from our services anytime by "
-"deleting your account."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:66
-msgid ""
-"Please read our <gdprLink>GDPR compliance statement</gdprLink> for more "
-"details."
-msgstr "Les vår <gdprLink>GDPR-kravserklæring</gdprLink> for mer informasjon."
-
-#: frontend/js/src/forms/ConditionsModal.tsx:78
-msgid ""
-"Creating an account on MetaBrainz will give you access to all of our "
-"projects, such as MusicBrainz, ListenBrainz, BookBrainz, and more."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:82
-msgid ""
-"We create a placeholder account for all the MetaBrainz projects when you "
-"sign up, and you are one log-in away from activating them."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:91
+#: frontend/js/src/forms/ConditionsModal.tsx:29
 msgid "Sounds good"
 msgstr "Høres bra ut"
 
@@ -3877,8 +4866,8 @@ msgstr "Glemt brukernavnet?"
 msgid "Forgot your password?"
 msgstr "Glemt passorded?"
 
-#: frontend/js/src/forms/LoginUser.tsx:109
-msgid "Don't have an account?"
+#: frontend/js/src/forms/LoginUser.tsx:110
+msgid "Don't have an account? <signupLink>Sign up</signupLink>"
 msgstr ""
 
 #: frontend/js/src/forms/LostPassword.tsx:38
@@ -3907,15 +4896,72 @@ msgstr ""
 msgid "Allow access"
 msgstr "Tillat tilgang"
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:71
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:10
+msgid "Licensing"
+msgstr "Lisensiering"
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:12
+msgid ""
+"Any contributions you make to any MetaBrainz service will be released "
+"into the Public Domain and/or licensed under a Creative Commons by-nc-sa "
+"license. Furthermore, you give the MetaBrainz Foundation the right to "
+"license this data for commercial use."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:17
+msgid "Please read our <licenseLink>license page</licenseLink> for more details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:34
+msgid ""
+"MetaBrainz strongly believes in the privacy of its users. Any personal "
+"information you choose to provide will not be sold or shared with anyone "
+"else."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:39
+msgid ""
+"Please read our <privacyLink>privacy policy</privacyLink> for more "
+"details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:50
+msgid "GDPR compliance"
+msgstr "GDPR krav"
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:52
+msgid ""
+"You may remove your personal information from our services anytime by "
+"deleting your account."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:57
+msgid ""
+"Please read our <gdprLink>GDPR compliance statement</gdprLink> for more "
+"details."
+msgstr "Les vår <gdprLink>GDPR-kravserklæring</gdprLink> for mer informasjon."
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:71
+msgid ""
+"Creating an account on MetaBrainz will give you access to all of our "
+"projects, such as MusicBrainz, ListenBrainz, BookBrainz, and more."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:75
+msgid ""
+"We create a placeholder account for all the MetaBrainz projects when you "
+"sign up, and you are one log-in away from activating them."
+msgstr ""
+
+#: frontend/js/src/forms/ProfileChangePassword.tsx:70
 msgid "Current Password"
 msgstr "Nåværende passord"
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:80
+#: frontend/js/src/forms/ProfileChangePassword.tsx:79
 msgid "New Password"
 msgstr "Nytt passord"
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:89
+#: frontend/js/src/forms/ProfileChangePassword.tsx:88
 msgid "Confirm New Password"
 msgstr "Bekreft nytt passord"
 
@@ -3927,84 +4973,82 @@ msgstr "Oppdatering"
 msgid "Reset Password"
 msgstr "Tilbakestill passord"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:38
-msgid "If you would like to support us with more than $"
+#: frontend/js/src/forms/SignupCommercial.tsx:40
+msgid ""
+"If you would like to support us with more than ${{minPledge}}, please "
+"enter the actual amount here:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:39
-msgid ", please enter the actual amount here:"
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:144
+#: frontend/js/src/forms/SignupCommercial.tsx:149
 #: frontend/js/src/forms/SignupNonCommercial.tsx:75
-#: frontend/js/src/forms/SignupUser.tsx:87
+#: frontend/js/src/forms/SignupUser.tsx:93
 msgid "Captcha is required!"
 msgstr "Captcha er obligatorisk!"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:179
+#: frontend/js/src/forms/SignupCommercial.tsx:184
 #: frontend/js/src/forms/SignupNonCommercial.tsx:110
 #: frontend/js/src/forms/SignupUser.tsx:46
 msgid "Access all MetaBrainz projects"
 msgstr "Få tilgang til alle MetaBrainz-prosjekter"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:182
+#: frontend/js/src/forms/SignupCommercial.tsx:187
 msgid "Note:"
 msgstr "Bemerk:"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:184
+#: frontend/js/src/forms/SignupCommercial.tsx:189
 msgid ""
 "Signing up for any tier other than the <italic>Stealth startup</italic> "
 "tier will publicly list your company on this web site. However, we will "
 "not publish any of your private details."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:221
+#: frontend/js/src/forms/SignupCommercial.tsx:226
 #: frontend/js/src/forms/SignupNonCommercial.tsx:145
 msgid "Account type"
 msgstr "Kontotype"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:234
+#: frontend/js/src/forms/SignupCommercial.tsx:239
 msgid "Selected tier"
 msgstr "Valgt nivå"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:242
-msgid "month and up"
+#: frontend/js/src/forms/SignupCommercial.tsx:247
+msgid "${{tierPrice}}/month and up"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:250
+#: frontend/js/src/forms/SignupCommercial.tsx:255
 msgid "Change account type or tier"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:261
+#: frontend/js/src/forms/SignupCommercial.tsx:266
 #: frontend/js/src/forms/SignupNonCommercial.tsx:166
 msgid "Your account:"
 msgstr "Din brukerkonto:"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:271
+#: frontend/js/src/forms/SignupCommercial.tsx:276
 #: frontend/js/src/forms/SignupNonCommercial.tsx:176
-#: frontend/js/src/forms/SignupUser.tsx:114
+#: frontend/js/src/forms/SignupUser.tsx:120
 msgid "(public)"
 msgstr "(offentlig)"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:291
+#: frontend/js/src/forms/SignupCommercial.tsx:296
 #: frontend/js/src/forms/SignupNonCommercial.tsx:196
-#: frontend/js/src/forms/SignupUser.tsx:127
+#: frontend/js/src/forms/SignupUser.tsx:133
 msgid "E-mail address"
 msgstr "E-postadresse"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:295
+#: frontend/js/src/forms/SignupCommercial.tsx:300
 #: frontend/js/src/forms/SignupNonCommercial.tsx:200
-#: frontend/js/src/forms/SignupUser.tsx:131
+#: frontend/js/src/forms/SignupUser.tsx:137
 msgid "(checking...)"
 msgstr "(undersøker...)"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:314
+#: frontend/js/src/forms/SignupCommercial.tsx:319
 #: frontend/js/src/forms/SignupNonCommercial.tsx:220
-#: frontend/js/src/forms/SignupUser.tsx:163
+#: frontend/js/src/forms/SignupUser.tsx:169
 msgid "Must be at least 8 characters"
 msgstr "Må være minst 8 tegn"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:348
+#: frontend/js/src/forms/SignupCommercial.tsx:353
 msgid ""
 "If you don't have an organization name, you probably want to become a "
 "supporter as a <nonCommercialLink>Non-commercial / "
@@ -4014,7 +5058,7 @@ msgstr ""
 ">Ikke-kommersiell / personlig</nonCommercialLink>, mest sannsynlig riktig"
 " løsning for deg."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:358
+#: frontend/js/src/forms/SignupCommercial.tsx:363
 msgid ""
 "If you don't have an organization name, you probably want to sign up as a"
 " <nonCommercialLink>Non-commercial / Personal</nonCommercialLink> user."
@@ -4023,7 +5067,7 @@ msgstr ""
 "<nonCommercialLink>Ikke-kommersiell / personlig</nonCommercialLink> "
 "bruker sannsynligvis riktig løsning for deg."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:378
+#: frontend/js/src/forms/SignupCommercial.tsx:383
 msgid ""
 "Please tell us a little about your company and whether you plan to use "
 "our <apiLink>API</apiLink> or to <hostLink>host your own copy</hostLink> "
@@ -4033,15 +5077,15 @@ msgstr ""
 "<apiLink>API</apiLink> eller lagre en kopi av datane på <hostLink>din "
 "egen server</hostLink>."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:404
+#: frontend/js/src/forms/SignupCommercial.tsx:408
 msgid "Logo URL"
 msgstr "Nettadresse for logo"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:405
+#: frontend/js/src/forms/SignupCommercial.tsx:409
 msgid "(preferably in SVG format)"
 msgstr "(fortrinnsvist i SVG format)"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:408
+#: frontend/js/src/forms/SignupCommercial.tsx:412
 msgid ""
 "Image should be about 250 pixels wide on a white or transparent "
 "background. We will host it on our site."
@@ -4049,28 +5093,26 @@ msgstr ""
 "Bildet bør være omtrent 250 piksler bredt på en hvit eller gjennomsiktig "
 "bakgrunn. Vi vil lagre det på nettstedet vårt."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:421
+#: frontend/js/src/forms/SignupCommercial.tsx:425
 msgid ""
 "URL to where developers can use your APIs using MusicBrainz IDs, if "
-"available.."
+"available."
 msgstr ""
-"Nettstedslenke til der utviklere kan få tilgang til dine MusicBrainz-ID "
-"integrerte API-er, hvis tilgjengelig.."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:430
+#: frontend/js/src/forms/SignupCommercial.tsx:434
 msgid "Your project"
 msgstr "Ditt prosjekt"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:434
+#: frontend/js/src/forms/SignupCommercial.tsx:438
 #: frontend/js/src/forms/SignupNonCommercial.tsx:261
 msgid "(max 150 characters)"
 msgstr "(maks 150 tegn)"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:451
+#: frontend/js/src/forms/SignupCommercial.tsx:455
 msgid "Billing address"
 msgstr "Faktureringsadresse"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:502
+#: frontend/js/src/forms/SignupCommercial.tsx:506
 msgid ""
 "I agree to support the MetaBrainz Foundation when my organization is able"
 " to do so."
@@ -4078,18 +5120,19 @@ msgstr ""
 "Jeg samtykker i å støtte MetaBrainz-stiftelsen når organisasjonen min "
 "blir i stand til det."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:507
+#: frontend/js/src/forms/SignupCommercial.tsx:511
+#: frontend/js/src/forms/SignupNonCommercial.tsx:284
 msgid ""
-"I also agree that if I generate a Live Data Feed access token, that I "
-"treat my access token as a secret and will not share this token publicly "
-"or commit it to a source code repository."
+"I also agree that if I generate a Live Data Feed access token, then I "
+"will treat my access token as a secret and will not share this token "
+"publicly or commit it to a source code repository."
 msgstr ""
 "Jeg samtykker også i at hvis jeg genererer en sanntidsdatastrøms "
-"tilgangspollett, behandler jeg tilgangspolletten min som en hemmelighet "
-"og vil ikke dele denne polletten offentlig eller lagre den i et "
+"tilgangspollett, behandler jeg denne tilgangspolletten som en hemmelighet"
+" og vil ikke dele denne polletten offentlig eller lagre den i et "
 "kildekodelager."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:515
+#: frontend/js/src/forms/SignupCommercial.tsx:519
 msgid ""
 "The following information will be shown publicly: organization name, "
 "logo, website and API URLs, data usage description."
@@ -4097,7 +5140,7 @@ msgstr ""
 "Følgende informasjon vil bli vist offentlig: organisasjonsnavn, logo, "
 "nettsted og API-nettadresser, beskrivelse av databruk."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:520
+#: frontend/js/src/forms/SignupCommercial.tsx:524
 msgid ""
 "We'll send you more details about payment process once your application "
 "is approved."
@@ -4105,36 +5148,27 @@ msgstr ""
 "Vi sender deg mer informasjon om betalingsprosessen når søknaden din er "
 "godkjent."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:552
+#: frontend/js/src/forms/SignupCommercial.tsx:556
 #: frontend/js/src/forms/SignupNonCommercial.tsx:316
-#: frontend/js/src/forms/SignupUser.tsx:224
+#: frontend/js/src/forms/SignupUser.tsx:230
 msgid "Validating..."
 msgstr "Bekrefter..."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:564
+#: frontend/js/src/forms/SignupCommercial.tsx:568
 #: frontend/js/src/forms/SignupNonCommercial.tsx:329
 msgid "Back to profile"
 msgstr "Tilbake til profilen"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:569
-#: frontend/js/src/forms/SignupNonCommercial.tsx:334
-msgid "Not a supporter?"
-msgstr "Ikke en støttespiller?"
-
-#: frontend/js/src/forms/SignupCommercial.tsx:570
+#: frontend/js/src/forms/SignupCommercial.tsx:574
 #: frontend/js/src/forms/SignupNonCommercial.tsx:335
-msgid "Create a user account"
-msgstr "Opprett en brukerkonto"
+msgid "Not a supporter? <signupLink>Create a user account</signupLink>"
+msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:573
-#: frontend/js/src/forms/SignupNonCommercial.tsx:338
-#: frontend/js/src/forms/SignupUser.tsx:231
-msgid "Already have an account?"
-msgstr "Har du allerede en brukerkonto?"
-
-#: frontend/js/src/forms/SignupNonCommercial.tsx:107
-msgid "non-commercial"
-msgstr "ikke-kommersiell"
+#: frontend/js/src/forms/SignupCommercial.tsx:583
+#: frontend/js/src/forms/SignupNonCommercial.tsx:344
+#: frontend/js/src/forms/SignupUser.tsx:238
+msgid "Already have an account? <loginLink>Sign in</loginLink>"
+msgstr ""
 
 #: frontend/js/src/forms/SignupNonCommercial.tsx:113
 msgid ""
@@ -4143,9 +5177,9 @@ msgid ""
 "you for your commercial use of our datasets or the Live Data Feed."
 msgstr ""
 "Vær oppmerksom på at misbruk av den ikke-kommersielle tjenesten til "
-"kommersielle formål vil føre til at vi tilbakekaller din tilgangspollett og "
-"deretter fakturerer deg for kommersiell bruk av sanntidsdatastrøm og/eller "
-"datasettene våre."
+"kommersielle formål vil føre til at vi tilbakekaller din tilgangspollett "
+"og deretter fakturerer deg for kommersiell bruk av sanntidsdatastrøm "
+"og/eller datasettene våre."
 
 #: frontend/js/src/forms/SignupNonCommercial.tsx:157
 msgid "Change account type"
@@ -4167,37 +5201,28 @@ msgstr ""
 "Jeg samtykker i å bruke MetaBrainz-dataene kun til personlig eller ikke-"
 "kommersiell (inntekt mindre enn 4 500 NOK ($500) per år) bruk."
 
-#: frontend/js/src/forms/SignupNonCommercial.tsx:284
-msgid ""
-"I also agree that if I generate a Live Data Feed access token, then I "
-"will treat my access token as a secret and will not share this token "
-"publicly or commit it to a source code repository."
-msgstr ""
-"Jeg samtykker også i at hvis jeg genererer en sanntidsdatastrøms "
-"tilgangspollett, behandler jeg denne tilgangspolletten som en hemmelighet og "
-"vil ikke dele denne polletten offentlig eller lagre den i et kildekodelager."
-
 #: frontend/js/src/forms/SignupUser.tsx:43
 msgid "Create your account"
 msgstr "Opprett brukerkonto"
 
-#: frontend/js/src/forms/SignupUser.tsx:50
-msgid "Registration started by"
-msgstr "Registreringen startet av"
+#: frontend/js/src/forms/SignupUser.tsx:51
+msgid "Registration started by <client />"
+msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:69
+#: frontend/js/src/forms/SignupUser.tsx:75
+#: frontend/js/src/hooks/useEmailValidation.ts:82
 msgid "Invalid email address."
 msgstr "Ugyldig e-postadresse."
 
-#: frontend/js/src/forms/SignupUser.tsx:150
+#: frontend/js/src/forms/SignupUser.tsx:156
 msgid ""
 "This username and email were provided by the app that started "
 "registration. You can change them later from MetaBrainz settings."
 msgstr ""
-"Dette brukernavnet og e-postadressen kommer fra programregistreringen. Du "
-"kan endre dem senere i MetaBrainz-innstillingene."
+"Dette brukernavnet og e-postadressen kommer fra programregistreringen. Du"
+" kan endre dem senere i MetaBrainz-innstillingene."
 
-#: frontend/js/src/forms/SignupUser.tsx:182
+#: frontend/js/src/forms/SignupUser.tsx:188
 msgid ""
 "I accept that my contributions will be released into the public domain or"
 " licensed for use."
@@ -4205,15 +5230,15 @@ msgstr ""
 "Jeg godtar at mine bidrag puttes i det offentlige domene eller blir "
 "lisensiert for bruk."
 
-#: frontend/js/src/forms/SignupUser.tsx:191
+#: frontend/js/src/forms/SignupUser.tsx:197
 msgid "We will never share your personal information."
 msgstr "Vi vil aldri dele din personlige informasjon."
 
-#: frontend/js/src/forms/SignupUser.tsx:200
+#: frontend/js/src/forms/SignupUser.tsx:206
 msgid "Click here to read more"
 msgstr "Klikk her for mer informasjon"
 
-#: frontend/js/src/forms/SignupUser.tsx:224
+#: frontend/js/src/forms/SignupUser.tsx:230
 msgid "Create account"
 msgstr "Opprett brukerkonto"
 
@@ -4224,10 +5249,6 @@ msgstr "Denne e-postadressen er allerede i bruk."
 #: frontend/js/src/hooks/useEmailValidation.ts:47
 msgid "Email validation failed"
 msgstr "E-postbekreftelsen mislyktes"
-
-#: frontend/js/src/hooks/useEmailValidation.ts:82
-msgid "Invalid email address"
-msgstr "Ugyldig e-postadresse"
 
 #~ msgid "You need to specify amount!"
 #~ msgstr "Du må oppgi mengde!"
@@ -5068,9 +6089,6 @@ msgstr "Ugyldig e-postadresse"
 #~ " new access token? Current token will"
 #~ " be revoked!"
 #~ msgstr ""
-#~ "Er du sikker på at du vil "
-#~ "opprette et nytt tilgangssymbol? Det "
-#~ "nåværende symbolet vil bli tilbakekalt!"
 
 #~ msgid "Sign up <small>Commercial</small>"
 #~ msgstr ""
@@ -5115,6 +6133,9 @@ msgstr "Ugyldig e-postadresse"
 #~ "your APIs using MusicBrainz IDs, if "
 #~ "available.."
 #~ msgstr ""
+#~ "Nettstedslenke til der utviklere kan få"
+#~ " tilgang til dine MusicBrainz-ID "
+#~ "integrerte API-er, hvis tilgjengelig.."
 
 #~ msgid "(max 150 characters)"
 #~ msgstr "(maks. 150 tegn)"
@@ -5437,3 +6458,109 @@ msgstr "Ugyldig e-postadresse"
 
 #~ msgid "Privacy policy"
 #~ msgstr "Personvernspraksis"
+
+#~ msgid "You need to specify website of the organization."
+#~ msgstr "Du må oppgi nettsideadresse for organisasjonen."
+
+#~ msgid ""
+#~ "We are currently evaluating our overall"
+#~ " online advertising strategy. We are "
+#~ "evaluating advertising, traffic optimization,\n"
+#~ ""
+#~ "    search engine optimization and "
+#~ "software monitization technologies. If you "
+#~ "provide these professional services, please"
+#~ " provide a detailed\n"
+#~ "    deck of your comprehensive services"
+#~ " to the following email address. "
+#~ "<em>Please respect our other non-media"
+#~ " teams and do not contact us \n"
+#~ "    regarding these services on any "
+#~ "other of our email addresses. We "
+#~ "will disregard the entirety of your "
+#~ "submissions if you contact us any "
+#~ "other way!</em>"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Please come ask your questions at "
+#~ "our <a href=\"%(forums_url)s\">forums</a>! We "
+#~ "would love to\n"
+#~ "    answer any questions you may have."
+#~ msgstr ""
+#~ "Kom og still spørsmål på vårt <a"
+#~ " href=\"%(forums_url)s\">forum</a>! Vi ser fram"
+#~ " til å svare\n"
+#~ "    på ethvert spørsmål du måtte ha."
+
+#~ msgid ""
+#~ "Due to the increased unreliability of"
+#~ " the US Postal Service we have "
+#~ "stopped accepting paper checks. Sorry!"
+#~ msgstr ""
+#~ "På grunn av den økte upåliteligheten "
+#~ "til det amerikanske postvesenet har vi"
+#~ " sluttet å godta papirsjekker. Beklager!"
+
+#~ msgid "Upgrade"
+#~ msgstr "Oppgrader"
+
+#~ msgid "Back to Profile"
+#~ msgstr "Tilbake til profil"
+
+#~ msgid ""
+#~ "Deletion of supporter accounts requires "
+#~ "manual review. Please contact us at"
+#~ msgstr ""
+
+#~ msgid "Revoke all your API tokens and access"
+#~ msgstr "Oppheve alle API-polletter og tilgang"
+
+#~ msgid "Your username will be reserved and cannot be reused."
+#~ msgstr "Brukernavnet ditt vil bli reservert og kan ikke brukes om igjen."
+
+#~ msgid "Don't have an account?"
+#~ msgstr ""
+
+#~ msgid "If you would like to support us with more than $"
+#~ msgstr ""
+
+#~ msgid ", please enter the actual amount here:"
+#~ msgstr ""
+
+#~ msgid "month and up"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "I also agree that if I generate"
+#~ " a Live Data Feed access token, "
+#~ "that I treat my access token as"
+#~ " a secret and will not share "
+#~ "this token publicly or commit it "
+#~ "to a source code repository."
+#~ msgstr ""
+#~ "Jeg samtykker også i at hvis jeg"
+#~ " genererer en sanntidsdatastrøms tilgangspollett,"
+#~ " behandler jeg tilgangspolletten min som"
+#~ " en hemmelighet og vil ikke dele "
+#~ "denne polletten offentlig eller lagre "
+#~ "den i et kildekodelager."
+
+#~ msgid "Not a supporter?"
+#~ msgstr "Ikke en støttespiller?"
+
+#~ msgid "Create a user account"
+#~ msgstr "Opprett en brukerkonto"
+
+#~ msgid "Already have an account?"
+#~ msgstr "Har du allerede en brukerkonto?"
+
+#~ msgid "non-commercial"
+#~ msgstr "ikke-kommersiell"
+
+#~ msgid "Registration started by"
+#~ msgstr "Registreringen startet av"
+
+#~ msgid "Invalid email address"
+#~ msgstr "Ugyldig e-postadresse"
+

--- a/metabrainz/translations/nl/LC_MESSAGES/messages.po
+++ b/metabrainz/translations/nl/LC_MESSAGES/messages.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-07-25 16:21+0200\n"
+"POT-Creation-Date: 2026-09-08 11:18+0200\n"
 "PO-Revision-Date: 2026-06-12 00:54+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: nl\n"
@@ -21,163 +21,248 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.18.0\n"
 
-#: metabrainz/index/forms.py:46
+#: metabrainz/errors.py:24
+msgid "Authorization was declined."
+msgstr ""
+
+#: metabrainz/errors.py:25
+msgid "The authorization request was invalid."
+msgstr ""
+
+#: metabrainz/errors.py:26
+msgid "The application could not be authenticated."
+msgstr ""
+
+#: metabrainz/errors.py:27
+msgid "This application is not allowed to request authorization."
+msgstr ""
+
+#: metabrainz/errors.py:28
+msgid "The application asked for a response type this server does not support."
+msgstr ""
+
+#: metabrainz/errors.py:29
+msgid "The permissions requested by the application are invalid."
+msgstr ""
+
+#: metabrainz/errors.py:30
+msgid "You need to sign in to continue."
+msgstr ""
+
+#: metabrainz/errors.py:31
+msgid "Your consent is required to continue."
+msgstr ""
+
+#: metabrainz/password.py:12
+#, python-format
+msgid "Password must not exceed %(max_bytes)s bytes."
+msgstr ""
+
+#: metabrainz/index/forms.py:48
 #, python-format
 msgid "'%(value)s' is not a valid choice for this field"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileEdit.tsx:27
-#: frontend/js/src/forms/SignupCommercial.tsx:154
+#: frontend/js/src/forms/SignupCommercial.tsx:159
 #: frontend/js/src/forms/SignupNonCommercial.tsx:85
-#: frontend/js/src/forms/SignupUser.tsx:70
-#: frontend/js/src/hooks/useEmailValidation.ts:78 metabrainz/index/forms.py:57
-#: metabrainz/user/forms.py:25 metabrainz/user/forms.py:57
-#: metabrainz/user/forms.py:63
+#: frontend/js/src/forms/SignupUser.tsx:76
+#: frontend/js/src/hooks/useEmailValidation.ts:78 metabrainz/index/forms.py:59
+#: metabrainz/user/forms.py:31 metabrainz/user/forms.py:70
+#: metabrainz/user/forms.py:76
 msgid "Email address is required!"
 msgstr "Het e-mailadres is verplicht!"
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:34
-#: metabrainz/index/forms.py:63
+#: metabrainz/index/forms.py:65
 msgid "Current password is required!"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:43
 #: frontend/js/src/forms/ProfileChangePassword.tsx:37
 #: frontend/js/src/forms/ResetPassword.tsx:39
-#: frontend/js/src/forms/SignupCommercial.tsx:156
+#: frontend/js/src/forms/SignupCommercial.tsx:161
 #: frontend/js/src/forms/SignupNonCommercial.tsx:87
-#: frontend/js/src/forms/SignupUser.tsx:72 metabrainz/index/forms.py:66
-#: metabrainz/user/forms.py:29 metabrainz/user/forms.py:46
-#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:69
+#: frontend/js/src/forms/SignupUser.tsx:78 metabrainz/index/forms.py:69
+#: metabrainz/user/forms.py:35 metabrainz/user/forms.py:54
+#: metabrainz/user/forms.py:63 metabrainz/user/forms.py:82
 msgid "Password is required!"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:41
-#: frontend/js/src/forms/SignupCommercial.tsx:160
+#: frontend/js/src/forms/SignupCommercial.tsx:165
 #: frontend/js/src/forms/SignupNonCommercial.tsx:91
-#: frontend/js/src/forms/SignupUser.tsx:76 metabrainz/index/forms.py:70
-#: metabrainz/user/forms.py:33 metabrainz/user/forms.py:73
+#: frontend/js/src/forms/SignupUser.tsx:82 metabrainz/index/forms.py:74
+#: metabrainz/user/forms.py:40 metabrainz/user/forms.py:87
 msgid "Confirm Password is required!"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:46
 #: frontend/js/src/forms/ResetPassword.tsx:48
-#: frontend/js/src/forms/SignupCommercial.tsx:165
+#: frontend/js/src/forms/SignupCommercial.tsx:170
 #: frontend/js/src/forms/SignupNonCommercial.tsx:96
-#: frontend/js/src/forms/SignupUser.tsx:81 metabrainz/index/forms.py:72
-#: metabrainz/user/forms.py:35 metabrainz/user/forms.py:75
+#: frontend/js/src/forms/SignupUser.tsx:87 metabrainz/index/forms.py:76
+#: metabrainz/user/forms.py:42 metabrainz/user/forms.py:89
 msgid "Confirm Password should match password!"
 msgstr ""
 
 #: frontend/js/src/Applications.tsx:56 frontend/js/src/Applications.tsx:86
 #: frontend/js/src/Profile.tsx:272 frontend/js/src/Profile.tsx:482
-#: metabrainz/index/forms.py:78
+#: metabrainz/index/forms.py:82
 msgid "Name"
 msgstr "Naam"
 
-#: metabrainz/index/forms.py:79
+#: metabrainz/index/forms.py:83
 msgid "Contact name field is empty."
 msgstr "De naam van de contactpersoon is leeg."
 
-#: metabrainz/index/views.py:234
+#: metabrainz/index/views.py:251
 msgid "Profile updated successfully."
 msgstr ""
 
-#: metabrainz/index/views.py:261
+#: metabrainz/index/views.py:278
 msgid "Current password is incorrect."
 msgstr ""
 
-#: metabrainz/index/views.py:266
+#: metabrainz/index/views.py:283
 msgid "Password changed successfully."
 msgstr ""
 
-#: metabrainz/index/views.py:372
+#: metabrainz/index/views.py:389
 msgid "You have updated an application!"
 msgstr ""
 
-#: metabrainz/index/views.py:424
+#: metabrainz/index/views.py:441
 msgid "You have deleted an application."
 msgstr ""
 
-#: metabrainz/index/views.py:426
+#: metabrainz/index/views.py:443
 msgid "Failed to delete an application."
 msgstr ""
 
-#: metabrainz/index/views.py:449
+#: metabrainz/index/views.py:466
 msgid "Revoked tokens successfully!"
 msgstr ""
 
-#: metabrainz/index/views.py:478
+#: metabrainz/index/views.py:495
 msgid "Your account has been deleted."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:106 metabrainz/oauth/forms.py:58
+#: frontend/js/src/forms/CreateApplication.tsx:106 metabrainz/oauth/forms.py:57
 msgid "Application Name"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:59
+#: metabrainz/oauth/forms.py:58
 msgid "Application name field is empty."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:60 metabrainz/oauth/forms.py:60
+#: frontend/js/src/forms/CreateApplication.tsx:60 metabrainz/oauth/forms.py:59
 msgid "Application name needs to be at least 3 characters long."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:64 metabrainz/oauth/forms.py:61
+#: frontend/js/src/forms/CreateApplication.tsx:64 metabrainz/oauth/forms.py:60
 msgid "Application name needs to be at most 64 characters long."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:114 metabrainz/oauth/forms.py:63
+#: frontend/js/src/forms/CreateApplication.tsx:114 metabrainz/oauth/forms.py:62
 #, fuzzy
 msgid "Description"
 msgstr "Beschrijving van de organisatie"
 
-#: metabrainz/oauth/forms.py:64
+#: metabrainz/oauth/forms.py:63
 msgid "Client description field is empty."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:65
+#: metabrainz/oauth/forms.py:64
 msgid "Client description needs to be at least 3 characters long."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:66
+#: metabrainz/oauth/forms.py:65
 msgid "Client description needs to be at most 512 characters long."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:122 metabrainz/oauth/forms.py:68
+#: frontend/js/src/forms/CreateApplication.tsx:122 metabrainz/oauth/forms.py:67
 msgid "Homepage"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:69
+#: metabrainz/oauth/forms.py:68
 msgid "Homepage field is empty."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:70
+#: metabrainz/oauth/forms.py:69
 msgid "Homepage is not a valid URI."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:71
+#: metabrainz/oauth/forms.py:70
 msgid "Homepage URL must use http or https"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:73
+#: metabrainz/oauth/forms.py:72
 msgid "Authorization callback URL"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:74
+#: metabrainz/oauth/forms.py:73
 msgid "Authorization callback URL field is empty."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:75
+#: metabrainz/oauth/forms.py:74
 msgid "Authorization callback URL is invalid."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:76
+#: metabrainz/oauth/forms.py:75
 msgid "Authorization callback URL must use http or https."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:81 metabrainz/oauth/forms.py:85
+#: metabrainz/oauth/forms.py:80 metabrainz/oauth/forms.py:84
 msgid "Confirm"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:15
+msgid "View your public account information"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:16
+msgid "View your email address"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:17
+msgid "View and modify your private tags"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:18
+msgid "View and modify your private ratings"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:19
+msgid "View and modify your private collections"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:20
+msgid "Submit new ISRCs to the database"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:21
+msgid "Submit new barcodes to the database"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:22
+msgid "Sign you in and view your unique user id"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:23
+msgid "Submit listens to ListenBrainz."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:24
+msgid "Create and modify CritiqueBrainz reviews."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:25
+msgid "Submit and delete votes on CritiqueBrainz reviews."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:26
+msgid "Modify profile info and delete profile on CritiqueBrainz."
 msgstr ""
 
 #: metabrainz/payments/views.py:164
@@ -235,135 +320,136 @@ msgid "Requested annual report was not found."
 msgstr "Het opgevraagde jaarverslag is niet aangetroffen."
 
 #: frontend/js/src/forms/ProfileEdit.tsx:30
-#: frontend/js/src/forms/SignupCommercial.tsx:139
+#: frontend/js/src/forms/SignupCommercial.tsx:144
 #: frontend/js/src/forms/SignupNonCommercial.tsx:70
-#: metabrainz/supporter/forms.py:13
+#: metabrainz/supporter/forms.py:15
 msgid "Contact name is required!"
 msgstr "De naam van de contactpersoon is verplicht!"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:437
+#: frontend/js/src/forms/SignupCommercial.tsx:441
 #: frontend/js/src/forms/SignupNonCommercial.tsx:264
-#: metabrainz/supporter/forms.py:15
+#: metabrainz/supporter/forms.py:17
 msgid ""
 "Can you please tell us more about the project in which you'd like to use "
 "our data? Do you plan to self host the data or use our APIs?"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:137
+#: frontend/js/src/forms/SignupCommercial.tsx:142
 #: frontend/js/src/forms/SignupNonCommercial.tsx:68
-#: metabrainz/supporter/forms.py:17
+#: metabrainz/supporter/forms.py:19
 msgid "Please, tell us how you (will) use our data."
 msgstr "Vertel ons hoe je onze data (gaat) gebruiken."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:138
+#: frontend/js/src/forms/SignupCommercial.tsx:143
 #: frontend/js/src/forms/SignupNonCommercial.tsx:69
-#: metabrainz/supporter/forms.py:18
+#: metabrainz/supporter/forms.py:20
 msgid "Please, limit usage description to 500 characters."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:141
-#: frontend/js/src/forms/SignupCommercial.tsx:142
+#: frontend/js/src/forms/SignupCommercial.tsx:146
+#: frontend/js/src/forms/SignupCommercial.tsx:147
 #: frontend/js/src/forms/SignupNonCommercial.tsx:72
 #: frontend/js/src/forms/SignupNonCommercial.tsx:73
-#: frontend/js/src/forms/SignupUser.tsx:84
-#: frontend/js/src/forms/SignupUser.tsx:85 metabrainz/supporter/forms.py:21
-#: metabrainz/user/forms.py:38
+#: frontend/js/src/forms/SignupUser.tsx:90
+#: frontend/js/src/forms/SignupUser.tsx:91 metabrainz/supporter/forms.py:23
+#: metabrainz/user/forms.py:45
 msgid "You need to accept the agreement!"
 msgstr "Je moet de overeenkomst accepteren!"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:342
-#: metabrainz/supporter/forms.py:27
+#: frontend/js/src/forms/SignupCommercial.tsx:347
+#: metabrainz/supporter/forms.py:29
 msgid "Organization name"
 msgstr "Naam van de organisatie"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:113
-#: metabrainz/supporter/forms.py:28
+#: frontend/js/src/forms/SignupCommercial.tsx:115
+#: metabrainz/supporter/forms.py:30
 msgid "You need to specify the name of your organization."
 msgstr "Je moet de naam van je organisatie opgeven."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:373
-#: metabrainz/supporter/forms.py:30
+#: frontend/js/src/forms/SignupCommercial.tsx:378
+#: metabrainz/supporter/forms.py:32
 msgid "Organization description"
 msgstr "Beschrijving van de organisatie"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:116
-#: metabrainz/supporter/forms.py:31
+#: frontend/js/src/forms/SignupCommercial.tsx:118
+#: metabrainz/supporter/forms.py:33
 msgid "You need to provide description of your organization."
 msgstr "Je moet een beschrijving van je organisatie opgeven."
 
 #: frontend/js/src/Profile.tsx:278
-#: frontend/js/src/forms/SignupCommercial.tsx:396
-#: metabrainz/supporter/forms.py:34
+#: frontend/js/src/forms/SignupCommercial.tsx:401
+#: metabrainz/supporter/forms.py:36
 msgid "Website URL"
 msgstr "Website:"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:119
-#: metabrainz/supporter/forms.py:35
-msgid "You need to specify website of the organization."
-msgstr "Je moet de website van je organisatie opgeven."
+#: frontend/js/src/forms/SignupCommercial.tsx:121
+#: frontend/js/src/forms/SignupCommercial.tsx:123
+#: metabrainz/supporter/forms.py:38 metabrainz/supporter/forms.py:42
+msgid "Website URL must be a valid URL."
+msgstr ""
 
-#: metabrainz/supporter/forms.py:37
+#: metabrainz/supporter/forms.py:45
 msgid "Logo image URL"
 msgstr "Logo-URL:"
 
 #: frontend/js/src/Profile.tsx:284
-#: frontend/js/src/forms/SignupCommercial.tsx:418
-#: metabrainz/supporter/forms.py:38
+#: frontend/js/src/forms/SignupCommercial.tsx:422
+#: metabrainz/supporter/forms.py:46
 msgid "API URL"
 msgstr "API-URL:"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:457
-#: metabrainz/supporter/forms.py:40
+#: frontend/js/src/forms/SignupCommercial.tsx:461
+#: metabrainz/supporter/forms.py:48
 msgid "Street"
 msgstr "Straatnaam"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:123
-#: metabrainz/supporter/forms.py:41
+#: frontend/js/src/forms/SignupCommercial.tsx:128
+#: metabrainz/supporter/forms.py:49
 msgid "You need to specify street."
 msgstr "Je moet een straatnaam opgeven."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:465
-#: metabrainz/supporter/forms.py:43
+#: frontend/js/src/forms/SignupCommercial.tsx:469
+#: metabrainz/supporter/forms.py:51
 msgid "City"
 msgstr "Stad"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:124
-#: metabrainz/supporter/forms.py:44
+#: frontend/js/src/forms/SignupCommercial.tsx:129
+#: metabrainz/supporter/forms.py:52
 msgid "You need to specify city."
 msgstr "Je moet een stad opgeven."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:473
-#: metabrainz/supporter/forms.py:46
+#: frontend/js/src/forms/SignupCommercial.tsx:477
+#: metabrainz/supporter/forms.py:54
 msgid "State / Province"
 msgstr "Staat of provincie"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:126
-#: metabrainz/supporter/forms.py:47
+#: frontend/js/src/forms/SignupCommercial.tsx:131
+#: metabrainz/supporter/forms.py:55
 msgid "You need to specify state/province."
 msgstr "Je moet een staat of provincie opgeven."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:481
-#: metabrainz/supporter/forms.py:49
+#: frontend/js/src/forms/SignupCommercial.tsx:485
+#: metabrainz/supporter/forms.py:57
 msgid "Postcode"
 msgstr "Postcode"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:128
-#: metabrainz/supporter/forms.py:50
+#: frontend/js/src/forms/SignupCommercial.tsx:133
+#: metabrainz/supporter/forms.py:58
 msgid "You need to specify postcode."
 msgstr "Je moet een postcode opgeven."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:489
-#: metabrainz/supporter/forms.py:52
+#: frontend/js/src/forms/SignupCommercial.tsx:493
+#: metabrainz/supporter/forms.py:60
 msgid "Country"
 msgstr "Land"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:129
-#: metabrainz/supporter/forms.py:53
+#: frontend/js/src/forms/SignupCommercial.tsx:134
+#: metabrainz/supporter/forms.py:61
 msgid "You need to specify country."
 msgstr "Je moet een land opgeven."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:132
-#: metabrainz/supporter/forms.py:64
+#: frontend/js/src/forms/SignupCommercial.tsx:137
+#: metabrainz/supporter/forms.py:72
 #, fuzzy
 msgid ""
 "Custom amount must be more than threshold amount for selected tier or "
@@ -372,24 +458,30 @@ msgstr ""
 "Het zelf gekozen bedrag moet even hoog of hoger zijn dan het "
 "minimumbedrag voor het geselecteerde niveau!"
 
-#: metabrainz/supporter/views.py:46 metabrainz/supporter/views.py:119
-#: metabrainz/supporter/views.py:220
+#: metabrainz/supporter/views.py:54
+msgid ""
+"The verification email could not be sent. Please request a new one from "
+"your profile."
+msgstr ""
+
+#: metabrainz/supporter/views.py:85 metabrainz/supporter/views.py:158
+#: metabrainz/supporter/views.py:260
 msgid "You are already a supporter."
 msgstr ""
 
-#: metabrainz/supporter/views.py:61
+#: metabrainz/supporter/views.py:100
 msgid "Can't find tier with a specified ID."
 msgstr "Een niveau met dit ID kan niet worden gevonden."
 
-#: metabrainz/supporter/views.py:127
+#: metabrainz/supporter/views.py:166
 msgid "You need to choose support tier before signing up!"
 msgstr "Voordat je je registreert moet je een ondersteuningsniveau kiezen!"
 
-#: metabrainz/supporter/views.py:137
+#: metabrainz/supporter/views.py:176
 msgid "You need to choose existing tier before signing up!"
 msgstr "Voordat je je registreert moet je een bestaand niveau kiezen!"
 
-#: metabrainz/supporter/views.py:164
+#: metabrainz/supporter/views.py:204
 #, fuzzy
 msgid ""
 "Thanks for becoming a supporter! Your application will be reviewed soon. "
@@ -398,7 +490,7 @@ msgstr ""
 "Bedankt voor je registratie! Je registratie wordt binnenkort behandeld. "
 "We zullen je per e-mail op de hoogte houden."
 
-#: metabrainz/supporter/views.py:187
+#: metabrainz/supporter/views.py:228
 msgid ""
 "Thanks for signing up! Your application will be reviewed soon. We will "
 "send you updates via email."
@@ -406,15 +498,15 @@ msgstr ""
 "Bedankt voor je registratie! Je registratie wordt binnenkort behandeld. "
 "We zullen je per e-mail op de hoogte houden."
 
-#: metabrainz/supporter/views.py:248
+#: metabrainz/supporter/views.py:288
 msgid "Thanks for becoming a supporter!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:274
+#: metabrainz/supporter/views.py:312
 msgid "Thanks for signing up! Please check your inbox to complete verification."
 msgstr ""
 
-#: metabrainz/supporter/views.py:302
+#: metabrainz/supporter/views.py:340
 msgid "Can't generate new token unless account is active."
 msgstr "We kunnen geen nieuwe token aanmaken als je account niet actief is."
 
@@ -448,7 +540,7 @@ msgstr ""
 msgid "Policies"
 msgstr ""
 
-#: metabrainz/templates/base.html:55 metabrainz/templates/index/gdpr.html:178
+#: metabrainz/templates/base.html:55
 #: metabrainz/templates/index/social-contract.html:3
 #: metabrainz/templates/index/social-contract.html:6
 #: metabrainz/templates/navbar.html:34
@@ -458,14 +550,15 @@ msgstr ""
 #: metabrainz/templates/base.html:56
 #: metabrainz/templates/index/code-of-conduct.html:3
 #: metabrainz/templates/index/code-of-conduct.html:16
-#: metabrainz/templates/index/gdpr.html:181 metabrainz/templates/navbar.html:35
+#: metabrainz/templates/navbar.html:35
 msgid "Code of Conduct"
 msgstr ""
 
+#: frontend/js/src/PrivacySummary.tsx:11
 #: frontend/js/src/forms/ConditionsModal.tsx:21
-#: metabrainz/templates/base.html:57 metabrainz/templates/index/gdpr.html:184
-#: metabrainz/templates/index/privacy.html:6
+#: metabrainz/templates/base.html:57 metabrainz/templates/index/privacy.html:6
 #: metabrainz/templates/navbar.html:36
+#: metabrainz/templates/users/privacy-summary.html:3
 msgid "Privacy Policy"
 msgstr "Privacybeleid"
 
@@ -499,10 +592,7 @@ msgstr "Sponsoren"
 msgid "Supporters"
 msgstr "Partners"
 
-#: frontend/js/src/forms/LoginUser.tsx:103
-#: frontend/js/src/forms/SignupCommercial.tsx:574
-#: frontend/js/src/forms/SignupNonCommercial.tsx:339
-#: frontend/js/src/forms/SignupUser.tsx:232 metabrainz/templates/base.html:73
+#: frontend/js/src/forms/LoginUser.tsx:103 metabrainz/templates/base.html:73
 #: metabrainz/templates/navbar.html:66 metabrainz/templates/users/login.html:3
 msgid "Sign in"
 msgstr "Inloggen"
@@ -524,26 +614,26 @@ msgid "Contact us"
 msgstr "Contact"
 
 #: metabrainz/templates/base.html:85
-#: metabrainz/templates/index/contact.html:105
+#: metabrainz/templates/index/contact.html:106
 msgid "Blog"
 msgstr "Weblog"
 
-#: metabrainz/templates/base.html:86 metabrainz/templates/index/contact.html:90
+#: metabrainz/templates/base.html:86 metabrainz/templates/index/contact.html:91
 msgid "Chat"
 msgstr ""
 
 #: metabrainz/templates/base.html:87
-#: metabrainz/templates/index/contact.html:106
+#: metabrainz/templates/index/contact.html:107
 msgid "Mastodon"
 msgstr ""
 
 #: metabrainz/templates/base.html:88
-#: metabrainz/templates/index/contact.html:107
+#: metabrainz/templates/index/contact.html:108
 msgid "Bluesky"
 msgstr ""
 
 #: metabrainz/templates/base.html:89
-#: metabrainz/templates/index/contact.html:108
+#: metabrainz/templates/index/contact.html:109
 msgid "Instagram"
 msgstr ""
 
@@ -601,15 +691,14 @@ msgstr "Financiële verslagen"
 msgid "Donate"
 msgstr "Doneren"
 
-#: frontend/js/src/forms/LoginUser.tsx:110
-#: frontend/js/src/forms/SignupCommercial.tsx:175
-#: frontend/js/src/forms/SignupCommercial.tsx:555
+#: frontend/js/src/forms/SignupCommercial.tsx:180
+#: frontend/js/src/forms/SignupCommercial.tsx:559
 #: frontend/js/src/forms/SignupNonCommercial.tsx:106
 #: frontend/js/src/forms/SignupNonCommercial.tsx:319
 #: metabrainz/templates/navbar.html:65
-#: metabrainz/templates/supporters/account-type.html:51
-#: metabrainz/templates/supporters/account-type.html:93
-#: metabrainz/templates/supporters/account-type.html:144
+#: metabrainz/templates/supporters/account-type.html:47
+#: metabrainz/templates/supporters/account-type.html:84
+#: metabrainz/templates/supporters/account-type.html:130
 #: metabrainz/templates/users/signup.html:3
 msgid "Sign up"
 msgstr "Registreren"
@@ -952,8 +1041,430 @@ msgstr ""
 msgid "Introduction"
 msgstr ""
 
-#: metabrainz/templates/index/conflict-policy.html:55
+#: metabrainz/templates/index/conflict-policy.html:17
+msgid ""
+"Conflicts between people arise in open source projects constantly and the"
+" projects by the \n"
+"    MetaBrainz Foundation are no different. This policy aims to establish"
+" a clear and unambiguous \n"
+"    policy for reporting and addressing conflicts in our community. In "
+"this policy we aim to \n"
+"    establish a fair practice that balances the need for confidentiality "
+"and our desire for \n"
+"    transparency in our operations."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:25
+#, python-format
+msgid ""
+"Before you continue to read this policy, we encourage you to review our "
+"existing community policies \n"
+"    including our <a href=\"%(social_contract_url)s\">Social "
+"Contract</a>, \n"
+"    <a href=\"%(code_of_conduct_url)s\">the Code of Conduct</a>, \n"
+"    and our <a href=\"%(privacy_policy_url)s\">Privacy Policy</a>. These "
+"policies establish the norms and rules for \n"
+"    participation in our projects; these policies apply equally to the "
+"contractors of the MetaBrainz \n"
+"    Foundation and any participants in our projects."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:37
+msgid ""
+"This policy divides conflicts into two categories: Private and public. "
+"Private conflicts are conflicts \n"
+"    that involve *confidential* information regarding contributors, "
+"contractors or supporters. Otherwise, any conflicts \n"
+"    that do not involve confidential information are considered to be "
+"public conflicts. For instance, a \n"
+"    conflict between a contractor and the Executive Director (aka BDFL) "
+"that involves contractor pay is \n"
+"    considered a private conflict because pay rates are confidential "
+"information. A public conflict in edit \n"
+"    notes between two editors in our community does not involve "
+"confidential information and therefore should \n"
+"    be considered a public conflict."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:47
+msgid ""
+"When conflicts arise we aim to disclose as much information as possible "
+"about the conflict in a timely \n"
+"    fashion. When conflicts contain confidential matters we will aim to "
+"disclose as much information as \n"
+"    possible, while fully respecting the confidentiality of the people "
+"involved in the conflict. With any \n"
+"    private conflict we will aim to extract the relevant lessons for the "
+"team and community in an effort to \n"
+"    evolve our policies to prevent future conflicts. Should the involved "
+"parties disagree whether a conflict \n"
+"    is private or public, the question about the nature of the conflict "
+"will be presented for the next higher \n"
+"    level in the chain of command to decide. (e.g. if a community member "
+"and the community manager disagree on \n"
+"    a conflict being public or private, the Executive Director shall "
+"decide if the conflict is public or private)."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:58
 msgid "Reporting and Response"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:61
+msgid ""
+"We aim to not have conflict in our community, but we recognize that in "
+"reality conflicts will arise and we \n"
+"    must be prepared to address them in a fair manner. When conflicts "
+"arise, we prefer to have community or team \n"
+"    members resolve the conflicts among themselves, using our existing "
+"policies as guidelines for resolving the \n"
+"    conflict."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:69
+msgid ""
+"If you do not feel comfortable resolving a conflict on your own, you "
+"should feel free to report the conflict to \n"
+"    us. How you address the conflict depends on who is involved in the "
+"conflict and your comfort level. Please see \n"
+"    the detailed sections below on how and with whom to address your "
+"conflict. We aim to address conflicts as soon \n"
+"    as possible in an effort to prevent them from escalating "
+"unnecessarily."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:75
+msgid "Direct conflict resolution"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:78
+msgid ""
+"In direct conflict resolution, the involved parties will attempt to "
+"resolve the conflict themselves without \n"
+"   involving any MetaBrainz Foundation team member. You should aim to use"
+" direct resolution when the conflict does \n"
+"   not involve the violation of one of our policies or if the conflict is"
+" minor."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:84
+#, python-format
+msgid ""
+"For instance, if a user uses a rude tone, is disruptive or flagrantly "
+"ignores our project guidelines, we suggest \n"
+"    that you use direct conflict resolution to resolve the conflict. Some"
+" resources that might give you some suggestions \n"
+"    on how to go about resolving the conflict might be this <a "
+"href=\"%(conflict_resolution_primer_url)s\">\n"
+"    conflict resolution primer</a> and <a "
+"href=\"%(difficult_conversations_url)s\">how to\n"
+"    have difficult conversations at work</a>."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:93
+msgid "Informal reporting"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:96
+msgid ""
+"You may use informal reporting of a conflict if you aim to communicate a "
+"concern or incident without \n"
+"    seeking a corrective outcome. Informal reporting may also be an "
+"option if you have not been personally \n"
+"    victimized, but you’ve witnessed a violation of our policies or where"
+" you wish to maintain confidentiality \n"
+"    throughout the entire reporting process."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:103
+msgid ""
+"For editing in MusicBrainz you may informally report a user using the "
+"“Report this user for bad behavior” \n"
+"    link from the user’s profile. For reporting bad user behavior in "
+"other of our projects, please report them to our \n"
+"    community manager by mailing <span class=\"backemail\">gro.zniarbatem"
+"@reganam-ytinummoc</span> . For conflicts \n"
+"    that involve the community manager, report them by mailing <span "
+"class=\"backemail\">gro.zniarbatem@de</span> ."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:110
+msgid ""
+"Depending the the severity of the issue, repeated informal complaints may"
+" eventually require a formal response \n"
+"    from the MetaBrainz team. If an involved party requires anonymity, "
+"the conflict becomes a private conflict. If at \n"
+"    all possible minor issues should be resolved in a public forum in "
+"order for all people to witness and learn from \n"
+"    the issue at hand."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:116
+msgid "Formal complaint process"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:119
+msgid ""
+"All complaints about conflicts should be submitted via email. To whom a "
+"complaint should be mailed and who will \n"
+"    carry out the investigation will be described in the next section."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:124
+msgid "All complaint submissions to the Foundation should include the following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:128
+msgid ""
+"Contact info, if it is different than the email used to submit the "
+"conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:129
+msgid "Who was involved in the conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:130
+msgid "Where and when the incident happened"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:131
+msgid ""
+"A description of what happened -- ideally with links (e.g. chatlogs, edit"
+" notes) that outlines what \n"
+"         happened so that the persons evaluating the conflict may "
+"understand the issue at hand"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:133
+msgid ""
+"Any related pieces of information that provide more context on the "
+"conflict (e.g. links, screenshots)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:134
+msgid "An indication if this conflict is ongoing or not"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:139
+msgid "The investigation that follows aims to determine:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:143
+msgid "The nature and severity of the incident"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:144
+msgid ""
+"Whether or not the incident is considered a violation of MetaBrainz’ "
+"conduct policies or core values"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:145
+msgid ""
+"The amount of harm experienced by the person who submitted the complaint "
+"and the broader MetaBrainz community \n"
+"         as a result of the incident"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:147
+msgid ""
+"Whether there have been prior complaints against the individual or "
+"individuals reported"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:148
+msgid "Whether the incident is ongoing"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:152
+msgid ""
+"The following potential forms of resolution may apply to any team members"
+" involved in the conflict:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:155
+#: metabrainz/templates/index/conflict-policy.html:168
+msgid "Nothing (if it has been found no violation occurred)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:156
+msgid "Creating a plan to improve the performance"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:157
+msgid "Creating a negative performance evaluation"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:158
+msgid "Mediation, an intervention by a third party to resolve the conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:159
+msgid "Suspension or forced leave"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:160
+msgid "Termination of contract"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:164
+msgid ""
+"The following potential forms of resolution may apply to non team members"
+" involved in the conflict:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:169
+msgid "A reprimand, either public or private"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:170
+msgid "Suspension of the users’ account"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:171
+msgid "Deletion of the users’ account"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:172
+msgid ""
+"Removal of user privileges (e.g. if an auto editor commits a serious "
+"offence, they may lose their auto editor status)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:175
+msgid "Filing a complaint"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:178
+msgid ""
+"NOTE: For complaints not about MetaBrainz staff, please see the "
+"<em>Informal reporting</em> section above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:182
+msgid ""
+"If the complaint does not involve the Executive Director (ED), do the "
+"following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:186
+msgid ""
+"If team member has directly violated conduct policies or engaged in "
+"otherwise harmful behavior, a formal complaint should be filed."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:187
+msgid ""
+"Mail <span class=\"backemail\">gro.zniarbatem@de</span> and include the "
+"complaint information outlined above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:188
+msgid ""
+"You should expect a response within a working day acknowledging the "
+"complaint."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:189
+msgid ""
+"The complaint will be investigated by the ED, member(s) of the board of "
+"directors or a neutral third party."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:190
+msgid ""
+"Once the investigation has been completed, the ED, with the support of "
+"others involved in the investigation will respond. The \n"
+"        ED will respond to incidents no later than 7 working days after a"
+" complaint has been filed with either a resolution or an \n"
+"        explanation of why the process must be extended."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:196
+msgid "If a complaint involves the Executive Director, do the following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:200
+msgid ""
+"If the Executive Director has directly violated conduct policies or "
+"engaged in otherwise harmful behavior, \n"
+"        a formal complaint should be filed with the board of directors."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:202
+msgid ""
+"Mail <span class=\"backemail\">gro.zniarbatem@noituloser-tcilfnoc</span> "
+"and include the complaint information outlined above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:203
+msgid ""
+"You should get a response within 5 working days acknowledging the "
+"complaint."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:204
+msgid ""
+"The complaint will be investigated by the member(s) of the board of "
+"directors, the community manager, a neutral \n"
+"        third party or a combination thereof."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:206
+msgid ""
+"Once the investigation has been completed, the board, with the support of"
+" others involved in the investigation \n"
+"        will respond. The board will aim to respond to incidents no later"
+" than 15 working days after a complaint has been filed \n"
+"        with either a resolution or an explanation of why the process "
+"must be extended."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:211
+msgid "Confidentiality"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:214
+msgid ""
+"Confidentiality is an important aspect of conflict resolution and all of "
+"the conflicts brought to the attention of the foundation \n"
+"    will be evaluated with confidentiality in mind and acted upon "
+"accordingly."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:219
+msgid ""
+"We work hard to make all of the actions of the foundation as transparent "
+"and open as possible. In cases where we cannot \n"
+"    disclose all aspects of a conflict we will disclose that a conflict "
+"is or has occurred and we will attempt to disclose the \n"
+"    appropriate amount of information about the conflict while balancing "
+"the need for confidentiality and our desire to learn \n"
+"    from conflicts so that we as a foundation and community can learn "
+"from these conflicts and improve our policies to avoid the \n"
+"    conflicts in the future."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:227
+msgid ""
+"Any breaches of confidentiality will be treated as severe breaches of our"
+" conduct policies."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:230
+msgid "Retaliation"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:233
+msgid ""
+"We will not allow retaliation for any contractor or volunteer that files "
+"a complaint or is involved in an investigation. If you \n"
+"    believe that you are being treated negatively because of your "
+"involvement in a complaint please report this complaint directly \n"
+"    to the ED at <span class=\"backemail\">gro.zniarbatem@de</span> or "
+"the board at \n"
+"    <span class=\"backemail\">gro.zniarbatem@noituloser-tcilfnoc</span>."
 msgstr ""
 
 #: metabrainz/templates/index/contact.html:3
@@ -1058,7 +1569,7 @@ msgstr ""
 msgid ""
 "We are currently evaluating our overall online advertising strategy. We "
 "are evaluating advertising, traffic optimization,\n"
-"    search engine optimization and software monitization technologies. If"
+"    search engine optimization and software monetization technologies. If"
 " you provide these professional services, please provide a detailed\n"
 "    deck of your comprehensive services to the following email address. "
 "<em>Please respect our other non-media teams and do not contact us \n"
@@ -1138,13 +1649,11 @@ msgstr "Forum"
 #, python-format
 msgid ""
 "Please come ask your questions at our <a "
-"href=\"%(forums_url)s\">forums</a>! We would love to\n"
-"    answer any questions you may have."
+"href=\"%(forums_url)s\">forums</a>!\n"
+"    The community and the team will be more than happy to help you."
 msgstr ""
-"Stel ons je vraag op ons <a href=\"%(forums_url)s\">forum</a>! We "
-"beantwoorden graag al je vragen."
 
-#: metabrainz/templates/index/contact.html:92
+#: metabrainz/templates/index/contact.html:93
 #, python-format
 msgid ""
 "The MetaBrainz/MusicBrainz/ListenBrainz team and community hang out\n"
@@ -1154,15 +1663,15 @@ msgid ""
 "    <a href=\"%(chatlogs_url)s\">chat log archives</a>."
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:101
+#: metabrainz/templates/index/contact.html:102
 msgid "Social media"
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:103
+#: metabrainz/templates/index/contact.html:104
 msgid "You can follow us on these social channels:"
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:112
+#: metabrainz/templates/index/contact.html:113
 msgid "Mailing address"
 msgstr "Postadres"
 
@@ -1175,33 +1684,349 @@ msgstr ""
 msgid "GDPR Compliance Statement"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:37
+#: metabrainz/templates/index/gdpr.html:10
+msgid ""
+"The General Data Protection Regulation is a complex EU regulation that "
+"stipulates many points for protecting private data of\n"
+"    users on the Internet. Even though this is an EU regulation, it has a"
+" worldwide impact due to the nature of the Internet.\n"
+"    The MetaBrainz Foundation with its collection of projects is also "
+"affected by this regulation. We’ve been learning and adapting\n"
+"    our sites to be compliant with the GDPR – sadly this regulation isn’t"
+" entirely black and white and there is an incredible\n"
+"    amount of room left for interpretation of these rules."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:17
+msgid ""
+"The good news is that this regulation is roughly in line with our "
+"established practices: We’ve always held private information\n"
+"    in a high regard and applied the sort of rules to ourselves as we "
+"wish to have our own private data treated. Luckily, this\n"
+"    makes our compliance effort considerably easier. We’ve made two "
+"significant changes to how we treat your data and also adopted\n"
+"    terminology as used in the GDPR in order to use the same languages "
+"that many other sites are now adopting. Please keep reading\n"
+"    to find out the exact details of what we are doing to comply."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:24
+#, python-format
+msgid ""
+"However, we do ask for your compassion and help in our process of "
+"complying with the GDPR. As we already mentioned, the GDPR is\n"
+"    a complex set of rules that are not fully clarified yet. We’ve taken "
+"action on the steps that are clear to us and we’re following\n"
+"    ongoing conversations on points that are in gray zones or unclear to "
+"us. We’ve made our best initial effort on compliance and\n"
+"    promise to keep working on it as the picture becomes more clear. If "
+"you believe that we could improve our compliance, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a> and let us know what we "
+"can do to improve. It would also help us if you\n"
+"    could provide concrete discussion or examples to help us understand "
+"and take action on your suggestion."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:33
+msgid ""
+"Finally, below are the key sections of the GDPR as we understand them and"
+" how they affect your data in our ecosystem. Where\n"
+"    possible, we provide links for deeper understanding, links for you to"
+" examine our relevant code and links to tickets to follow\n"
+"    the process of improving our compliance."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:38
 msgid "Right to be forgotten"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:77
+#: metabrainz/templates/index/gdpr.html:41
+msgid ""
+"Summary: <i>Provide the user with the ability to remove their private "
+"data from our services</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:44
+msgid ""
+"The most important aspect of the right to be forgotten is the ability to "
+"delete your account. Once you request for us to delete\n"
+"    your account, we will remove any personally identifying information "
+"you may have provided us from your account (name, email\n"
+"    address, gender, biography, URL, etc.). The visible name on your "
+"account will be changed to “Deleted User #####” and effectively\n"
+"    the account will no longer be identifiable as your account."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:50
+msgid ""
+"However, given the nature of our projects where we work on collaborative "
+"databases, your contributions that are not personally\n"
+"    identifying are valuable assets to our database and these "
+"contributions will not be removed from our databases. But we will\n"
+"    ensure that these contributions no longer contain personally "
+"identifying data."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:55
+#, python-format
+msgid ""
+"Our process of automatically deleting your accounts across the MetaBrainz"
+" ecosystem is not complete yet (see below for a set of\n"
+"    tickets where you can track our progress). If you would like to "
+"delete your accounts in the MetaBrainz ecosystem or mark a\n"
+"    donation that is currently public as a private donation, please <a "
+"href=\"%(contact_url)s\">contact us</a>\n"
+"    and we will address your request as soon as possible."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:62
+#: metabrainz/templates/index/gdpr.html:182
+msgid "Links:"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:66
+#, python-format
+msgid ""
+"<a href=\"%(editor_deletion_doc_url)s\">How we delete accounts\n"
+"       in MusicBrainz</a> (warning, geek content ahead!)"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:70
+msgid ""
+"Implement sitewide user account deletion in\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/MBS-9680\">MusicBrainz</a>,"
+"\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/AB-337\">AcousticBrainz</a>,"
+"\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/BB-260\">BookBrainz</a>,\n"
+"         <a href=\"https://tickets.metabrainz.org/browse/MEB-103\">the "
+"MetaBrainz Site</a>,\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/LB-354\">ListenBrainz</a>, "
+"and\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/CB-307\">CritiqueBrainz</a>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:80
 msgid "Restriction of processing"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:110
+#: metabrainz/templates/index/gdpr.html:83
+msgid ""
+"Summary: <i>To allow the user to control how their personally identifying"
+" data is being used.</i>"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:86
+msgid ""
+"Except for the ListenBrainz and AcousticBrainz projects, we do not "
+"process personally identifying data. Any personally\n"
+"    identifying data that our projects store is for the purpose of being "
+"able to contact you about your contributions to our database\n"
+"    (email address) or for voluntarily showing information about you to "
+"other users (biography, homepage, location, etc)."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:91
+#, python-format
+msgid ""
+"The ListenBrainz project differs in that the Listens (metadata about what"
+" music you have listened to) are stored on our servers\n"
+"    and <a href=\"%(listenbrainz_data_url)s\">made available to the "
+"public</a>. We believe Listens to be personally identifying\n"
+"    data and furthermore, we have goals of creating open source "
+"recommendation engines with this data, which involves processing the\n"
+"    user’s data. These two points are fundamental goals of the "
+"ListenBrainz project and we do not see a reasonable way to reach another"
+"\n"
+"    compromise position."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:99
+msgid ""
+"Because of this, we are going to require users to either acknowledge that"
+" we may process their Listen data or alternatively to\n"
+"    delete their account, including all of their Listens. Please note "
+"that if you decide to delete your ListenBrainz account, it may\n"
+"    take up to two weeks for all of your listens to no longer be included"
+" in our efforts to build a recommendation engine."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:104
+msgid ""
+"We have always made it clear that the data in ListenBrainz was to be "
+"public and that we plan to build new tools with your data, so\n"
+"    this should not come as a surprise to our users."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:108
+msgid ""
+"The AcousticBrainz project does not track who submits data to the "
+"database. If you create an account and use our data creation\n"
+"    tools (e.g. create a dataset or participate in a challenge) then we "
+"link your participation and the things that you create to\n"
+"    your account. If you choose to delete your account then we keep the "
+"non personally identifying data that you create, but anonymize\n"
+"    it so that it cannot be linked back to you."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:114
 msgid "Right to data portability / exporting your data"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:150
+#: metabrainz/templates/index/gdpr.html:117
+msgid ""
+"Summary: <i>You have the right to access/download the data we store about"
+" you</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:120
+msgid ""
+"Except for the ListenBrainz and AcousticBrainz projects, we do not store "
+"personally identifying data beyond the\n"
+"    information that is available in your public profile on each of our "
+"projects. Since this data is plainly available in your\n"
+"    profile we do not provide a means for you to export this data."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:125
+msgid "There are the following exceptions to this:"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:129
+msgid ""
+"<b>IP addresses</b>: If you visit one of our sites the IP address of your"
+" computer is stored in our web logs for 7 days\n"
+"        before our servers automatically delete them. This data is almost"
+" never used by anyone: the only time we look at the\n"
+"        IP addresses is if our sites are adversely impacted by the "
+"actions of some unknown users. In that case, we may investigate\n"
+"        the logs to identify the IP address that needs to be blocked in "
+"order to restore the stability of our service.\n"
+"        This data is not available to anyone but the contractors of the "
+"MetaBrainz Foundation and is not available to download\n"
+"        to anyone at all."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:137
+#, python-format
+msgid ""
+"<b>ListenBrainz Listen data</b>: Users may <a "
+"href=\"%(listenbrainz_export_url)s\">export their ListenBrainz Listen\n"
+"        data</a> directly from the site. The user Listen data is also "
+"included in the <a href=\"%(listenbrainz_data_url)s\">ListenBrainz\n"
+"        data dumps</a> that are available for public download."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:146
+msgid ""
+"All of the non personally identifying data, such as your metadata "
+"contributions, are publicly visible, available for download\n"
+"    and available via the project APIs. For details about this data, "
+"downloads and APIs please check the documentation for the\n"
+"    respective projects you are interested in."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:151
+#, python-format
+msgid ""
+"Anyone wishing to get a list of financial donations they have made to the"
+" MetaBrainz Foundation, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a> and provide your "
+"MusicBrainz editor name so that we can look up\n"
+"    your donations."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:157
 msgid "Right to rectification"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:165
+#: metabrainz/templates/index/gdpr.html:160
+msgid "Summary: <i>You have the right to correct your data</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:163
+msgid ""
+"All of our projects allow their users to update their personally "
+"identifying information in their profiles. Furthermore, most\n"
+"    of our projects allow the editing of their own metadata "
+"contributions. If you find that some of your data is incorrect, please\n"
+"    feel free to edit the data since we provide the tools to do so."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:168
+#, python-format
+msgid ""
+"If anyone who has made a financial donation to the MetaBrainz Foundation "
+"would like to make their donation private, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:173
 msgid "Right to be informed"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:188
+#: metabrainz/templates/index/gdpr.html:175
+msgid ""
+"Summary: <i>You have the right to be informed about how we use your data "
+"in plain English</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:178
+msgid ""
+"Our privacy policy, as well as other policies, have always been written "
+"by humans for human consumption. We abhor legalese and\n"
+"    not speaking in direct terms."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:186
+msgid "Social contract"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:189
+msgid "Code of conduct"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:192
+msgid "Privacy policy"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:196
 msgid "Right to access"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:198
-#: metabrainz/templates/index/privacy.html:166
+#: metabrainz/templates/index/gdpr.html:199
+msgid ""
+"Summary: <i>You have the right to access the data that we collect about "
+"you</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:202
+msgid ""
+"All of our projects make all of the data we collect on your behalf, "
+"privately identifying or not, available to you. The\n"
+"    only exception to this are the IP addresses we store for 7 days – see"
+" above for details."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:206
+#: metabrainz/templates/index/privacy.html:168
 msgid "Privacy/GDPR Representative"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:209
+#, python-format
+msgid ""
+"If you have any questions about our privacy policy, please <a "
+"href=\"%(contact_url)s\">contact us</a>. To report\n"
+"   any privacy problems, violations or leaks, our GDPR representative is "
+"our Interim Executive Director Nicolás Tamargo and for\n"
+"   privacy issues contact him at <strong><a "
+"href=\"mailto:gdpr@metabrainz.org\">gdpr@metabrainz.org</a></strong>."
 msgstr ""
 
 #: metabrainz/templates/index/index.html:6
@@ -1336,7 +2161,7 @@ msgstr ""
 "Kijk op onze <a href=\"%(about_url)s\">informatiepagina</a> voor meer "
 "informatie over de stichting."
 
-#: frontend/js/src/forms/ConditionsModal.tsx:43
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:32
 #: metabrainz/templates/index/privacy.html:3
 msgid "Privacy"
 msgstr "Privacy"
@@ -1344,6 +2169,44 @@ msgstr "Privacy"
 #: metabrainz/templates/index/privacy.html:8
 msgid "Summary"
 msgstr "Samenvatting"
+
+#: metabrainz/templates/index/privacy.html:12
+msgid ""
+"You do not have to provide any personal data to be able to browse the "
+"contents of the databases published by MetaBrainz."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:15
+msgid ""
+"You do not have to provide any personally-identifying information if you "
+"choose not to."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:18
+msgid ""
+"We will never reveal your email address on MetaBrainz controlled web "
+"sites."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:22
+msgid ""
+"In order to get maximum value out of the MetaBrainz projects, you may "
+"want to create an account and log in. \n"
+"    Doing so grants you the ability to: edit the databases, contribute "
+"your own data, communicate with other users, and keep track \n"
+"    of recently released music from artists in your MusicBrainz "
+"collection. If you choose to create an account then the minimum we \n"
+"    ask is that you: choose a unique username and password, use a web "
+"browser that accepts \"session\" cookies, and provide a verified \n"
+"    email address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:29
+msgid ""
+"If you do not create an account (or are not logged in) you will not have "
+"access to the above listed features, however, you will \n"
+"    still have full access to browse and examine the databases."
+msgstr ""
 
 #: metabrainz/templates/index/privacy.html:33
 msgid "Applicable to all users"
@@ -1353,40 +2216,198 @@ msgstr ""
 msgid "Cookies"
 msgstr ""
 
+#: metabrainz/templates/index/privacy.html:37
+msgid "We use two cookies that contain sensitive information:"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:42
+msgid ""
+"<b>remember_login</b>: If you choose the \"Log in permanently\" option "
+"when logging in to one of our sites; the cookie will be used to \n"
+"      remember your login details."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:46
+msgid ""
+"<b>musicbrainz_server_session, session, or connect.sid</b>: If you are "
+"logged into one of our sites, your current session ID is stored in this "
+"cookie."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:51
+msgid ""
+"We may store dynamic preference information in other cookies, but these "
+"do not contain any sensitive information."
+msgstr ""
+
 #: metabrainz/templates/index/privacy.html:54
 #, fuzzy
 msgid "Web and FTP access logs"
 msgstr "Toegangslogboeken voor web en ftp (alle gebruikers)"
 
+#: metabrainz/templates/index/privacy.html:57
+msgid ""
+"In a practice similar to other web sites (and APIs) we keep logs of all "
+"web requests made against our servers. These logs include: your IP\n"
+"    address, your browser's (or API client's) \"User-Agent\" string, and "
+"which page (or API endpoint) you requested with which parameters. "
+"Aggregate information about web and FTP traffic is\n"
+"    made available to the public via our site usage pages."
+msgstr ""
+
 #: metabrainz/templates/index/privacy.html:62
 msgid "Third-Party content"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:92
+#: metabrainz/templates/index/privacy.html:64
+msgid ""
+"Our projects' web pages may load some third-party content. Some, but "
+"possibly not all sites are listed below:"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:69
+#, python-format
+msgid ""
+"Cover art and other images: These are provided by the various cover art "
+"sites that have given MusicBrainz permission to do so and our own \n"
+"      <a href=\"%(caa_url)s\">Cover Art Archive</a>. This means that the "
+"relevant site will know (if they want to) your IP \n"
+"      address, User-Agent string, etc., and which MusicBrainz web page "
+"you were visiting (the one which included the cover art image)."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:75
+msgid ""
+"AcoustID: Our fingerprints tab loads fingerprint information from "
+"acoustid.org."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:78
+msgid ""
+"MTCaptcha: Our account creation page loads third party content in order "
+"to prevent spammers from creating accounts."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:83
+msgid ""
+"<i>The above information assumes that you are using \"normal\" web "
+"browser settings, whereby images are always loaded and HTTP referrer \n"
+"    information is always sent.</i>"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:88
+msgid ""
+"It is impractical to constantly modify this privacy policy when "
+"MetaBrainz projects change which third party content they utilize. We "
+"will \n"
+"    aim to use common sense, respect to our community and community "
+"review when adding more content from third party sites. We will also \n"
+"    periodically review our policy to ensure that it remains current."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:93
 msgid "Applicable to account holders"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:94
+#: metabrainz/templates/index/privacy.html:95
 msgid "Account creation"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:108
+#: metabrainz/templates/index/privacy.html:97
+msgid ""
+"When creating an account with a MetaBrainz project you need to pick a "
+"unique username and choose a password, the username you pick is the \n"
+"    only name associated with your account and will be what other "
+"MetaBrainz users know you as. You may optionally also tell us other \n"
+"    information about yourself that will be displayed to other MetaBrainz"
+" users and the public."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:103
+msgid ""
+"Additionally, in order to edit the databases you will need to provide a "
+"confirmed email address. This email address will be held in \n"
+"    confidence, the only method of revealing your email address to "
+"another user is if you choose to send a message to another \n"
+"    user and enable the option to \"reveal my email address\". Changing "
+"the email address stored with your account will require you to \n"
+"    verify the new address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:109
 msgid "Edits and Notes"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:114
+#: metabrainz/templates/index/privacy.html:111
+msgid ""
+"If you make any changes to a MetaBrainz project database, such as adding "
+"any data, the details of those changes will be visible to \n"
+"    other logged-in users and the change will be associated with your "
+"username."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:115
 msgid "Subscriptions on MusicBrainz"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:131
+#: metabrainz/templates/index/privacy.html:117
+msgid ""
+"As a logged-in user you can subscribe to one or more artists, labels, "
+"collections or other editors. The act of subscribing causes \n"
+"    any edits made to (or by in the case of another editor) those "
+"entities to be emailed to you. By default, other users can see your \n"
+"    list of subscriptions, however, you can opt out of this by editing "
+"the appropriate preference."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:123
+msgid ""
+"This does not provide \"perfect\" privacy though, in some cases it will "
+"be possible to infer information about the contents of your \n"
+"    subscription list even though you have disallowed others from viewing"
+" that list directly. This imperfection arises because various \n"
+"    parts of the system behave differently depending on whether or not an"
+" entity has any subscribers; also, the number of users \n"
+"    subscribed to each artist is available via the artist pages. In the "
+"most extreme (possibly contrived) example, imagine that all \n"
+"    users have their subscriptions set to \"public\", except for exactly "
+"one user whose list is \"private\". In that case, any discrepancy \n"
+"    for a given artist between the shown list of subscribers and the "
+"total number of subscribers must be down to that one user. Thus, \n"
+"    you can infer what artists are on that user's list."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:132
 msgid "Third-party sites"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:145
+#: metabrainz/templates/index/privacy.html:134
+#, python-format
+msgid ""
+"Our code reviews are done on GitHub, which is not under the control of "
+"MetaBrainz. Participating in code reviews or other\n"
+"    tasks carried out on GitHub are subject to <a "
+"href=\"%(github_url)s\">GitHub's privacy policy</a>."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:140
+#, python-format
+msgid ""
+"Our translations platform is provided and hosted by Weblate, which has a "
+"data processing agreement with MetaBrainz.\n"
+"    Participating in translations is subject to <a "
+"href=\"%(weblate_url)s\">dedicated legal terms</a>.\n"
+"    Any translations you make will be submitted to our Git repositories "
+"and publicly associated with your username;\n"
+"    if you so choose, you can also publicly associate them with your own "
+"verified email address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:147
 msgid "MetaBrainz donors"
 msgstr "Donateurs"
 
-#: metabrainz/templates/index/privacy.html:147
+#: metabrainz/templates/index/privacy.html:149
 msgid ""
 "When you make a donation to the MetaBrainz Foundation, we are legally\n"
 "    required to collect your personal information and keep it in our "
@@ -1399,7 +2420,7 @@ msgstr ""
 "donateurs te bewaren. Maar behalve met de belastingdienst zullen we je "
 "privéinformatie nooit met anderen delen."
 
-#: metabrainz/templates/index/privacy.html:153
+#: metabrainz/templates/index/privacy.html:155
 msgid ""
 "We believe in transparent finances, which means that we list all "
 "donations\n"
@@ -1412,11 +2433,34 @@ msgstr ""
 "onze website. We zullen alleen je naam en het bedrag vermelden, tenzij je"
 " bij de donatie aangeeft anoniem te willen blijven."
 
-#: metabrainz/templates/index/privacy.html:158
+#: metabrainz/templates/index/privacy.html:160
 msgid "Exceptions"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:598
+#: metabrainz/templates/index/privacy.html:162
+msgid ""
+"<i><b>Please note</b>: Reasonable exceptions may apply to the above "
+"policy, for example to comply with applicable laws.\n"
+"    Also, members of the MetaBrainz team and other personnel contracted "
+"to provide services to MetaBrainz may have access to\n"
+"    our infrastructure and could therefore view any information contained"
+" therein. However all personnel are contractually bound\n"
+"    by non-disclosure clauses which prevent them from making any such "
+"information available to others."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:171
+#, python-format
+msgid ""
+"If you have any questions about our GDPR statement, please <a "
+"href=\"%(contact_url)s\">contact us</a>. To report\n"
+"   any privacy problems, violations or leaks, our GDPR representative is "
+"our Interim Executive Director Nicolás Tamargo and for\n"
+"   privacy issues contact him at <strong><a "
+"href=\"mailto:gdpr@metabrainz.org\">gdpr@metabrainz.org</a></strong>."
+msgstr ""
+
+#: frontend/js/src/Profile.tsx:603
 #: frontend/js/src/forms/ProfileChangePassword.tsx:22
 #: frontend/js/src/forms/ProfileChangePassword.tsx:111
 #: metabrainz/templates/index/profile-change-password.html:3
@@ -1729,6 +2773,11 @@ msgstr ""
 
 #: metabrainz/templates/index/team.html:26
 msgid "He lives on in our hearts and in open source."
+msgstr ""
+
+#: metabrainz/templates/index/team.html:29
+#: metabrainz/templates/index/team.html:315
+msgid "you’re welcome to try"
 msgstr ""
 
 #: metabrainz/templates/index/team.html:39
@@ -2281,8 +3330,10 @@ msgstr "Amerikaanse cheque"
 
 #: metabrainz/templates/payments/donate.html:146
 msgid ""
-"Due to the increased unreliability of the US Postal Service we have "
-"stopped accepting paper checks. Sorry!"
+"Due to the increased unreliability of the US Postal Service and the "
+"relatively large fees involved, we ask you to only send a paper check if "
+"it is the only possible option. Due to the fees, we will not cash checks "
+"for less than $25."
 msgstr ""
 
 #: metabrainz/templates/payments/donate.html:241
@@ -3209,8 +4260,8 @@ msgid "Monthly balance sheets"
 msgstr "Maandelijkse balansen"
 
 #: frontend/js/src/Profile.tsx:520
-#: frontend/js/src/forms/SignupCommercial.tsx:175
-#: frontend/js/src/forms/SignupCommercial.tsx:554
+#: frontend/js/src/forms/SignupCommercial.tsx:180
+#: frontend/js/src/forms/SignupCommercial.tsx:558
 #: frontend/js/src/forms/SignupNonCommercial.tsx:106
 #: frontend/js/src/forms/SignupNonCommercial.tsx:318
 #: metabrainz/templates/supporters/account-type.html:3
@@ -3231,6 +4282,7 @@ msgid "Non-commercial / Personal"
 msgstr "Niet-commercieel / persoonlijk"
 
 #: frontend/js/src/Profile.tsx:235
+#: frontend/js/src/forms/SignupNonCommercial.tsx:107
 #: frontend/js/src/forms/SignupNonCommercial.tsx:151
 #: metabrainz/templates/supporters/account-type.html:42
 msgid "Non-commercial"
@@ -3244,47 +4296,41 @@ msgstr ""
 msgid "Personal or university assignment user."
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:48
-#: metabrainz/templates/supporters/account-type.html:90
-#: metabrainz/templates/supporters/account-type.html:141
-msgid "Upgrade"
-msgstr ""
-
 #: frontend/js/src/Profile.tsx:235
-#: frontend/js/src/forms/SignupCommercial.tsx:176
-#: frontend/js/src/forms/SignupCommercial.tsx:228
-#: metabrainz/templates/supporters/account-type.html:61
+#: frontend/js/src/forms/SignupCommercial.tsx:181
+#: frontend/js/src/forms/SignupCommercial.tsx:233
+#: metabrainz/templates/supporters/account-type.html:56
 msgid "Commercial"
 msgstr "Commercieel"
 
-#: metabrainz/templates/supporters/account-type.html:83
-#: metabrainz/templates/supporters/account-type.html:135
+#: metabrainz/templates/supporters/account-type.html:78
+#: metabrainz/templates/supporters/account-type.html:125
 #, python-format
 msgid "$%(tier_price)s/month and up"
 msgstr "vanaf $%(tier_price)s per maand"
 
-#: metabrainz/templates/supporters/account-type.html:87
-#: metabrainz/templates/supporters/account-type.html:138
+#: metabrainz/templates/supporters/account-type.html:82
+#: metabrainz/templates/supporters/account-type.html:128
 msgid "More info"
 msgstr "Meer informatie"
 
-#: metabrainz/templates/supporters/account-type.html:104
+#: metabrainz/templates/supporters/account-type.html:94
 msgid "View all tiers"
 msgstr "Bekijk alle niveaus"
 
-#: metabrainz/templates/supporters/account-type.html:112
+#: metabrainz/templates/supporters/account-type.html:102
 msgid "Some of our Unicorn members"
 msgstr "Een paar van onze Eenhoorns"
 
-#: metabrainz/templates/supporters/account-type.html:123
+#: metabrainz/templates/supporters/account-type.html:113
 msgid "See all our supporters"
 msgstr "Al onze partners"
 
-#: metabrainz/templates/supporters/account-type.html:151
+#: metabrainz/templates/supporters/account-type.html:136
 msgid "View featured tiers"
 msgstr "Bekijk de belangrijkste niveaus"
 
-#: metabrainz/templates/supporters/account-type.html:158
+#: metabrainz/templates/supporters/account-type.html:143
 #, python-format
 msgid ""
 "If you are not sure which tier to pick, please\n"
@@ -3292,11 +4338,6 @@ msgid ""
 msgstr ""
 "<a href=\"%(contact_url)s\">Neem contact met ons op</a> als je niet zeker"
 " weet welk niveau je moet kiezen."
-
-#: metabrainz/templates/supporters/account-type.html:166
-#, fuzzy
-msgid "Back to Profile"
-msgstr "Je profiel"
 
 #: metabrainz/templates/supporters/bad-standing.html:3
 #: metabrainz/templates/supporters/bad-standing.html:6
@@ -3366,9 +4407,9 @@ msgid "Forgot your username"
 msgstr ""
 
 #: frontend/js/src/forms/ResetPassword.tsx:79
-#: frontend/js/src/forms/SignupCommercial.tsx:320
+#: frontend/js/src/forms/SignupCommercial.tsx:325
 #: frontend/js/src/forms/SignupNonCommercial.tsx:227
-#: frontend/js/src/forms/SignupUser.tsx:169
+#: frontend/js/src/forms/SignupUser.tsx:175
 #: metabrainz/templates/users/reauthenticate.html:3
 #: metabrainz/templates/users/reauthenticate.html:6
 msgid "Confirm Password"
@@ -3378,17 +4419,22 @@ msgstr ""
 msgid "Please re-enter your password to continue."
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:108
+#: frontend/js/src/ProfileDelete.tsx:110
 #: frontend/js/src/forms/DeleteApplication.tsx:53
 #: frontend/js/src/forms/OAuthPrompt.tsx:54
 #: frontend/js/src/forms/ProfileChangePassword.tsx:104
 #: frontend/js/src/forms/ProfileEdit.tsx:105
-#: metabrainz/templates/users/reauthenticate.html:23
+#: metabrainz/templates/users/reauthenticate.html:28
 msgid "Cancel"
 msgstr ""
 
-#: metabrainz/templates/users/reauthenticate.html:24
+#: metabrainz/templates/users/reauthenticate.html:29
 msgid "Continue"
+msgstr ""
+
+#: frontend/js/src/forms/utils.tsx:202
+#: metabrainz/templates/users/reauthenticate.html:40
+msgid "Password must not exceed 72 bytes."
 msgstr ""
 
 #: frontend/js/src/forms/ResetPassword.tsx:27
@@ -3396,38 +4442,38 @@ msgstr ""
 msgid "Reset your password"
 msgstr ""
 
-#: frontend/js/src/hooks/useEmailValidation.ts:41 metabrainz/user/forms.py:15
+#: frontend/js/src/hooks/useEmailValidation.ts:41 metabrainz/user/forms.py:16
 msgid "Registration from this email domain is not allowed."
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:50
 #: frontend/js/src/forms/LostPassword.tsx:45
-#: frontend/js/src/forms/SignupCommercial.tsx:270
+#: frontend/js/src/forms/SignupCommercial.tsx:275
 #: frontend/js/src/forms/SignupNonCommercial.tsx:175
-#: frontend/js/src/forms/SignupUser.tsx:114 metabrainz/user/forms.py:20
-#: metabrainz/user/forms.py:45 metabrainz/user/forms.py:62
+#: frontend/js/src/forms/SignupUser.tsx:120 metabrainz/user/forms.py:22
+#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:75
 msgid "Username"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:42
 #: frontend/js/src/forms/LostPassword.tsx:37
-#: frontend/js/src/forms/SignupCommercial.tsx:153
+#: frontend/js/src/forms/SignupCommercial.tsx:158
 #: frontend/js/src/forms/SignupNonCommercial.tsx:84
-#: frontend/js/src/forms/SignupUser.tsx:67 metabrainz/user/forms.py:21
-#: metabrainz/user/forms.py:45 metabrainz/user/forms.py:62
+#: frontend/js/src/forms/SignupUser.tsx:73 metabrainz/user/forms.py:26
+#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:75
 msgid "Username is required!"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:63
 #: frontend/js/src/forms/ResetPassword.tsx:72
-#: frontend/js/src/forms/SignupCommercial.tsx:308
+#: frontend/js/src/forms/SignupCommercial.tsx:313
 #: frontend/js/src/forms/SignupNonCommercial.tsx:214
-#: frontend/js/src/forms/SignupUser.tsx:157 metabrainz/user/forms.py:46
-#: metabrainz/user/forms.py:52
+#: frontend/js/src/forms/SignupUser.tsx:163 metabrainz/user/forms.py:53
+#: metabrainz/user/forms.py:62
 msgid "Password"
 msgstr ""
 
-#: frontend/js/src/forms/LoginUser.tsx:76 metabrainz/user/forms.py:47
+#: frontend/js/src/forms/LoginUser.tsx:76 metabrainz/user/forms.py:57
 msgid "Remember me"
 msgstr ""
 
@@ -3439,11 +4485,11 @@ msgstr ""
 msgid "Username contains invalid or invisible characters."
 msgstr ""
 
-#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:181
+#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:220
 msgid "Hide password"
 msgstr ""
 
-#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:181
+#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:220
 msgid "Show password"
 msgstr ""
 
@@ -3502,11 +4548,11 @@ msgstr ""
 msgid "Revoke access"
 msgstr ""
 
-#: frontend/js/src/OAuthError.tsx:17
+#: frontend/js/src/OAuthError.tsx:18
 msgid "OAuth2 Error"
 msgstr ""
 
-#: frontend/js/src/OAuthError.tsx:18
+#: frontend/js/src/OAuthError.tsx:19
 msgid "An error occurred during OAuth authentication process."
 msgstr ""
 
@@ -3536,8 +4582,8 @@ msgstr ""
 
 #: frontend/js/src/Profile.tsx:109
 msgid ""
-"Are you sure you want to generate new access token? Current token will be"
-" revoked!"
+"Are you sure you want to generate a new access token? The current token "
+"will be revoked!"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:118
@@ -3653,8 +4699,8 @@ msgid "Contact Information"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:310 frontend/js/src/forms/ProfileEdit.tsx:70
-#: frontend/js/src/forms/SignupCommercial.tsx:284
-#: frontend/js/src/forms/SignupCommercial.tsx:333
+#: frontend/js/src/forms/SignupCommercial.tsx:289
+#: frontend/js/src/forms/SignupCommercial.tsx:338
 #: frontend/js/src/forms/SignupNonCommercial.tsx:189
 #: frontend/js/src/forms/SignupNonCommercial.tsx:241
 msgid "Contact name"
@@ -3770,7 +4816,7 @@ msgstr ""
 msgid "Once you delete your account, there is no going back. Please be certain."
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:550 frontend/js/src/ProfileDelete.tsx:105
+#: frontend/js/src/Profile.tsx:550 frontend/js/src/ProfileDelete.tsx:107
 msgid "Delete My Account"
 msgstr ""
 
@@ -3782,39 +4828,39 @@ msgstr ""
 msgid "Need to delete your account?"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:574
+#: frontend/js/src/Profile.tsx:575
 msgid ""
 "Deletion of supporter accounts requires manual review. Please contact us "
-"at"
+"at <email />."
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:594
+#: frontend/js/src/Profile.tsx:599
 msgid "Security"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:626
+#: frontend/js/src/Profile.tsx:631
 msgid "MetaBrainz Applications"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:630
+#: frontend/js/src/Profile.tsx:635
 msgid ""
 "With your MetaBrainz account, you can access every project in the "
 "MetaBrainz family:"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:643
+#: frontend/js/src/Profile.tsx:648
 msgid "The open-source music encyclopedia"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:655
+#: frontend/js/src/Profile.tsx:660
 msgid "Track, visualise and share the music you listen to"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:667
+#: frontend/js/src/Profile.tsx:672
 msgid "The open-source book database"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:679
+#: frontend/js/src/Profile.tsx:684
 msgid "Creative Commons licensed reviews"
 msgstr ""
 
@@ -3837,7 +4883,7 @@ msgid "Permanently remove all your account information"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:64
-msgid "Revoke all your API tokens and access"
+msgid "Revoke all your tokens and access to the replication API"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:65
@@ -3849,14 +4895,16 @@ msgid "Log you out of all MetaBrainz services"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:70
-msgid "Your username will be reserved and cannot be reused."
+msgid ""
+"Your username will be reserved and cannot be reused without the "
+"intervention of an administrator."
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:82
+#: frontend/js/src/ProfileDelete.tsx:84
 msgid "To confirm, type your username '<username />' below:"
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:105
+#: frontend/js/src/ProfileDelete.tsx:107
 msgid "Deleting..."
 msgstr ""
 
@@ -3869,64 +4917,7 @@ msgstr "Je profiel"
 msgid "Close"
 msgstr ""
 
-#: frontend/js/src/forms/ConditionsModal.tsx:23
-msgid "Licensing"
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:25
-msgid ""
-"Any contributions you make to any MetaBrainz service will be released "
-"into the Public Domain and/or licensed under a Creative Commons by-nc-sa "
-"license. Furthermore, you give the MetaBrainz Foundation the right to "
-"license this data for commercial use."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:30
-msgid "Please read our <licenseLink>license page</licenseLink> for more details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:45
-msgid ""
-"MetaBrainz strongly believes in the privacy of its users. Any personal "
-"information you choose to provide will not be sold or shared with anyone "
-"else."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:50
-msgid ""
-"Please read our <privacyLink>privacy policy</privacyLink> for more "
-"details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:59
-msgid "GDPR compliance"
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:61
-msgid ""
-"You may remove your personal information from our services anytime by "
-"deleting your account."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:66
-msgid ""
-"Please read our <gdprLink>GDPR compliance statement</gdprLink> for more "
-"details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:78
-msgid ""
-"Creating an account on MetaBrainz will give you access to all of our "
-"projects, such as MusicBrainz, ListenBrainz, BookBrainz, and more."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:82
-msgid ""
-"We create a placeholder account for all the MetaBrainz projects when you "
-"sign up, and you are one log-in away from activating them."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:91
+#: frontend/js/src/forms/ConditionsModal.tsx:29
 msgid "Sounds good"
 msgstr ""
 
@@ -4015,8 +5006,8 @@ msgstr ""
 msgid "Forgot your password?"
 msgstr ""
 
-#: frontend/js/src/forms/LoginUser.tsx:109
-msgid "Don't have an account?"
+#: frontend/js/src/forms/LoginUser.tsx:110
+msgid "Don't have an account? <signupLink>Sign up</signupLink>"
 msgstr ""
 
 #: frontend/js/src/forms/LostPassword.tsx:38
@@ -4047,15 +5038,72 @@ msgstr ""
 msgid "Allow access"
 msgstr "Toegang toestaan"
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:71
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:10
+msgid "Licensing"
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:12
+msgid ""
+"Any contributions you make to any MetaBrainz service will be released "
+"into the Public Domain and/or licensed under a Creative Commons by-nc-sa "
+"license. Furthermore, you give the MetaBrainz Foundation the right to "
+"license this data for commercial use."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:17
+msgid "Please read our <licenseLink>license page</licenseLink> for more details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:34
+msgid ""
+"MetaBrainz strongly believes in the privacy of its users. Any personal "
+"information you choose to provide will not be sold or shared with anyone "
+"else."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:39
+msgid ""
+"Please read our <privacyLink>privacy policy</privacyLink> for more "
+"details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:50
+msgid "GDPR compliance"
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:52
+msgid ""
+"You may remove your personal information from our services anytime by "
+"deleting your account."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:57
+msgid ""
+"Please read our <gdprLink>GDPR compliance statement</gdprLink> for more "
+"details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:71
+msgid ""
+"Creating an account on MetaBrainz will give you access to all of our "
+"projects, such as MusicBrainz, ListenBrainz, BookBrainz, and more."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:75
+msgid ""
+"We create a placeholder account for all the MetaBrainz projects when you "
+"sign up, and you are one log-in away from activating them."
+msgstr ""
+
+#: frontend/js/src/forms/ProfileChangePassword.tsx:70
 msgid "Current Password"
 msgstr ""
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:80
+#: frontend/js/src/forms/ProfileChangePassword.tsx:79
 msgid "New Password"
 msgstr ""
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:89
+#: frontend/js/src/forms/ProfileChangePassword.tsx:88
 msgid "Confirm New Password"
 msgstr ""
 
@@ -4067,196 +5115,185 @@ msgstr ""
 msgid "Reset Password"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:38
-msgid "If you would like to support us with more than $"
+#: frontend/js/src/forms/SignupCommercial.tsx:40
+msgid ""
+"If you would like to support us with more than ${{minPledge}}, please "
+"enter the actual amount here:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:39
-msgid ", please enter the actual amount here:"
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:144
+#: frontend/js/src/forms/SignupCommercial.tsx:149
 #: frontend/js/src/forms/SignupNonCommercial.tsx:75
-#: frontend/js/src/forms/SignupUser.tsx:87
+#: frontend/js/src/forms/SignupUser.tsx:93
 msgid "Captcha is required!"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:179
+#: frontend/js/src/forms/SignupCommercial.tsx:184
 #: frontend/js/src/forms/SignupNonCommercial.tsx:110
 #: frontend/js/src/forms/SignupUser.tsx:46
 #, fuzzy
 msgid "Access all MetaBrainz projects"
 msgstr "Onze projecten"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:182
+#: frontend/js/src/forms/SignupCommercial.tsx:187
 msgid "Note:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:184
+#: frontend/js/src/forms/SignupCommercial.tsx:189
 msgid ""
 "Signing up for any tier other than the <italic>Stealth startup</italic> "
 "tier will publicly list your company on this web site. However, we will "
 "not publish any of your private details."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:221
+#: frontend/js/src/forms/SignupCommercial.tsx:226
 #: frontend/js/src/forms/SignupNonCommercial.tsx:145
 #, fuzzy
 msgid "Account type"
 msgstr "Soort account"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:234
+#: frontend/js/src/forms/SignupCommercial.tsx:239
 msgid "Selected tier"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:242
-msgid "month and up"
+#: frontend/js/src/forms/SignupCommercial.tsx:247
+msgid "${{tierPrice}}/month and up"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:250
+#: frontend/js/src/forms/SignupCommercial.tsx:255
 msgid "Change account type or tier"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:261
+#: frontend/js/src/forms/SignupCommercial.tsx:266
 #: frontend/js/src/forms/SignupNonCommercial.tsx:166
 msgid "Your account:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:271
+#: frontend/js/src/forms/SignupCommercial.tsx:276
 #: frontend/js/src/forms/SignupNonCommercial.tsx:176
-#: frontend/js/src/forms/SignupUser.tsx:114
+#: frontend/js/src/forms/SignupUser.tsx:120
 msgid "(public)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:291
+#: frontend/js/src/forms/SignupCommercial.tsx:296
 #: frontend/js/src/forms/SignupNonCommercial.tsx:196
-#: frontend/js/src/forms/SignupUser.tsx:127
+#: frontend/js/src/forms/SignupUser.tsx:133
 msgid "E-mail address"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:295
+#: frontend/js/src/forms/SignupCommercial.tsx:300
 #: frontend/js/src/forms/SignupNonCommercial.tsx:200
-#: frontend/js/src/forms/SignupUser.tsx:131
+#: frontend/js/src/forms/SignupUser.tsx:137
 msgid "(checking...)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:314
+#: frontend/js/src/forms/SignupCommercial.tsx:319
 #: frontend/js/src/forms/SignupNonCommercial.tsx:220
-#: frontend/js/src/forms/SignupUser.tsx:163
+#: frontend/js/src/forms/SignupUser.tsx:169
 msgid "Must be at least 8 characters"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:348
+#: frontend/js/src/forms/SignupCommercial.tsx:353
 msgid ""
 "If you don't have an organization name, you probably want to become a "
 "supporter as a <nonCommercialLink>Non-commercial / "
 "Personal</nonCommercialLink> supporter."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:358
+#: frontend/js/src/forms/SignupCommercial.tsx:363
 msgid ""
 "If you don't have an organization name, you probably want to sign up as a"
 " <nonCommercialLink>Non-commercial / Personal</nonCommercialLink> user."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:378
+#: frontend/js/src/forms/SignupCommercial.tsx:383
 msgid ""
 "Please tell us a little about your company and whether you plan to use "
 "our <apiLink>API</apiLink> or to <hostLink>host your own copy</hostLink> "
 "of the data."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:404
+#: frontend/js/src/forms/SignupCommercial.tsx:408
 #, fuzzy
 msgid "Logo URL"
 msgstr "Logo-URL:"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:405
+#: frontend/js/src/forms/SignupCommercial.tsx:409
 msgid "(preferably in SVG format)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:408
+#: frontend/js/src/forms/SignupCommercial.tsx:412
 msgid ""
 "Image should be about 250 pixels wide on a white or transparent "
 "background. We will host it on our site."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:421
+#: frontend/js/src/forms/SignupCommercial.tsx:425
 msgid ""
 "URL to where developers can use your APIs using MusicBrainz IDs, if "
-"available.."
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:430
-msgid "Your project"
+"available."
 msgstr ""
 
 #: frontend/js/src/forms/SignupCommercial.tsx:434
+msgid "Your project"
+msgstr ""
+
+#: frontend/js/src/forms/SignupCommercial.tsx:438
 #: frontend/js/src/forms/SignupNonCommercial.tsx:261
 msgid "(max 150 characters)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:451
+#: frontend/js/src/forms/SignupCommercial.tsx:455
 msgid "Billing address"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:502
+#: frontend/js/src/forms/SignupCommercial.tsx:506
 msgid ""
 "I agree to support the MetaBrainz Foundation when my organization is able"
 " to do so."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:507
+#: frontend/js/src/forms/SignupCommercial.tsx:511
+#: frontend/js/src/forms/SignupNonCommercial.tsx:284
 msgid ""
-"I also agree that if I generate a Live Data Feed access token, that I "
-"treat my access token as a secret and will not share this token publicly "
-"or commit it to a source code repository."
+"I also agree that if I generate a Live Data Feed access token, then I "
+"will treat my access token as a secret and will not share this token "
+"publicly or commit it to a source code repository."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:515
+#: frontend/js/src/forms/SignupCommercial.tsx:519
 msgid ""
 "The following information will be shown publicly: organization name, "
 "logo, website and API URLs, data usage description."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:520
+#: frontend/js/src/forms/SignupCommercial.tsx:524
 msgid ""
 "We'll send you more details about payment process once your application "
 "is approved."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:552
+#: frontend/js/src/forms/SignupCommercial.tsx:556
 #: frontend/js/src/forms/SignupNonCommercial.tsx:316
-#: frontend/js/src/forms/SignupUser.tsx:224
+#: frontend/js/src/forms/SignupUser.tsx:230
 msgid "Validating..."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:564
+#: frontend/js/src/forms/SignupCommercial.tsx:568
 #: frontend/js/src/forms/SignupNonCommercial.tsx:329
 #, fuzzy
 msgid "Back to profile"
 msgstr "Je profiel"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:569
-#: frontend/js/src/forms/SignupNonCommercial.tsx:334
-msgid "Not a supporter?"
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:570
+#: frontend/js/src/forms/SignupCommercial.tsx:574
 #: frontend/js/src/forms/SignupNonCommercial.tsx:335
-msgid "Create a user account"
+msgid "Not a supporter? <signupLink>Create a user account</signupLink>"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:573
-#: frontend/js/src/forms/SignupNonCommercial.tsx:338
-#: frontend/js/src/forms/SignupUser.tsx:231
-msgid "Already have an account?"
+#: frontend/js/src/forms/SignupCommercial.tsx:583
+#: frontend/js/src/forms/SignupNonCommercial.tsx:344
+#: frontend/js/src/forms/SignupUser.tsx:238
+msgid "Already have an account? <loginLink>Sign in</loginLink>"
 msgstr ""
-
-#: frontend/js/src/forms/SignupNonCommercial.tsx:107
-#, fuzzy
-msgid "non-commercial"
-msgstr "Niet-commercieel"
 
 #: frontend/js/src/forms/SignupNonCommercial.tsx:113
 msgid ""
@@ -4283,46 +5320,40 @@ msgid ""
 "income per year) or personal uses only."
 msgstr ""
 
-#: frontend/js/src/forms/SignupNonCommercial.tsx:284
-msgid ""
-"I also agree that if I generate a Live Data Feed access token, then I "
-"will treat my access token as a secret and will not share this token "
-"publicly or commit it to a source code repository."
-msgstr ""
-
 #: frontend/js/src/forms/SignupUser.tsx:43
 msgid "Create your account"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:50
-msgid "Registration started by"
+#: frontend/js/src/forms/SignupUser.tsx:51
+msgid "Registration started by <client />"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:69
+#: frontend/js/src/forms/SignupUser.tsx:75
+#: frontend/js/src/hooks/useEmailValidation.ts:82
 msgid "Invalid email address."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:150
+#: frontend/js/src/forms/SignupUser.tsx:156
 msgid ""
 "This username and email were provided by the app that started "
 "registration. You can change them later from MetaBrainz settings."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:182
+#: frontend/js/src/forms/SignupUser.tsx:188
 msgid ""
 "I accept that my contributions will be released into the public domain or"
 " licensed for use."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:191
+#: frontend/js/src/forms/SignupUser.tsx:197
 msgid "We will never share your personal information."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:200
+#: frontend/js/src/forms/SignupUser.tsx:206
 msgid "Click here to read more"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:224
+#: frontend/js/src/forms/SignupUser.tsx:230
 msgid "Create account"
 msgstr ""
 
@@ -4332,10 +5363,6 @@ msgstr ""
 
 #: frontend/js/src/hooks/useEmailValidation.ts:47
 msgid "Email validation failed"
-msgstr ""
-
-#: frontend/js/src/hooks/useEmailValidation.ts:82
-msgid "Invalid email address"
 msgstr ""
 
 #~ msgid "You need to specify amount!"
@@ -5216,9 +6243,6 @@ msgstr ""
 #~ " new access token? Current token will"
 #~ " be revoked!"
 #~ msgstr ""
-#~ "Weet je zeker dat je een nieuwe"
-#~ " toegangstoken wil aanmaken? De oude "
-#~ "wordt dan ingetrokken!"
 
 #~ msgid "Sign up <small>Commercial</small>"
 #~ msgstr "Registreren als <small>commerciële gebruiker</small>"
@@ -5277,9 +6301,6 @@ msgstr ""
 #~ "your APIs using MusicBrainz IDs, if "
 #~ "available.."
 #~ msgstr ""
-#~ "URL van je API’s die van "
-#~ "MusicBrainz-ID’s gebruik maken, als je "
-#~ "die hebt …"
 
 #~ msgid "(max 150 characters)"
 #~ msgstr "(maximaal 150 tekens)"
@@ -5611,4 +6632,99 @@ msgstr ""
 
 #~ msgid "Privacy policy"
 #~ msgstr "Privacybeleid"
+
+#~ msgid "You need to specify website of the organization."
+#~ msgstr "Je moet de website van je organisatie opgeven."
+
+#~ msgid ""
+#~ "We are currently evaluating our overall"
+#~ " online advertising strategy. We are "
+#~ "evaluating advertising, traffic optimization,\n"
+#~ ""
+#~ "    search engine optimization and "
+#~ "software monitization technologies. If you "
+#~ "provide these professional services, please"
+#~ " provide a detailed\n"
+#~ "    deck of your comprehensive services"
+#~ " to the following email address. "
+#~ "<em>Please respect our other non-media"
+#~ " teams and do not contact us \n"
+#~ "    regarding these services on any "
+#~ "other of our email addresses. We "
+#~ "will disregard the entirety of your "
+#~ "submissions if you contact us any "
+#~ "other way!</em>"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Please come ask your questions at "
+#~ "our <a href=\"%(forums_url)s\">forums</a>! We "
+#~ "would love to\n"
+#~ "    answer any questions you may have."
+#~ msgstr ""
+#~ "Stel ons je vraag op ons <a "
+#~ "href=\"%(forums_url)s\">forum</a>! We beantwoorden "
+#~ "graag al je vragen."
+
+#~ msgid ""
+#~ "Due to the increased unreliability of"
+#~ " the US Postal Service we have "
+#~ "stopped accepting paper checks. Sorry!"
+#~ msgstr ""
+
+#~ msgid "Upgrade"
+#~ msgstr ""
+
+#~ msgid "Back to Profile"
+#~ msgstr "Je profiel"
+
+#~ msgid ""
+#~ "Deletion of supporter accounts requires "
+#~ "manual review. Please contact us at"
+#~ msgstr ""
+
+#~ msgid "Revoke all your API tokens and access"
+#~ msgstr ""
+
+#~ msgid "Your username will be reserved and cannot be reused."
+#~ msgstr ""
+
+#~ msgid "Don't have an account?"
+#~ msgstr ""
+
+#~ msgid "If you would like to support us with more than $"
+#~ msgstr ""
+
+#~ msgid ", please enter the actual amount here:"
+#~ msgstr ""
+
+#~ msgid "month and up"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "I also agree that if I generate"
+#~ " a Live Data Feed access token, "
+#~ "that I treat my access token as"
+#~ " a secret and will not share "
+#~ "this token publicly or commit it "
+#~ "to a source code repository."
+#~ msgstr ""
+
+#~ msgid "Not a supporter?"
+#~ msgstr ""
+
+#~ msgid "Create a user account"
+#~ msgstr ""
+
+#~ msgid "Already have an account?"
+#~ msgstr ""
+
+#~ msgid "non-commercial"
+#~ msgstr "Niet-commercieel"
+
+#~ msgid "Registration started by"
+#~ msgstr ""
+
+#~ msgid "Invalid email address"
+#~ msgstr ""
 

--- a/metabrainz/translations/pa/LC_MESSAGES/messages.po
+++ b/metabrainz/translations/pa/LC_MESSAGES/messages.po
@@ -1,4 +1,4 @@
-# Translations template for metabrainz.org.
+# Punjabi translations for metabrainz.org.
 # Copyright (C) 2026 MetaBrainz Foundation
 # This file is distributed under the same license as the metabrainz.org
 # project.
@@ -8,176 +8,260 @@ msgid ""
 msgstr ""
 "Project-Id-Version: metabrainz.org VERSION\n"
 "Report-Msgid-Bugs-To: support@metabrainz.org\n"
-"POT-Creation-Date: 2026-07-25 16:21+0200\n"
+"POT-Creation-Date: 2026-09-08 11:18+0200\n"
 "PO-Revision-Date: 2026-07-27 19:34+0000\n"
 "Last-Translator: lucifer <kartikohri13@gmail.com>\n"
-"Language-Team: Punjabi <https://translations.metabrainz.org/projects/"
-"metabrainz/website/pa/>\n"
+"Language: pa\n"
+"Language-Team: Punjabi "
+"<https://translations.metabrainz.org/projects/metabrainz/website/pa/>\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.18.0\n"
-"Language: pa\n"
-"Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 2026.7.1\n"
 
-#: metabrainz/index/forms.py:46
+#: metabrainz/errors.py:24
+msgid "Authorization was declined."
+msgstr ""
+
+#: metabrainz/errors.py:25
+msgid "The authorization request was invalid."
+msgstr ""
+
+#: metabrainz/errors.py:26
+msgid "The application could not be authenticated."
+msgstr ""
+
+#: metabrainz/errors.py:27
+msgid "This application is not allowed to request authorization."
+msgstr ""
+
+#: metabrainz/errors.py:28
+msgid "The application asked for a response type this server does not support."
+msgstr ""
+
+#: metabrainz/errors.py:29
+msgid "The permissions requested by the application are invalid."
+msgstr ""
+
+#: metabrainz/errors.py:30
+msgid "You need to sign in to continue."
+msgstr ""
+
+#: metabrainz/errors.py:31
+msgid "Your consent is required to continue."
+msgstr ""
+
+#: metabrainz/password.py:12
+#, python-format
+msgid "Password must not exceed %(max_bytes)s bytes."
+msgstr ""
+
+#: metabrainz/index/forms.py:48
 #, python-format
 msgid "'%(value)s' is not a valid choice for this field"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileEdit.tsx:27
-#: frontend/js/src/forms/SignupCommercial.tsx:154
+#: frontend/js/src/forms/SignupCommercial.tsx:159
 #: frontend/js/src/forms/SignupNonCommercial.tsx:85
-#: frontend/js/src/forms/SignupUser.tsx:70
-#: frontend/js/src/hooks/useEmailValidation.ts:78 metabrainz/index/forms.py:57
-#: metabrainz/user/forms.py:25 metabrainz/user/forms.py:57
-#: metabrainz/user/forms.py:63
+#: frontend/js/src/forms/SignupUser.tsx:76
+#: frontend/js/src/hooks/useEmailValidation.ts:78 metabrainz/index/forms.py:59
+#: metabrainz/user/forms.py:31 metabrainz/user/forms.py:70
+#: metabrainz/user/forms.py:76
 msgid "Email address is required!"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:34
-#: metabrainz/index/forms.py:63
+#: metabrainz/index/forms.py:65
 msgid "Current password is required!"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:43
 #: frontend/js/src/forms/ProfileChangePassword.tsx:37
 #: frontend/js/src/forms/ResetPassword.tsx:39
-#: frontend/js/src/forms/SignupCommercial.tsx:156
+#: frontend/js/src/forms/SignupCommercial.tsx:161
 #: frontend/js/src/forms/SignupNonCommercial.tsx:87
-#: frontend/js/src/forms/SignupUser.tsx:72 metabrainz/index/forms.py:66
-#: metabrainz/user/forms.py:29 metabrainz/user/forms.py:46
-#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:69
+#: frontend/js/src/forms/SignupUser.tsx:78 metabrainz/index/forms.py:69
+#: metabrainz/user/forms.py:35 metabrainz/user/forms.py:54
+#: metabrainz/user/forms.py:63 metabrainz/user/forms.py:82
 msgid "Password is required!"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:41
-#: frontend/js/src/forms/SignupCommercial.tsx:160
+#: frontend/js/src/forms/SignupCommercial.tsx:165
 #: frontend/js/src/forms/SignupNonCommercial.tsx:91
-#: frontend/js/src/forms/SignupUser.tsx:76 metabrainz/index/forms.py:70
-#: metabrainz/user/forms.py:33 metabrainz/user/forms.py:73
+#: frontend/js/src/forms/SignupUser.tsx:82 metabrainz/index/forms.py:74
+#: metabrainz/user/forms.py:40 metabrainz/user/forms.py:87
 msgid "Confirm Password is required!"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:46
 #: frontend/js/src/forms/ResetPassword.tsx:48
-#: frontend/js/src/forms/SignupCommercial.tsx:165
+#: frontend/js/src/forms/SignupCommercial.tsx:170
 #: frontend/js/src/forms/SignupNonCommercial.tsx:96
-#: frontend/js/src/forms/SignupUser.tsx:81 metabrainz/index/forms.py:72
-#: metabrainz/user/forms.py:35 metabrainz/user/forms.py:75
+#: frontend/js/src/forms/SignupUser.tsx:87 metabrainz/index/forms.py:76
+#: metabrainz/user/forms.py:42 metabrainz/user/forms.py:89
 msgid "Confirm Password should match password!"
 msgstr ""
 
 #: frontend/js/src/Applications.tsx:56 frontend/js/src/Applications.tsx:86
 #: frontend/js/src/Profile.tsx:272 frontend/js/src/Profile.tsx:482
-#: metabrainz/index/forms.py:78
+#: metabrainz/index/forms.py:82
 msgid "Name"
 msgstr "ਨਾਮ"
 
-#: metabrainz/index/forms.py:79
+#: metabrainz/index/forms.py:83
 msgid "Contact name field is empty."
 msgstr ""
 
-#: metabrainz/index/views.py:234
+#: metabrainz/index/views.py:251
 msgid "Profile updated successfully."
 msgstr ""
 
-#: metabrainz/index/views.py:261
+#: metabrainz/index/views.py:278
 msgid "Current password is incorrect."
 msgstr ""
 
-#: metabrainz/index/views.py:266
+#: metabrainz/index/views.py:283
 msgid "Password changed successfully."
 msgstr ""
 
-#: metabrainz/index/views.py:372
+#: metabrainz/index/views.py:389
 msgid "You have updated an application!"
 msgstr ""
 
-#: metabrainz/index/views.py:424
+#: metabrainz/index/views.py:441
 msgid "You have deleted an application."
 msgstr ""
 
-#: metabrainz/index/views.py:426
+#: metabrainz/index/views.py:443
 msgid "Failed to delete an application."
 msgstr ""
 
-#: metabrainz/index/views.py:449
+#: metabrainz/index/views.py:466
 msgid "Revoked tokens successfully!"
 msgstr ""
 
-#: metabrainz/index/views.py:478
+#: metabrainz/index/views.py:495
 msgid "Your account has been deleted."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:106 metabrainz/oauth/forms.py:58
+#: frontend/js/src/forms/CreateApplication.tsx:106 metabrainz/oauth/forms.py:57
 msgid "Application Name"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:59
+#: metabrainz/oauth/forms.py:58
 msgid "Application name field is empty."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:60 metabrainz/oauth/forms.py:60
+#: frontend/js/src/forms/CreateApplication.tsx:60 metabrainz/oauth/forms.py:59
 msgid "Application name needs to be at least 3 characters long."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:64 metabrainz/oauth/forms.py:61
+#: frontend/js/src/forms/CreateApplication.tsx:64 metabrainz/oauth/forms.py:60
 msgid "Application name needs to be at most 64 characters long."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:114 metabrainz/oauth/forms.py:63
+#: frontend/js/src/forms/CreateApplication.tsx:114 metabrainz/oauth/forms.py:62
 msgid "Description"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:64
+#: metabrainz/oauth/forms.py:63
 msgid "Client description field is empty."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:65
+#: metabrainz/oauth/forms.py:64
 msgid "Client description needs to be at least 3 characters long."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:66
+#: metabrainz/oauth/forms.py:65
 msgid "Client description needs to be at most 512 characters long."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:122 metabrainz/oauth/forms.py:68
+#: frontend/js/src/forms/CreateApplication.tsx:122 metabrainz/oauth/forms.py:67
 msgid "Homepage"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:69
+#: metabrainz/oauth/forms.py:68
 msgid "Homepage field is empty."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:70
+#: metabrainz/oauth/forms.py:69
 msgid "Homepage is not a valid URI."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:71
+#: metabrainz/oauth/forms.py:70
 msgid "Homepage URL must use http or https"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:73
+#: metabrainz/oauth/forms.py:72
 msgid "Authorization callback URL"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:74
+#: metabrainz/oauth/forms.py:73
 msgid "Authorization callback URL field is empty."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:75
+#: metabrainz/oauth/forms.py:74
 msgid "Authorization callback URL is invalid."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:76
+#: metabrainz/oauth/forms.py:75
 msgid "Authorization callback URL must use http or https."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:81 metabrainz/oauth/forms.py:85
+#: metabrainz/oauth/forms.py:80 metabrainz/oauth/forms.py:84
 msgid "Confirm"
 msgstr "ਪੁਸ਼ਟੀ ਕਰੋ"
+
+#: metabrainz/oauth/scopes.py:15
+msgid "View your public account information"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:16
+msgid "View your email address"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:17
+msgid "View and modify your private tags"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:18
+msgid "View and modify your private ratings"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:19
+msgid "View and modify your private collections"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:20
+msgid "Submit new ISRCs to the database"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:21
+msgid "Submit new barcodes to the database"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:22
+msgid "Sign you in and view your unique user id"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:23
+msgid "Submit listens to ListenBrainz."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:24
+msgid "Create and modify CritiqueBrainz reviews."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:25
+msgid "Submit and delete votes on CritiqueBrainz reviews."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:26
+msgid "Modify profile info and delete profile on CritiqueBrainz."
+msgstr ""
 
 #: metabrainz/payments/views.py:164
 msgid ""
@@ -185,38 +269,41 @@ msgid ""
 "support is greatly appreciated! It may take some time before your "
 "donation appears in the list due to processing delays."
 msgstr ""
-"ਮੈਟਾਬ੍ਰੇਂਜ਼ ਫਾਊਂਡੇਸ਼ਨ ਨੂੰ ਦਾਨ ਦੇਣ ਲਈ ਤੁਹਾਡਾ ਧੰਨਵਾਦ। ਤੁਹਾਡੇ ਸਮਰਥਨ ਦੀ ਬਹੁਤ ਪ੍ਰਸ਼ੰਸਾ ਕੀਤੀ ਜਾਂਦੀ ਹੈ! "
-"ਪ੍ਰਕਿਰਿਆ ਵਿੱਚ ਦੇਰੀ ਦੇ ਕਾਰਨ ਤੁਹਾਡੇ ਦਾਨ ਨੂੰ ਸੂਚੀ ਵਿੱਚ ਆਉਣ ਵਿੱਚ ਕੁਝ ਸਮਾਂ ਲੱਗ ਸਕਦਾ ਹੈ।"
+"ਮੈਟਾਬ੍ਰੇਂਜ਼ ਫਾਊਂਡੇਸ਼ਨ ਨੂੰ ਦਾਨ ਦੇਣ ਲਈ ਤੁਹਾਡਾ ਧੰਨਵਾਦ। ਤੁਹਾਡੇ ਸਮਰਥਨ ਦੀ ਬਹੁਤ "
+"ਪ੍ਰਸ਼ੰਸਾ ਕੀਤੀ ਜਾਂਦੀ ਹੈ! ਪ੍ਰਕਿਰਿਆ ਵਿੱਚ ਦੇਰੀ ਦੇ ਕਾਰਨ ਤੁਹਾਡੇ ਦਾਨ ਨੂੰ ਸੂਚੀ "
+"ਵਿੱਚ ਆਉਣ ਵਿੱਚ ਕੁਝ ਸਮਾਂ ਲੱਗ ਸਕਦਾ ਹੈ।"
 
 #: metabrainz/payments/views.py:171
 msgid ""
 "Thank you for making a payment to the MetaBrainz Foundation. Your support"
 " is greatly appreciated!"
 msgstr ""
-"ਮੈਟਾਬ੍ਰੇਂਜ਼ ਫਾਊਂਡੇਸ਼ਨ ਨੂੰ ਭੁਗਤਾਨ ਕਰਨ ਲਈ ਤੁਹਾਡਾ ਧੰਨਵਾਦ। ਤੁਹਾਡੇ ਸਮਰਥਨ ਦੀ ਬਹੁਤ ਪ੍ਰਸ਼ੰਸਾ ਕੀਤੀ ਜਾਂਦੀ "
-"ਹੈ!"
+"ਮੈਟਾਬ੍ਰੇਂਜ਼ ਫਾਊਂਡੇਸ਼ਨ ਨੂੰ ਭੁਗਤਾਨ ਕਰਨ ਲਈ ਤੁਹਾਡਾ ਧੰਨਵਾਦ। ਤੁਹਾਡੇ ਸਮਰਥਨ ਦੀ "
+"ਬਹੁਤ ਪ੍ਰਸ਼ੰਸਾ ਕੀਤੀ ਜਾਂਦੀ ਹੈ!"
 
 #: metabrainz/payments/views.py:182
 msgid ""
 "We're sorry to see that you won't be donating today. We hope that you'll "
 "change your mind!"
 msgstr ""
-"ਸਾਨੂੰ ਇਹ ਦੇਖ ਕੇ ਦੁੱਖ ਹੋਇਆ ਕਿ ਤੁਸੀਂ ਅੱਜ ਦਾਨ ਨਹੀਂ ਕਰ ਰਹੇ। ਸਾਨੂੰ ਉਮੀਦ ਹੈ ਕਿ ਤੁਸੀਂ ਆਪਣਾ ਮਨ ਬਦਲੋਗੇ!"
+"ਸਾਨੂੰ ਇਹ ਦੇਖ ਕੇ ਦੁੱਖ ਹੋਇਆ ਕਿ ਤੁਸੀਂ ਅੱਜ ਦਾਨ ਨਹੀਂ ਕਰ ਰਹੇ। ਸਾਨੂੰ ਉਮੀਦ ਹੈ ਕਿ "
+"ਤੁਸੀਂ ਆਪਣਾ ਮਨ ਬਦਲੋਗੇ!"
 
 #: metabrainz/payments/views.py:188
 msgid ""
 "We're sorry to see that you won't be paying today. We hope that you'll "
 "change your mind!"
 msgstr ""
-"ਸਾਨੂੰ ਇਹ ਦੇਖ ਕੇ ਦੁੱਖ ਹੋਇਆ ਕਿ ਤੁਸੀਂ ਅੱਜ ਭੁਗਤਾਨ ਨਹੀਂ ਕਰੋਗੇ। ਸਾਨੂੰ ਉਮੀਦ ਹੈ ਕਿ ਤੁਸੀਂ ਆਪਣਾ ਮਨ ਬਦਲੋਗੇ!"
+"ਸਾਨੂੰ ਇਹ ਦੇਖ ਕੇ ਦੁੱਖ ਹੋਇਆ ਕਿ ਤੁਸੀਂ ਅੱਜ ਭੁਗਤਾਨ ਨਹੀਂ ਕਰੋਗੇ। ਸਾਨੂੰ ਉਮੀਦ ਹੈ "
+"ਕਿ ਤੁਸੀਂ ਆਪਣਾ ਮਨ ਬਦਲੋਗੇ!"
 
 #: metabrainz/payments/views.py:202
 msgid ""
 "We're sorry, but it appears we've run into an error and can't process "
 "your donation."
 msgstr ""
-"ਸਾਨੂੰ ਮਾਫ਼ ਕਰਨਾ, ਪਰ ਇੰਝ ਲੱਗਦਾ ਹੈ ਕਿ ਸਾਨੂੰ ਕੋਈ ਗਲਤੀ ਹੋ ਗਈ ਹੈ ਅਤੇ ਅਸੀਂ ਤੁਹਾਡੇ ਦਾਨ ਦੀ ਪ੍ਰਕਿਰਿਆ "
-"ਨਹੀਂ ਕਰ ਸਕਦੇ।"
+"ਸਾਨੂੰ ਮਾਫ਼ ਕਰਨਾ, ਪਰ ਇੰਝ ਲੱਗਦਾ ਹੈ ਕਿ ਸਾਨੂੰ ਕੋਈ ਗਲਤੀ ਹੋ ਗਈ ਹੈ ਅਤੇ ਅਸੀਂ "
+"ਤੁਹਾਡੇ ਦਾਨ ਦੀ ਪ੍ਰਕਿਰਿਆ ਨਹੀਂ ਕਰ ਸਕਦੇ।"
 
 #: metabrainz/payments/views.py:208
 msgid ""
@@ -229,178 +316,185 @@ msgid "Requested annual report was not found."
 msgstr ""
 
 #: frontend/js/src/forms/ProfileEdit.tsx:30
-#: frontend/js/src/forms/SignupCommercial.tsx:139
+#: frontend/js/src/forms/SignupCommercial.tsx:144
 #: frontend/js/src/forms/SignupNonCommercial.tsx:70
-#: metabrainz/supporter/forms.py:13
+#: metabrainz/supporter/forms.py:15
 msgid "Contact name is required!"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:437
+#: frontend/js/src/forms/SignupCommercial.tsx:441
 #: frontend/js/src/forms/SignupNonCommercial.tsx:264
-#: metabrainz/supporter/forms.py:15
+#: metabrainz/supporter/forms.py:17
 msgid ""
 "Can you please tell us more about the project in which you'd like to use "
 "our data? Do you plan to self host the data or use our APIs?"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:137
+#: frontend/js/src/forms/SignupCommercial.tsx:142
 #: frontend/js/src/forms/SignupNonCommercial.tsx:68
-#: metabrainz/supporter/forms.py:17
+#: metabrainz/supporter/forms.py:19
 msgid "Please, tell us how you (will) use our data."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:138
+#: frontend/js/src/forms/SignupCommercial.tsx:143
 #: frontend/js/src/forms/SignupNonCommercial.tsx:69
-#: metabrainz/supporter/forms.py:18
+#: metabrainz/supporter/forms.py:20
 msgid "Please, limit usage description to 500 characters."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:141
-#: frontend/js/src/forms/SignupCommercial.tsx:142
+#: frontend/js/src/forms/SignupCommercial.tsx:146
+#: frontend/js/src/forms/SignupCommercial.tsx:147
 #: frontend/js/src/forms/SignupNonCommercial.tsx:72
 #: frontend/js/src/forms/SignupNonCommercial.tsx:73
-#: frontend/js/src/forms/SignupUser.tsx:84
-#: frontend/js/src/forms/SignupUser.tsx:85 metabrainz/supporter/forms.py:21
-#: metabrainz/user/forms.py:38
+#: frontend/js/src/forms/SignupUser.tsx:90
+#: frontend/js/src/forms/SignupUser.tsx:91 metabrainz/supporter/forms.py:23
+#: metabrainz/user/forms.py:45
 msgid "You need to accept the agreement!"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:342
-#: metabrainz/supporter/forms.py:27
+#: frontend/js/src/forms/SignupCommercial.tsx:347
+#: metabrainz/supporter/forms.py:29
 msgid "Organization name"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:113
-#: metabrainz/supporter/forms.py:28
+#: frontend/js/src/forms/SignupCommercial.tsx:115
+#: metabrainz/supporter/forms.py:30
 msgid "You need to specify the name of your organization."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:373
-#: metabrainz/supporter/forms.py:30
+#: frontend/js/src/forms/SignupCommercial.tsx:378
+#: metabrainz/supporter/forms.py:32
 msgid "Organization description"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:116
-#: metabrainz/supporter/forms.py:31
+#: frontend/js/src/forms/SignupCommercial.tsx:118
+#: metabrainz/supporter/forms.py:33
 msgid "You need to provide description of your organization."
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:278
-#: frontend/js/src/forms/SignupCommercial.tsx:396
-#: metabrainz/supporter/forms.py:34
+#: frontend/js/src/forms/SignupCommercial.tsx:401
+#: metabrainz/supporter/forms.py:36
 msgid "Website URL"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:119
-#: metabrainz/supporter/forms.py:35
-msgid "You need to specify website of the organization."
+#: frontend/js/src/forms/SignupCommercial.tsx:121
+#: frontend/js/src/forms/SignupCommercial.tsx:123
+#: metabrainz/supporter/forms.py:38 metabrainz/supporter/forms.py:42
+msgid "Website URL must be a valid URL."
 msgstr ""
 
-#: metabrainz/supporter/forms.py:37
+#: metabrainz/supporter/forms.py:45
 msgid "Logo image URL"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:284
-#: frontend/js/src/forms/SignupCommercial.tsx:418
-#: metabrainz/supporter/forms.py:38
+#: frontend/js/src/forms/SignupCommercial.tsx:422
+#: metabrainz/supporter/forms.py:46
 msgid "API URL"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:457
-#: metabrainz/supporter/forms.py:40
+#: frontend/js/src/forms/SignupCommercial.tsx:461
+#: metabrainz/supporter/forms.py:48
 msgid "Street"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:123
-#: metabrainz/supporter/forms.py:41
+#: frontend/js/src/forms/SignupCommercial.tsx:128
+#: metabrainz/supporter/forms.py:49
 msgid "You need to specify street."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:465
-#: metabrainz/supporter/forms.py:43
+#: frontend/js/src/forms/SignupCommercial.tsx:469
+#: metabrainz/supporter/forms.py:51
 msgid "City"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:124
-#: metabrainz/supporter/forms.py:44
+#: frontend/js/src/forms/SignupCommercial.tsx:129
+#: metabrainz/supporter/forms.py:52
 msgid "You need to specify city."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:473
-#: metabrainz/supporter/forms.py:46
+#: frontend/js/src/forms/SignupCommercial.tsx:477
+#: metabrainz/supporter/forms.py:54
 msgid "State / Province"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:126
-#: metabrainz/supporter/forms.py:47
+#: frontend/js/src/forms/SignupCommercial.tsx:131
+#: metabrainz/supporter/forms.py:55
 msgid "You need to specify state/province."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:481
-#: metabrainz/supporter/forms.py:49
+#: frontend/js/src/forms/SignupCommercial.tsx:485
+#: metabrainz/supporter/forms.py:57
 msgid "Postcode"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:128
-#: metabrainz/supporter/forms.py:50
+#: frontend/js/src/forms/SignupCommercial.tsx:133
+#: metabrainz/supporter/forms.py:58
 msgid "You need to specify postcode."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:489
-#: metabrainz/supporter/forms.py:52
+#: frontend/js/src/forms/SignupCommercial.tsx:493
+#: metabrainz/supporter/forms.py:60
 msgid "Country"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:129
-#: metabrainz/supporter/forms.py:53
+#: frontend/js/src/forms/SignupCommercial.tsx:134
+#: metabrainz/supporter/forms.py:61
 msgid "You need to specify country."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:132
-#: metabrainz/supporter/forms.py:64
+#: frontend/js/src/forms/SignupCommercial.tsx:137
+#: metabrainz/supporter/forms.py:72
 msgid ""
 "Custom amount must be more than threshold amount for selected tier or "
 "equal to it!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:46 metabrainz/supporter/views.py:119
-#: metabrainz/supporter/views.py:220
+#: metabrainz/supporter/views.py:54
+msgid ""
+"The verification email could not be sent. Please request a new one from "
+"your profile."
+msgstr ""
+
+#: metabrainz/supporter/views.py:85 metabrainz/supporter/views.py:158
+#: metabrainz/supporter/views.py:260
 msgid "You are already a supporter."
 msgstr ""
 
-#: metabrainz/supporter/views.py:61
+#: metabrainz/supporter/views.py:100
 msgid "Can't find tier with a specified ID."
 msgstr ""
 
-#: metabrainz/supporter/views.py:127
+#: metabrainz/supporter/views.py:166
 msgid "You need to choose support tier before signing up!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:137
+#: metabrainz/supporter/views.py:176
 msgid "You need to choose existing tier before signing up!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:164
+#: metabrainz/supporter/views.py:204
 msgid ""
 "Thanks for becoming a supporter! Your application will be reviewed soon. "
 "We will send you updates via email."
 msgstr ""
 
-#: metabrainz/supporter/views.py:187
+#: metabrainz/supporter/views.py:228
 msgid ""
 "Thanks for signing up! Your application will be reviewed soon. We will "
 "send you updates via email."
 msgstr ""
 
-#: metabrainz/supporter/views.py:248
+#: metabrainz/supporter/views.py:288
 msgid "Thanks for becoming a supporter!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:274
+#: metabrainz/supporter/views.py:312
 msgid "Thanks for signing up! Please check your inbox to complete verification."
 msgstr ""
 
-#: metabrainz/supporter/views.py:302
+#: metabrainz/supporter/views.py:340
 msgid "Can't generate new token unless account is active."
 msgstr ""
 
@@ -434,7 +528,7 @@ msgstr ""
 msgid "Policies"
 msgstr ""
 
-#: metabrainz/templates/base.html:55 metabrainz/templates/index/gdpr.html:178
+#: metabrainz/templates/base.html:55
 #: metabrainz/templates/index/social-contract.html:3
 #: metabrainz/templates/index/social-contract.html:6
 #: metabrainz/templates/navbar.html:34
@@ -444,14 +538,15 @@ msgstr ""
 #: metabrainz/templates/base.html:56
 #: metabrainz/templates/index/code-of-conduct.html:3
 #: metabrainz/templates/index/code-of-conduct.html:16
-#: metabrainz/templates/index/gdpr.html:181 metabrainz/templates/navbar.html:35
+#: metabrainz/templates/navbar.html:35
 msgid "Code of Conduct"
 msgstr ""
 
+#: frontend/js/src/PrivacySummary.tsx:11
 #: frontend/js/src/forms/ConditionsModal.tsx:21
-#: metabrainz/templates/base.html:57 metabrainz/templates/index/gdpr.html:184
-#: metabrainz/templates/index/privacy.html:6
+#: metabrainz/templates/base.html:57 metabrainz/templates/index/privacy.html:6
 #: metabrainz/templates/navbar.html:36
+#: metabrainz/templates/users/privacy-summary.html:3
 msgid "Privacy Policy"
 msgstr ""
 
@@ -484,10 +579,7 @@ msgstr ""
 msgid "Supporters"
 msgstr ""
 
-#: frontend/js/src/forms/LoginUser.tsx:103
-#: frontend/js/src/forms/SignupCommercial.tsx:574
-#: frontend/js/src/forms/SignupNonCommercial.tsx:339
-#: frontend/js/src/forms/SignupUser.tsx:232 metabrainz/templates/base.html:73
+#: frontend/js/src/forms/LoginUser.tsx:103 metabrainz/templates/base.html:73
 #: metabrainz/templates/navbar.html:66 metabrainz/templates/users/login.html:3
 msgid "Sign in"
 msgstr ""
@@ -509,26 +601,26 @@ msgid "Contact us"
 msgstr ""
 
 #: metabrainz/templates/base.html:85
-#: metabrainz/templates/index/contact.html:105
+#: metabrainz/templates/index/contact.html:106
 msgid "Blog"
 msgstr ""
 
-#: metabrainz/templates/base.html:86 metabrainz/templates/index/contact.html:90
+#: metabrainz/templates/base.html:86 metabrainz/templates/index/contact.html:91
 msgid "Chat"
 msgstr ""
 
 #: metabrainz/templates/base.html:87
-#: metabrainz/templates/index/contact.html:106
+#: metabrainz/templates/index/contact.html:107
 msgid "Mastodon"
 msgstr ""
 
 #: metabrainz/templates/base.html:88
-#: metabrainz/templates/index/contact.html:107
+#: metabrainz/templates/index/contact.html:108
 msgid "Bluesky"
 msgstr ""
 
 #: metabrainz/templates/base.html:89
-#: metabrainz/templates/index/contact.html:108
+#: metabrainz/templates/index/contact.html:109
 msgid "Instagram"
 msgstr ""
 
@@ -584,15 +676,14 @@ msgstr ""
 msgid "Donate"
 msgstr ""
 
-#: frontend/js/src/forms/LoginUser.tsx:110
-#: frontend/js/src/forms/SignupCommercial.tsx:175
-#: frontend/js/src/forms/SignupCommercial.tsx:555
+#: frontend/js/src/forms/SignupCommercial.tsx:180
+#: frontend/js/src/forms/SignupCommercial.tsx:559
 #: frontend/js/src/forms/SignupNonCommercial.tsx:106
 #: frontend/js/src/forms/SignupNonCommercial.tsx:319
 #: metabrainz/templates/navbar.html:65
-#: metabrainz/templates/supporters/account-type.html:51
-#: metabrainz/templates/supporters/account-type.html:93
-#: metabrainz/templates/supporters/account-type.html:144
+#: metabrainz/templates/supporters/account-type.html:47
+#: metabrainz/templates/supporters/account-type.html:84
+#: metabrainz/templates/supporters/account-type.html:130
 #: metabrainz/templates/users/signup.html:3
 msgid "Sign up"
 msgstr ""
@@ -899,8 +990,430 @@ msgstr ""
 msgid "Introduction"
 msgstr ""
 
-#: metabrainz/templates/index/conflict-policy.html:55
+#: metabrainz/templates/index/conflict-policy.html:17
+msgid ""
+"Conflicts between people arise in open source projects constantly and the"
+" projects by the \n"
+"    MetaBrainz Foundation are no different. This policy aims to establish"
+" a clear and unambiguous \n"
+"    policy for reporting and addressing conflicts in our community. In "
+"this policy we aim to \n"
+"    establish a fair practice that balances the need for confidentiality "
+"and our desire for \n"
+"    transparency in our operations."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:25
+#, python-format
+msgid ""
+"Before you continue to read this policy, we encourage you to review our "
+"existing community policies \n"
+"    including our <a href=\"%(social_contract_url)s\">Social "
+"Contract</a>, \n"
+"    <a href=\"%(code_of_conduct_url)s\">the Code of Conduct</a>, \n"
+"    and our <a href=\"%(privacy_policy_url)s\">Privacy Policy</a>. These "
+"policies establish the norms and rules for \n"
+"    participation in our projects; these policies apply equally to the "
+"contractors of the MetaBrainz \n"
+"    Foundation and any participants in our projects."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:37
+msgid ""
+"This policy divides conflicts into two categories: Private and public. "
+"Private conflicts are conflicts \n"
+"    that involve *confidential* information regarding contributors, "
+"contractors or supporters. Otherwise, any conflicts \n"
+"    that do not involve confidential information are considered to be "
+"public conflicts. For instance, a \n"
+"    conflict between a contractor and the Executive Director (aka BDFL) "
+"that involves contractor pay is \n"
+"    considered a private conflict because pay rates are confidential "
+"information. A public conflict in edit \n"
+"    notes between two editors in our community does not involve "
+"confidential information and therefore should \n"
+"    be considered a public conflict."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:47
+msgid ""
+"When conflicts arise we aim to disclose as much information as possible "
+"about the conflict in a timely \n"
+"    fashion. When conflicts contain confidential matters we will aim to "
+"disclose as much information as \n"
+"    possible, while fully respecting the confidentiality of the people "
+"involved in the conflict. With any \n"
+"    private conflict we will aim to extract the relevant lessons for the "
+"team and community in an effort to \n"
+"    evolve our policies to prevent future conflicts. Should the involved "
+"parties disagree whether a conflict \n"
+"    is private or public, the question about the nature of the conflict "
+"will be presented for the next higher \n"
+"    level in the chain of command to decide. (e.g. if a community member "
+"and the community manager disagree on \n"
+"    a conflict being public or private, the Executive Director shall "
+"decide if the conflict is public or private)."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:58
 msgid "Reporting and Response"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:61
+msgid ""
+"We aim to not have conflict in our community, but we recognize that in "
+"reality conflicts will arise and we \n"
+"    must be prepared to address them in a fair manner. When conflicts "
+"arise, we prefer to have community or team \n"
+"    members resolve the conflicts among themselves, using our existing "
+"policies as guidelines for resolving the \n"
+"    conflict."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:69
+msgid ""
+"If you do not feel comfortable resolving a conflict on your own, you "
+"should feel free to report the conflict to \n"
+"    us. How you address the conflict depends on who is involved in the "
+"conflict and your comfort level. Please see \n"
+"    the detailed sections below on how and with whom to address your "
+"conflict. We aim to address conflicts as soon \n"
+"    as possible in an effort to prevent them from escalating "
+"unnecessarily."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:75
+msgid "Direct conflict resolution"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:78
+msgid ""
+"In direct conflict resolution, the involved parties will attempt to "
+"resolve the conflict themselves without \n"
+"   involving any MetaBrainz Foundation team member. You should aim to use"
+" direct resolution when the conflict does \n"
+"   not involve the violation of one of our policies or if the conflict is"
+" minor."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:84
+#, python-format
+msgid ""
+"For instance, if a user uses a rude tone, is disruptive or flagrantly "
+"ignores our project guidelines, we suggest \n"
+"    that you use direct conflict resolution to resolve the conflict. Some"
+" resources that might give you some suggestions \n"
+"    on how to go about resolving the conflict might be this <a "
+"href=\"%(conflict_resolution_primer_url)s\">\n"
+"    conflict resolution primer</a> and <a "
+"href=\"%(difficult_conversations_url)s\">how to\n"
+"    have difficult conversations at work</a>."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:93
+msgid "Informal reporting"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:96
+msgid ""
+"You may use informal reporting of a conflict if you aim to communicate a "
+"concern or incident without \n"
+"    seeking a corrective outcome. Informal reporting may also be an "
+"option if you have not been personally \n"
+"    victimized, but you’ve witnessed a violation of our policies or where"
+" you wish to maintain confidentiality \n"
+"    throughout the entire reporting process."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:103
+msgid ""
+"For editing in MusicBrainz you may informally report a user using the "
+"“Report this user for bad behavior” \n"
+"    link from the user’s profile. For reporting bad user behavior in "
+"other of our projects, please report them to our \n"
+"    community manager by mailing <span class=\"backemail\">gro.zniarbatem"
+"@reganam-ytinummoc</span> . For conflicts \n"
+"    that involve the community manager, report them by mailing <span "
+"class=\"backemail\">gro.zniarbatem@de</span> ."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:110
+msgid ""
+"Depending the the severity of the issue, repeated informal complaints may"
+" eventually require a formal response \n"
+"    from the MetaBrainz team. If an involved party requires anonymity, "
+"the conflict becomes a private conflict. If at \n"
+"    all possible minor issues should be resolved in a public forum in "
+"order for all people to witness and learn from \n"
+"    the issue at hand."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:116
+msgid "Formal complaint process"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:119
+msgid ""
+"All complaints about conflicts should be submitted via email. To whom a "
+"complaint should be mailed and who will \n"
+"    carry out the investigation will be described in the next section."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:124
+msgid "All complaint submissions to the Foundation should include the following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:128
+msgid ""
+"Contact info, if it is different than the email used to submit the "
+"conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:129
+msgid "Who was involved in the conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:130
+msgid "Where and when the incident happened"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:131
+msgid ""
+"A description of what happened -- ideally with links (e.g. chatlogs, edit"
+" notes) that outlines what \n"
+"         happened so that the persons evaluating the conflict may "
+"understand the issue at hand"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:133
+msgid ""
+"Any related pieces of information that provide more context on the "
+"conflict (e.g. links, screenshots)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:134
+msgid "An indication if this conflict is ongoing or not"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:139
+msgid "The investigation that follows aims to determine:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:143
+msgid "The nature and severity of the incident"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:144
+msgid ""
+"Whether or not the incident is considered a violation of MetaBrainz’ "
+"conduct policies or core values"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:145
+msgid ""
+"The amount of harm experienced by the person who submitted the complaint "
+"and the broader MetaBrainz community \n"
+"         as a result of the incident"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:147
+msgid ""
+"Whether there have been prior complaints against the individual or "
+"individuals reported"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:148
+msgid "Whether the incident is ongoing"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:152
+msgid ""
+"The following potential forms of resolution may apply to any team members"
+" involved in the conflict:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:155
+#: metabrainz/templates/index/conflict-policy.html:168
+msgid "Nothing (if it has been found no violation occurred)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:156
+msgid "Creating a plan to improve the performance"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:157
+msgid "Creating a negative performance evaluation"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:158
+msgid "Mediation, an intervention by a third party to resolve the conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:159
+msgid "Suspension or forced leave"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:160
+msgid "Termination of contract"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:164
+msgid ""
+"The following potential forms of resolution may apply to non team members"
+" involved in the conflict:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:169
+msgid "A reprimand, either public or private"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:170
+msgid "Suspension of the users’ account"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:171
+msgid "Deletion of the users’ account"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:172
+msgid ""
+"Removal of user privileges (e.g. if an auto editor commits a serious "
+"offence, they may lose their auto editor status)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:175
+msgid "Filing a complaint"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:178
+msgid ""
+"NOTE: For complaints not about MetaBrainz staff, please see the "
+"<em>Informal reporting</em> section above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:182
+msgid ""
+"If the complaint does not involve the Executive Director (ED), do the "
+"following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:186
+msgid ""
+"If team member has directly violated conduct policies or engaged in "
+"otherwise harmful behavior, a formal complaint should be filed."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:187
+msgid ""
+"Mail <span class=\"backemail\">gro.zniarbatem@de</span> and include the "
+"complaint information outlined above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:188
+msgid ""
+"You should expect a response within a working day acknowledging the "
+"complaint."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:189
+msgid ""
+"The complaint will be investigated by the ED, member(s) of the board of "
+"directors or a neutral third party."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:190
+msgid ""
+"Once the investigation has been completed, the ED, with the support of "
+"others involved in the investigation will respond. The \n"
+"        ED will respond to incidents no later than 7 working days after a"
+" complaint has been filed with either a resolution or an \n"
+"        explanation of why the process must be extended."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:196
+msgid "If a complaint involves the Executive Director, do the following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:200
+msgid ""
+"If the Executive Director has directly violated conduct policies or "
+"engaged in otherwise harmful behavior, \n"
+"        a formal complaint should be filed with the board of directors."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:202
+msgid ""
+"Mail <span class=\"backemail\">gro.zniarbatem@noituloser-tcilfnoc</span> "
+"and include the complaint information outlined above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:203
+msgid ""
+"You should get a response within 5 working days acknowledging the "
+"complaint."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:204
+msgid ""
+"The complaint will be investigated by the member(s) of the board of "
+"directors, the community manager, a neutral \n"
+"        third party or a combination thereof."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:206
+msgid ""
+"Once the investigation has been completed, the board, with the support of"
+" others involved in the investigation \n"
+"        will respond. The board will aim to respond to incidents no later"
+" than 15 working days after a complaint has been filed \n"
+"        with either a resolution or an explanation of why the process "
+"must be extended."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:211
+msgid "Confidentiality"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:214
+msgid ""
+"Confidentiality is an important aspect of conflict resolution and all of "
+"the conflicts brought to the attention of the foundation \n"
+"    will be evaluated with confidentiality in mind and acted upon "
+"accordingly."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:219
+msgid ""
+"We work hard to make all of the actions of the foundation as transparent "
+"and open as possible. In cases where we cannot \n"
+"    disclose all aspects of a conflict we will disclose that a conflict "
+"is or has occurred and we will attempt to disclose the \n"
+"    appropriate amount of information about the conflict while balancing "
+"the need for confidentiality and our desire to learn \n"
+"    from conflicts so that we as a foundation and community can learn "
+"from these conflicts and improve our policies to avoid the \n"
+"    conflicts in the future."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:227
+msgid ""
+"Any breaches of confidentiality will be treated as severe breaches of our"
+" conduct policies."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:230
+msgid "Retaliation"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:233
+msgid ""
+"We will not allow retaliation for any contractor or volunteer that files "
+"a complaint or is involved in an investigation. If you \n"
+"    believe that you are being treated negatively because of your "
+"involvement in a complaint please report this complaint directly \n"
+"    to the ED at <span class=\"backemail\">gro.zniarbatem@de</span> or "
+"the board at \n"
+"    <span class=\"backemail\">gro.zniarbatem@noituloser-tcilfnoc</span>."
 msgstr ""
 
 #: metabrainz/templates/index/contact.html:3
@@ -981,7 +1494,7 @@ msgstr ""
 msgid ""
 "We are currently evaluating our overall online advertising strategy. We "
 "are evaluating advertising, traffic optimization,\n"
-"    search engine optimization and software monitization technologies. If"
+"    search engine optimization and software monetization technologies. If"
 " you provide these professional services, please provide a detailed\n"
 "    deck of your comprehensive services to the following email address. "
 "<em>Please respect our other non-media teams and do not contact us \n"
@@ -1056,11 +1569,11 @@ msgstr ""
 #, python-format
 msgid ""
 "Please come ask your questions at our <a "
-"href=\"%(forums_url)s\">forums</a>! We would love to\n"
-"    answer any questions you may have."
+"href=\"%(forums_url)s\">forums</a>!\n"
+"    The community and the team will be more than happy to help you."
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:92
+#: metabrainz/templates/index/contact.html:93
 #, python-format
 msgid ""
 "The MetaBrainz/MusicBrainz/ListenBrainz team and community hang out\n"
@@ -1070,15 +1583,15 @@ msgid ""
 "    <a href=\"%(chatlogs_url)s\">chat log archives</a>."
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:101
+#: metabrainz/templates/index/contact.html:102
 msgid "Social media"
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:103
+#: metabrainz/templates/index/contact.html:104
 msgid "You can follow us on these social channels:"
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:112
+#: metabrainz/templates/index/contact.html:113
 msgid "Mailing address"
 msgstr ""
 
@@ -1091,33 +1604,349 @@ msgstr ""
 msgid "GDPR Compliance Statement"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:37
+#: metabrainz/templates/index/gdpr.html:10
+msgid ""
+"The General Data Protection Regulation is a complex EU regulation that "
+"stipulates many points for protecting private data of\n"
+"    users on the Internet. Even though this is an EU regulation, it has a"
+" worldwide impact due to the nature of the Internet.\n"
+"    The MetaBrainz Foundation with its collection of projects is also "
+"affected by this regulation. We’ve been learning and adapting\n"
+"    our sites to be compliant with the GDPR – sadly this regulation isn’t"
+" entirely black and white and there is an incredible\n"
+"    amount of room left for interpretation of these rules."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:17
+msgid ""
+"The good news is that this regulation is roughly in line with our "
+"established practices: We’ve always held private information\n"
+"    in a high regard and applied the sort of rules to ourselves as we "
+"wish to have our own private data treated. Luckily, this\n"
+"    makes our compliance effort considerably easier. We’ve made two "
+"significant changes to how we treat your data and also adopted\n"
+"    terminology as used in the GDPR in order to use the same languages "
+"that many other sites are now adopting. Please keep reading\n"
+"    to find out the exact details of what we are doing to comply."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:24
+#, python-format
+msgid ""
+"However, we do ask for your compassion and help in our process of "
+"complying with the GDPR. As we already mentioned, the GDPR is\n"
+"    a complex set of rules that are not fully clarified yet. We’ve taken "
+"action on the steps that are clear to us and we’re following\n"
+"    ongoing conversations on points that are in gray zones or unclear to "
+"us. We’ve made our best initial effort on compliance and\n"
+"    promise to keep working on it as the picture becomes more clear. If "
+"you believe that we could improve our compliance, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a> and let us know what we "
+"can do to improve. It would also help us if you\n"
+"    could provide concrete discussion or examples to help us understand "
+"and take action on your suggestion."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:33
+msgid ""
+"Finally, below are the key sections of the GDPR as we understand them and"
+" how they affect your data in our ecosystem. Where\n"
+"    possible, we provide links for deeper understanding, links for you to"
+" examine our relevant code and links to tickets to follow\n"
+"    the process of improving our compliance."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:38
 msgid "Right to be forgotten"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:77
+#: metabrainz/templates/index/gdpr.html:41
+msgid ""
+"Summary: <i>Provide the user with the ability to remove their private "
+"data from our services</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:44
+msgid ""
+"The most important aspect of the right to be forgotten is the ability to "
+"delete your account. Once you request for us to delete\n"
+"    your account, we will remove any personally identifying information "
+"you may have provided us from your account (name, email\n"
+"    address, gender, biography, URL, etc.). The visible name on your "
+"account will be changed to “Deleted User #####” and effectively\n"
+"    the account will no longer be identifiable as your account."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:50
+msgid ""
+"However, given the nature of our projects where we work on collaborative "
+"databases, your contributions that are not personally\n"
+"    identifying are valuable assets to our database and these "
+"contributions will not be removed from our databases. But we will\n"
+"    ensure that these contributions no longer contain personally "
+"identifying data."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:55
+#, python-format
+msgid ""
+"Our process of automatically deleting your accounts across the MetaBrainz"
+" ecosystem is not complete yet (see below for a set of\n"
+"    tickets where you can track our progress). If you would like to "
+"delete your accounts in the MetaBrainz ecosystem or mark a\n"
+"    donation that is currently public as a private donation, please <a "
+"href=\"%(contact_url)s\">contact us</a>\n"
+"    and we will address your request as soon as possible."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:62
+#: metabrainz/templates/index/gdpr.html:182
+msgid "Links:"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:66
+#, python-format
+msgid ""
+"<a href=\"%(editor_deletion_doc_url)s\">How we delete accounts\n"
+"       in MusicBrainz</a> (warning, geek content ahead!)"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:70
+msgid ""
+"Implement sitewide user account deletion in\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/MBS-9680\">MusicBrainz</a>,"
+"\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/AB-337\">AcousticBrainz</a>,"
+"\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/BB-260\">BookBrainz</a>,\n"
+"         <a href=\"https://tickets.metabrainz.org/browse/MEB-103\">the "
+"MetaBrainz Site</a>,\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/LB-354\">ListenBrainz</a>, "
+"and\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/CB-307\">CritiqueBrainz</a>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:80
 msgid "Restriction of processing"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:110
+#: metabrainz/templates/index/gdpr.html:83
+msgid ""
+"Summary: <i>To allow the user to control how their personally identifying"
+" data is being used.</i>"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:86
+msgid ""
+"Except for the ListenBrainz and AcousticBrainz projects, we do not "
+"process personally identifying data. Any personally\n"
+"    identifying data that our projects store is for the purpose of being "
+"able to contact you about your contributions to our database\n"
+"    (email address) or for voluntarily showing information about you to "
+"other users (biography, homepage, location, etc)."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:91
+#, python-format
+msgid ""
+"The ListenBrainz project differs in that the Listens (metadata about what"
+" music you have listened to) are stored on our servers\n"
+"    and <a href=\"%(listenbrainz_data_url)s\">made available to the "
+"public</a>. We believe Listens to be personally identifying\n"
+"    data and furthermore, we have goals of creating open source "
+"recommendation engines with this data, which involves processing the\n"
+"    user’s data. These two points are fundamental goals of the "
+"ListenBrainz project and we do not see a reasonable way to reach another"
+"\n"
+"    compromise position."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:99
+msgid ""
+"Because of this, we are going to require users to either acknowledge that"
+" we may process their Listen data or alternatively to\n"
+"    delete their account, including all of their Listens. Please note "
+"that if you decide to delete your ListenBrainz account, it may\n"
+"    take up to two weeks for all of your listens to no longer be included"
+" in our efforts to build a recommendation engine."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:104
+msgid ""
+"We have always made it clear that the data in ListenBrainz was to be "
+"public and that we plan to build new tools with your data, so\n"
+"    this should not come as a surprise to our users."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:108
+msgid ""
+"The AcousticBrainz project does not track who submits data to the "
+"database. If you create an account and use our data creation\n"
+"    tools (e.g. create a dataset or participate in a challenge) then we "
+"link your participation and the things that you create to\n"
+"    your account. If you choose to delete your account then we keep the "
+"non personally identifying data that you create, but anonymize\n"
+"    it so that it cannot be linked back to you."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:114
 msgid "Right to data portability / exporting your data"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:150
+#: metabrainz/templates/index/gdpr.html:117
+msgid ""
+"Summary: <i>You have the right to access/download the data we store about"
+" you</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:120
+msgid ""
+"Except for the ListenBrainz and AcousticBrainz projects, we do not store "
+"personally identifying data beyond the\n"
+"    information that is available in your public profile on each of our "
+"projects. Since this data is plainly available in your\n"
+"    profile we do not provide a means for you to export this data."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:125
+msgid "There are the following exceptions to this:"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:129
+msgid ""
+"<b>IP addresses</b>: If you visit one of our sites the IP address of your"
+" computer is stored in our web logs for 7 days\n"
+"        before our servers automatically delete them. This data is almost"
+" never used by anyone: the only time we look at the\n"
+"        IP addresses is if our sites are adversely impacted by the "
+"actions of some unknown users. In that case, we may investigate\n"
+"        the logs to identify the IP address that needs to be blocked in "
+"order to restore the stability of our service.\n"
+"        This data is not available to anyone but the contractors of the "
+"MetaBrainz Foundation and is not available to download\n"
+"        to anyone at all."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:137
+#, python-format
+msgid ""
+"<b>ListenBrainz Listen data</b>: Users may <a "
+"href=\"%(listenbrainz_export_url)s\">export their ListenBrainz Listen\n"
+"        data</a> directly from the site. The user Listen data is also "
+"included in the <a href=\"%(listenbrainz_data_url)s\">ListenBrainz\n"
+"        data dumps</a> that are available for public download."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:146
+msgid ""
+"All of the non personally identifying data, such as your metadata "
+"contributions, are publicly visible, available for download\n"
+"    and available via the project APIs. For details about this data, "
+"downloads and APIs please check the documentation for the\n"
+"    respective projects you are interested in."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:151
+#, python-format
+msgid ""
+"Anyone wishing to get a list of financial donations they have made to the"
+" MetaBrainz Foundation, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a> and provide your "
+"MusicBrainz editor name so that we can look up\n"
+"    your donations."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:157
 msgid "Right to rectification"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:165
+#: metabrainz/templates/index/gdpr.html:160
+msgid "Summary: <i>You have the right to correct your data</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:163
+msgid ""
+"All of our projects allow their users to update their personally "
+"identifying information in their profiles. Furthermore, most\n"
+"    of our projects allow the editing of their own metadata "
+"contributions. If you find that some of your data is incorrect, please\n"
+"    feel free to edit the data since we provide the tools to do so."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:168
+#, python-format
+msgid ""
+"If anyone who has made a financial donation to the MetaBrainz Foundation "
+"would like to make their donation private, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:173
 msgid "Right to be informed"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:188
+#: metabrainz/templates/index/gdpr.html:175
+msgid ""
+"Summary: <i>You have the right to be informed about how we use your data "
+"in plain English</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:178
+msgid ""
+"Our privacy policy, as well as other policies, have always been written "
+"by humans for human consumption. We abhor legalese and\n"
+"    not speaking in direct terms."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:186
+msgid "Social contract"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:189
+msgid "Code of conduct"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:192
+msgid "Privacy policy"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:196
 msgid "Right to access"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:198
-#: metabrainz/templates/index/privacy.html:166
+#: metabrainz/templates/index/gdpr.html:199
+msgid ""
+"Summary: <i>You have the right to access the data that we collect about "
+"you</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:202
+msgid ""
+"All of our projects make all of the data we collect on your behalf, "
+"privately identifying or not, available to you. The\n"
+"    only exception to this are the IP addresses we store for 7 days – see"
+" above for details."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:206
+#: metabrainz/templates/index/privacy.html:168
 msgid "Privacy/GDPR Representative"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:209
+#, python-format
+msgid ""
+"If you have any questions about our privacy policy, please <a "
+"href=\"%(contact_url)s\">contact us</a>. To report\n"
+"   any privacy problems, violations or leaks, our GDPR representative is "
+"our Interim Executive Director Nicolás Tamargo and for\n"
+"   privacy issues contact him at <strong><a "
+"href=\"mailto:gdpr@metabrainz.org\">gdpr@metabrainz.org</a></strong>."
 msgstr ""
 
 #: metabrainz/templates/index/index.html:6
@@ -1222,13 +2051,51 @@ msgid ""
 "      <a href=\"%(about_url)s\">about</a> page."
 msgstr ""
 
-#: frontend/js/src/forms/ConditionsModal.tsx:43
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:32
 #: metabrainz/templates/index/privacy.html:3
 msgid "Privacy"
 msgstr ""
 
 #: metabrainz/templates/index/privacy.html:8
 msgid "Summary"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:12
+msgid ""
+"You do not have to provide any personal data to be able to browse the "
+"contents of the databases published by MetaBrainz."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:15
+msgid ""
+"You do not have to provide any personally-identifying information if you "
+"choose not to."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:18
+msgid ""
+"We will never reveal your email address on MetaBrainz controlled web "
+"sites."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:22
+msgid ""
+"In order to get maximum value out of the MetaBrainz projects, you may "
+"want to create an account and log in. \n"
+"    Doing so grants you the ability to: edit the databases, contribute "
+"your own data, communicate with other users, and keep track \n"
+"    of recently released music from artists in your MusicBrainz "
+"collection. If you choose to create an account then the minimum we \n"
+"    ask is that you: choose a unique username and password, use a web "
+"browser that accepts \"session\" cookies, and provide a verified \n"
+"    email address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:29
+msgid ""
+"If you do not create an account (or are not logged in) you will not have "
+"access to the above listed features, however, you will \n"
+"    still have full access to browse and examine the databases."
 msgstr ""
 
 #: metabrainz/templates/index/privacy.html:33
@@ -1239,39 +2106,197 @@ msgstr ""
 msgid "Cookies"
 msgstr ""
 
+#: metabrainz/templates/index/privacy.html:37
+msgid "We use two cookies that contain sensitive information:"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:42
+msgid ""
+"<b>remember_login</b>: If you choose the \"Log in permanently\" option "
+"when logging in to one of our sites; the cookie will be used to \n"
+"      remember your login details."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:46
+msgid ""
+"<b>musicbrainz_server_session, session, or connect.sid</b>: If you are "
+"logged into one of our sites, your current session ID is stored in this "
+"cookie."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:51
+msgid ""
+"We may store dynamic preference information in other cookies, but these "
+"do not contain any sensitive information."
+msgstr ""
+
 #: metabrainz/templates/index/privacy.html:54
 msgid "Web and FTP access logs"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:57
+msgid ""
+"In a practice similar to other web sites (and APIs) we keep logs of all "
+"web requests made against our servers. These logs include: your IP\n"
+"    address, your browser's (or API client's) \"User-Agent\" string, and "
+"which page (or API endpoint) you requested with which parameters. "
+"Aggregate information about web and FTP traffic is\n"
+"    made available to the public via our site usage pages."
 msgstr ""
 
 #: metabrainz/templates/index/privacy.html:62
 msgid "Third-Party content"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:92
+#: metabrainz/templates/index/privacy.html:64
+msgid ""
+"Our projects' web pages may load some third-party content. Some, but "
+"possibly not all sites are listed below:"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:69
+#, python-format
+msgid ""
+"Cover art and other images: These are provided by the various cover art "
+"sites that have given MusicBrainz permission to do so and our own \n"
+"      <a href=\"%(caa_url)s\">Cover Art Archive</a>. This means that the "
+"relevant site will know (if they want to) your IP \n"
+"      address, User-Agent string, etc., and which MusicBrainz web page "
+"you were visiting (the one which included the cover art image)."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:75
+msgid ""
+"AcoustID: Our fingerprints tab loads fingerprint information from "
+"acoustid.org."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:78
+msgid ""
+"MTCaptcha: Our account creation page loads third party content in order "
+"to prevent spammers from creating accounts."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:83
+msgid ""
+"<i>The above information assumes that you are using \"normal\" web "
+"browser settings, whereby images are always loaded and HTTP referrer \n"
+"    information is always sent.</i>"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:88
+msgid ""
+"It is impractical to constantly modify this privacy policy when "
+"MetaBrainz projects change which third party content they utilize. We "
+"will \n"
+"    aim to use common sense, respect to our community and community "
+"review when adding more content from third party sites. We will also \n"
+"    periodically review our policy to ensure that it remains current."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:93
 msgid "Applicable to account holders"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:94
+#: metabrainz/templates/index/privacy.html:95
 msgid "Account creation"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:108
+#: metabrainz/templates/index/privacy.html:97
+msgid ""
+"When creating an account with a MetaBrainz project you need to pick a "
+"unique username and choose a password, the username you pick is the \n"
+"    only name associated with your account and will be what other "
+"MetaBrainz users know you as. You may optionally also tell us other \n"
+"    information about yourself that will be displayed to other MetaBrainz"
+" users and the public."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:103
+msgid ""
+"Additionally, in order to edit the databases you will need to provide a "
+"confirmed email address. This email address will be held in \n"
+"    confidence, the only method of revealing your email address to "
+"another user is if you choose to send a message to another \n"
+"    user and enable the option to \"reveal my email address\". Changing "
+"the email address stored with your account will require you to \n"
+"    verify the new address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:109
 msgid "Edits and Notes"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:114
+#: metabrainz/templates/index/privacy.html:111
+msgid ""
+"If you make any changes to a MetaBrainz project database, such as adding "
+"any data, the details of those changes will be visible to \n"
+"    other logged-in users and the change will be associated with your "
+"username."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:115
 msgid "Subscriptions on MusicBrainz"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:131
+#: metabrainz/templates/index/privacy.html:117
+msgid ""
+"As a logged-in user you can subscribe to one or more artists, labels, "
+"collections or other editors. The act of subscribing causes \n"
+"    any edits made to (or by in the case of another editor) those "
+"entities to be emailed to you. By default, other users can see your \n"
+"    list of subscriptions, however, you can opt out of this by editing "
+"the appropriate preference."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:123
+msgid ""
+"This does not provide \"perfect\" privacy though, in some cases it will "
+"be possible to infer information about the contents of your \n"
+"    subscription list even though you have disallowed others from viewing"
+" that list directly. This imperfection arises because various \n"
+"    parts of the system behave differently depending on whether or not an"
+" entity has any subscribers; also, the number of users \n"
+"    subscribed to each artist is available via the artist pages. In the "
+"most extreme (possibly contrived) example, imagine that all \n"
+"    users have their subscriptions set to \"public\", except for exactly "
+"one user whose list is \"private\". In that case, any discrepancy \n"
+"    for a given artist between the shown list of subscribers and the "
+"total number of subscribers must be down to that one user. Thus, \n"
+"    you can infer what artists are on that user's list."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:132
 msgid "Third-party sites"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:145
-msgid "MetaBrainz donors"
+#: metabrainz/templates/index/privacy.html:134
+#, python-format
+msgid ""
+"Our code reviews are done on GitHub, which is not under the control of "
+"MetaBrainz. Participating in code reviews or other\n"
+"    tasks carried out on GitHub are subject to <a "
+"href=\"%(github_url)s\">GitHub's privacy policy</a>."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:140
+#, python-format
+msgid ""
+"Our translations platform is provided and hosted by Weblate, which has a "
+"data processing agreement with MetaBrainz.\n"
+"    Participating in translations is subject to <a "
+"href=\"%(weblate_url)s\">dedicated legal terms</a>.\n"
+"    Any translations you make will be submitted to our Git repositories "
+"and publicly associated with your username;\n"
+"    if you so choose, you can also publicly associate them with your own "
+"verified email address."
 msgstr ""
 
 #: metabrainz/templates/index/privacy.html:147
+msgid "MetaBrainz donors"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:149
 msgid ""
 "When you make a donation to the MetaBrainz Foundation, we are legally\n"
 "    required to collect your personal information and keep it in our "
@@ -1281,7 +2306,7 @@ msgid ""
 "    information to anyone else, ever."
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:153
+#: metabrainz/templates/index/privacy.html:155
 msgid ""
 "We believe in transparent finances, which means that we list all "
 "donations\n"
@@ -1291,11 +2316,34 @@ msgid ""
 "process."
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:158
+#: metabrainz/templates/index/privacy.html:160
 msgid "Exceptions"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:598
+#: metabrainz/templates/index/privacy.html:162
+msgid ""
+"<i><b>Please note</b>: Reasonable exceptions may apply to the above "
+"policy, for example to comply with applicable laws.\n"
+"    Also, members of the MetaBrainz team and other personnel contracted "
+"to provide services to MetaBrainz may have access to\n"
+"    our infrastructure and could therefore view any information contained"
+" therein. However all personnel are contractually bound\n"
+"    by non-disclosure clauses which prevent them from making any such "
+"information available to others."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:171
+#, python-format
+msgid ""
+"If you have any questions about our GDPR statement, please <a "
+"href=\"%(contact_url)s\">contact us</a>. To report\n"
+"   any privacy problems, violations or leaks, our GDPR representative is "
+"our Interim Executive Director Nicolás Tamargo and for\n"
+"   privacy issues contact him at <strong><a "
+"href=\"mailto:gdpr@metabrainz.org\">gdpr@metabrainz.org</a></strong>."
+msgstr ""
+
+#: frontend/js/src/Profile.tsx:603
 #: frontend/js/src/forms/ProfileChangePassword.tsx:22
 #: frontend/js/src/forms/ProfileChangePassword.tsx:111
 #: metabrainz/templates/index/profile-change-password.html:3
@@ -1539,6 +2587,11 @@ msgstr ""
 
 #: metabrainz/templates/index/team.html:26
 msgid "He lives on in our hearts and in open source."
+msgstr ""
+
+#: metabrainz/templates/index/team.html:29
+#: metabrainz/templates/index/team.html:315
+msgid "you’re welcome to try"
 msgstr ""
 
 #: metabrainz/templates/index/team.html:39
@@ -2036,8 +3089,10 @@ msgstr ""
 
 #: metabrainz/templates/payments/donate.html:146
 msgid ""
-"Due to the increased unreliability of the US Postal Service we have "
-"stopped accepting paper checks. Sorry!"
+"Due to the increased unreliability of the US Postal Service and the "
+"relatively large fees involved, we ask you to only send a paper check if "
+"it is the only possible option. Due to the fees, we will not cash checks "
+"for less than $25."
 msgstr ""
 
 #: metabrainz/templates/payments/donate.html:241
@@ -2921,8 +3976,8 @@ msgid "Monthly balance sheets"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:520
-#: frontend/js/src/forms/SignupCommercial.tsx:175
-#: frontend/js/src/forms/SignupCommercial.tsx:554
+#: frontend/js/src/forms/SignupCommercial.tsx:180
+#: frontend/js/src/forms/SignupCommercial.tsx:558
 #: frontend/js/src/forms/SignupNonCommercial.tsx:106
 #: frontend/js/src/forms/SignupNonCommercial.tsx:318
 #: metabrainz/templates/supporters/account-type.html:3
@@ -2943,6 +3998,7 @@ msgid "Non-commercial / Personal"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:235
+#: frontend/js/src/forms/SignupNonCommercial.tsx:107
 #: frontend/js/src/forms/SignupNonCommercial.tsx:151
 #: metabrainz/templates/supporters/account-type.html:42
 msgid "Non-commercial"
@@ -2956,55 +4012,45 @@ msgstr ""
 msgid "Personal or university assignment user."
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:48
-#: metabrainz/templates/supporters/account-type.html:90
-#: metabrainz/templates/supporters/account-type.html:141
-msgid "Upgrade"
-msgstr ""
-
 #: frontend/js/src/Profile.tsx:235
-#: frontend/js/src/forms/SignupCommercial.tsx:176
-#: frontend/js/src/forms/SignupCommercial.tsx:228
-#: metabrainz/templates/supporters/account-type.html:61
+#: frontend/js/src/forms/SignupCommercial.tsx:181
+#: frontend/js/src/forms/SignupCommercial.tsx:233
+#: metabrainz/templates/supporters/account-type.html:56
 msgid "Commercial"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:83
-#: metabrainz/templates/supporters/account-type.html:135
+#: metabrainz/templates/supporters/account-type.html:78
+#: metabrainz/templates/supporters/account-type.html:125
 #, python-format
 msgid "$%(tier_price)s/month and up"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:87
-#: metabrainz/templates/supporters/account-type.html:138
+#: metabrainz/templates/supporters/account-type.html:82
+#: metabrainz/templates/supporters/account-type.html:128
 msgid "More info"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:104
+#: metabrainz/templates/supporters/account-type.html:94
 msgid "View all tiers"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:112
+#: metabrainz/templates/supporters/account-type.html:102
 msgid "Some of our Unicorn members"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:123
+#: metabrainz/templates/supporters/account-type.html:113
 msgid "See all our supporters"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:151
+#: metabrainz/templates/supporters/account-type.html:136
 msgid "View featured tiers"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:158
+#: metabrainz/templates/supporters/account-type.html:143
 #, python-format
 msgid ""
 "If you are not sure which tier to pick, please\n"
 "      <a href=\"%(contact_url)s\">contact us</a>."
-msgstr ""
-
-#: metabrainz/templates/supporters/account-type.html:166
-msgid "Back to Profile"
 msgstr ""
 
 #: metabrainz/templates/supporters/bad-standing.html:3
@@ -3066,9 +4112,9 @@ msgid "Forgot your username"
 msgstr ""
 
 #: frontend/js/src/forms/ResetPassword.tsx:79
-#: frontend/js/src/forms/SignupCommercial.tsx:320
+#: frontend/js/src/forms/SignupCommercial.tsx:325
 #: frontend/js/src/forms/SignupNonCommercial.tsx:227
-#: frontend/js/src/forms/SignupUser.tsx:169
+#: frontend/js/src/forms/SignupUser.tsx:175
 #: metabrainz/templates/users/reauthenticate.html:3
 #: metabrainz/templates/users/reauthenticate.html:6
 msgid "Confirm Password"
@@ -3078,17 +4124,22 @@ msgstr ""
 msgid "Please re-enter your password to continue."
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:108
+#: frontend/js/src/ProfileDelete.tsx:110
 #: frontend/js/src/forms/DeleteApplication.tsx:53
 #: frontend/js/src/forms/OAuthPrompt.tsx:54
 #: frontend/js/src/forms/ProfileChangePassword.tsx:104
 #: frontend/js/src/forms/ProfileEdit.tsx:105
-#: metabrainz/templates/users/reauthenticate.html:23
+#: metabrainz/templates/users/reauthenticate.html:28
 msgid "Cancel"
 msgstr ""
 
-#: metabrainz/templates/users/reauthenticate.html:24
+#: metabrainz/templates/users/reauthenticate.html:29
 msgid "Continue"
+msgstr ""
+
+#: frontend/js/src/forms/utils.tsx:202
+#: metabrainz/templates/users/reauthenticate.html:40
+msgid "Password must not exceed 72 bytes."
 msgstr ""
 
 #: frontend/js/src/forms/ResetPassword.tsx:27
@@ -3096,38 +4147,38 @@ msgstr ""
 msgid "Reset your password"
 msgstr ""
 
-#: frontend/js/src/hooks/useEmailValidation.ts:41 metabrainz/user/forms.py:15
+#: frontend/js/src/hooks/useEmailValidation.ts:41 metabrainz/user/forms.py:16
 msgid "Registration from this email domain is not allowed."
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:50
 #: frontend/js/src/forms/LostPassword.tsx:45
-#: frontend/js/src/forms/SignupCommercial.tsx:270
+#: frontend/js/src/forms/SignupCommercial.tsx:275
 #: frontend/js/src/forms/SignupNonCommercial.tsx:175
-#: frontend/js/src/forms/SignupUser.tsx:114 metabrainz/user/forms.py:20
-#: metabrainz/user/forms.py:45 metabrainz/user/forms.py:62
+#: frontend/js/src/forms/SignupUser.tsx:120 metabrainz/user/forms.py:22
+#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:75
 msgid "Username"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:42
 #: frontend/js/src/forms/LostPassword.tsx:37
-#: frontend/js/src/forms/SignupCommercial.tsx:153
+#: frontend/js/src/forms/SignupCommercial.tsx:158
 #: frontend/js/src/forms/SignupNonCommercial.tsx:84
-#: frontend/js/src/forms/SignupUser.tsx:67 metabrainz/user/forms.py:21
-#: metabrainz/user/forms.py:45 metabrainz/user/forms.py:62
+#: frontend/js/src/forms/SignupUser.tsx:73 metabrainz/user/forms.py:26
+#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:75
 msgid "Username is required!"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:63
 #: frontend/js/src/forms/ResetPassword.tsx:72
-#: frontend/js/src/forms/SignupCommercial.tsx:308
+#: frontend/js/src/forms/SignupCommercial.tsx:313
 #: frontend/js/src/forms/SignupNonCommercial.tsx:214
-#: frontend/js/src/forms/SignupUser.tsx:157 metabrainz/user/forms.py:46
-#: metabrainz/user/forms.py:52
+#: frontend/js/src/forms/SignupUser.tsx:163 metabrainz/user/forms.py:53
+#: metabrainz/user/forms.py:62
 msgid "Password"
 msgstr ""
 
-#: frontend/js/src/forms/LoginUser.tsx:76 metabrainz/user/forms.py:47
+#: frontend/js/src/forms/LoginUser.tsx:76 metabrainz/user/forms.py:57
 msgid "Remember me"
 msgstr ""
 
@@ -3139,11 +4190,11 @@ msgstr ""
 msgid "Username contains invalid or invisible characters."
 msgstr ""
 
-#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:181
+#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:220
 msgid "Hide password"
 msgstr ""
 
-#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:181
+#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:220
 msgid "Show password"
 msgstr ""
 
@@ -3200,11 +4251,11 @@ msgstr ""
 msgid "Revoke access"
 msgstr ""
 
-#: frontend/js/src/OAuthError.tsx:17
+#: frontend/js/src/OAuthError.tsx:18
 msgid "OAuth2 Error"
 msgstr ""
 
-#: frontend/js/src/OAuthError.tsx:18
+#: frontend/js/src/OAuthError.tsx:19
 msgid "An error occurred during OAuth authentication process."
 msgstr ""
 
@@ -3234,8 +4285,8 @@ msgstr ""
 
 #: frontend/js/src/Profile.tsx:109
 msgid ""
-"Are you sure you want to generate new access token? Current token will be"
-" revoked!"
+"Are you sure you want to generate a new access token? The current token "
+"will be revoked!"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:118
@@ -3350,8 +4401,8 @@ msgid "Contact Information"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:310 frontend/js/src/forms/ProfileEdit.tsx:70
-#: frontend/js/src/forms/SignupCommercial.tsx:284
-#: frontend/js/src/forms/SignupCommercial.tsx:333
+#: frontend/js/src/forms/SignupCommercial.tsx:289
+#: frontend/js/src/forms/SignupCommercial.tsx:338
 #: frontend/js/src/forms/SignupNonCommercial.tsx:189
 #: frontend/js/src/forms/SignupNonCommercial.tsx:241
 msgid "Contact name"
@@ -3466,7 +4517,7 @@ msgstr ""
 msgid "Once you delete your account, there is no going back. Please be certain."
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:550 frontend/js/src/ProfileDelete.tsx:105
+#: frontend/js/src/Profile.tsx:550 frontend/js/src/ProfileDelete.tsx:107
 msgid "Delete My Account"
 msgstr ""
 
@@ -3478,39 +4529,39 @@ msgstr ""
 msgid "Need to delete your account?"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:574
+#: frontend/js/src/Profile.tsx:575
 msgid ""
 "Deletion of supporter accounts requires manual review. Please contact us "
-"at"
+"at <email />."
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:594
+#: frontend/js/src/Profile.tsx:599
 msgid "Security"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:626
+#: frontend/js/src/Profile.tsx:631
 msgid "MetaBrainz Applications"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:630
+#: frontend/js/src/Profile.tsx:635
 msgid ""
 "With your MetaBrainz account, you can access every project in the "
 "MetaBrainz family:"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:643
+#: frontend/js/src/Profile.tsx:648
 msgid "The open-source music encyclopedia"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:655
+#: frontend/js/src/Profile.tsx:660
 msgid "Track, visualise and share the music you listen to"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:667
+#: frontend/js/src/Profile.tsx:672
 msgid "The open-source book database"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:679
+#: frontend/js/src/Profile.tsx:684
 msgid "Creative Commons licensed reviews"
 msgstr ""
 
@@ -3533,7 +4584,7 @@ msgid "Permanently remove all your account information"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:64
-msgid "Revoke all your API tokens and access"
+msgid "Revoke all your tokens and access to the replication API"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:65
@@ -3545,14 +4596,16 @@ msgid "Log you out of all MetaBrainz services"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:70
-msgid "Your username will be reserved and cannot be reused."
+msgid ""
+"Your username will be reserved and cannot be reused without the "
+"intervention of an administrator."
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:82
+#: frontend/js/src/ProfileDelete.tsx:84
 msgid "To confirm, type your username '<username />' below:"
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:105
+#: frontend/js/src/ProfileDelete.tsx:107
 msgid "Deleting..."
 msgstr ""
 
@@ -3564,64 +4617,7 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: frontend/js/src/forms/ConditionsModal.tsx:23
-msgid "Licensing"
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:25
-msgid ""
-"Any contributions you make to any MetaBrainz service will be released "
-"into the Public Domain and/or licensed under a Creative Commons by-nc-sa "
-"license. Furthermore, you give the MetaBrainz Foundation the right to "
-"license this data for commercial use."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:30
-msgid "Please read our <licenseLink>license page</licenseLink> for more details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:45
-msgid ""
-"MetaBrainz strongly believes in the privacy of its users. Any personal "
-"information you choose to provide will not be sold or shared with anyone "
-"else."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:50
-msgid ""
-"Please read our <privacyLink>privacy policy</privacyLink> for more "
-"details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:59
-msgid "GDPR compliance"
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:61
-msgid ""
-"You may remove your personal information from our services anytime by "
-"deleting your account."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:66
-msgid ""
-"Please read our <gdprLink>GDPR compliance statement</gdprLink> for more "
-"details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:78
-msgid ""
-"Creating an account on MetaBrainz will give you access to all of our "
-"projects, such as MusicBrainz, ListenBrainz, BookBrainz, and more."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:82
-msgid ""
-"We create a placeholder account for all the MetaBrainz projects when you "
-"sign up, and you are one log-in away from activating them."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:91
+#: frontend/js/src/forms/ConditionsModal.tsx:29
 msgid "Sounds good"
 msgstr ""
 
@@ -3707,8 +4703,8 @@ msgstr ""
 msgid "Forgot your password?"
 msgstr ""
 
-#: frontend/js/src/forms/LoginUser.tsx:109
-msgid "Don't have an account?"
+#: frontend/js/src/forms/LoginUser.tsx:110
+msgid "Don't have an account? <signupLink>Sign up</signupLink>"
 msgstr ""
 
 #: frontend/js/src/forms/LostPassword.tsx:38
@@ -3737,15 +4733,72 @@ msgstr ""
 msgid "Allow access"
 msgstr ""
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:71
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:10
+msgid "Licensing"
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:12
+msgid ""
+"Any contributions you make to any MetaBrainz service will be released "
+"into the Public Domain and/or licensed under a Creative Commons by-nc-sa "
+"license. Furthermore, you give the MetaBrainz Foundation the right to "
+"license this data for commercial use."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:17
+msgid "Please read our <licenseLink>license page</licenseLink> for more details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:34
+msgid ""
+"MetaBrainz strongly believes in the privacy of its users. Any personal "
+"information you choose to provide will not be sold or shared with anyone "
+"else."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:39
+msgid ""
+"Please read our <privacyLink>privacy policy</privacyLink> for more "
+"details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:50
+msgid "GDPR compliance"
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:52
+msgid ""
+"You may remove your personal information from our services anytime by "
+"deleting your account."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:57
+msgid ""
+"Please read our <gdprLink>GDPR compliance statement</gdprLink> for more "
+"details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:71
+msgid ""
+"Creating an account on MetaBrainz will give you access to all of our "
+"projects, such as MusicBrainz, ListenBrainz, BookBrainz, and more."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:75
+msgid ""
+"We create a placeholder account for all the MetaBrainz projects when you "
+"sign up, and you are one log-in away from activating them."
+msgstr ""
+
+#: frontend/js/src/forms/ProfileChangePassword.tsx:70
 msgid "Current Password"
 msgstr ""
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:80
+#: frontend/js/src/forms/ProfileChangePassword.tsx:79
 msgid "New Password"
 msgstr ""
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:89
+#: frontend/js/src/forms/ProfileChangePassword.tsx:88
 msgid "Confirm New Password"
 msgstr ""
 
@@ -3757,190 +4810,180 @@ msgstr ""
 msgid "Reset Password"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:38
-msgid "If you would like to support us with more than $"
+#: frontend/js/src/forms/SignupCommercial.tsx:40
+msgid ""
+"If you would like to support us with more than ${{minPledge}}, please "
+"enter the actual amount here:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:39
-msgid ", please enter the actual amount here:"
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:144
+#: frontend/js/src/forms/SignupCommercial.tsx:149
 #: frontend/js/src/forms/SignupNonCommercial.tsx:75
-#: frontend/js/src/forms/SignupUser.tsx:87
+#: frontend/js/src/forms/SignupUser.tsx:93
 msgid "Captcha is required!"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:179
+#: frontend/js/src/forms/SignupCommercial.tsx:184
 #: frontend/js/src/forms/SignupNonCommercial.tsx:110
 #: frontend/js/src/forms/SignupUser.tsx:46
 msgid "Access all MetaBrainz projects"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:182
+#: frontend/js/src/forms/SignupCommercial.tsx:187
 msgid "Note:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:184
+#: frontend/js/src/forms/SignupCommercial.tsx:189
 msgid ""
 "Signing up for any tier other than the <italic>Stealth startup</italic> "
 "tier will publicly list your company on this web site. However, we will "
 "not publish any of your private details."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:221
+#: frontend/js/src/forms/SignupCommercial.tsx:226
 #: frontend/js/src/forms/SignupNonCommercial.tsx:145
 msgid "Account type"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:234
+#: frontend/js/src/forms/SignupCommercial.tsx:239
 msgid "Selected tier"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:242
-msgid "month and up"
+#: frontend/js/src/forms/SignupCommercial.tsx:247
+msgid "${{tierPrice}}/month and up"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:250
+#: frontend/js/src/forms/SignupCommercial.tsx:255
 msgid "Change account type or tier"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:261
+#: frontend/js/src/forms/SignupCommercial.tsx:266
 #: frontend/js/src/forms/SignupNonCommercial.tsx:166
 msgid "Your account:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:271
+#: frontend/js/src/forms/SignupCommercial.tsx:276
 #: frontend/js/src/forms/SignupNonCommercial.tsx:176
-#: frontend/js/src/forms/SignupUser.tsx:114
+#: frontend/js/src/forms/SignupUser.tsx:120
 msgid "(public)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:291
+#: frontend/js/src/forms/SignupCommercial.tsx:296
 #: frontend/js/src/forms/SignupNonCommercial.tsx:196
-#: frontend/js/src/forms/SignupUser.tsx:127
+#: frontend/js/src/forms/SignupUser.tsx:133
 msgid "E-mail address"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:295
+#: frontend/js/src/forms/SignupCommercial.tsx:300
 #: frontend/js/src/forms/SignupNonCommercial.tsx:200
-#: frontend/js/src/forms/SignupUser.tsx:131
+#: frontend/js/src/forms/SignupUser.tsx:137
 msgid "(checking...)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:314
+#: frontend/js/src/forms/SignupCommercial.tsx:319
 #: frontend/js/src/forms/SignupNonCommercial.tsx:220
-#: frontend/js/src/forms/SignupUser.tsx:163
+#: frontend/js/src/forms/SignupUser.tsx:169
 msgid "Must be at least 8 characters"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:348
+#: frontend/js/src/forms/SignupCommercial.tsx:353
 msgid ""
 "If you don't have an organization name, you probably want to become a "
 "supporter as a <nonCommercialLink>Non-commercial / "
 "Personal</nonCommercialLink> supporter."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:358
+#: frontend/js/src/forms/SignupCommercial.tsx:363
 msgid ""
 "If you don't have an organization name, you probably want to sign up as a"
 " <nonCommercialLink>Non-commercial / Personal</nonCommercialLink> user."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:378
+#: frontend/js/src/forms/SignupCommercial.tsx:383
 msgid ""
 "Please tell us a little about your company and whether you plan to use "
 "our <apiLink>API</apiLink> or to <hostLink>host your own copy</hostLink> "
 "of the data."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:404
+#: frontend/js/src/forms/SignupCommercial.tsx:408
 msgid "Logo URL"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:405
+#: frontend/js/src/forms/SignupCommercial.tsx:409
 msgid "(preferably in SVG format)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:408
+#: frontend/js/src/forms/SignupCommercial.tsx:412
 msgid ""
 "Image should be about 250 pixels wide on a white or transparent "
 "background. We will host it on our site."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:421
+#: frontend/js/src/forms/SignupCommercial.tsx:425
 msgid ""
 "URL to where developers can use your APIs using MusicBrainz IDs, if "
-"available.."
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:430
-msgid "Your project"
+"available."
 msgstr ""
 
 #: frontend/js/src/forms/SignupCommercial.tsx:434
+msgid "Your project"
+msgstr ""
+
+#: frontend/js/src/forms/SignupCommercial.tsx:438
 #: frontend/js/src/forms/SignupNonCommercial.tsx:261
 msgid "(max 150 characters)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:451
+#: frontend/js/src/forms/SignupCommercial.tsx:455
 msgid "Billing address"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:502
+#: frontend/js/src/forms/SignupCommercial.tsx:506
 msgid ""
 "I agree to support the MetaBrainz Foundation when my organization is able"
 " to do so."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:507
+#: frontend/js/src/forms/SignupCommercial.tsx:511
+#: frontend/js/src/forms/SignupNonCommercial.tsx:284
 msgid ""
-"I also agree that if I generate a Live Data Feed access token, that I "
-"treat my access token as a secret and will not share this token publicly "
-"or commit it to a source code repository."
+"I also agree that if I generate a Live Data Feed access token, then I "
+"will treat my access token as a secret and will not share this token "
+"publicly or commit it to a source code repository."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:515
+#: frontend/js/src/forms/SignupCommercial.tsx:519
 msgid ""
 "The following information will be shown publicly: organization name, "
 "logo, website and API URLs, data usage description."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:520
+#: frontend/js/src/forms/SignupCommercial.tsx:524
 msgid ""
 "We'll send you more details about payment process once your application "
 "is approved."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:552
+#: frontend/js/src/forms/SignupCommercial.tsx:556
 #: frontend/js/src/forms/SignupNonCommercial.tsx:316
-#: frontend/js/src/forms/SignupUser.tsx:224
+#: frontend/js/src/forms/SignupUser.tsx:230
 msgid "Validating..."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:564
+#: frontend/js/src/forms/SignupCommercial.tsx:568
 #: frontend/js/src/forms/SignupNonCommercial.tsx:329
 msgid "Back to profile"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:569
-#: frontend/js/src/forms/SignupNonCommercial.tsx:334
-msgid "Not a supporter?"
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:570
+#: frontend/js/src/forms/SignupCommercial.tsx:574
 #: frontend/js/src/forms/SignupNonCommercial.tsx:335
-msgid "Create a user account"
+msgid "Not a supporter? <signupLink>Create a user account</signupLink>"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:573
-#: frontend/js/src/forms/SignupNonCommercial.tsx:338
-#: frontend/js/src/forms/SignupUser.tsx:231
-msgid "Already have an account?"
-msgstr ""
-
-#: frontend/js/src/forms/SignupNonCommercial.tsx:107
-msgid "non-commercial"
+#: frontend/js/src/forms/SignupCommercial.tsx:583
+#: frontend/js/src/forms/SignupNonCommercial.tsx:344
+#: frontend/js/src/forms/SignupUser.tsx:238
+msgid "Already have an account? <loginLink>Sign in</loginLink>"
 msgstr ""
 
 #: frontend/js/src/forms/SignupNonCommercial.tsx:113
@@ -3968,46 +5011,40 @@ msgid ""
 "income per year) or personal uses only."
 msgstr ""
 
-#: frontend/js/src/forms/SignupNonCommercial.tsx:284
-msgid ""
-"I also agree that if I generate a Live Data Feed access token, then I "
-"will treat my access token as a secret and will not share this token "
-"publicly or commit it to a source code repository."
-msgstr ""
-
 #: frontend/js/src/forms/SignupUser.tsx:43
 msgid "Create your account"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:50
-msgid "Registration started by"
+#: frontend/js/src/forms/SignupUser.tsx:51
+msgid "Registration started by <client />"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:69
+#: frontend/js/src/forms/SignupUser.tsx:75
+#: frontend/js/src/hooks/useEmailValidation.ts:82
 msgid "Invalid email address."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:150
+#: frontend/js/src/forms/SignupUser.tsx:156
 msgid ""
 "This username and email were provided by the app that started "
 "registration. You can change them later from MetaBrainz settings."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:182
+#: frontend/js/src/forms/SignupUser.tsx:188
 msgid ""
 "I accept that my contributions will be released into the public domain or"
 " licensed for use."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:191
+#: frontend/js/src/forms/SignupUser.tsx:197
 msgid "We will never share your personal information."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:200
+#: frontend/js/src/forms/SignupUser.tsx:206
 msgid "Click here to read more"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:224
+#: frontend/js/src/forms/SignupUser.tsx:230
 msgid "Create account"
 msgstr ""
 
@@ -4019,6 +5056,107 @@ msgstr ""
 msgid "Email validation failed"
 msgstr ""
 
-#: frontend/js/src/hooks/useEmailValidation.ts:82
-msgid "Invalid email address"
-msgstr ""
+#~ msgid "You need to specify website of the organization."
+#~ msgstr ""
+
+#~ msgid ""
+#~ "We are currently evaluating our overall"
+#~ " online advertising strategy. We are "
+#~ "evaluating advertising, traffic optimization,\n"
+#~ ""
+#~ "    search engine optimization and "
+#~ "software monitization technologies. If you "
+#~ "provide these professional services, please"
+#~ " provide a detailed\n"
+#~ "    deck of your comprehensive services"
+#~ " to the following email address. "
+#~ "<em>Please respect our other non-media"
+#~ " teams and do not contact us \n"
+#~ "    regarding these services on any "
+#~ "other of our email addresses. We "
+#~ "will disregard the entirety of your "
+#~ "submissions if you contact us any "
+#~ "other way!</em>"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Please come ask your questions at "
+#~ "our <a href=\"%(forums_url)s\">forums</a>! We "
+#~ "would love to\n"
+#~ "    answer any questions you may have."
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Due to the increased unreliability of"
+#~ " the US Postal Service we have "
+#~ "stopped accepting paper checks. Sorry!"
+#~ msgstr ""
+
+#~ msgid "Upgrade"
+#~ msgstr ""
+
+#~ msgid "Back to Profile"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Are you sure you want to generate"
+#~ " new access token? Current token will"
+#~ " be revoked!"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Deletion of supporter accounts requires "
+#~ "manual review. Please contact us at"
+#~ msgstr ""
+
+#~ msgid "Revoke all your API tokens and access"
+#~ msgstr ""
+
+#~ msgid "Your username will be reserved and cannot be reused."
+#~ msgstr ""
+
+#~ msgid "Don't have an account?"
+#~ msgstr ""
+
+#~ msgid "If you would like to support us with more than $"
+#~ msgstr ""
+
+#~ msgid ", please enter the actual amount here:"
+#~ msgstr ""
+
+#~ msgid "month and up"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "URL to where developers can use "
+#~ "your APIs using MusicBrainz IDs, if "
+#~ "available.."
+#~ msgstr ""
+
+#~ msgid ""
+#~ "I also agree that if I generate"
+#~ " a Live Data Feed access token, "
+#~ "that I treat my access token as"
+#~ " a secret and will not share "
+#~ "this token publicly or commit it "
+#~ "to a source code repository."
+#~ msgstr ""
+
+#~ msgid "Not a supporter?"
+#~ msgstr ""
+
+#~ msgid "Create a user account"
+#~ msgstr ""
+
+#~ msgid "Already have an account?"
+#~ msgstr ""
+
+#~ msgid "non-commercial"
+#~ msgstr ""
+
+#~ msgid "Registration started by"
+#~ msgstr ""
+
+#~ msgid "Invalid email address"
+#~ msgstr ""
+

--- a/metabrainz/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/metabrainz/translations/pt_BR/LC_MESSAGES/messages.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-07-25 16:21+0200\n"
+"POT-Creation-Date: 2026-09-08 11:18+0200\n"
 "PO-Revision-Date: 2026-06-12 00:54+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: pt_BR\n"
@@ -27,162 +27,247 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.18.0\n"
 
-#: metabrainz/index/forms.py:46
+#: metabrainz/errors.py:24
+msgid "Authorization was declined."
+msgstr ""
+
+#: metabrainz/errors.py:25
+msgid "The authorization request was invalid."
+msgstr ""
+
+#: metabrainz/errors.py:26
+msgid "The application could not be authenticated."
+msgstr ""
+
+#: metabrainz/errors.py:27
+msgid "This application is not allowed to request authorization."
+msgstr ""
+
+#: metabrainz/errors.py:28
+msgid "The application asked for a response type this server does not support."
+msgstr ""
+
+#: metabrainz/errors.py:29
+msgid "The permissions requested by the application are invalid."
+msgstr ""
+
+#: metabrainz/errors.py:30
+msgid "You need to sign in to continue."
+msgstr ""
+
+#: metabrainz/errors.py:31
+msgid "Your consent is required to continue."
+msgstr ""
+
+#: metabrainz/password.py:12
+#, python-format
+msgid "Password must not exceed %(max_bytes)s bytes."
+msgstr ""
+
+#: metabrainz/index/forms.py:48
 #, python-format
 msgid "'%(value)s' is not a valid choice for this field"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileEdit.tsx:27
-#: frontend/js/src/forms/SignupCommercial.tsx:154
+#: frontend/js/src/forms/SignupCommercial.tsx:159
 #: frontend/js/src/forms/SignupNonCommercial.tsx:85
-#: frontend/js/src/forms/SignupUser.tsx:70
-#: frontend/js/src/hooks/useEmailValidation.ts:78 metabrainz/index/forms.py:57
-#: metabrainz/user/forms.py:25 metabrainz/user/forms.py:57
-#: metabrainz/user/forms.py:63
+#: frontend/js/src/forms/SignupUser.tsx:76
+#: frontend/js/src/hooks/useEmailValidation.ts:78 metabrainz/index/forms.py:59
+#: metabrainz/user/forms.py:31 metabrainz/user/forms.py:70
+#: metabrainz/user/forms.py:76
 msgid "Email address is required!"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:34
-#: metabrainz/index/forms.py:63
+#: metabrainz/index/forms.py:65
 msgid "Current password is required!"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:43
 #: frontend/js/src/forms/ProfileChangePassword.tsx:37
 #: frontend/js/src/forms/ResetPassword.tsx:39
-#: frontend/js/src/forms/SignupCommercial.tsx:156
+#: frontend/js/src/forms/SignupCommercial.tsx:161
 #: frontend/js/src/forms/SignupNonCommercial.tsx:87
-#: frontend/js/src/forms/SignupUser.tsx:72 metabrainz/index/forms.py:66
-#: metabrainz/user/forms.py:29 metabrainz/user/forms.py:46
-#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:69
+#: frontend/js/src/forms/SignupUser.tsx:78 metabrainz/index/forms.py:69
+#: metabrainz/user/forms.py:35 metabrainz/user/forms.py:54
+#: metabrainz/user/forms.py:63 metabrainz/user/forms.py:82
 msgid "Password is required!"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:41
-#: frontend/js/src/forms/SignupCommercial.tsx:160
+#: frontend/js/src/forms/SignupCommercial.tsx:165
 #: frontend/js/src/forms/SignupNonCommercial.tsx:91
-#: frontend/js/src/forms/SignupUser.tsx:76 metabrainz/index/forms.py:70
-#: metabrainz/user/forms.py:33 metabrainz/user/forms.py:73
+#: frontend/js/src/forms/SignupUser.tsx:82 metabrainz/index/forms.py:74
+#: metabrainz/user/forms.py:40 metabrainz/user/forms.py:87
 msgid "Confirm Password is required!"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:46
 #: frontend/js/src/forms/ResetPassword.tsx:48
-#: frontend/js/src/forms/SignupCommercial.tsx:165
+#: frontend/js/src/forms/SignupCommercial.tsx:170
 #: frontend/js/src/forms/SignupNonCommercial.tsx:96
-#: frontend/js/src/forms/SignupUser.tsx:81 metabrainz/index/forms.py:72
-#: metabrainz/user/forms.py:35 metabrainz/user/forms.py:75
+#: frontend/js/src/forms/SignupUser.tsx:87 metabrainz/index/forms.py:76
+#: metabrainz/user/forms.py:42 metabrainz/user/forms.py:89
 msgid "Confirm Password should match password!"
 msgstr ""
 
 #: frontend/js/src/Applications.tsx:56 frontend/js/src/Applications.tsx:86
 #: frontend/js/src/Profile.tsx:272 frontend/js/src/Profile.tsx:482
-#: metabrainz/index/forms.py:78
+#: metabrainz/index/forms.py:82
 msgid "Name"
 msgstr ""
 
-#: metabrainz/index/forms.py:79
+#: metabrainz/index/forms.py:83
 msgid "Contact name field is empty."
 msgstr ""
 
-#: metabrainz/index/views.py:234
+#: metabrainz/index/views.py:251
 msgid "Profile updated successfully."
 msgstr ""
 
-#: metabrainz/index/views.py:261
+#: metabrainz/index/views.py:278
 msgid "Current password is incorrect."
 msgstr ""
 
-#: metabrainz/index/views.py:266
+#: metabrainz/index/views.py:283
 msgid "Password changed successfully."
 msgstr ""
 
-#: metabrainz/index/views.py:372
+#: metabrainz/index/views.py:389
 msgid "You have updated an application!"
 msgstr ""
 
-#: metabrainz/index/views.py:424
+#: metabrainz/index/views.py:441
 msgid "You have deleted an application."
 msgstr ""
 
-#: metabrainz/index/views.py:426
+#: metabrainz/index/views.py:443
 msgid "Failed to delete an application."
 msgstr ""
 
-#: metabrainz/index/views.py:449
+#: metabrainz/index/views.py:466
 msgid "Revoked tokens successfully!"
 msgstr ""
 
-#: metabrainz/index/views.py:478
+#: metabrainz/index/views.py:495
 msgid "Your account has been deleted."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:106 metabrainz/oauth/forms.py:58
+#: frontend/js/src/forms/CreateApplication.tsx:106 metabrainz/oauth/forms.py:57
 msgid "Application Name"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:59
+#: metabrainz/oauth/forms.py:58
 msgid "Application name field is empty."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:60 metabrainz/oauth/forms.py:60
+#: frontend/js/src/forms/CreateApplication.tsx:60 metabrainz/oauth/forms.py:59
 msgid "Application name needs to be at least 3 characters long."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:64 metabrainz/oauth/forms.py:61
+#: frontend/js/src/forms/CreateApplication.tsx:64 metabrainz/oauth/forms.py:60
 msgid "Application name needs to be at most 64 characters long."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:114 metabrainz/oauth/forms.py:63
+#: frontend/js/src/forms/CreateApplication.tsx:114 metabrainz/oauth/forms.py:62
 msgid "Description"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:64
+#: metabrainz/oauth/forms.py:63
 msgid "Client description field is empty."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:65
+#: metabrainz/oauth/forms.py:64
 msgid "Client description needs to be at least 3 characters long."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:66
+#: metabrainz/oauth/forms.py:65
 msgid "Client description needs to be at most 512 characters long."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:122 metabrainz/oauth/forms.py:68
+#: frontend/js/src/forms/CreateApplication.tsx:122 metabrainz/oauth/forms.py:67
 msgid "Homepage"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:69
+#: metabrainz/oauth/forms.py:68
 msgid "Homepage field is empty."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:70
+#: metabrainz/oauth/forms.py:69
 msgid "Homepage is not a valid URI."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:71
+#: metabrainz/oauth/forms.py:70
 msgid "Homepage URL must use http or https"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:73
+#: metabrainz/oauth/forms.py:72
 msgid "Authorization callback URL"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:74
+#: metabrainz/oauth/forms.py:73
 msgid "Authorization callback URL field is empty."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:75
+#: metabrainz/oauth/forms.py:74
 msgid "Authorization callback URL is invalid."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:76
+#: metabrainz/oauth/forms.py:75
 msgid "Authorization callback URL must use http or https."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:81 metabrainz/oauth/forms.py:85
+#: metabrainz/oauth/forms.py:80 metabrainz/oauth/forms.py:84
 msgid "Confirm"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:15
+msgid "View your public account information"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:16
+msgid "View your email address"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:17
+msgid "View and modify your private tags"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:18
+msgid "View and modify your private ratings"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:19
+msgid "View and modify your private collections"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:20
+msgid "Submit new ISRCs to the database"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:21
+msgid "Submit new barcodes to the database"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:22
+msgid "Sign you in and view your unique user id"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:23
+msgid "Submit listens to ListenBrainz."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:24
+msgid "Create and modify CritiqueBrainz reviews."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:25
+msgid "Submit and delete votes on CritiqueBrainz reviews."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:26
+msgid "Modify profile info and delete profile on CritiqueBrainz."
 msgstr ""
 
 #: metabrainz/payments/views.py:164
@@ -238,178 +323,185 @@ msgid "Requested annual report was not found."
 msgstr "Relatório Anual solicitado não foi encontrado."
 
 #: frontend/js/src/forms/ProfileEdit.tsx:30
-#: frontend/js/src/forms/SignupCommercial.tsx:139
+#: frontend/js/src/forms/SignupCommercial.tsx:144
 #: frontend/js/src/forms/SignupNonCommercial.tsx:70
-#: metabrainz/supporter/forms.py:13
+#: metabrainz/supporter/forms.py:15
 msgid "Contact name is required!"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:437
+#: frontend/js/src/forms/SignupCommercial.tsx:441
 #: frontend/js/src/forms/SignupNonCommercial.tsx:264
-#: metabrainz/supporter/forms.py:15
+#: metabrainz/supporter/forms.py:17
 msgid ""
 "Can you please tell us more about the project in which you'd like to use "
 "our data? Do you plan to self host the data or use our APIs?"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:137
+#: frontend/js/src/forms/SignupCommercial.tsx:142
 #: frontend/js/src/forms/SignupNonCommercial.tsx:68
-#: metabrainz/supporter/forms.py:17
+#: metabrainz/supporter/forms.py:19
 msgid "Please, tell us how you (will) use our data."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:138
+#: frontend/js/src/forms/SignupCommercial.tsx:143
 #: frontend/js/src/forms/SignupNonCommercial.tsx:69
-#: metabrainz/supporter/forms.py:18
+#: metabrainz/supporter/forms.py:20
 msgid "Please, limit usage description to 500 characters."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:141
-#: frontend/js/src/forms/SignupCommercial.tsx:142
+#: frontend/js/src/forms/SignupCommercial.tsx:146
+#: frontend/js/src/forms/SignupCommercial.tsx:147
 #: frontend/js/src/forms/SignupNonCommercial.tsx:72
 #: frontend/js/src/forms/SignupNonCommercial.tsx:73
-#: frontend/js/src/forms/SignupUser.tsx:84
-#: frontend/js/src/forms/SignupUser.tsx:85 metabrainz/supporter/forms.py:21
-#: metabrainz/user/forms.py:38
+#: frontend/js/src/forms/SignupUser.tsx:90
+#: frontend/js/src/forms/SignupUser.tsx:91 metabrainz/supporter/forms.py:23
+#: metabrainz/user/forms.py:45
 msgid "You need to accept the agreement!"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:342
-#: metabrainz/supporter/forms.py:27
+#: frontend/js/src/forms/SignupCommercial.tsx:347
+#: metabrainz/supporter/forms.py:29
 msgid "Organization name"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:113
-#: metabrainz/supporter/forms.py:28
+#: frontend/js/src/forms/SignupCommercial.tsx:115
+#: metabrainz/supporter/forms.py:30
 msgid "You need to specify the name of your organization."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:373
-#: metabrainz/supporter/forms.py:30
+#: frontend/js/src/forms/SignupCommercial.tsx:378
+#: metabrainz/supporter/forms.py:32
 msgid "Organization description"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:116
-#: metabrainz/supporter/forms.py:31
+#: frontend/js/src/forms/SignupCommercial.tsx:118
+#: metabrainz/supporter/forms.py:33
 msgid "You need to provide description of your organization."
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:278
-#: frontend/js/src/forms/SignupCommercial.tsx:396
-#: metabrainz/supporter/forms.py:34
+#: frontend/js/src/forms/SignupCommercial.tsx:401
+#: metabrainz/supporter/forms.py:36
 msgid "Website URL"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:119
-#: metabrainz/supporter/forms.py:35
-msgid "You need to specify website of the organization."
+#: frontend/js/src/forms/SignupCommercial.tsx:121
+#: frontend/js/src/forms/SignupCommercial.tsx:123
+#: metabrainz/supporter/forms.py:38 metabrainz/supporter/forms.py:42
+msgid "Website URL must be a valid URL."
 msgstr ""
 
-#: metabrainz/supporter/forms.py:37
+#: metabrainz/supporter/forms.py:45
 msgid "Logo image URL"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:284
-#: frontend/js/src/forms/SignupCommercial.tsx:418
-#: metabrainz/supporter/forms.py:38
+#: frontend/js/src/forms/SignupCommercial.tsx:422
+#: metabrainz/supporter/forms.py:46
 msgid "API URL"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:457
-#: metabrainz/supporter/forms.py:40
+#: frontend/js/src/forms/SignupCommercial.tsx:461
+#: metabrainz/supporter/forms.py:48
 msgid "Street"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:123
-#: metabrainz/supporter/forms.py:41
+#: frontend/js/src/forms/SignupCommercial.tsx:128
+#: metabrainz/supporter/forms.py:49
 msgid "You need to specify street."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:465
-#: metabrainz/supporter/forms.py:43
+#: frontend/js/src/forms/SignupCommercial.tsx:469
+#: metabrainz/supporter/forms.py:51
 msgid "City"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:124
-#: metabrainz/supporter/forms.py:44
+#: frontend/js/src/forms/SignupCommercial.tsx:129
+#: metabrainz/supporter/forms.py:52
 msgid "You need to specify city."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:473
-#: metabrainz/supporter/forms.py:46
+#: frontend/js/src/forms/SignupCommercial.tsx:477
+#: metabrainz/supporter/forms.py:54
 msgid "State / Province"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:126
-#: metabrainz/supporter/forms.py:47
+#: frontend/js/src/forms/SignupCommercial.tsx:131
+#: metabrainz/supporter/forms.py:55
 msgid "You need to specify state/province."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:481
-#: metabrainz/supporter/forms.py:49
+#: frontend/js/src/forms/SignupCommercial.tsx:485
+#: metabrainz/supporter/forms.py:57
 msgid "Postcode"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:128
-#: metabrainz/supporter/forms.py:50
+#: frontend/js/src/forms/SignupCommercial.tsx:133
+#: metabrainz/supporter/forms.py:58
 msgid "You need to specify postcode."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:489
-#: metabrainz/supporter/forms.py:52
+#: frontend/js/src/forms/SignupCommercial.tsx:493
+#: metabrainz/supporter/forms.py:60
 msgid "Country"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:129
-#: metabrainz/supporter/forms.py:53
+#: frontend/js/src/forms/SignupCommercial.tsx:134
+#: metabrainz/supporter/forms.py:61
 msgid "You need to specify country."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:132
-#: metabrainz/supporter/forms.py:64
+#: frontend/js/src/forms/SignupCommercial.tsx:137
+#: metabrainz/supporter/forms.py:72
 msgid ""
 "Custom amount must be more than threshold amount for selected tier or "
 "equal to it!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:46 metabrainz/supporter/views.py:119
-#: metabrainz/supporter/views.py:220
+#: metabrainz/supporter/views.py:54
+msgid ""
+"The verification email could not be sent. Please request a new one from "
+"your profile."
+msgstr ""
+
+#: metabrainz/supporter/views.py:85 metabrainz/supporter/views.py:158
+#: metabrainz/supporter/views.py:260
 msgid "You are already a supporter."
 msgstr ""
 
-#: metabrainz/supporter/views.py:61
+#: metabrainz/supporter/views.py:100
 msgid "Can't find tier with a specified ID."
 msgstr ""
 
-#: metabrainz/supporter/views.py:127
+#: metabrainz/supporter/views.py:166
 msgid "You need to choose support tier before signing up!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:137
+#: metabrainz/supporter/views.py:176
 msgid "You need to choose existing tier before signing up!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:164
+#: metabrainz/supporter/views.py:204
 msgid ""
 "Thanks for becoming a supporter! Your application will be reviewed soon. "
 "We will send you updates via email."
 msgstr ""
 
-#: metabrainz/supporter/views.py:187
+#: metabrainz/supporter/views.py:228
 msgid ""
 "Thanks for signing up! Your application will be reviewed soon. We will "
 "send you updates via email."
 msgstr ""
 
-#: metabrainz/supporter/views.py:248
+#: metabrainz/supporter/views.py:288
 msgid "Thanks for becoming a supporter!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:274
+#: metabrainz/supporter/views.py:312
 msgid "Thanks for signing up! Please check your inbox to complete verification."
 msgstr ""
 
-#: metabrainz/supporter/views.py:302
+#: metabrainz/supporter/views.py:340
 msgid "Can't generate new token unless account is active."
 msgstr "Não é possível gerar um novo token a menos que a conta esteja ativa."
 
@@ -443,7 +535,7 @@ msgstr ""
 msgid "Policies"
 msgstr ""
 
-#: metabrainz/templates/base.html:55 metabrainz/templates/index/gdpr.html:178
+#: metabrainz/templates/base.html:55
 #: metabrainz/templates/index/social-contract.html:3
 #: metabrainz/templates/index/social-contract.html:6
 #: metabrainz/templates/navbar.html:34
@@ -453,14 +545,15 @@ msgstr ""
 #: metabrainz/templates/base.html:56
 #: metabrainz/templates/index/code-of-conduct.html:3
 #: metabrainz/templates/index/code-of-conduct.html:16
-#: metabrainz/templates/index/gdpr.html:181 metabrainz/templates/navbar.html:35
+#: metabrainz/templates/navbar.html:35
 msgid "Code of Conduct"
 msgstr ""
 
+#: frontend/js/src/PrivacySummary.tsx:11
 #: frontend/js/src/forms/ConditionsModal.tsx:21
-#: metabrainz/templates/base.html:57 metabrainz/templates/index/gdpr.html:184
-#: metabrainz/templates/index/privacy.html:6
+#: metabrainz/templates/base.html:57 metabrainz/templates/index/privacy.html:6
 #: metabrainz/templates/navbar.html:36
+#: metabrainz/templates/users/privacy-summary.html:3
 msgid "Privacy Policy"
 msgstr "Termos de Privacidade"
 
@@ -494,10 +587,7 @@ msgstr "Patrocinadores"
 msgid "Supporters"
 msgstr "Apoiadores"
 
-#: frontend/js/src/forms/LoginUser.tsx:103
-#: frontend/js/src/forms/SignupCommercial.tsx:574
-#: frontend/js/src/forms/SignupNonCommercial.tsx:339
-#: frontend/js/src/forms/SignupUser.tsx:232 metabrainz/templates/base.html:73
+#: frontend/js/src/forms/LoginUser.tsx:103 metabrainz/templates/base.html:73
 #: metabrainz/templates/navbar.html:66 metabrainz/templates/users/login.html:3
 msgid "Sign in"
 msgstr "Entrar"
@@ -519,26 +609,26 @@ msgid "Contact us"
 msgstr "Contate-nos"
 
 #: metabrainz/templates/base.html:85
-#: metabrainz/templates/index/contact.html:105
+#: metabrainz/templates/index/contact.html:106
 msgid "Blog"
 msgstr "Blog"
 
-#: metabrainz/templates/base.html:86 metabrainz/templates/index/contact.html:90
+#: metabrainz/templates/base.html:86 metabrainz/templates/index/contact.html:91
 msgid "Chat"
 msgstr ""
 
 #: metabrainz/templates/base.html:87
-#: metabrainz/templates/index/contact.html:106
+#: metabrainz/templates/index/contact.html:107
 msgid "Mastodon"
 msgstr ""
 
 #: metabrainz/templates/base.html:88
-#: metabrainz/templates/index/contact.html:107
+#: metabrainz/templates/index/contact.html:108
 msgid "Bluesky"
 msgstr ""
 
 #: metabrainz/templates/base.html:89
-#: metabrainz/templates/index/contact.html:108
+#: metabrainz/templates/index/contact.html:109
 msgid "Instagram"
 msgstr ""
 
@@ -597,15 +687,14 @@ msgstr "Relatórios Financeiros"
 msgid "Donate"
 msgstr "Doar"
 
-#: frontend/js/src/forms/LoginUser.tsx:110
-#: frontend/js/src/forms/SignupCommercial.tsx:175
-#: frontend/js/src/forms/SignupCommercial.tsx:555
+#: frontend/js/src/forms/SignupCommercial.tsx:180
+#: frontend/js/src/forms/SignupCommercial.tsx:559
 #: frontend/js/src/forms/SignupNonCommercial.tsx:106
 #: frontend/js/src/forms/SignupNonCommercial.tsx:319
 #: metabrainz/templates/navbar.html:65
-#: metabrainz/templates/supporters/account-type.html:51
-#: metabrainz/templates/supporters/account-type.html:93
-#: metabrainz/templates/supporters/account-type.html:144
+#: metabrainz/templates/supporters/account-type.html:47
+#: metabrainz/templates/supporters/account-type.html:84
+#: metabrainz/templates/supporters/account-type.html:130
 #: metabrainz/templates/users/signup.html:3
 msgid "Sign up"
 msgstr "Cadastrar"
@@ -952,8 +1041,430 @@ msgstr ""
 msgid "Introduction"
 msgstr ""
 
-#: metabrainz/templates/index/conflict-policy.html:55
+#: metabrainz/templates/index/conflict-policy.html:17
+msgid ""
+"Conflicts between people arise in open source projects constantly and the"
+" projects by the \n"
+"    MetaBrainz Foundation are no different. This policy aims to establish"
+" a clear and unambiguous \n"
+"    policy for reporting and addressing conflicts in our community. In "
+"this policy we aim to \n"
+"    establish a fair practice that balances the need for confidentiality "
+"and our desire for \n"
+"    transparency in our operations."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:25
+#, python-format
+msgid ""
+"Before you continue to read this policy, we encourage you to review our "
+"existing community policies \n"
+"    including our <a href=\"%(social_contract_url)s\">Social "
+"Contract</a>, \n"
+"    <a href=\"%(code_of_conduct_url)s\">the Code of Conduct</a>, \n"
+"    and our <a href=\"%(privacy_policy_url)s\">Privacy Policy</a>. These "
+"policies establish the norms and rules for \n"
+"    participation in our projects; these policies apply equally to the "
+"contractors of the MetaBrainz \n"
+"    Foundation and any participants in our projects."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:37
+msgid ""
+"This policy divides conflicts into two categories: Private and public. "
+"Private conflicts are conflicts \n"
+"    that involve *confidential* information regarding contributors, "
+"contractors or supporters. Otherwise, any conflicts \n"
+"    that do not involve confidential information are considered to be "
+"public conflicts. For instance, a \n"
+"    conflict between a contractor and the Executive Director (aka BDFL) "
+"that involves contractor pay is \n"
+"    considered a private conflict because pay rates are confidential "
+"information. A public conflict in edit \n"
+"    notes between two editors in our community does not involve "
+"confidential information and therefore should \n"
+"    be considered a public conflict."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:47
+msgid ""
+"When conflicts arise we aim to disclose as much information as possible "
+"about the conflict in a timely \n"
+"    fashion. When conflicts contain confidential matters we will aim to "
+"disclose as much information as \n"
+"    possible, while fully respecting the confidentiality of the people "
+"involved in the conflict. With any \n"
+"    private conflict we will aim to extract the relevant lessons for the "
+"team and community in an effort to \n"
+"    evolve our policies to prevent future conflicts. Should the involved "
+"parties disagree whether a conflict \n"
+"    is private or public, the question about the nature of the conflict "
+"will be presented for the next higher \n"
+"    level in the chain of command to decide. (e.g. if a community member "
+"and the community manager disagree on \n"
+"    a conflict being public or private, the Executive Director shall "
+"decide if the conflict is public or private)."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:58
 msgid "Reporting and Response"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:61
+msgid ""
+"We aim to not have conflict in our community, but we recognize that in "
+"reality conflicts will arise and we \n"
+"    must be prepared to address them in a fair manner. When conflicts "
+"arise, we prefer to have community or team \n"
+"    members resolve the conflicts among themselves, using our existing "
+"policies as guidelines for resolving the \n"
+"    conflict."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:69
+msgid ""
+"If you do not feel comfortable resolving a conflict on your own, you "
+"should feel free to report the conflict to \n"
+"    us. How you address the conflict depends on who is involved in the "
+"conflict and your comfort level. Please see \n"
+"    the detailed sections below on how and with whom to address your "
+"conflict. We aim to address conflicts as soon \n"
+"    as possible in an effort to prevent them from escalating "
+"unnecessarily."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:75
+msgid "Direct conflict resolution"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:78
+msgid ""
+"In direct conflict resolution, the involved parties will attempt to "
+"resolve the conflict themselves without \n"
+"   involving any MetaBrainz Foundation team member. You should aim to use"
+" direct resolution when the conflict does \n"
+"   not involve the violation of one of our policies or if the conflict is"
+" minor."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:84
+#, python-format
+msgid ""
+"For instance, if a user uses a rude tone, is disruptive or flagrantly "
+"ignores our project guidelines, we suggest \n"
+"    that you use direct conflict resolution to resolve the conflict. Some"
+" resources that might give you some suggestions \n"
+"    on how to go about resolving the conflict might be this <a "
+"href=\"%(conflict_resolution_primer_url)s\">\n"
+"    conflict resolution primer</a> and <a "
+"href=\"%(difficult_conversations_url)s\">how to\n"
+"    have difficult conversations at work</a>."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:93
+msgid "Informal reporting"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:96
+msgid ""
+"You may use informal reporting of a conflict if you aim to communicate a "
+"concern or incident without \n"
+"    seeking a corrective outcome. Informal reporting may also be an "
+"option if you have not been personally \n"
+"    victimized, but you’ve witnessed a violation of our policies or where"
+" you wish to maintain confidentiality \n"
+"    throughout the entire reporting process."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:103
+msgid ""
+"For editing in MusicBrainz you may informally report a user using the "
+"“Report this user for bad behavior” \n"
+"    link from the user’s profile. For reporting bad user behavior in "
+"other of our projects, please report them to our \n"
+"    community manager by mailing <span class=\"backemail\">gro.zniarbatem"
+"@reganam-ytinummoc</span> . For conflicts \n"
+"    that involve the community manager, report them by mailing <span "
+"class=\"backemail\">gro.zniarbatem@de</span> ."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:110
+msgid ""
+"Depending the the severity of the issue, repeated informal complaints may"
+" eventually require a formal response \n"
+"    from the MetaBrainz team. If an involved party requires anonymity, "
+"the conflict becomes a private conflict. If at \n"
+"    all possible minor issues should be resolved in a public forum in "
+"order for all people to witness and learn from \n"
+"    the issue at hand."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:116
+msgid "Formal complaint process"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:119
+msgid ""
+"All complaints about conflicts should be submitted via email. To whom a "
+"complaint should be mailed and who will \n"
+"    carry out the investigation will be described in the next section."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:124
+msgid "All complaint submissions to the Foundation should include the following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:128
+msgid ""
+"Contact info, if it is different than the email used to submit the "
+"conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:129
+msgid "Who was involved in the conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:130
+msgid "Where and when the incident happened"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:131
+msgid ""
+"A description of what happened -- ideally with links (e.g. chatlogs, edit"
+" notes) that outlines what \n"
+"         happened so that the persons evaluating the conflict may "
+"understand the issue at hand"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:133
+msgid ""
+"Any related pieces of information that provide more context on the "
+"conflict (e.g. links, screenshots)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:134
+msgid "An indication if this conflict is ongoing or not"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:139
+msgid "The investigation that follows aims to determine:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:143
+msgid "The nature and severity of the incident"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:144
+msgid ""
+"Whether or not the incident is considered a violation of MetaBrainz’ "
+"conduct policies or core values"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:145
+msgid ""
+"The amount of harm experienced by the person who submitted the complaint "
+"and the broader MetaBrainz community \n"
+"         as a result of the incident"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:147
+msgid ""
+"Whether there have been prior complaints against the individual or "
+"individuals reported"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:148
+msgid "Whether the incident is ongoing"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:152
+msgid ""
+"The following potential forms of resolution may apply to any team members"
+" involved in the conflict:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:155
+#: metabrainz/templates/index/conflict-policy.html:168
+msgid "Nothing (if it has been found no violation occurred)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:156
+msgid "Creating a plan to improve the performance"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:157
+msgid "Creating a negative performance evaluation"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:158
+msgid "Mediation, an intervention by a third party to resolve the conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:159
+msgid "Suspension or forced leave"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:160
+msgid "Termination of contract"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:164
+msgid ""
+"The following potential forms of resolution may apply to non team members"
+" involved in the conflict:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:169
+msgid "A reprimand, either public or private"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:170
+msgid "Suspension of the users’ account"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:171
+msgid "Deletion of the users’ account"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:172
+msgid ""
+"Removal of user privileges (e.g. if an auto editor commits a serious "
+"offence, they may lose their auto editor status)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:175
+msgid "Filing a complaint"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:178
+msgid ""
+"NOTE: For complaints not about MetaBrainz staff, please see the "
+"<em>Informal reporting</em> section above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:182
+msgid ""
+"If the complaint does not involve the Executive Director (ED), do the "
+"following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:186
+msgid ""
+"If team member has directly violated conduct policies or engaged in "
+"otherwise harmful behavior, a formal complaint should be filed."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:187
+msgid ""
+"Mail <span class=\"backemail\">gro.zniarbatem@de</span> and include the "
+"complaint information outlined above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:188
+msgid ""
+"You should expect a response within a working day acknowledging the "
+"complaint."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:189
+msgid ""
+"The complaint will be investigated by the ED, member(s) of the board of "
+"directors or a neutral third party."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:190
+msgid ""
+"Once the investigation has been completed, the ED, with the support of "
+"others involved in the investigation will respond. The \n"
+"        ED will respond to incidents no later than 7 working days after a"
+" complaint has been filed with either a resolution or an \n"
+"        explanation of why the process must be extended."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:196
+msgid "If a complaint involves the Executive Director, do the following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:200
+msgid ""
+"If the Executive Director has directly violated conduct policies or "
+"engaged in otherwise harmful behavior, \n"
+"        a formal complaint should be filed with the board of directors."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:202
+msgid ""
+"Mail <span class=\"backemail\">gro.zniarbatem@noituloser-tcilfnoc</span> "
+"and include the complaint information outlined above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:203
+msgid ""
+"You should get a response within 5 working days acknowledging the "
+"complaint."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:204
+msgid ""
+"The complaint will be investigated by the member(s) of the board of "
+"directors, the community manager, a neutral \n"
+"        third party or a combination thereof."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:206
+msgid ""
+"Once the investigation has been completed, the board, with the support of"
+" others involved in the investigation \n"
+"        will respond. The board will aim to respond to incidents no later"
+" than 15 working days after a complaint has been filed \n"
+"        with either a resolution or an explanation of why the process "
+"must be extended."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:211
+msgid "Confidentiality"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:214
+msgid ""
+"Confidentiality is an important aspect of conflict resolution and all of "
+"the conflicts brought to the attention of the foundation \n"
+"    will be evaluated with confidentiality in mind and acted upon "
+"accordingly."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:219
+msgid ""
+"We work hard to make all of the actions of the foundation as transparent "
+"and open as possible. In cases where we cannot \n"
+"    disclose all aspects of a conflict we will disclose that a conflict "
+"is or has occurred and we will attempt to disclose the \n"
+"    appropriate amount of information about the conflict while balancing "
+"the need for confidentiality and our desire to learn \n"
+"    from conflicts so that we as a foundation and community can learn "
+"from these conflicts and improve our policies to avoid the \n"
+"    conflicts in the future."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:227
+msgid ""
+"Any breaches of confidentiality will be treated as severe breaches of our"
+" conduct policies."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:230
+msgid "Retaliation"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:233
+msgid ""
+"We will not allow retaliation for any contractor or volunteer that files "
+"a complaint or is involved in an investigation. If you \n"
+"    believe that you are being treated negatively because of your "
+"involvement in a complaint please report this complaint directly \n"
+"    to the ED at <span class=\"backemail\">gro.zniarbatem@de</span> or "
+"the board at \n"
+"    <span class=\"backemail\">gro.zniarbatem@noituloser-tcilfnoc</span>."
 msgstr ""
 
 #: metabrainz/templates/index/contact.html:3
@@ -1064,7 +1575,7 @@ msgstr ""
 msgid ""
 "We are currently evaluating our overall online advertising strategy. We "
 "are evaluating advertising, traffic optimization,\n"
-"    search engine optimization and software monitization technologies. If"
+"    search engine optimization and software monetization technologies. If"
 " you provide these professional services, please provide a detailed\n"
 "    deck of your comprehensive services to the following email address. "
 "<em>Please respect our other non-media teams and do not contact us \n"
@@ -1146,14 +1657,11 @@ msgstr "Fóruns"
 #, python-format
 msgid ""
 "Please come ask your questions at our <a "
-"href=\"%(forums_url)s\">forums</a>! We would love to\n"
-"    answer any questions you may have."
+"href=\"%(forums_url)s\">forums</a>!\n"
+"    The community and the team will be more than happy to help you."
 msgstr ""
-"Por favor venha perguntar suas perguntas em nossos <a "
-"href=\"%(forums_url)s\">fóruns</a>! Vamos adorar\n"
-"responder qualquer perguntar que tiver."
 
-#: metabrainz/templates/index/contact.html:92
+#: metabrainz/templates/index/contact.html:93
 #, python-format
 msgid ""
 "The MetaBrainz/MusicBrainz/ListenBrainz team and community hang out\n"
@@ -1163,15 +1671,15 @@ msgid ""
 "    <a href=\"%(chatlogs_url)s\">chat log archives</a>."
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:101
+#: metabrainz/templates/index/contact.html:102
 msgid "Social media"
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:103
+#: metabrainz/templates/index/contact.html:104
 msgid "You can follow us on these social channels:"
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:112
+#: metabrainz/templates/index/contact.html:113
 msgid "Mailing address"
 msgstr "Endereço postal"
 
@@ -1184,33 +1692,349 @@ msgstr ""
 msgid "GDPR Compliance Statement"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:37
+#: metabrainz/templates/index/gdpr.html:10
+msgid ""
+"The General Data Protection Regulation is a complex EU regulation that "
+"stipulates many points for protecting private data of\n"
+"    users on the Internet. Even though this is an EU regulation, it has a"
+" worldwide impact due to the nature of the Internet.\n"
+"    The MetaBrainz Foundation with its collection of projects is also "
+"affected by this regulation. We’ve been learning and adapting\n"
+"    our sites to be compliant with the GDPR – sadly this regulation isn’t"
+" entirely black and white and there is an incredible\n"
+"    amount of room left for interpretation of these rules."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:17
+msgid ""
+"The good news is that this regulation is roughly in line with our "
+"established practices: We’ve always held private information\n"
+"    in a high regard and applied the sort of rules to ourselves as we "
+"wish to have our own private data treated. Luckily, this\n"
+"    makes our compliance effort considerably easier. We’ve made two "
+"significant changes to how we treat your data and also adopted\n"
+"    terminology as used in the GDPR in order to use the same languages "
+"that many other sites are now adopting. Please keep reading\n"
+"    to find out the exact details of what we are doing to comply."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:24
+#, python-format
+msgid ""
+"However, we do ask for your compassion and help in our process of "
+"complying with the GDPR. As we already mentioned, the GDPR is\n"
+"    a complex set of rules that are not fully clarified yet. We’ve taken "
+"action on the steps that are clear to us and we’re following\n"
+"    ongoing conversations on points that are in gray zones or unclear to "
+"us. We’ve made our best initial effort on compliance and\n"
+"    promise to keep working on it as the picture becomes more clear. If "
+"you believe that we could improve our compliance, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a> and let us know what we "
+"can do to improve. It would also help us if you\n"
+"    could provide concrete discussion or examples to help us understand "
+"and take action on your suggestion."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:33
+msgid ""
+"Finally, below are the key sections of the GDPR as we understand them and"
+" how they affect your data in our ecosystem. Where\n"
+"    possible, we provide links for deeper understanding, links for you to"
+" examine our relevant code and links to tickets to follow\n"
+"    the process of improving our compliance."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:38
 msgid "Right to be forgotten"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:77
+#: metabrainz/templates/index/gdpr.html:41
+msgid ""
+"Summary: <i>Provide the user with the ability to remove their private "
+"data from our services</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:44
+msgid ""
+"The most important aspect of the right to be forgotten is the ability to "
+"delete your account. Once you request for us to delete\n"
+"    your account, we will remove any personally identifying information "
+"you may have provided us from your account (name, email\n"
+"    address, gender, biography, URL, etc.). The visible name on your "
+"account will be changed to “Deleted User #####” and effectively\n"
+"    the account will no longer be identifiable as your account."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:50
+msgid ""
+"However, given the nature of our projects where we work on collaborative "
+"databases, your contributions that are not personally\n"
+"    identifying are valuable assets to our database and these "
+"contributions will not be removed from our databases. But we will\n"
+"    ensure that these contributions no longer contain personally "
+"identifying data."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:55
+#, python-format
+msgid ""
+"Our process of automatically deleting your accounts across the MetaBrainz"
+" ecosystem is not complete yet (see below for a set of\n"
+"    tickets where you can track our progress). If you would like to "
+"delete your accounts in the MetaBrainz ecosystem or mark a\n"
+"    donation that is currently public as a private donation, please <a "
+"href=\"%(contact_url)s\">contact us</a>\n"
+"    and we will address your request as soon as possible."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:62
+#: metabrainz/templates/index/gdpr.html:182
+msgid "Links:"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:66
+#, python-format
+msgid ""
+"<a href=\"%(editor_deletion_doc_url)s\">How we delete accounts\n"
+"       in MusicBrainz</a> (warning, geek content ahead!)"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:70
+msgid ""
+"Implement sitewide user account deletion in\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/MBS-9680\">MusicBrainz</a>,"
+"\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/AB-337\">AcousticBrainz</a>,"
+"\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/BB-260\">BookBrainz</a>,\n"
+"         <a href=\"https://tickets.metabrainz.org/browse/MEB-103\">the "
+"MetaBrainz Site</a>,\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/LB-354\">ListenBrainz</a>, "
+"and\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/CB-307\">CritiqueBrainz</a>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:80
 msgid "Restriction of processing"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:110
+#: metabrainz/templates/index/gdpr.html:83
+msgid ""
+"Summary: <i>To allow the user to control how their personally identifying"
+" data is being used.</i>"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:86
+msgid ""
+"Except for the ListenBrainz and AcousticBrainz projects, we do not "
+"process personally identifying data. Any personally\n"
+"    identifying data that our projects store is for the purpose of being "
+"able to contact you about your contributions to our database\n"
+"    (email address) or for voluntarily showing information about you to "
+"other users (biography, homepage, location, etc)."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:91
+#, python-format
+msgid ""
+"The ListenBrainz project differs in that the Listens (metadata about what"
+" music you have listened to) are stored on our servers\n"
+"    and <a href=\"%(listenbrainz_data_url)s\">made available to the "
+"public</a>. We believe Listens to be personally identifying\n"
+"    data and furthermore, we have goals of creating open source "
+"recommendation engines with this data, which involves processing the\n"
+"    user’s data. These two points are fundamental goals of the "
+"ListenBrainz project and we do not see a reasonable way to reach another"
+"\n"
+"    compromise position."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:99
+msgid ""
+"Because of this, we are going to require users to either acknowledge that"
+" we may process their Listen data or alternatively to\n"
+"    delete their account, including all of their Listens. Please note "
+"that if you decide to delete your ListenBrainz account, it may\n"
+"    take up to two weeks for all of your listens to no longer be included"
+" in our efforts to build a recommendation engine."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:104
+msgid ""
+"We have always made it clear that the data in ListenBrainz was to be "
+"public and that we plan to build new tools with your data, so\n"
+"    this should not come as a surprise to our users."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:108
+msgid ""
+"The AcousticBrainz project does not track who submits data to the "
+"database. If you create an account and use our data creation\n"
+"    tools (e.g. create a dataset or participate in a challenge) then we "
+"link your participation and the things that you create to\n"
+"    your account. If you choose to delete your account then we keep the "
+"non personally identifying data that you create, but anonymize\n"
+"    it so that it cannot be linked back to you."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:114
 msgid "Right to data portability / exporting your data"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:150
+#: metabrainz/templates/index/gdpr.html:117
+msgid ""
+"Summary: <i>You have the right to access/download the data we store about"
+" you</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:120
+msgid ""
+"Except for the ListenBrainz and AcousticBrainz projects, we do not store "
+"personally identifying data beyond the\n"
+"    information that is available in your public profile on each of our "
+"projects. Since this data is plainly available in your\n"
+"    profile we do not provide a means for you to export this data."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:125
+msgid "There are the following exceptions to this:"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:129
+msgid ""
+"<b>IP addresses</b>: If you visit one of our sites the IP address of your"
+" computer is stored in our web logs for 7 days\n"
+"        before our servers automatically delete them. This data is almost"
+" never used by anyone: the only time we look at the\n"
+"        IP addresses is if our sites are adversely impacted by the "
+"actions of some unknown users. In that case, we may investigate\n"
+"        the logs to identify the IP address that needs to be blocked in "
+"order to restore the stability of our service.\n"
+"        This data is not available to anyone but the contractors of the "
+"MetaBrainz Foundation and is not available to download\n"
+"        to anyone at all."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:137
+#, python-format
+msgid ""
+"<b>ListenBrainz Listen data</b>: Users may <a "
+"href=\"%(listenbrainz_export_url)s\">export their ListenBrainz Listen\n"
+"        data</a> directly from the site. The user Listen data is also "
+"included in the <a href=\"%(listenbrainz_data_url)s\">ListenBrainz\n"
+"        data dumps</a> that are available for public download."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:146
+msgid ""
+"All of the non personally identifying data, such as your metadata "
+"contributions, are publicly visible, available for download\n"
+"    and available via the project APIs. For details about this data, "
+"downloads and APIs please check the documentation for the\n"
+"    respective projects you are interested in."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:151
+#, python-format
+msgid ""
+"Anyone wishing to get a list of financial donations they have made to the"
+" MetaBrainz Foundation, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a> and provide your "
+"MusicBrainz editor name so that we can look up\n"
+"    your donations."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:157
 msgid "Right to rectification"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:165
+#: metabrainz/templates/index/gdpr.html:160
+msgid "Summary: <i>You have the right to correct your data</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:163
+msgid ""
+"All of our projects allow their users to update their personally "
+"identifying information in their profiles. Furthermore, most\n"
+"    of our projects allow the editing of their own metadata "
+"contributions. If you find that some of your data is incorrect, please\n"
+"    feel free to edit the data since we provide the tools to do so."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:168
+#, python-format
+msgid ""
+"If anyone who has made a financial donation to the MetaBrainz Foundation "
+"would like to make their donation private, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:173
 msgid "Right to be informed"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:188
+#: metabrainz/templates/index/gdpr.html:175
+msgid ""
+"Summary: <i>You have the right to be informed about how we use your data "
+"in plain English</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:178
+msgid ""
+"Our privacy policy, as well as other policies, have always been written "
+"by humans for human consumption. We abhor legalese and\n"
+"    not speaking in direct terms."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:186
+msgid "Social contract"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:189
+msgid "Code of conduct"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:192
+msgid "Privacy policy"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:196
 msgid "Right to access"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:198
-#: metabrainz/templates/index/privacy.html:166
+#: metabrainz/templates/index/gdpr.html:199
+msgid ""
+"Summary: <i>You have the right to access the data that we collect about "
+"you</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:202
+msgid ""
+"All of our projects make all of the data we collect on your behalf, "
+"privately identifying or not, available to you. The\n"
+"    only exception to this are the IP addresses we store for 7 days – see"
+" above for details."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:206
+#: metabrainz/templates/index/privacy.html:168
 msgid "Privacy/GDPR Representative"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:209
+#, python-format
+msgid ""
+"If you have any questions about our privacy policy, please <a "
+"href=\"%(contact_url)s\">contact us</a>. To report\n"
+"   any privacy problems, violations or leaks, our GDPR representative is "
+"our Interim Executive Director Nicolás Tamargo and for\n"
+"   privacy issues contact him at <strong><a "
+"href=\"mailto:gdpr@metabrainz.org\">gdpr@metabrainz.org</a></strong>."
 msgstr ""
 
 #: metabrainz/templates/index/index.html:6
@@ -1350,7 +2174,7 @@ msgstr ""
 "Para obter mais informações sobre a fundação, vá para a página \n"
 "      <a href=\"%(about_url)s\">sobre</a>."
 
-#: frontend/js/src/forms/ConditionsModal.tsx:43
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:32
 #: metabrainz/templates/index/privacy.html:3
 msgid "Privacy"
 msgstr "Privacidade"
@@ -1358,6 +2182,44 @@ msgstr "Privacidade"
 #: metabrainz/templates/index/privacy.html:8
 msgid "Summary"
 msgstr "Sumário"
+
+#: metabrainz/templates/index/privacy.html:12
+msgid ""
+"You do not have to provide any personal data to be able to browse the "
+"contents of the databases published by MetaBrainz."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:15
+msgid ""
+"You do not have to provide any personally-identifying information if you "
+"choose not to."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:18
+msgid ""
+"We will never reveal your email address on MetaBrainz controlled web "
+"sites."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:22
+msgid ""
+"In order to get maximum value out of the MetaBrainz projects, you may "
+"want to create an account and log in. \n"
+"    Doing so grants you the ability to: edit the databases, contribute "
+"your own data, communicate with other users, and keep track \n"
+"    of recently released music from artists in your MusicBrainz "
+"collection. If you choose to create an account then the minimum we \n"
+"    ask is that you: choose a unique username and password, use a web "
+"browser that accepts \"session\" cookies, and provide a verified \n"
+"    email address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:29
+msgid ""
+"If you do not create an account (or are not logged in) you will not have "
+"access to the above listed features, however, you will \n"
+"    still have full access to browse and examine the databases."
+msgstr ""
 
 #: metabrainz/templates/index/privacy.html:33
 msgid "Applicable to all users"
@@ -1367,40 +2229,198 @@ msgstr ""
 msgid "Cookies"
 msgstr ""
 
+#: metabrainz/templates/index/privacy.html:37
+msgid "We use two cookies that contain sensitive information:"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:42
+msgid ""
+"<b>remember_login</b>: If you choose the \"Log in permanently\" option "
+"when logging in to one of our sites; the cookie will be used to \n"
+"      remember your login details."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:46
+msgid ""
+"<b>musicbrainz_server_session, session, or connect.sid</b>: If you are "
+"logged into one of our sites, your current session ID is stored in this "
+"cookie."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:51
+msgid ""
+"We may store dynamic preference information in other cookies, but these "
+"do not contain any sensitive information."
+msgstr ""
+
 #: metabrainz/templates/index/privacy.html:54
 #, fuzzy
 msgid "Web and FTP access logs"
 msgstr "Registro de acesso Web e FTP (todos os usuários)"
 
+#: metabrainz/templates/index/privacy.html:57
+msgid ""
+"In a practice similar to other web sites (and APIs) we keep logs of all "
+"web requests made against our servers. These logs include: your IP\n"
+"    address, your browser's (or API client's) \"User-Agent\" string, and "
+"which page (or API endpoint) you requested with which parameters. "
+"Aggregate information about web and FTP traffic is\n"
+"    made available to the public via our site usage pages."
+msgstr ""
+
 #: metabrainz/templates/index/privacy.html:62
 msgid "Third-Party content"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:92
+#: metabrainz/templates/index/privacy.html:64
+msgid ""
+"Our projects' web pages may load some third-party content. Some, but "
+"possibly not all sites are listed below:"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:69
+#, python-format
+msgid ""
+"Cover art and other images: These are provided by the various cover art "
+"sites that have given MusicBrainz permission to do so and our own \n"
+"      <a href=\"%(caa_url)s\">Cover Art Archive</a>. This means that the "
+"relevant site will know (if they want to) your IP \n"
+"      address, User-Agent string, etc., and which MusicBrainz web page "
+"you were visiting (the one which included the cover art image)."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:75
+msgid ""
+"AcoustID: Our fingerprints tab loads fingerprint information from "
+"acoustid.org."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:78
+msgid ""
+"MTCaptcha: Our account creation page loads third party content in order "
+"to prevent spammers from creating accounts."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:83
+msgid ""
+"<i>The above information assumes that you are using \"normal\" web "
+"browser settings, whereby images are always loaded and HTTP referrer \n"
+"    information is always sent.</i>"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:88
+msgid ""
+"It is impractical to constantly modify this privacy policy when "
+"MetaBrainz projects change which third party content they utilize. We "
+"will \n"
+"    aim to use common sense, respect to our community and community "
+"review when adding more content from third party sites. We will also \n"
+"    periodically review our policy to ensure that it remains current."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:93
 msgid "Applicable to account holders"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:94
+#: metabrainz/templates/index/privacy.html:95
 msgid "Account creation"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:108
+#: metabrainz/templates/index/privacy.html:97
+msgid ""
+"When creating an account with a MetaBrainz project you need to pick a "
+"unique username and choose a password, the username you pick is the \n"
+"    only name associated with your account and will be what other "
+"MetaBrainz users know you as. You may optionally also tell us other \n"
+"    information about yourself that will be displayed to other MetaBrainz"
+" users and the public."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:103
+msgid ""
+"Additionally, in order to edit the databases you will need to provide a "
+"confirmed email address. This email address will be held in \n"
+"    confidence, the only method of revealing your email address to "
+"another user is if you choose to send a message to another \n"
+"    user and enable the option to \"reveal my email address\". Changing "
+"the email address stored with your account will require you to \n"
+"    verify the new address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:109
 msgid "Edits and Notes"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:114
+#: metabrainz/templates/index/privacy.html:111
+msgid ""
+"If you make any changes to a MetaBrainz project database, such as adding "
+"any data, the details of those changes will be visible to \n"
+"    other logged-in users and the change will be associated with your "
+"username."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:115
 msgid "Subscriptions on MusicBrainz"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:131
+#: metabrainz/templates/index/privacy.html:117
+msgid ""
+"As a logged-in user you can subscribe to one or more artists, labels, "
+"collections or other editors. The act of subscribing causes \n"
+"    any edits made to (or by in the case of another editor) those "
+"entities to be emailed to you. By default, other users can see your \n"
+"    list of subscriptions, however, you can opt out of this by editing "
+"the appropriate preference."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:123
+msgid ""
+"This does not provide \"perfect\" privacy though, in some cases it will "
+"be possible to infer information about the contents of your \n"
+"    subscription list even though you have disallowed others from viewing"
+" that list directly. This imperfection arises because various \n"
+"    parts of the system behave differently depending on whether or not an"
+" entity has any subscribers; also, the number of users \n"
+"    subscribed to each artist is available via the artist pages. In the "
+"most extreme (possibly contrived) example, imagine that all \n"
+"    users have their subscriptions set to \"public\", except for exactly "
+"one user whose list is \"private\". In that case, any discrepancy \n"
+"    for a given artist between the shown list of subscribers and the "
+"total number of subscribers must be down to that one user. Thus, \n"
+"    you can infer what artists are on that user's list."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:132
 msgid "Third-party sites"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:145
+#: metabrainz/templates/index/privacy.html:134
+#, python-format
+msgid ""
+"Our code reviews are done on GitHub, which is not under the control of "
+"MetaBrainz. Participating in code reviews or other\n"
+"    tasks carried out on GitHub are subject to <a "
+"href=\"%(github_url)s\">GitHub's privacy policy</a>."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:140
+#, python-format
+msgid ""
+"Our translations platform is provided and hosted by Weblate, which has a "
+"data processing agreement with MetaBrainz.\n"
+"    Participating in translations is subject to <a "
+"href=\"%(weblate_url)s\">dedicated legal terms</a>.\n"
+"    Any translations you make will be submitted to our Git repositories "
+"and publicly associated with your username;\n"
+"    if you so choose, you can also publicly associate them with your own "
+"verified email address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:147
 msgid "MetaBrainz donors"
 msgstr "Doadores MetaBrainz"
 
-#: metabrainz/templates/index/privacy.html:147
+#: metabrainz/templates/index/privacy.html:149
 msgid ""
 "When you make a donation to the MetaBrainz Foundation, we are legally\n"
 "    required to collect your personal information and keep it in our "
@@ -1416,7 +2436,7 @@ msgstr ""
 "caso sejamos auditados pelo IRS. Não divulgaremos suas informações\n"
 "pessoais a mais ninguém, nunca."
 
-#: metabrainz/templates/index/privacy.html:153
+#: metabrainz/templates/index/privacy.html:155
 msgid ""
 "We believe in transparent finances, which means that we list all "
 "donations\n"
@@ -1426,11 +2446,34 @@ msgid ""
 "process."
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:158
+#: metabrainz/templates/index/privacy.html:160
 msgid "Exceptions"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:598
+#: metabrainz/templates/index/privacy.html:162
+msgid ""
+"<i><b>Please note</b>: Reasonable exceptions may apply to the above "
+"policy, for example to comply with applicable laws.\n"
+"    Also, members of the MetaBrainz team and other personnel contracted "
+"to provide services to MetaBrainz may have access to\n"
+"    our infrastructure and could therefore view any information contained"
+" therein. However all personnel are contractually bound\n"
+"    by non-disclosure clauses which prevent them from making any such "
+"information available to others."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:171
+#, python-format
+msgid ""
+"If you have any questions about our GDPR statement, please <a "
+"href=\"%(contact_url)s\">contact us</a>. To report\n"
+"   any privacy problems, violations or leaks, our GDPR representative is "
+"our Interim Executive Director Nicolás Tamargo and for\n"
+"   privacy issues contact him at <strong><a "
+"href=\"mailto:gdpr@metabrainz.org\">gdpr@metabrainz.org</a></strong>."
+msgstr ""
+
+#: frontend/js/src/Profile.tsx:603
 #: frontend/js/src/forms/ProfileChangePassword.tsx:22
 #: frontend/js/src/forms/ProfileChangePassword.tsx:111
 #: metabrainz/templates/index/profile-change-password.html:3
@@ -1681,6 +2724,11 @@ msgstr ""
 
 #: metabrainz/templates/index/team.html:26
 msgid "He lives on in our hearts and in open source."
+msgstr ""
+
+#: metabrainz/templates/index/team.html:29
+#: metabrainz/templates/index/team.html:315
+msgid "you’re welcome to try"
 msgstr ""
 
 #: metabrainz/templates/index/team.html:39
@@ -2183,8 +3231,10 @@ msgstr ""
 
 #: metabrainz/templates/payments/donate.html:146
 msgid ""
-"Due to the increased unreliability of the US Postal Service we have "
-"stopped accepting paper checks. Sorry!"
+"Due to the increased unreliability of the US Postal Service and the "
+"relatively large fees involved, we ask you to only send a paper check if "
+"it is the only possible option. Due to the fees, we will not cash checks "
+"for less than $25."
 msgstr ""
 
 #: metabrainz/templates/payments/donate.html:241
@@ -3071,8 +4121,8 @@ msgid "Monthly balance sheets"
 msgstr "Balanços mensais"
 
 #: frontend/js/src/Profile.tsx:520
-#: frontend/js/src/forms/SignupCommercial.tsx:175
-#: frontend/js/src/forms/SignupCommercial.tsx:554
+#: frontend/js/src/forms/SignupCommercial.tsx:180
+#: frontend/js/src/forms/SignupCommercial.tsx:558
 #: frontend/js/src/forms/SignupNonCommercial.tsx:106
 #: frontend/js/src/forms/SignupNonCommercial.tsx:318
 #: metabrainz/templates/supporters/account-type.html:3
@@ -3094,6 +4144,7 @@ msgid "Non-commercial / Personal"
 msgstr "Não comercial / Pessoal"
 
 #: frontend/js/src/Profile.tsx:235
+#: frontend/js/src/forms/SignupNonCommercial.tsx:107
 #: frontend/js/src/forms/SignupNonCommercial.tsx:151
 #: metabrainz/templates/supporters/account-type.html:42
 msgid "Non-commercial"
@@ -3107,57 +4158,46 @@ msgstr ""
 msgid "Personal or university assignment user."
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:48
-#: metabrainz/templates/supporters/account-type.html:90
-#: metabrainz/templates/supporters/account-type.html:141
-msgid "Upgrade"
-msgstr ""
-
 #: frontend/js/src/Profile.tsx:235
-#: frontend/js/src/forms/SignupCommercial.tsx:176
-#: frontend/js/src/forms/SignupCommercial.tsx:228
-#: metabrainz/templates/supporters/account-type.html:61
+#: frontend/js/src/forms/SignupCommercial.tsx:181
+#: frontend/js/src/forms/SignupCommercial.tsx:233
+#: metabrainz/templates/supporters/account-type.html:56
 msgid "Commercial"
 msgstr "Comercial"
 
-#: metabrainz/templates/supporters/account-type.html:83
-#: metabrainz/templates/supporters/account-type.html:135
+#: metabrainz/templates/supporters/account-type.html:78
+#: metabrainz/templates/supporters/account-type.html:125
 #, python-format
 msgid "$%(tier_price)s/month and up"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:87
-#: metabrainz/templates/supporters/account-type.html:138
+#: metabrainz/templates/supporters/account-type.html:82
+#: metabrainz/templates/supporters/account-type.html:128
 msgid "More info"
 msgstr "Mais informações"
 
-#: metabrainz/templates/supporters/account-type.html:104
+#: metabrainz/templates/supporters/account-type.html:94
 msgid "View all tiers"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:112
+#: metabrainz/templates/supporters/account-type.html:102
 msgid "Some of our Unicorn members"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:123
+#: metabrainz/templates/supporters/account-type.html:113
 msgid "See all our supporters"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:151
+#: metabrainz/templates/supporters/account-type.html:136
 msgid "View featured tiers"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:158
+#: metabrainz/templates/supporters/account-type.html:143
 #, python-format
 msgid ""
 "If you are not sure which tier to pick, please\n"
 "      <a href=\"%(contact_url)s\">contact us</a>."
 msgstr ""
-
-#: metabrainz/templates/supporters/account-type.html:166
-#, fuzzy
-msgid "Back to Profile"
-msgstr "Seu perfil"
 
 #: metabrainz/templates/supporters/bad-standing.html:3
 #: metabrainz/templates/supporters/bad-standing.html:6
@@ -3218,9 +4258,9 @@ msgid "Forgot your username"
 msgstr ""
 
 #: frontend/js/src/forms/ResetPassword.tsx:79
-#: frontend/js/src/forms/SignupCommercial.tsx:320
+#: frontend/js/src/forms/SignupCommercial.tsx:325
 #: frontend/js/src/forms/SignupNonCommercial.tsx:227
-#: frontend/js/src/forms/SignupUser.tsx:169
+#: frontend/js/src/forms/SignupUser.tsx:175
 #: metabrainz/templates/users/reauthenticate.html:3
 #: metabrainz/templates/users/reauthenticate.html:6
 msgid "Confirm Password"
@@ -3230,17 +4270,22 @@ msgstr ""
 msgid "Please re-enter your password to continue."
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:108
+#: frontend/js/src/ProfileDelete.tsx:110
 #: frontend/js/src/forms/DeleteApplication.tsx:53
 #: frontend/js/src/forms/OAuthPrompt.tsx:54
 #: frontend/js/src/forms/ProfileChangePassword.tsx:104
 #: frontend/js/src/forms/ProfileEdit.tsx:105
-#: metabrainz/templates/users/reauthenticate.html:23
+#: metabrainz/templates/users/reauthenticate.html:28
 msgid "Cancel"
 msgstr ""
 
-#: metabrainz/templates/users/reauthenticate.html:24
+#: metabrainz/templates/users/reauthenticate.html:29
 msgid "Continue"
+msgstr ""
+
+#: frontend/js/src/forms/utils.tsx:202
+#: metabrainz/templates/users/reauthenticate.html:40
+msgid "Password must not exceed 72 bytes."
 msgstr ""
 
 #: frontend/js/src/forms/ResetPassword.tsx:27
@@ -3248,38 +4293,38 @@ msgstr ""
 msgid "Reset your password"
 msgstr ""
 
-#: frontend/js/src/hooks/useEmailValidation.ts:41 metabrainz/user/forms.py:15
+#: frontend/js/src/hooks/useEmailValidation.ts:41 metabrainz/user/forms.py:16
 msgid "Registration from this email domain is not allowed."
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:50
 #: frontend/js/src/forms/LostPassword.tsx:45
-#: frontend/js/src/forms/SignupCommercial.tsx:270
+#: frontend/js/src/forms/SignupCommercial.tsx:275
 #: frontend/js/src/forms/SignupNonCommercial.tsx:175
-#: frontend/js/src/forms/SignupUser.tsx:114 metabrainz/user/forms.py:20
-#: metabrainz/user/forms.py:45 metabrainz/user/forms.py:62
+#: frontend/js/src/forms/SignupUser.tsx:120 metabrainz/user/forms.py:22
+#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:75
 msgid "Username"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:42
 #: frontend/js/src/forms/LostPassword.tsx:37
-#: frontend/js/src/forms/SignupCommercial.tsx:153
+#: frontend/js/src/forms/SignupCommercial.tsx:158
 #: frontend/js/src/forms/SignupNonCommercial.tsx:84
-#: frontend/js/src/forms/SignupUser.tsx:67 metabrainz/user/forms.py:21
-#: metabrainz/user/forms.py:45 metabrainz/user/forms.py:62
+#: frontend/js/src/forms/SignupUser.tsx:73 metabrainz/user/forms.py:26
+#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:75
 msgid "Username is required!"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:63
 #: frontend/js/src/forms/ResetPassword.tsx:72
-#: frontend/js/src/forms/SignupCommercial.tsx:308
+#: frontend/js/src/forms/SignupCommercial.tsx:313
 #: frontend/js/src/forms/SignupNonCommercial.tsx:214
-#: frontend/js/src/forms/SignupUser.tsx:157 metabrainz/user/forms.py:46
-#: metabrainz/user/forms.py:52
+#: frontend/js/src/forms/SignupUser.tsx:163 metabrainz/user/forms.py:53
+#: metabrainz/user/forms.py:62
 msgid "Password"
 msgstr ""
 
-#: frontend/js/src/forms/LoginUser.tsx:76 metabrainz/user/forms.py:47
+#: frontend/js/src/forms/LoginUser.tsx:76 metabrainz/user/forms.py:57
 msgid "Remember me"
 msgstr ""
 
@@ -3291,11 +4336,11 @@ msgstr ""
 msgid "Username contains invalid or invisible characters."
 msgstr ""
 
-#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:181
+#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:220
 msgid "Hide password"
 msgstr ""
 
-#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:181
+#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:220
 msgid "Show password"
 msgstr ""
 
@@ -3352,11 +4397,11 @@ msgstr ""
 msgid "Revoke access"
 msgstr ""
 
-#: frontend/js/src/OAuthError.tsx:17
+#: frontend/js/src/OAuthError.tsx:18
 msgid "OAuth2 Error"
 msgstr ""
 
-#: frontend/js/src/OAuthError.tsx:18
+#: frontend/js/src/OAuthError.tsx:19
 msgid "An error occurred during OAuth authentication process."
 msgstr ""
 
@@ -3386,8 +4431,8 @@ msgstr ""
 
 #: frontend/js/src/Profile.tsx:109
 msgid ""
-"Are you sure you want to generate new access token? Current token will be"
-" revoked!"
+"Are you sure you want to generate a new access token? The current token "
+"will be revoked!"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:118
@@ -3502,8 +4547,8 @@ msgid "Contact Information"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:310 frontend/js/src/forms/ProfileEdit.tsx:70
-#: frontend/js/src/forms/SignupCommercial.tsx:284
-#: frontend/js/src/forms/SignupCommercial.tsx:333
+#: frontend/js/src/forms/SignupCommercial.tsx:289
+#: frontend/js/src/forms/SignupCommercial.tsx:338
 #: frontend/js/src/forms/SignupNonCommercial.tsx:189
 #: frontend/js/src/forms/SignupNonCommercial.tsx:241
 msgid "Contact name"
@@ -3618,7 +4663,7 @@ msgstr ""
 msgid "Once you delete your account, there is no going back. Please be certain."
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:550 frontend/js/src/ProfileDelete.tsx:105
+#: frontend/js/src/Profile.tsx:550 frontend/js/src/ProfileDelete.tsx:107
 msgid "Delete My Account"
 msgstr ""
 
@@ -3630,39 +4675,39 @@ msgstr ""
 msgid "Need to delete your account?"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:574
+#: frontend/js/src/Profile.tsx:575
 msgid ""
 "Deletion of supporter accounts requires manual review. Please contact us "
-"at"
+"at <email />."
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:594
+#: frontend/js/src/Profile.tsx:599
 msgid "Security"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:626
+#: frontend/js/src/Profile.tsx:631
 msgid "MetaBrainz Applications"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:630
+#: frontend/js/src/Profile.tsx:635
 msgid ""
 "With your MetaBrainz account, you can access every project in the "
 "MetaBrainz family:"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:643
+#: frontend/js/src/Profile.tsx:648
 msgid "The open-source music encyclopedia"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:655
+#: frontend/js/src/Profile.tsx:660
 msgid "Track, visualise and share the music you listen to"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:667
+#: frontend/js/src/Profile.tsx:672
 msgid "The open-source book database"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:679
+#: frontend/js/src/Profile.tsx:684
 msgid "Creative Commons licensed reviews"
 msgstr ""
 
@@ -3685,7 +4730,7 @@ msgid "Permanently remove all your account information"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:64
-msgid "Revoke all your API tokens and access"
+msgid "Revoke all your tokens and access to the replication API"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:65
@@ -3697,14 +4742,16 @@ msgid "Log you out of all MetaBrainz services"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:70
-msgid "Your username will be reserved and cannot be reused."
+msgid ""
+"Your username will be reserved and cannot be reused without the "
+"intervention of an administrator."
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:82
+#: frontend/js/src/ProfileDelete.tsx:84
 msgid "To confirm, type your username '<username />' below:"
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:105
+#: frontend/js/src/ProfileDelete.tsx:107
 msgid "Deleting..."
 msgstr ""
 
@@ -3717,64 +4764,7 @@ msgstr "Seu perfil"
 msgid "Close"
 msgstr ""
 
-#: frontend/js/src/forms/ConditionsModal.tsx:23
-msgid "Licensing"
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:25
-msgid ""
-"Any contributions you make to any MetaBrainz service will be released "
-"into the Public Domain and/or licensed under a Creative Commons by-nc-sa "
-"license. Furthermore, you give the MetaBrainz Foundation the right to "
-"license this data for commercial use."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:30
-msgid "Please read our <licenseLink>license page</licenseLink> for more details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:45
-msgid ""
-"MetaBrainz strongly believes in the privacy of its users. Any personal "
-"information you choose to provide will not be sold or shared with anyone "
-"else."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:50
-msgid ""
-"Please read our <privacyLink>privacy policy</privacyLink> for more "
-"details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:59
-msgid "GDPR compliance"
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:61
-msgid ""
-"You may remove your personal information from our services anytime by "
-"deleting your account."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:66
-msgid ""
-"Please read our <gdprLink>GDPR compliance statement</gdprLink> for more "
-"details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:78
-msgid ""
-"Creating an account on MetaBrainz will give you access to all of our "
-"projects, such as MusicBrainz, ListenBrainz, BookBrainz, and more."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:82
-msgid ""
-"We create a placeholder account for all the MetaBrainz projects when you "
-"sign up, and you are one log-in away from activating them."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:91
+#: frontend/js/src/forms/ConditionsModal.tsx:29
 msgid "Sounds good"
 msgstr ""
 
@@ -3860,8 +4850,8 @@ msgstr ""
 msgid "Forgot your password?"
 msgstr ""
 
-#: frontend/js/src/forms/LoginUser.tsx:109
-msgid "Don't have an account?"
+#: frontend/js/src/forms/LoginUser.tsx:110
+msgid "Don't have an account? <signupLink>Sign up</signupLink>"
 msgstr ""
 
 #: frontend/js/src/forms/LostPassword.tsx:38
@@ -3890,15 +4880,72 @@ msgstr ""
 msgid "Allow access"
 msgstr ""
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:71
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:10
+msgid "Licensing"
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:12
+msgid ""
+"Any contributions you make to any MetaBrainz service will be released "
+"into the Public Domain and/or licensed under a Creative Commons by-nc-sa "
+"license. Furthermore, you give the MetaBrainz Foundation the right to "
+"license this data for commercial use."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:17
+msgid "Please read our <licenseLink>license page</licenseLink> for more details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:34
+msgid ""
+"MetaBrainz strongly believes in the privacy of its users. Any personal "
+"information you choose to provide will not be sold or shared with anyone "
+"else."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:39
+msgid ""
+"Please read our <privacyLink>privacy policy</privacyLink> for more "
+"details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:50
+msgid "GDPR compliance"
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:52
+msgid ""
+"You may remove your personal information from our services anytime by "
+"deleting your account."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:57
+msgid ""
+"Please read our <gdprLink>GDPR compliance statement</gdprLink> for more "
+"details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:71
+msgid ""
+"Creating an account on MetaBrainz will give you access to all of our "
+"projects, such as MusicBrainz, ListenBrainz, BookBrainz, and more."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:75
+msgid ""
+"We create a placeholder account for all the MetaBrainz projects when you "
+"sign up, and you are one log-in away from activating them."
+msgstr ""
+
+#: frontend/js/src/forms/ProfileChangePassword.tsx:70
 msgid "Current Password"
 msgstr ""
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:80
+#: frontend/js/src/forms/ProfileChangePassword.tsx:79
 msgid "New Password"
 msgstr ""
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:89
+#: frontend/js/src/forms/ProfileChangePassword.tsx:88
 msgid "Confirm New Password"
 msgstr ""
 
@@ -3910,194 +4957,183 @@ msgstr ""
 msgid "Reset Password"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:38
-msgid "If you would like to support us with more than $"
+#: frontend/js/src/forms/SignupCommercial.tsx:40
+msgid ""
+"If you would like to support us with more than ${{minPledge}}, please "
+"enter the actual amount here:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:39
-msgid ", please enter the actual amount here:"
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:144
+#: frontend/js/src/forms/SignupCommercial.tsx:149
 #: frontend/js/src/forms/SignupNonCommercial.tsx:75
-#: frontend/js/src/forms/SignupUser.tsx:87
+#: frontend/js/src/forms/SignupUser.tsx:93
 msgid "Captcha is required!"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:179
+#: frontend/js/src/forms/SignupCommercial.tsx:184
 #: frontend/js/src/forms/SignupNonCommercial.tsx:110
 #: frontend/js/src/forms/SignupUser.tsx:46
 #, fuzzy
 msgid "Access all MetaBrainz projects"
 msgstr "Projetos MetaBrainz"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:182
+#: frontend/js/src/forms/SignupCommercial.tsx:187
 msgid "Note:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:184
+#: frontend/js/src/forms/SignupCommercial.tsx:189
 msgid ""
 "Signing up for any tier other than the <italic>Stealth startup</italic> "
 "tier will publicly list your company on this web site. However, we will "
 "not publish any of your private details."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:221
+#: frontend/js/src/forms/SignupCommercial.tsx:226
 #: frontend/js/src/forms/SignupNonCommercial.tsx:145
 msgid "Account type"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:234
+#: frontend/js/src/forms/SignupCommercial.tsx:239
 msgid "Selected tier"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:242
-msgid "month and up"
+#: frontend/js/src/forms/SignupCommercial.tsx:247
+msgid "${{tierPrice}}/month and up"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:250
+#: frontend/js/src/forms/SignupCommercial.tsx:255
 msgid "Change account type or tier"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:261
+#: frontend/js/src/forms/SignupCommercial.tsx:266
 #: frontend/js/src/forms/SignupNonCommercial.tsx:166
 msgid "Your account:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:271
+#: frontend/js/src/forms/SignupCommercial.tsx:276
 #: frontend/js/src/forms/SignupNonCommercial.tsx:176
-#: frontend/js/src/forms/SignupUser.tsx:114
+#: frontend/js/src/forms/SignupUser.tsx:120
 msgid "(public)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:291
+#: frontend/js/src/forms/SignupCommercial.tsx:296
 #: frontend/js/src/forms/SignupNonCommercial.tsx:196
-#: frontend/js/src/forms/SignupUser.tsx:127
+#: frontend/js/src/forms/SignupUser.tsx:133
 msgid "E-mail address"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:295
+#: frontend/js/src/forms/SignupCommercial.tsx:300
 #: frontend/js/src/forms/SignupNonCommercial.tsx:200
-#: frontend/js/src/forms/SignupUser.tsx:131
+#: frontend/js/src/forms/SignupUser.tsx:137
 msgid "(checking...)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:314
+#: frontend/js/src/forms/SignupCommercial.tsx:319
 #: frontend/js/src/forms/SignupNonCommercial.tsx:220
-#: frontend/js/src/forms/SignupUser.tsx:163
+#: frontend/js/src/forms/SignupUser.tsx:169
 msgid "Must be at least 8 characters"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:348
+#: frontend/js/src/forms/SignupCommercial.tsx:353
 msgid ""
 "If you don't have an organization name, you probably want to become a "
 "supporter as a <nonCommercialLink>Non-commercial / "
 "Personal</nonCommercialLink> supporter."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:358
+#: frontend/js/src/forms/SignupCommercial.tsx:363
 msgid ""
 "If you don't have an organization name, you probably want to sign up as a"
 " <nonCommercialLink>Non-commercial / Personal</nonCommercialLink> user."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:378
+#: frontend/js/src/forms/SignupCommercial.tsx:383
 msgid ""
 "Please tell us a little about your company and whether you plan to use "
 "our <apiLink>API</apiLink> or to <hostLink>host your own copy</hostLink> "
 "of the data."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:404
+#: frontend/js/src/forms/SignupCommercial.tsx:408
 msgid "Logo URL"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:405
+#: frontend/js/src/forms/SignupCommercial.tsx:409
 msgid "(preferably in SVG format)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:408
+#: frontend/js/src/forms/SignupCommercial.tsx:412
 msgid ""
 "Image should be about 250 pixels wide on a white or transparent "
 "background. We will host it on our site."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:421
+#: frontend/js/src/forms/SignupCommercial.tsx:425
 msgid ""
 "URL to where developers can use your APIs using MusicBrainz IDs, if "
-"available.."
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:430
-msgid "Your project"
+"available."
 msgstr ""
 
 #: frontend/js/src/forms/SignupCommercial.tsx:434
+msgid "Your project"
+msgstr ""
+
+#: frontend/js/src/forms/SignupCommercial.tsx:438
 #: frontend/js/src/forms/SignupNonCommercial.tsx:261
 msgid "(max 150 characters)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:451
+#: frontend/js/src/forms/SignupCommercial.tsx:455
 msgid "Billing address"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:502
+#: frontend/js/src/forms/SignupCommercial.tsx:506
 msgid ""
 "I agree to support the MetaBrainz Foundation when my organization is able"
 " to do so."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:507
+#: frontend/js/src/forms/SignupCommercial.tsx:511
+#: frontend/js/src/forms/SignupNonCommercial.tsx:284
 msgid ""
-"I also agree that if I generate a Live Data Feed access token, that I "
-"treat my access token as a secret and will not share this token publicly "
-"or commit it to a source code repository."
+"I also agree that if I generate a Live Data Feed access token, then I "
+"will treat my access token as a secret and will not share this token "
+"publicly or commit it to a source code repository."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:515
+#: frontend/js/src/forms/SignupCommercial.tsx:519
 msgid ""
 "The following information will be shown publicly: organization name, "
 "logo, website and API URLs, data usage description."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:520
+#: frontend/js/src/forms/SignupCommercial.tsx:524
 msgid ""
 "We'll send you more details about payment process once your application "
 "is approved."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:552
+#: frontend/js/src/forms/SignupCommercial.tsx:556
 #: frontend/js/src/forms/SignupNonCommercial.tsx:316
-#: frontend/js/src/forms/SignupUser.tsx:224
+#: frontend/js/src/forms/SignupUser.tsx:230
 msgid "Validating..."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:564
+#: frontend/js/src/forms/SignupCommercial.tsx:568
 #: frontend/js/src/forms/SignupNonCommercial.tsx:329
 #, fuzzy
 msgid "Back to profile"
 msgstr "Seu perfil"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:569
-#: frontend/js/src/forms/SignupNonCommercial.tsx:334
-msgid "Not a supporter?"
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:570
+#: frontend/js/src/forms/SignupCommercial.tsx:574
 #: frontend/js/src/forms/SignupNonCommercial.tsx:335
-msgid "Create a user account"
+msgid "Not a supporter? <signupLink>Create a user account</signupLink>"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:573
-#: frontend/js/src/forms/SignupNonCommercial.tsx:338
-#: frontend/js/src/forms/SignupUser.tsx:231
-msgid "Already have an account?"
+#: frontend/js/src/forms/SignupCommercial.tsx:583
+#: frontend/js/src/forms/SignupNonCommercial.tsx:344
+#: frontend/js/src/forms/SignupUser.tsx:238
+msgid "Already have an account? <loginLink>Sign in</loginLink>"
 msgstr ""
-
-#: frontend/js/src/forms/SignupNonCommercial.tsx:107
-#, fuzzy
-msgid "non-commercial"
-msgstr "Não comercial"
 
 #: frontend/js/src/forms/SignupNonCommercial.tsx:113
 msgid ""
@@ -4124,46 +5160,40 @@ msgid ""
 "income per year) or personal uses only."
 msgstr ""
 
-#: frontend/js/src/forms/SignupNonCommercial.tsx:284
-msgid ""
-"I also agree that if I generate a Live Data Feed access token, then I "
-"will treat my access token as a secret and will not share this token "
-"publicly or commit it to a source code repository."
-msgstr ""
-
 #: frontend/js/src/forms/SignupUser.tsx:43
 msgid "Create your account"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:50
-msgid "Registration started by"
+#: frontend/js/src/forms/SignupUser.tsx:51
+msgid "Registration started by <client />"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:69
+#: frontend/js/src/forms/SignupUser.tsx:75
+#: frontend/js/src/hooks/useEmailValidation.ts:82
 msgid "Invalid email address."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:150
+#: frontend/js/src/forms/SignupUser.tsx:156
 msgid ""
 "This username and email were provided by the app that started "
 "registration. You can change them later from MetaBrainz settings."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:182
+#: frontend/js/src/forms/SignupUser.tsx:188
 msgid ""
 "I accept that my contributions will be released into the public domain or"
 " licensed for use."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:191
+#: frontend/js/src/forms/SignupUser.tsx:197
 msgid "We will never share your personal information."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:200
+#: frontend/js/src/forms/SignupUser.tsx:206
 msgid "Click here to read more"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:224
+#: frontend/js/src/forms/SignupUser.tsx:230
 msgid "Create account"
 msgstr ""
 
@@ -4173,10 +5203,6 @@ msgstr ""
 
 #: frontend/js/src/hooks/useEmailValidation.ts:47
 msgid "Email validation failed"
-msgstr ""
-
-#: frontend/js/src/hooks/useEmailValidation.ts:82
-msgid "Invalid email address"
 msgstr ""
 
 #~ msgid "You need to specify amount!"
@@ -5412,4 +6438,100 @@ msgstr ""
 
 #~ msgid "Privacy policy"
 #~ msgstr "Termos de Privacidade"
+
+#~ msgid "You need to specify website of the organization."
+#~ msgstr ""
+
+#~ msgid ""
+#~ "We are currently evaluating our overall"
+#~ " online advertising strategy. We are "
+#~ "evaluating advertising, traffic optimization,\n"
+#~ ""
+#~ "    search engine optimization and "
+#~ "software monitization technologies. If you "
+#~ "provide these professional services, please"
+#~ " provide a detailed\n"
+#~ "    deck of your comprehensive services"
+#~ " to the following email address. "
+#~ "<em>Please respect our other non-media"
+#~ " teams and do not contact us \n"
+#~ "    regarding these services on any "
+#~ "other of our email addresses. We "
+#~ "will disregard the entirety of your "
+#~ "submissions if you contact us any "
+#~ "other way!</em>"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Please come ask your questions at "
+#~ "our <a href=\"%(forums_url)s\">forums</a>! We "
+#~ "would love to\n"
+#~ "    answer any questions you may have."
+#~ msgstr ""
+#~ "Por favor venha perguntar suas perguntas"
+#~ " em nossos <a href=\"%(forums_url)s\">fóruns</a>!"
+#~ " Vamos adorar\n"
+#~ "responder qualquer perguntar que tiver."
+
+#~ msgid ""
+#~ "Due to the increased unreliability of"
+#~ " the US Postal Service we have "
+#~ "stopped accepting paper checks. Sorry!"
+#~ msgstr ""
+
+#~ msgid "Upgrade"
+#~ msgstr ""
+
+#~ msgid "Back to Profile"
+#~ msgstr "Seu perfil"
+
+#~ msgid ""
+#~ "Deletion of supporter accounts requires "
+#~ "manual review. Please contact us at"
+#~ msgstr ""
+
+#~ msgid "Revoke all your API tokens and access"
+#~ msgstr ""
+
+#~ msgid "Your username will be reserved and cannot be reused."
+#~ msgstr ""
+
+#~ msgid "Don't have an account?"
+#~ msgstr ""
+
+#~ msgid "If you would like to support us with more than $"
+#~ msgstr ""
+
+#~ msgid ", please enter the actual amount here:"
+#~ msgstr ""
+
+#~ msgid "month and up"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "I also agree that if I generate"
+#~ " a Live Data Feed access token, "
+#~ "that I treat my access token as"
+#~ " a secret and will not share "
+#~ "this token publicly or commit it "
+#~ "to a source code repository."
+#~ msgstr ""
+
+#~ msgid "Not a supporter?"
+#~ msgstr ""
+
+#~ msgid "Create a user account"
+#~ msgstr ""
+
+#~ msgid "Already have an account?"
+#~ msgstr ""
+
+#~ msgid "non-commercial"
+#~ msgstr "Não comercial"
+
+#~ msgid "Registration started by"
+#~ msgstr ""
+
+#~ msgid "Invalid email address"
+#~ msgstr ""
 

--- a/metabrainz/translations/pt_PT/LC_MESSAGES/messages.po
+++ b/metabrainz/translations/pt_PT/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-07-25 16:21+0200\n"
+"POT-Creation-Date: 2026-09-08 11:18+0200\n"
 "PO-Revision-Date: 2026-06-12 00:54+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: pt_PT\n"
@@ -22,162 +22,247 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.18.0\n"
 
-#: metabrainz/index/forms.py:46
+#: metabrainz/errors.py:24
+msgid "Authorization was declined."
+msgstr ""
+
+#: metabrainz/errors.py:25
+msgid "The authorization request was invalid."
+msgstr ""
+
+#: metabrainz/errors.py:26
+msgid "The application could not be authenticated."
+msgstr ""
+
+#: metabrainz/errors.py:27
+msgid "This application is not allowed to request authorization."
+msgstr ""
+
+#: metabrainz/errors.py:28
+msgid "The application asked for a response type this server does not support."
+msgstr ""
+
+#: metabrainz/errors.py:29
+msgid "The permissions requested by the application are invalid."
+msgstr ""
+
+#: metabrainz/errors.py:30
+msgid "You need to sign in to continue."
+msgstr ""
+
+#: metabrainz/errors.py:31
+msgid "Your consent is required to continue."
+msgstr ""
+
+#: metabrainz/password.py:12
+#, python-format
+msgid "Password must not exceed %(max_bytes)s bytes."
+msgstr ""
+
+#: metabrainz/index/forms.py:48
 #, python-format
 msgid "'%(value)s' is not a valid choice for this field"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileEdit.tsx:27
-#: frontend/js/src/forms/SignupCommercial.tsx:154
+#: frontend/js/src/forms/SignupCommercial.tsx:159
 #: frontend/js/src/forms/SignupNonCommercial.tsx:85
-#: frontend/js/src/forms/SignupUser.tsx:70
-#: frontend/js/src/hooks/useEmailValidation.ts:78 metabrainz/index/forms.py:57
-#: metabrainz/user/forms.py:25 metabrainz/user/forms.py:57
-#: metabrainz/user/forms.py:63
+#: frontend/js/src/forms/SignupUser.tsx:76
+#: frontend/js/src/hooks/useEmailValidation.ts:78 metabrainz/index/forms.py:59
+#: metabrainz/user/forms.py:31 metabrainz/user/forms.py:70
+#: metabrainz/user/forms.py:76
 msgid "Email address is required!"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:34
-#: metabrainz/index/forms.py:63
+#: metabrainz/index/forms.py:65
 msgid "Current password is required!"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:43
 #: frontend/js/src/forms/ProfileChangePassword.tsx:37
 #: frontend/js/src/forms/ResetPassword.tsx:39
-#: frontend/js/src/forms/SignupCommercial.tsx:156
+#: frontend/js/src/forms/SignupCommercial.tsx:161
 #: frontend/js/src/forms/SignupNonCommercial.tsx:87
-#: frontend/js/src/forms/SignupUser.tsx:72 metabrainz/index/forms.py:66
-#: metabrainz/user/forms.py:29 metabrainz/user/forms.py:46
-#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:69
+#: frontend/js/src/forms/SignupUser.tsx:78 metabrainz/index/forms.py:69
+#: metabrainz/user/forms.py:35 metabrainz/user/forms.py:54
+#: metabrainz/user/forms.py:63 metabrainz/user/forms.py:82
 msgid "Password is required!"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:41
-#: frontend/js/src/forms/SignupCommercial.tsx:160
+#: frontend/js/src/forms/SignupCommercial.tsx:165
 #: frontend/js/src/forms/SignupNonCommercial.tsx:91
-#: frontend/js/src/forms/SignupUser.tsx:76 metabrainz/index/forms.py:70
-#: metabrainz/user/forms.py:33 metabrainz/user/forms.py:73
+#: frontend/js/src/forms/SignupUser.tsx:82 metabrainz/index/forms.py:74
+#: metabrainz/user/forms.py:40 metabrainz/user/forms.py:87
 msgid "Confirm Password is required!"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:46
 #: frontend/js/src/forms/ResetPassword.tsx:48
-#: frontend/js/src/forms/SignupCommercial.tsx:165
+#: frontend/js/src/forms/SignupCommercial.tsx:170
 #: frontend/js/src/forms/SignupNonCommercial.tsx:96
-#: frontend/js/src/forms/SignupUser.tsx:81 metabrainz/index/forms.py:72
-#: metabrainz/user/forms.py:35 metabrainz/user/forms.py:75
+#: frontend/js/src/forms/SignupUser.tsx:87 metabrainz/index/forms.py:76
+#: metabrainz/user/forms.py:42 metabrainz/user/forms.py:89
 msgid "Confirm Password should match password!"
 msgstr ""
 
 #: frontend/js/src/Applications.tsx:56 frontend/js/src/Applications.tsx:86
 #: frontend/js/src/Profile.tsx:272 frontend/js/src/Profile.tsx:482
-#: metabrainz/index/forms.py:78
+#: metabrainz/index/forms.py:82
 msgid "Name"
 msgstr ""
 
-#: metabrainz/index/forms.py:79
+#: metabrainz/index/forms.py:83
 msgid "Contact name field is empty."
 msgstr ""
 
-#: metabrainz/index/views.py:234
+#: metabrainz/index/views.py:251
 msgid "Profile updated successfully."
 msgstr ""
 
-#: metabrainz/index/views.py:261
+#: metabrainz/index/views.py:278
 msgid "Current password is incorrect."
 msgstr ""
 
-#: metabrainz/index/views.py:266
+#: metabrainz/index/views.py:283
 msgid "Password changed successfully."
 msgstr ""
 
-#: metabrainz/index/views.py:372
+#: metabrainz/index/views.py:389
 msgid "You have updated an application!"
 msgstr ""
 
-#: metabrainz/index/views.py:424
+#: metabrainz/index/views.py:441
 msgid "You have deleted an application."
 msgstr ""
 
-#: metabrainz/index/views.py:426
+#: metabrainz/index/views.py:443
 msgid "Failed to delete an application."
 msgstr ""
 
-#: metabrainz/index/views.py:449
+#: metabrainz/index/views.py:466
 msgid "Revoked tokens successfully!"
 msgstr ""
 
-#: metabrainz/index/views.py:478
+#: metabrainz/index/views.py:495
 msgid "Your account has been deleted."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:106 metabrainz/oauth/forms.py:58
+#: frontend/js/src/forms/CreateApplication.tsx:106 metabrainz/oauth/forms.py:57
 msgid "Application Name"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:59
+#: metabrainz/oauth/forms.py:58
 msgid "Application name field is empty."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:60 metabrainz/oauth/forms.py:60
+#: frontend/js/src/forms/CreateApplication.tsx:60 metabrainz/oauth/forms.py:59
 msgid "Application name needs to be at least 3 characters long."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:64 metabrainz/oauth/forms.py:61
+#: frontend/js/src/forms/CreateApplication.tsx:64 metabrainz/oauth/forms.py:60
 msgid "Application name needs to be at most 64 characters long."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:114 metabrainz/oauth/forms.py:63
+#: frontend/js/src/forms/CreateApplication.tsx:114 metabrainz/oauth/forms.py:62
 msgid "Description"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:64
+#: metabrainz/oauth/forms.py:63
 msgid "Client description field is empty."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:65
+#: metabrainz/oauth/forms.py:64
 msgid "Client description needs to be at least 3 characters long."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:66
+#: metabrainz/oauth/forms.py:65
 msgid "Client description needs to be at most 512 characters long."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:122 metabrainz/oauth/forms.py:68
+#: frontend/js/src/forms/CreateApplication.tsx:122 metabrainz/oauth/forms.py:67
 msgid "Homepage"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:69
+#: metabrainz/oauth/forms.py:68
 msgid "Homepage field is empty."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:70
+#: metabrainz/oauth/forms.py:69
 msgid "Homepage is not a valid URI."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:71
+#: metabrainz/oauth/forms.py:70
 msgid "Homepage URL must use http or https"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:73
+#: metabrainz/oauth/forms.py:72
 msgid "Authorization callback URL"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:74
+#: metabrainz/oauth/forms.py:73
 msgid "Authorization callback URL field is empty."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:75
+#: metabrainz/oauth/forms.py:74
 msgid "Authorization callback URL is invalid."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:76
+#: metabrainz/oauth/forms.py:75
 msgid "Authorization callback URL must use http or https."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:81 metabrainz/oauth/forms.py:85
+#: metabrainz/oauth/forms.py:80 metabrainz/oauth/forms.py:84
 msgid "Confirm"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:15
+msgid "View your public account information"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:16
+msgid "View your email address"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:17
+msgid "View and modify your private tags"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:18
+msgid "View and modify your private ratings"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:19
+msgid "View and modify your private collections"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:20
+msgid "Submit new ISRCs to the database"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:21
+msgid "Submit new barcodes to the database"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:22
+msgid "Sign you in and view your unique user id"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:23
+msgid "Submit listens to ListenBrainz."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:24
+msgid "Create and modify CritiqueBrainz reviews."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:25
+msgid "Submit and delete votes on CritiqueBrainz reviews."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:26
+msgid "Modify profile info and delete profile on CritiqueBrainz."
 msgstr ""
 
 #: metabrainz/payments/views.py:164
@@ -227,178 +312,185 @@ msgid "Requested annual report was not found."
 msgstr ""
 
 #: frontend/js/src/forms/ProfileEdit.tsx:30
-#: frontend/js/src/forms/SignupCommercial.tsx:139
+#: frontend/js/src/forms/SignupCommercial.tsx:144
 #: frontend/js/src/forms/SignupNonCommercial.tsx:70
-#: metabrainz/supporter/forms.py:13
+#: metabrainz/supporter/forms.py:15
 msgid "Contact name is required!"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:437
+#: frontend/js/src/forms/SignupCommercial.tsx:441
 #: frontend/js/src/forms/SignupNonCommercial.tsx:264
-#: metabrainz/supporter/forms.py:15
+#: metabrainz/supporter/forms.py:17
 msgid ""
 "Can you please tell us more about the project in which you'd like to use "
 "our data? Do you plan to self host the data or use our APIs?"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:137
+#: frontend/js/src/forms/SignupCommercial.tsx:142
 #: frontend/js/src/forms/SignupNonCommercial.tsx:68
-#: metabrainz/supporter/forms.py:17
+#: metabrainz/supporter/forms.py:19
 msgid "Please, tell us how you (will) use our data."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:138
+#: frontend/js/src/forms/SignupCommercial.tsx:143
 #: frontend/js/src/forms/SignupNonCommercial.tsx:69
-#: metabrainz/supporter/forms.py:18
+#: metabrainz/supporter/forms.py:20
 msgid "Please, limit usage description to 500 characters."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:141
-#: frontend/js/src/forms/SignupCommercial.tsx:142
+#: frontend/js/src/forms/SignupCommercial.tsx:146
+#: frontend/js/src/forms/SignupCommercial.tsx:147
 #: frontend/js/src/forms/SignupNonCommercial.tsx:72
 #: frontend/js/src/forms/SignupNonCommercial.tsx:73
-#: frontend/js/src/forms/SignupUser.tsx:84
-#: frontend/js/src/forms/SignupUser.tsx:85 metabrainz/supporter/forms.py:21
-#: metabrainz/user/forms.py:38
+#: frontend/js/src/forms/SignupUser.tsx:90
+#: frontend/js/src/forms/SignupUser.tsx:91 metabrainz/supporter/forms.py:23
+#: metabrainz/user/forms.py:45
 msgid "You need to accept the agreement!"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:342
-#: metabrainz/supporter/forms.py:27
+#: frontend/js/src/forms/SignupCommercial.tsx:347
+#: metabrainz/supporter/forms.py:29
 msgid "Organization name"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:113
-#: metabrainz/supporter/forms.py:28
+#: frontend/js/src/forms/SignupCommercial.tsx:115
+#: metabrainz/supporter/forms.py:30
 msgid "You need to specify the name of your organization."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:373
-#: metabrainz/supporter/forms.py:30
+#: frontend/js/src/forms/SignupCommercial.tsx:378
+#: metabrainz/supporter/forms.py:32
 msgid "Organization description"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:116
-#: metabrainz/supporter/forms.py:31
+#: frontend/js/src/forms/SignupCommercial.tsx:118
+#: metabrainz/supporter/forms.py:33
 msgid "You need to provide description of your organization."
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:278
-#: frontend/js/src/forms/SignupCommercial.tsx:396
-#: metabrainz/supporter/forms.py:34
+#: frontend/js/src/forms/SignupCommercial.tsx:401
+#: metabrainz/supporter/forms.py:36
 msgid "Website URL"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:119
-#: metabrainz/supporter/forms.py:35
-msgid "You need to specify website of the organization."
+#: frontend/js/src/forms/SignupCommercial.tsx:121
+#: frontend/js/src/forms/SignupCommercial.tsx:123
+#: metabrainz/supporter/forms.py:38 metabrainz/supporter/forms.py:42
+msgid "Website URL must be a valid URL."
 msgstr ""
 
-#: metabrainz/supporter/forms.py:37
+#: metabrainz/supporter/forms.py:45
 msgid "Logo image URL"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:284
-#: frontend/js/src/forms/SignupCommercial.tsx:418
-#: metabrainz/supporter/forms.py:38
+#: frontend/js/src/forms/SignupCommercial.tsx:422
+#: metabrainz/supporter/forms.py:46
 msgid "API URL"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:457
-#: metabrainz/supporter/forms.py:40
+#: frontend/js/src/forms/SignupCommercial.tsx:461
+#: metabrainz/supporter/forms.py:48
 msgid "Street"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:123
-#: metabrainz/supporter/forms.py:41
+#: frontend/js/src/forms/SignupCommercial.tsx:128
+#: metabrainz/supporter/forms.py:49
 msgid "You need to specify street."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:465
-#: metabrainz/supporter/forms.py:43
+#: frontend/js/src/forms/SignupCommercial.tsx:469
+#: metabrainz/supporter/forms.py:51
 msgid "City"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:124
-#: metabrainz/supporter/forms.py:44
+#: frontend/js/src/forms/SignupCommercial.tsx:129
+#: metabrainz/supporter/forms.py:52
 msgid "You need to specify city."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:473
-#: metabrainz/supporter/forms.py:46
+#: frontend/js/src/forms/SignupCommercial.tsx:477
+#: metabrainz/supporter/forms.py:54
 msgid "State / Province"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:126
-#: metabrainz/supporter/forms.py:47
+#: frontend/js/src/forms/SignupCommercial.tsx:131
+#: metabrainz/supporter/forms.py:55
 msgid "You need to specify state/province."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:481
-#: metabrainz/supporter/forms.py:49
+#: frontend/js/src/forms/SignupCommercial.tsx:485
+#: metabrainz/supporter/forms.py:57
 msgid "Postcode"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:128
-#: metabrainz/supporter/forms.py:50
+#: frontend/js/src/forms/SignupCommercial.tsx:133
+#: metabrainz/supporter/forms.py:58
 msgid "You need to specify postcode."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:489
-#: metabrainz/supporter/forms.py:52
+#: frontend/js/src/forms/SignupCommercial.tsx:493
+#: metabrainz/supporter/forms.py:60
 msgid "Country"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:129
-#: metabrainz/supporter/forms.py:53
+#: frontend/js/src/forms/SignupCommercial.tsx:134
+#: metabrainz/supporter/forms.py:61
 msgid "You need to specify country."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:132
-#: metabrainz/supporter/forms.py:64
+#: frontend/js/src/forms/SignupCommercial.tsx:137
+#: metabrainz/supporter/forms.py:72
 msgid ""
 "Custom amount must be more than threshold amount for selected tier or "
 "equal to it!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:46 metabrainz/supporter/views.py:119
-#: metabrainz/supporter/views.py:220
+#: metabrainz/supporter/views.py:54
+msgid ""
+"The verification email could not be sent. Please request a new one from "
+"your profile."
+msgstr ""
+
+#: metabrainz/supporter/views.py:85 metabrainz/supporter/views.py:158
+#: metabrainz/supporter/views.py:260
 msgid "You are already a supporter."
 msgstr ""
 
-#: metabrainz/supporter/views.py:61
+#: metabrainz/supporter/views.py:100
 msgid "Can't find tier with a specified ID."
 msgstr ""
 
-#: metabrainz/supporter/views.py:127
+#: metabrainz/supporter/views.py:166
 msgid "You need to choose support tier before signing up!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:137
+#: metabrainz/supporter/views.py:176
 msgid "You need to choose existing tier before signing up!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:164
+#: metabrainz/supporter/views.py:204
 msgid ""
 "Thanks for becoming a supporter! Your application will be reviewed soon. "
 "We will send you updates via email."
 msgstr ""
 
-#: metabrainz/supporter/views.py:187
+#: metabrainz/supporter/views.py:228
 msgid ""
 "Thanks for signing up! Your application will be reviewed soon. We will "
 "send you updates via email."
 msgstr ""
 
-#: metabrainz/supporter/views.py:248
+#: metabrainz/supporter/views.py:288
 msgid "Thanks for becoming a supporter!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:274
+#: metabrainz/supporter/views.py:312
 msgid "Thanks for signing up! Please check your inbox to complete verification."
 msgstr ""
 
-#: metabrainz/supporter/views.py:302
+#: metabrainz/supporter/views.py:340
 msgid "Can't generate new token unless account is active."
 msgstr ""
 
@@ -432,7 +524,7 @@ msgstr ""
 msgid "Policies"
 msgstr ""
 
-#: metabrainz/templates/base.html:55 metabrainz/templates/index/gdpr.html:178
+#: metabrainz/templates/base.html:55
 #: metabrainz/templates/index/social-contract.html:3
 #: metabrainz/templates/index/social-contract.html:6
 #: metabrainz/templates/navbar.html:34
@@ -442,14 +534,15 @@ msgstr ""
 #: metabrainz/templates/base.html:56
 #: metabrainz/templates/index/code-of-conduct.html:3
 #: metabrainz/templates/index/code-of-conduct.html:16
-#: metabrainz/templates/index/gdpr.html:181 metabrainz/templates/navbar.html:35
+#: metabrainz/templates/navbar.html:35
 msgid "Code of Conduct"
 msgstr ""
 
+#: frontend/js/src/PrivacySummary.tsx:11
 #: frontend/js/src/forms/ConditionsModal.tsx:21
-#: metabrainz/templates/base.html:57 metabrainz/templates/index/gdpr.html:184
-#: metabrainz/templates/index/privacy.html:6
+#: metabrainz/templates/base.html:57 metabrainz/templates/index/privacy.html:6
 #: metabrainz/templates/navbar.html:36
+#: metabrainz/templates/users/privacy-summary.html:3
 msgid "Privacy Policy"
 msgstr "Política de Privacidade"
 
@@ -483,10 +576,7 @@ msgstr "Patrocinadores"
 msgid "Supporters"
 msgstr "Patrocinadores"
 
-#: frontend/js/src/forms/LoginUser.tsx:103
-#: frontend/js/src/forms/SignupCommercial.tsx:574
-#: frontend/js/src/forms/SignupNonCommercial.tsx:339
-#: frontend/js/src/forms/SignupUser.tsx:232 metabrainz/templates/base.html:73
+#: frontend/js/src/forms/LoginUser.tsx:103 metabrainz/templates/base.html:73
 #: metabrainz/templates/navbar.html:66 metabrainz/templates/users/login.html:3
 msgid "Sign in"
 msgstr "Iniciar sessão"
@@ -508,26 +598,26 @@ msgid "Contact us"
 msgstr "Contactar-nos"
 
 #: metabrainz/templates/base.html:85
-#: metabrainz/templates/index/contact.html:105
+#: metabrainz/templates/index/contact.html:106
 msgid "Blog"
 msgstr "Blogue"
 
-#: metabrainz/templates/base.html:86 metabrainz/templates/index/contact.html:90
+#: metabrainz/templates/base.html:86 metabrainz/templates/index/contact.html:91
 msgid "Chat"
 msgstr ""
 
 #: metabrainz/templates/base.html:87
-#: metabrainz/templates/index/contact.html:106
+#: metabrainz/templates/index/contact.html:107
 msgid "Mastodon"
 msgstr ""
 
 #: metabrainz/templates/base.html:88
-#: metabrainz/templates/index/contact.html:107
+#: metabrainz/templates/index/contact.html:108
 msgid "Bluesky"
 msgstr ""
 
 #: metabrainz/templates/base.html:89
-#: metabrainz/templates/index/contact.html:108
+#: metabrainz/templates/index/contact.html:109
 msgid "Instagram"
 msgstr ""
 
@@ -584,15 +674,14 @@ msgstr "Relatórios Financeiros"
 msgid "Donate"
 msgstr "Doar"
 
-#: frontend/js/src/forms/LoginUser.tsx:110
-#: frontend/js/src/forms/SignupCommercial.tsx:175
-#: frontend/js/src/forms/SignupCommercial.tsx:555
+#: frontend/js/src/forms/SignupCommercial.tsx:180
+#: frontend/js/src/forms/SignupCommercial.tsx:559
 #: frontend/js/src/forms/SignupNonCommercial.tsx:106
 #: frontend/js/src/forms/SignupNonCommercial.tsx:319
 #: metabrainz/templates/navbar.html:65
-#: metabrainz/templates/supporters/account-type.html:51
-#: metabrainz/templates/supporters/account-type.html:93
-#: metabrainz/templates/supporters/account-type.html:144
+#: metabrainz/templates/supporters/account-type.html:47
+#: metabrainz/templates/supporters/account-type.html:84
+#: metabrainz/templates/supporters/account-type.html:130
 #: metabrainz/templates/users/signup.html:3
 msgid "Sign up"
 msgstr "Registar"
@@ -908,8 +997,430 @@ msgstr ""
 msgid "Introduction"
 msgstr ""
 
-#: metabrainz/templates/index/conflict-policy.html:55
+#: metabrainz/templates/index/conflict-policy.html:17
+msgid ""
+"Conflicts between people arise in open source projects constantly and the"
+" projects by the \n"
+"    MetaBrainz Foundation are no different. This policy aims to establish"
+" a clear and unambiguous \n"
+"    policy for reporting and addressing conflicts in our community. In "
+"this policy we aim to \n"
+"    establish a fair practice that balances the need for confidentiality "
+"and our desire for \n"
+"    transparency in our operations."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:25
+#, python-format
+msgid ""
+"Before you continue to read this policy, we encourage you to review our "
+"existing community policies \n"
+"    including our <a href=\"%(social_contract_url)s\">Social "
+"Contract</a>, \n"
+"    <a href=\"%(code_of_conduct_url)s\">the Code of Conduct</a>, \n"
+"    and our <a href=\"%(privacy_policy_url)s\">Privacy Policy</a>. These "
+"policies establish the norms and rules for \n"
+"    participation in our projects; these policies apply equally to the "
+"contractors of the MetaBrainz \n"
+"    Foundation and any participants in our projects."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:37
+msgid ""
+"This policy divides conflicts into two categories: Private and public. "
+"Private conflicts are conflicts \n"
+"    that involve *confidential* information regarding contributors, "
+"contractors or supporters. Otherwise, any conflicts \n"
+"    that do not involve confidential information are considered to be "
+"public conflicts. For instance, a \n"
+"    conflict between a contractor and the Executive Director (aka BDFL) "
+"that involves contractor pay is \n"
+"    considered a private conflict because pay rates are confidential "
+"information. A public conflict in edit \n"
+"    notes between two editors in our community does not involve "
+"confidential information and therefore should \n"
+"    be considered a public conflict."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:47
+msgid ""
+"When conflicts arise we aim to disclose as much information as possible "
+"about the conflict in a timely \n"
+"    fashion. When conflicts contain confidential matters we will aim to "
+"disclose as much information as \n"
+"    possible, while fully respecting the confidentiality of the people "
+"involved in the conflict. With any \n"
+"    private conflict we will aim to extract the relevant lessons for the "
+"team and community in an effort to \n"
+"    evolve our policies to prevent future conflicts. Should the involved "
+"parties disagree whether a conflict \n"
+"    is private or public, the question about the nature of the conflict "
+"will be presented for the next higher \n"
+"    level in the chain of command to decide. (e.g. if a community member "
+"and the community manager disagree on \n"
+"    a conflict being public or private, the Executive Director shall "
+"decide if the conflict is public or private)."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:58
 msgid "Reporting and Response"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:61
+msgid ""
+"We aim to not have conflict in our community, but we recognize that in "
+"reality conflicts will arise and we \n"
+"    must be prepared to address them in a fair manner. When conflicts "
+"arise, we prefer to have community or team \n"
+"    members resolve the conflicts among themselves, using our existing "
+"policies as guidelines for resolving the \n"
+"    conflict."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:69
+msgid ""
+"If you do not feel comfortable resolving a conflict on your own, you "
+"should feel free to report the conflict to \n"
+"    us. How you address the conflict depends on who is involved in the "
+"conflict and your comfort level. Please see \n"
+"    the detailed sections below on how and with whom to address your "
+"conflict. We aim to address conflicts as soon \n"
+"    as possible in an effort to prevent them from escalating "
+"unnecessarily."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:75
+msgid "Direct conflict resolution"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:78
+msgid ""
+"In direct conflict resolution, the involved parties will attempt to "
+"resolve the conflict themselves without \n"
+"   involving any MetaBrainz Foundation team member. You should aim to use"
+" direct resolution when the conflict does \n"
+"   not involve the violation of one of our policies or if the conflict is"
+" minor."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:84
+#, python-format
+msgid ""
+"For instance, if a user uses a rude tone, is disruptive or flagrantly "
+"ignores our project guidelines, we suggest \n"
+"    that you use direct conflict resolution to resolve the conflict. Some"
+" resources that might give you some suggestions \n"
+"    on how to go about resolving the conflict might be this <a "
+"href=\"%(conflict_resolution_primer_url)s\">\n"
+"    conflict resolution primer</a> and <a "
+"href=\"%(difficult_conversations_url)s\">how to\n"
+"    have difficult conversations at work</a>."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:93
+msgid "Informal reporting"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:96
+msgid ""
+"You may use informal reporting of a conflict if you aim to communicate a "
+"concern or incident without \n"
+"    seeking a corrective outcome. Informal reporting may also be an "
+"option if you have not been personally \n"
+"    victimized, but you’ve witnessed a violation of our policies or where"
+" you wish to maintain confidentiality \n"
+"    throughout the entire reporting process."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:103
+msgid ""
+"For editing in MusicBrainz you may informally report a user using the "
+"“Report this user for bad behavior” \n"
+"    link from the user’s profile. For reporting bad user behavior in "
+"other of our projects, please report them to our \n"
+"    community manager by mailing <span class=\"backemail\">gro.zniarbatem"
+"@reganam-ytinummoc</span> . For conflicts \n"
+"    that involve the community manager, report them by mailing <span "
+"class=\"backemail\">gro.zniarbatem@de</span> ."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:110
+msgid ""
+"Depending the the severity of the issue, repeated informal complaints may"
+" eventually require a formal response \n"
+"    from the MetaBrainz team. If an involved party requires anonymity, "
+"the conflict becomes a private conflict. If at \n"
+"    all possible minor issues should be resolved in a public forum in "
+"order for all people to witness and learn from \n"
+"    the issue at hand."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:116
+msgid "Formal complaint process"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:119
+msgid ""
+"All complaints about conflicts should be submitted via email. To whom a "
+"complaint should be mailed and who will \n"
+"    carry out the investigation will be described in the next section."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:124
+msgid "All complaint submissions to the Foundation should include the following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:128
+msgid ""
+"Contact info, if it is different than the email used to submit the "
+"conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:129
+msgid "Who was involved in the conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:130
+msgid "Where and when the incident happened"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:131
+msgid ""
+"A description of what happened -- ideally with links (e.g. chatlogs, edit"
+" notes) that outlines what \n"
+"         happened so that the persons evaluating the conflict may "
+"understand the issue at hand"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:133
+msgid ""
+"Any related pieces of information that provide more context on the "
+"conflict (e.g. links, screenshots)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:134
+msgid "An indication if this conflict is ongoing or not"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:139
+msgid "The investigation that follows aims to determine:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:143
+msgid "The nature and severity of the incident"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:144
+msgid ""
+"Whether or not the incident is considered a violation of MetaBrainz’ "
+"conduct policies or core values"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:145
+msgid ""
+"The amount of harm experienced by the person who submitted the complaint "
+"and the broader MetaBrainz community \n"
+"         as a result of the incident"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:147
+msgid ""
+"Whether there have been prior complaints against the individual or "
+"individuals reported"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:148
+msgid "Whether the incident is ongoing"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:152
+msgid ""
+"The following potential forms of resolution may apply to any team members"
+" involved in the conflict:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:155
+#: metabrainz/templates/index/conflict-policy.html:168
+msgid "Nothing (if it has been found no violation occurred)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:156
+msgid "Creating a plan to improve the performance"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:157
+msgid "Creating a negative performance evaluation"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:158
+msgid "Mediation, an intervention by a third party to resolve the conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:159
+msgid "Suspension or forced leave"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:160
+msgid "Termination of contract"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:164
+msgid ""
+"The following potential forms of resolution may apply to non team members"
+" involved in the conflict:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:169
+msgid "A reprimand, either public or private"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:170
+msgid "Suspension of the users’ account"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:171
+msgid "Deletion of the users’ account"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:172
+msgid ""
+"Removal of user privileges (e.g. if an auto editor commits a serious "
+"offence, they may lose their auto editor status)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:175
+msgid "Filing a complaint"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:178
+msgid ""
+"NOTE: For complaints not about MetaBrainz staff, please see the "
+"<em>Informal reporting</em> section above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:182
+msgid ""
+"If the complaint does not involve the Executive Director (ED), do the "
+"following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:186
+msgid ""
+"If team member has directly violated conduct policies or engaged in "
+"otherwise harmful behavior, a formal complaint should be filed."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:187
+msgid ""
+"Mail <span class=\"backemail\">gro.zniarbatem@de</span> and include the "
+"complaint information outlined above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:188
+msgid ""
+"You should expect a response within a working day acknowledging the "
+"complaint."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:189
+msgid ""
+"The complaint will be investigated by the ED, member(s) of the board of "
+"directors or a neutral third party."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:190
+msgid ""
+"Once the investigation has been completed, the ED, with the support of "
+"others involved in the investigation will respond. The \n"
+"        ED will respond to incidents no later than 7 working days after a"
+" complaint has been filed with either a resolution or an \n"
+"        explanation of why the process must be extended."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:196
+msgid "If a complaint involves the Executive Director, do the following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:200
+msgid ""
+"If the Executive Director has directly violated conduct policies or "
+"engaged in otherwise harmful behavior, \n"
+"        a formal complaint should be filed with the board of directors."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:202
+msgid ""
+"Mail <span class=\"backemail\">gro.zniarbatem@noituloser-tcilfnoc</span> "
+"and include the complaint information outlined above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:203
+msgid ""
+"You should get a response within 5 working days acknowledging the "
+"complaint."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:204
+msgid ""
+"The complaint will be investigated by the member(s) of the board of "
+"directors, the community manager, a neutral \n"
+"        third party or a combination thereof."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:206
+msgid ""
+"Once the investigation has been completed, the board, with the support of"
+" others involved in the investigation \n"
+"        will respond. The board will aim to respond to incidents no later"
+" than 15 working days after a complaint has been filed \n"
+"        with either a resolution or an explanation of why the process "
+"must be extended."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:211
+msgid "Confidentiality"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:214
+msgid ""
+"Confidentiality is an important aspect of conflict resolution and all of "
+"the conflicts brought to the attention of the foundation \n"
+"    will be evaluated with confidentiality in mind and acted upon "
+"accordingly."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:219
+msgid ""
+"We work hard to make all of the actions of the foundation as transparent "
+"and open as possible. In cases where we cannot \n"
+"    disclose all aspects of a conflict we will disclose that a conflict "
+"is or has occurred and we will attempt to disclose the \n"
+"    appropriate amount of information about the conflict while balancing "
+"the need for confidentiality and our desire to learn \n"
+"    from conflicts so that we as a foundation and community can learn "
+"from these conflicts and improve our policies to avoid the \n"
+"    conflicts in the future."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:227
+msgid ""
+"Any breaches of confidentiality will be treated as severe breaches of our"
+" conduct policies."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:230
+msgid "Retaliation"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:233
+msgid ""
+"We will not allow retaliation for any contractor or volunteer that files "
+"a complaint or is involved in an investigation. If you \n"
+"    believe that you are being treated negatively because of your "
+"involvement in a complaint please report this complaint directly \n"
+"    to the ED at <span class=\"backemail\">gro.zniarbatem@de</span> or "
+"the board at \n"
+"    <span class=\"backemail\">gro.zniarbatem@noituloser-tcilfnoc</span>."
 msgstr ""
 
 #: metabrainz/templates/index/contact.html:3
@@ -990,7 +1501,7 @@ msgstr ""
 msgid ""
 "We are currently evaluating our overall online advertising strategy. We "
 "are evaluating advertising, traffic optimization,\n"
-"    search engine optimization and software monitization technologies. If"
+"    search engine optimization and software monetization technologies. If"
 " you provide these professional services, please provide a detailed\n"
 "    deck of your comprehensive services to the following email address. "
 "<em>Please respect our other non-media teams and do not contact us \n"
@@ -1067,11 +1578,11 @@ msgstr "Fóruns"
 #, python-format
 msgid ""
 "Please come ask your questions at our <a "
-"href=\"%(forums_url)s\">forums</a>! We would love to\n"
-"    answer any questions you may have."
+"href=\"%(forums_url)s\">forums</a>!\n"
+"    The community and the team will be more than happy to help you."
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:92
+#: metabrainz/templates/index/contact.html:93
 #, python-format
 msgid ""
 "The MetaBrainz/MusicBrainz/ListenBrainz team and community hang out\n"
@@ -1081,15 +1592,15 @@ msgid ""
 "    <a href=\"%(chatlogs_url)s\">chat log archives</a>."
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:101
+#: metabrainz/templates/index/contact.html:102
 msgid "Social media"
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:103
+#: metabrainz/templates/index/contact.html:104
 msgid "You can follow us on these social channels:"
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:112
+#: metabrainz/templates/index/contact.html:113
 msgid "Mailing address"
 msgstr "Morada:"
 
@@ -1102,33 +1613,349 @@ msgstr ""
 msgid "GDPR Compliance Statement"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:37
+#: metabrainz/templates/index/gdpr.html:10
+msgid ""
+"The General Data Protection Regulation is a complex EU regulation that "
+"stipulates many points for protecting private data of\n"
+"    users on the Internet. Even though this is an EU regulation, it has a"
+" worldwide impact due to the nature of the Internet.\n"
+"    The MetaBrainz Foundation with its collection of projects is also "
+"affected by this regulation. We’ve been learning and adapting\n"
+"    our sites to be compliant with the GDPR – sadly this regulation isn’t"
+" entirely black and white and there is an incredible\n"
+"    amount of room left for interpretation of these rules."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:17
+msgid ""
+"The good news is that this regulation is roughly in line with our "
+"established practices: We’ve always held private information\n"
+"    in a high regard and applied the sort of rules to ourselves as we "
+"wish to have our own private data treated. Luckily, this\n"
+"    makes our compliance effort considerably easier. We’ve made two "
+"significant changes to how we treat your data and also adopted\n"
+"    terminology as used in the GDPR in order to use the same languages "
+"that many other sites are now adopting. Please keep reading\n"
+"    to find out the exact details of what we are doing to comply."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:24
+#, python-format
+msgid ""
+"However, we do ask for your compassion and help in our process of "
+"complying with the GDPR. As we already mentioned, the GDPR is\n"
+"    a complex set of rules that are not fully clarified yet. We’ve taken "
+"action on the steps that are clear to us and we’re following\n"
+"    ongoing conversations on points that are in gray zones or unclear to "
+"us. We’ve made our best initial effort on compliance and\n"
+"    promise to keep working on it as the picture becomes more clear. If "
+"you believe that we could improve our compliance, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a> and let us know what we "
+"can do to improve. It would also help us if you\n"
+"    could provide concrete discussion or examples to help us understand "
+"and take action on your suggestion."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:33
+msgid ""
+"Finally, below are the key sections of the GDPR as we understand them and"
+" how they affect your data in our ecosystem. Where\n"
+"    possible, we provide links for deeper understanding, links for you to"
+" examine our relevant code and links to tickets to follow\n"
+"    the process of improving our compliance."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:38
 msgid "Right to be forgotten"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:77
+#: metabrainz/templates/index/gdpr.html:41
+msgid ""
+"Summary: <i>Provide the user with the ability to remove their private "
+"data from our services</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:44
+msgid ""
+"The most important aspect of the right to be forgotten is the ability to "
+"delete your account. Once you request for us to delete\n"
+"    your account, we will remove any personally identifying information "
+"you may have provided us from your account (name, email\n"
+"    address, gender, biography, URL, etc.). The visible name on your "
+"account will be changed to “Deleted User #####” and effectively\n"
+"    the account will no longer be identifiable as your account."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:50
+msgid ""
+"However, given the nature of our projects where we work on collaborative "
+"databases, your contributions that are not personally\n"
+"    identifying are valuable assets to our database and these "
+"contributions will not be removed from our databases. But we will\n"
+"    ensure that these contributions no longer contain personally "
+"identifying data."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:55
+#, python-format
+msgid ""
+"Our process of automatically deleting your accounts across the MetaBrainz"
+" ecosystem is not complete yet (see below for a set of\n"
+"    tickets where you can track our progress). If you would like to "
+"delete your accounts in the MetaBrainz ecosystem or mark a\n"
+"    donation that is currently public as a private donation, please <a "
+"href=\"%(contact_url)s\">contact us</a>\n"
+"    and we will address your request as soon as possible."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:62
+#: metabrainz/templates/index/gdpr.html:182
+msgid "Links:"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:66
+#, python-format
+msgid ""
+"<a href=\"%(editor_deletion_doc_url)s\">How we delete accounts\n"
+"       in MusicBrainz</a> (warning, geek content ahead!)"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:70
+msgid ""
+"Implement sitewide user account deletion in\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/MBS-9680\">MusicBrainz</a>,"
+"\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/AB-337\">AcousticBrainz</a>,"
+"\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/BB-260\">BookBrainz</a>,\n"
+"         <a href=\"https://tickets.metabrainz.org/browse/MEB-103\">the "
+"MetaBrainz Site</a>,\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/LB-354\">ListenBrainz</a>, "
+"and\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/CB-307\">CritiqueBrainz</a>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:80
 msgid "Restriction of processing"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:110
+#: metabrainz/templates/index/gdpr.html:83
+msgid ""
+"Summary: <i>To allow the user to control how their personally identifying"
+" data is being used.</i>"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:86
+msgid ""
+"Except for the ListenBrainz and AcousticBrainz projects, we do not "
+"process personally identifying data. Any personally\n"
+"    identifying data that our projects store is for the purpose of being "
+"able to contact you about your contributions to our database\n"
+"    (email address) or for voluntarily showing information about you to "
+"other users (biography, homepage, location, etc)."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:91
+#, python-format
+msgid ""
+"The ListenBrainz project differs in that the Listens (metadata about what"
+" music you have listened to) are stored on our servers\n"
+"    and <a href=\"%(listenbrainz_data_url)s\">made available to the "
+"public</a>. We believe Listens to be personally identifying\n"
+"    data and furthermore, we have goals of creating open source "
+"recommendation engines with this data, which involves processing the\n"
+"    user’s data. These two points are fundamental goals of the "
+"ListenBrainz project and we do not see a reasonable way to reach another"
+"\n"
+"    compromise position."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:99
+msgid ""
+"Because of this, we are going to require users to either acknowledge that"
+" we may process their Listen data or alternatively to\n"
+"    delete their account, including all of their Listens. Please note "
+"that if you decide to delete your ListenBrainz account, it may\n"
+"    take up to two weeks for all of your listens to no longer be included"
+" in our efforts to build a recommendation engine."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:104
+msgid ""
+"We have always made it clear that the data in ListenBrainz was to be "
+"public and that we plan to build new tools with your data, so\n"
+"    this should not come as a surprise to our users."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:108
+msgid ""
+"The AcousticBrainz project does not track who submits data to the "
+"database. If you create an account and use our data creation\n"
+"    tools (e.g. create a dataset or participate in a challenge) then we "
+"link your participation and the things that you create to\n"
+"    your account. If you choose to delete your account then we keep the "
+"non personally identifying data that you create, but anonymize\n"
+"    it so that it cannot be linked back to you."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:114
 msgid "Right to data portability / exporting your data"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:150
+#: metabrainz/templates/index/gdpr.html:117
+msgid ""
+"Summary: <i>You have the right to access/download the data we store about"
+" you</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:120
+msgid ""
+"Except for the ListenBrainz and AcousticBrainz projects, we do not store "
+"personally identifying data beyond the\n"
+"    information that is available in your public profile on each of our "
+"projects. Since this data is plainly available in your\n"
+"    profile we do not provide a means for you to export this data."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:125
+msgid "There are the following exceptions to this:"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:129
+msgid ""
+"<b>IP addresses</b>: If you visit one of our sites the IP address of your"
+" computer is stored in our web logs for 7 days\n"
+"        before our servers automatically delete them. This data is almost"
+" never used by anyone: the only time we look at the\n"
+"        IP addresses is if our sites are adversely impacted by the "
+"actions of some unknown users. In that case, we may investigate\n"
+"        the logs to identify the IP address that needs to be blocked in "
+"order to restore the stability of our service.\n"
+"        This data is not available to anyone but the contractors of the "
+"MetaBrainz Foundation and is not available to download\n"
+"        to anyone at all."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:137
+#, python-format
+msgid ""
+"<b>ListenBrainz Listen data</b>: Users may <a "
+"href=\"%(listenbrainz_export_url)s\">export their ListenBrainz Listen\n"
+"        data</a> directly from the site. The user Listen data is also "
+"included in the <a href=\"%(listenbrainz_data_url)s\">ListenBrainz\n"
+"        data dumps</a> that are available for public download."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:146
+msgid ""
+"All of the non personally identifying data, such as your metadata "
+"contributions, are publicly visible, available for download\n"
+"    and available via the project APIs. For details about this data, "
+"downloads and APIs please check the documentation for the\n"
+"    respective projects you are interested in."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:151
+#, python-format
+msgid ""
+"Anyone wishing to get a list of financial donations they have made to the"
+" MetaBrainz Foundation, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a> and provide your "
+"MusicBrainz editor name so that we can look up\n"
+"    your donations."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:157
 msgid "Right to rectification"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:165
+#: metabrainz/templates/index/gdpr.html:160
+msgid "Summary: <i>You have the right to correct your data</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:163
+msgid ""
+"All of our projects allow their users to update their personally "
+"identifying information in their profiles. Furthermore, most\n"
+"    of our projects allow the editing of their own metadata "
+"contributions. If you find that some of your data is incorrect, please\n"
+"    feel free to edit the data since we provide the tools to do so."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:168
+#, python-format
+msgid ""
+"If anyone who has made a financial donation to the MetaBrainz Foundation "
+"would like to make their donation private, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:173
 msgid "Right to be informed"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:188
+#: metabrainz/templates/index/gdpr.html:175
+msgid ""
+"Summary: <i>You have the right to be informed about how we use your data "
+"in plain English</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:178
+msgid ""
+"Our privacy policy, as well as other policies, have always been written "
+"by humans for human consumption. We abhor legalese and\n"
+"    not speaking in direct terms."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:186
+msgid "Social contract"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:189
+msgid "Code of conduct"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:192
+msgid "Privacy policy"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:196
 msgid "Right to access"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:198
-#: metabrainz/templates/index/privacy.html:166
+#: metabrainz/templates/index/gdpr.html:199
+msgid ""
+"Summary: <i>You have the right to access the data that we collect about "
+"you</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:202
+msgid ""
+"All of our projects make all of the data we collect on your behalf, "
+"privately identifying or not, available to you. The\n"
+"    only exception to this are the IP addresses we store for 7 days – see"
+" above for details."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:206
+#: metabrainz/templates/index/privacy.html:168
 msgid "Privacy/GDPR Representative"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:209
+#, python-format
+msgid ""
+"If you have any questions about our privacy policy, please <a "
+"href=\"%(contact_url)s\">contact us</a>. To report\n"
+"   any privacy problems, violations or leaks, our GDPR representative is "
+"our Interim Executive Director Nicolás Tamargo and for\n"
+"   privacy issues contact him at <strong><a "
+"href=\"mailto:gdpr@metabrainz.org\">gdpr@metabrainz.org</a></strong>."
 msgstr ""
 
 #: metabrainz/templates/index/index.html:6
@@ -1235,7 +2062,7 @@ msgid ""
 "      <a href=\"%(about_url)s\">about</a> page."
 msgstr ""
 
-#: frontend/js/src/forms/ConditionsModal.tsx:43
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:32
 #: metabrainz/templates/index/privacy.html:3
 msgid "Privacy"
 msgstr "Privacidade"
@@ -1243,6 +2070,44 @@ msgstr "Privacidade"
 #: metabrainz/templates/index/privacy.html:8
 msgid "Summary"
 msgstr "Resumo"
+
+#: metabrainz/templates/index/privacy.html:12
+msgid ""
+"You do not have to provide any personal data to be able to browse the "
+"contents of the databases published by MetaBrainz."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:15
+msgid ""
+"You do not have to provide any personally-identifying information if you "
+"choose not to."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:18
+msgid ""
+"We will never reveal your email address on MetaBrainz controlled web "
+"sites."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:22
+msgid ""
+"In order to get maximum value out of the MetaBrainz projects, you may "
+"want to create an account and log in. \n"
+"    Doing so grants you the ability to: edit the databases, contribute "
+"your own data, communicate with other users, and keep track \n"
+"    of recently released music from artists in your MusicBrainz "
+"collection. If you choose to create an account then the minimum we \n"
+"    ask is that you: choose a unique username and password, use a web "
+"browser that accepts \"session\" cookies, and provide a verified \n"
+"    email address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:29
+msgid ""
+"If you do not create an account (or are not logged in) you will not have "
+"access to the above listed features, however, you will \n"
+"    still have full access to browse and examine the databases."
+msgstr ""
 
 #: metabrainz/templates/index/privacy.html:33
 msgid "Applicable to all users"
@@ -1252,39 +2117,197 @@ msgstr ""
 msgid "Cookies"
 msgstr ""
 
+#: metabrainz/templates/index/privacy.html:37
+msgid "We use two cookies that contain sensitive information:"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:42
+msgid ""
+"<b>remember_login</b>: If you choose the \"Log in permanently\" option "
+"when logging in to one of our sites; the cookie will be used to \n"
+"      remember your login details."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:46
+msgid ""
+"<b>musicbrainz_server_session, session, or connect.sid</b>: If you are "
+"logged into one of our sites, your current session ID is stored in this "
+"cookie."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:51
+msgid ""
+"We may store dynamic preference information in other cookies, but these "
+"do not contain any sensitive information."
+msgstr ""
+
 #: metabrainz/templates/index/privacy.html:54
 msgid "Web and FTP access logs"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:57
+msgid ""
+"In a practice similar to other web sites (and APIs) we keep logs of all "
+"web requests made against our servers. These logs include: your IP\n"
+"    address, your browser's (or API client's) \"User-Agent\" string, and "
+"which page (or API endpoint) you requested with which parameters. "
+"Aggregate information about web and FTP traffic is\n"
+"    made available to the public via our site usage pages."
 msgstr ""
 
 #: metabrainz/templates/index/privacy.html:62
 msgid "Third-Party content"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:92
+#: metabrainz/templates/index/privacy.html:64
+msgid ""
+"Our projects' web pages may load some third-party content. Some, but "
+"possibly not all sites are listed below:"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:69
+#, python-format
+msgid ""
+"Cover art and other images: These are provided by the various cover art "
+"sites that have given MusicBrainz permission to do so and our own \n"
+"      <a href=\"%(caa_url)s\">Cover Art Archive</a>. This means that the "
+"relevant site will know (if they want to) your IP \n"
+"      address, User-Agent string, etc., and which MusicBrainz web page "
+"you were visiting (the one which included the cover art image)."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:75
+msgid ""
+"AcoustID: Our fingerprints tab loads fingerprint information from "
+"acoustid.org."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:78
+msgid ""
+"MTCaptcha: Our account creation page loads third party content in order "
+"to prevent spammers from creating accounts."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:83
+msgid ""
+"<i>The above information assumes that you are using \"normal\" web "
+"browser settings, whereby images are always loaded and HTTP referrer \n"
+"    information is always sent.</i>"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:88
+msgid ""
+"It is impractical to constantly modify this privacy policy when "
+"MetaBrainz projects change which third party content they utilize. We "
+"will \n"
+"    aim to use common sense, respect to our community and community "
+"review when adding more content from third party sites. We will also \n"
+"    periodically review our policy to ensure that it remains current."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:93
 msgid "Applicable to account holders"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:94
+#: metabrainz/templates/index/privacy.html:95
 msgid "Account creation"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:108
+#: metabrainz/templates/index/privacy.html:97
+msgid ""
+"When creating an account with a MetaBrainz project you need to pick a "
+"unique username and choose a password, the username you pick is the \n"
+"    only name associated with your account and will be what other "
+"MetaBrainz users know you as. You may optionally also tell us other \n"
+"    information about yourself that will be displayed to other MetaBrainz"
+" users and the public."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:103
+msgid ""
+"Additionally, in order to edit the databases you will need to provide a "
+"confirmed email address. This email address will be held in \n"
+"    confidence, the only method of revealing your email address to "
+"another user is if you choose to send a message to another \n"
+"    user and enable the option to \"reveal my email address\". Changing "
+"the email address stored with your account will require you to \n"
+"    verify the new address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:109
 msgid "Edits and Notes"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:114
+#: metabrainz/templates/index/privacy.html:111
+msgid ""
+"If you make any changes to a MetaBrainz project database, such as adding "
+"any data, the details of those changes will be visible to \n"
+"    other logged-in users and the change will be associated with your "
+"username."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:115
 msgid "Subscriptions on MusicBrainz"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:131
+#: metabrainz/templates/index/privacy.html:117
+msgid ""
+"As a logged-in user you can subscribe to one or more artists, labels, "
+"collections or other editors. The act of subscribing causes \n"
+"    any edits made to (or by in the case of another editor) those "
+"entities to be emailed to you. By default, other users can see your \n"
+"    list of subscriptions, however, you can opt out of this by editing "
+"the appropriate preference."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:123
+msgid ""
+"This does not provide \"perfect\" privacy though, in some cases it will "
+"be possible to infer information about the contents of your \n"
+"    subscription list even though you have disallowed others from viewing"
+" that list directly. This imperfection arises because various \n"
+"    parts of the system behave differently depending on whether or not an"
+" entity has any subscribers; also, the number of users \n"
+"    subscribed to each artist is available via the artist pages. In the "
+"most extreme (possibly contrived) example, imagine that all \n"
+"    users have their subscriptions set to \"public\", except for exactly "
+"one user whose list is \"private\". In that case, any discrepancy \n"
+"    for a given artist between the shown list of subscribers and the "
+"total number of subscribers must be down to that one user. Thus, \n"
+"    you can infer what artists are on that user's list."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:132
 msgid "Third-party sites"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:145
+#: metabrainz/templates/index/privacy.html:134
+#, python-format
+msgid ""
+"Our code reviews are done on GitHub, which is not under the control of "
+"MetaBrainz. Participating in code reviews or other\n"
+"    tasks carried out on GitHub are subject to <a "
+"href=\"%(github_url)s\">GitHub's privacy policy</a>."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:140
+#, python-format
+msgid ""
+"Our translations platform is provided and hosted by Weblate, which has a "
+"data processing agreement with MetaBrainz.\n"
+"    Participating in translations is subject to <a "
+"href=\"%(weblate_url)s\">dedicated legal terms</a>.\n"
+"    Any translations you make will be submitted to our Git repositories "
+"and publicly associated with your username;\n"
+"    if you so choose, you can also publicly associate them with your own "
+"verified email address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:147
 msgid "MetaBrainz donors"
 msgstr "Doadores de MetaBrainz"
 
-#: metabrainz/templates/index/privacy.html:147
+#: metabrainz/templates/index/privacy.html:149
 msgid ""
 "When you make a donation to the MetaBrainz Foundation, we are legally\n"
 "    required to collect your personal information and keep it in our "
@@ -1294,7 +2317,7 @@ msgid ""
 "    information to anyone else, ever."
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:153
+#: metabrainz/templates/index/privacy.html:155
 msgid ""
 "We believe in transparent finances, which means that we list all "
 "donations\n"
@@ -1304,11 +2327,34 @@ msgid ""
 "process."
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:158
+#: metabrainz/templates/index/privacy.html:160
 msgid "Exceptions"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:598
+#: metabrainz/templates/index/privacy.html:162
+msgid ""
+"<i><b>Please note</b>: Reasonable exceptions may apply to the above "
+"policy, for example to comply with applicable laws.\n"
+"    Also, members of the MetaBrainz team and other personnel contracted "
+"to provide services to MetaBrainz may have access to\n"
+"    our infrastructure and could therefore view any information contained"
+" therein. However all personnel are contractually bound\n"
+"    by non-disclosure clauses which prevent them from making any such "
+"information available to others."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:171
+#, python-format
+msgid ""
+"If you have any questions about our GDPR statement, please <a "
+"href=\"%(contact_url)s\">contact us</a>. To report\n"
+"   any privacy problems, violations or leaks, our GDPR representative is "
+"our Interim Executive Director Nicolás Tamargo and for\n"
+"   privacy issues contact him at <strong><a "
+"href=\"mailto:gdpr@metabrainz.org\">gdpr@metabrainz.org</a></strong>."
+msgstr ""
+
+#: frontend/js/src/Profile.tsx:603
 #: frontend/js/src/forms/ProfileChangePassword.tsx:22
 #: frontend/js/src/forms/ProfileChangePassword.tsx:111
 #: metabrainz/templates/index/profile-change-password.html:3
@@ -1561,6 +2607,11 @@ msgstr ""
 
 #: metabrainz/templates/index/team.html:26
 msgid "He lives on in our hearts and in open source."
+msgstr ""
+
+#: metabrainz/templates/index/team.html:29
+#: metabrainz/templates/index/team.html:315
+msgid "you’re welcome to try"
 msgstr ""
 
 #: metabrainz/templates/index/team.html:39
@@ -2066,8 +3117,10 @@ msgstr ""
 
 #: metabrainz/templates/payments/donate.html:146
 msgid ""
-"Due to the increased unreliability of the US Postal Service we have "
-"stopped accepting paper checks. Sorry!"
+"Due to the increased unreliability of the US Postal Service and the "
+"relatively large fees involved, we ask you to only send a paper check if "
+"it is the only possible option. Due to the fees, we will not cash checks "
+"for less than $25."
 msgstr ""
 
 #: metabrainz/templates/payments/donate.html:241
@@ -2952,8 +4005,8 @@ msgid "Monthly balance sheets"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:520
-#: frontend/js/src/forms/SignupCommercial.tsx:175
-#: frontend/js/src/forms/SignupCommercial.tsx:554
+#: frontend/js/src/forms/SignupCommercial.tsx:180
+#: frontend/js/src/forms/SignupCommercial.tsx:558
 #: frontend/js/src/forms/SignupNonCommercial.tsx:106
 #: frontend/js/src/forms/SignupNonCommercial.tsx:318
 #: metabrainz/templates/supporters/account-type.html:3
@@ -2974,6 +4027,7 @@ msgid "Non-commercial / Personal"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:235
+#: frontend/js/src/forms/SignupNonCommercial.tsx:107
 #: frontend/js/src/forms/SignupNonCommercial.tsx:151
 #: metabrainz/templates/supporters/account-type.html:42
 msgid "Non-commercial"
@@ -2987,57 +4041,46 @@ msgstr ""
 msgid "Personal or university assignment user."
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:48
-#: metabrainz/templates/supporters/account-type.html:90
-#: metabrainz/templates/supporters/account-type.html:141
-msgid "Upgrade"
-msgstr ""
-
 #: frontend/js/src/Profile.tsx:235
-#: frontend/js/src/forms/SignupCommercial.tsx:176
-#: frontend/js/src/forms/SignupCommercial.tsx:228
-#: metabrainz/templates/supporters/account-type.html:61
+#: frontend/js/src/forms/SignupCommercial.tsx:181
+#: frontend/js/src/forms/SignupCommercial.tsx:233
+#: metabrainz/templates/supporters/account-type.html:56
 msgid "Commercial"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:83
-#: metabrainz/templates/supporters/account-type.html:135
+#: metabrainz/templates/supporters/account-type.html:78
+#: metabrainz/templates/supporters/account-type.html:125
 #, python-format
 msgid "$%(tier_price)s/month and up"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:87
-#: metabrainz/templates/supporters/account-type.html:138
+#: metabrainz/templates/supporters/account-type.html:82
+#: metabrainz/templates/supporters/account-type.html:128
 msgid "More info"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:104
+#: metabrainz/templates/supporters/account-type.html:94
 msgid "View all tiers"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:112
+#: metabrainz/templates/supporters/account-type.html:102
 msgid "Some of our Unicorn members"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:123
+#: metabrainz/templates/supporters/account-type.html:113
 msgid "See all our supporters"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:151
+#: metabrainz/templates/supporters/account-type.html:136
 msgid "View featured tiers"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:158
+#: metabrainz/templates/supporters/account-type.html:143
 #, python-format
 msgid ""
 "If you are not sure which tier to pick, please\n"
 "      <a href=\"%(contact_url)s\">contact us</a>."
 msgstr ""
-
-#: metabrainz/templates/supporters/account-type.html:166
-#, fuzzy
-msgid "Back to Profile"
-msgstr "O seu perfil"
 
 #: metabrainz/templates/supporters/bad-standing.html:3
 #: metabrainz/templates/supporters/bad-standing.html:6
@@ -3098,9 +4141,9 @@ msgid "Forgot your username"
 msgstr ""
 
 #: frontend/js/src/forms/ResetPassword.tsx:79
-#: frontend/js/src/forms/SignupCommercial.tsx:320
+#: frontend/js/src/forms/SignupCommercial.tsx:325
 #: frontend/js/src/forms/SignupNonCommercial.tsx:227
-#: frontend/js/src/forms/SignupUser.tsx:169
+#: frontend/js/src/forms/SignupUser.tsx:175
 #: metabrainz/templates/users/reauthenticate.html:3
 #: metabrainz/templates/users/reauthenticate.html:6
 msgid "Confirm Password"
@@ -3110,17 +4153,22 @@ msgstr ""
 msgid "Please re-enter your password to continue."
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:108
+#: frontend/js/src/ProfileDelete.tsx:110
 #: frontend/js/src/forms/DeleteApplication.tsx:53
 #: frontend/js/src/forms/OAuthPrompt.tsx:54
 #: frontend/js/src/forms/ProfileChangePassword.tsx:104
 #: frontend/js/src/forms/ProfileEdit.tsx:105
-#: metabrainz/templates/users/reauthenticate.html:23
+#: metabrainz/templates/users/reauthenticate.html:28
 msgid "Cancel"
 msgstr ""
 
-#: metabrainz/templates/users/reauthenticate.html:24
+#: metabrainz/templates/users/reauthenticate.html:29
 msgid "Continue"
+msgstr ""
+
+#: frontend/js/src/forms/utils.tsx:202
+#: metabrainz/templates/users/reauthenticate.html:40
+msgid "Password must not exceed 72 bytes."
 msgstr ""
 
 #: frontend/js/src/forms/ResetPassword.tsx:27
@@ -3128,38 +4176,38 @@ msgstr ""
 msgid "Reset your password"
 msgstr ""
 
-#: frontend/js/src/hooks/useEmailValidation.ts:41 metabrainz/user/forms.py:15
+#: frontend/js/src/hooks/useEmailValidation.ts:41 metabrainz/user/forms.py:16
 msgid "Registration from this email domain is not allowed."
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:50
 #: frontend/js/src/forms/LostPassword.tsx:45
-#: frontend/js/src/forms/SignupCommercial.tsx:270
+#: frontend/js/src/forms/SignupCommercial.tsx:275
 #: frontend/js/src/forms/SignupNonCommercial.tsx:175
-#: frontend/js/src/forms/SignupUser.tsx:114 metabrainz/user/forms.py:20
-#: metabrainz/user/forms.py:45 metabrainz/user/forms.py:62
+#: frontend/js/src/forms/SignupUser.tsx:120 metabrainz/user/forms.py:22
+#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:75
 msgid "Username"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:42
 #: frontend/js/src/forms/LostPassword.tsx:37
-#: frontend/js/src/forms/SignupCommercial.tsx:153
+#: frontend/js/src/forms/SignupCommercial.tsx:158
 #: frontend/js/src/forms/SignupNonCommercial.tsx:84
-#: frontend/js/src/forms/SignupUser.tsx:67 metabrainz/user/forms.py:21
-#: metabrainz/user/forms.py:45 metabrainz/user/forms.py:62
+#: frontend/js/src/forms/SignupUser.tsx:73 metabrainz/user/forms.py:26
+#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:75
 msgid "Username is required!"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:63
 #: frontend/js/src/forms/ResetPassword.tsx:72
-#: frontend/js/src/forms/SignupCommercial.tsx:308
+#: frontend/js/src/forms/SignupCommercial.tsx:313
 #: frontend/js/src/forms/SignupNonCommercial.tsx:214
-#: frontend/js/src/forms/SignupUser.tsx:157 metabrainz/user/forms.py:46
-#: metabrainz/user/forms.py:52
+#: frontend/js/src/forms/SignupUser.tsx:163 metabrainz/user/forms.py:53
+#: metabrainz/user/forms.py:62
 msgid "Password"
 msgstr ""
 
-#: frontend/js/src/forms/LoginUser.tsx:76 metabrainz/user/forms.py:47
+#: frontend/js/src/forms/LoginUser.tsx:76 metabrainz/user/forms.py:57
 msgid "Remember me"
 msgstr ""
 
@@ -3171,11 +4219,11 @@ msgstr ""
 msgid "Username contains invalid or invisible characters."
 msgstr ""
 
-#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:181
+#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:220
 msgid "Hide password"
 msgstr ""
 
-#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:181
+#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:220
 msgid "Show password"
 msgstr ""
 
@@ -3233,11 +4281,11 @@ msgstr ""
 msgid "Revoke access"
 msgstr ""
 
-#: frontend/js/src/OAuthError.tsx:17
+#: frontend/js/src/OAuthError.tsx:18
 msgid "OAuth2 Error"
 msgstr ""
 
-#: frontend/js/src/OAuthError.tsx:18
+#: frontend/js/src/OAuthError.tsx:19
 msgid "An error occurred during OAuth authentication process."
 msgstr ""
 
@@ -3267,8 +4315,8 @@ msgstr ""
 
 #: frontend/js/src/Profile.tsx:109
 msgid ""
-"Are you sure you want to generate new access token? Current token will be"
-" revoked!"
+"Are you sure you want to generate a new access token? The current token "
+"will be revoked!"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:118
@@ -3383,8 +4431,8 @@ msgid "Contact Information"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:310 frontend/js/src/forms/ProfileEdit.tsx:70
-#: frontend/js/src/forms/SignupCommercial.tsx:284
-#: frontend/js/src/forms/SignupCommercial.tsx:333
+#: frontend/js/src/forms/SignupCommercial.tsx:289
+#: frontend/js/src/forms/SignupCommercial.tsx:338
 #: frontend/js/src/forms/SignupNonCommercial.tsx:189
 #: frontend/js/src/forms/SignupNonCommercial.tsx:241
 msgid "Contact name"
@@ -3499,7 +4547,7 @@ msgstr ""
 msgid "Once you delete your account, there is no going back. Please be certain."
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:550 frontend/js/src/ProfileDelete.tsx:105
+#: frontend/js/src/Profile.tsx:550 frontend/js/src/ProfileDelete.tsx:107
 msgid "Delete My Account"
 msgstr ""
 
@@ -3511,39 +4559,39 @@ msgstr ""
 msgid "Need to delete your account?"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:574
+#: frontend/js/src/Profile.tsx:575
 msgid ""
 "Deletion of supporter accounts requires manual review. Please contact us "
-"at"
+"at <email />."
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:594
+#: frontend/js/src/Profile.tsx:599
 msgid "Security"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:626
+#: frontend/js/src/Profile.tsx:631
 msgid "MetaBrainz Applications"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:630
+#: frontend/js/src/Profile.tsx:635
 msgid ""
 "With your MetaBrainz account, you can access every project in the "
 "MetaBrainz family:"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:643
+#: frontend/js/src/Profile.tsx:648
 msgid "The open-source music encyclopedia"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:655
+#: frontend/js/src/Profile.tsx:660
 msgid "Track, visualise and share the music you listen to"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:667
+#: frontend/js/src/Profile.tsx:672
 msgid "The open-source book database"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:679
+#: frontend/js/src/Profile.tsx:684
 msgid "Creative Commons licensed reviews"
 msgstr ""
 
@@ -3566,7 +4614,7 @@ msgid "Permanently remove all your account information"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:64
-msgid "Revoke all your API tokens and access"
+msgid "Revoke all your tokens and access to the replication API"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:65
@@ -3578,14 +4626,16 @@ msgid "Log you out of all MetaBrainz services"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:70
-msgid "Your username will be reserved and cannot be reused."
+msgid ""
+"Your username will be reserved and cannot be reused without the "
+"intervention of an administrator."
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:82
+#: frontend/js/src/ProfileDelete.tsx:84
 msgid "To confirm, type your username '<username />' below:"
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:105
+#: frontend/js/src/ProfileDelete.tsx:107
 msgid "Deleting..."
 msgstr ""
 
@@ -3598,64 +4648,7 @@ msgstr "O seu perfil"
 msgid "Close"
 msgstr ""
 
-#: frontend/js/src/forms/ConditionsModal.tsx:23
-msgid "Licensing"
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:25
-msgid ""
-"Any contributions you make to any MetaBrainz service will be released "
-"into the Public Domain and/or licensed under a Creative Commons by-nc-sa "
-"license. Furthermore, you give the MetaBrainz Foundation the right to "
-"license this data for commercial use."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:30
-msgid "Please read our <licenseLink>license page</licenseLink> for more details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:45
-msgid ""
-"MetaBrainz strongly believes in the privacy of its users. Any personal "
-"information you choose to provide will not be sold or shared with anyone "
-"else."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:50
-msgid ""
-"Please read our <privacyLink>privacy policy</privacyLink> for more "
-"details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:59
-msgid "GDPR compliance"
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:61
-msgid ""
-"You may remove your personal information from our services anytime by "
-"deleting your account."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:66
-msgid ""
-"Please read our <gdprLink>GDPR compliance statement</gdprLink> for more "
-"details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:78
-msgid ""
-"Creating an account on MetaBrainz will give you access to all of our "
-"projects, such as MusicBrainz, ListenBrainz, BookBrainz, and more."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:82
-msgid ""
-"We create a placeholder account for all the MetaBrainz projects when you "
-"sign up, and you are one log-in away from activating them."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:91
+#: frontend/js/src/forms/ConditionsModal.tsx:29
 msgid "Sounds good"
 msgstr ""
 
@@ -3741,8 +4734,8 @@ msgstr ""
 msgid "Forgot your password?"
 msgstr ""
 
-#: frontend/js/src/forms/LoginUser.tsx:109
-msgid "Don't have an account?"
+#: frontend/js/src/forms/LoginUser.tsx:110
+msgid "Don't have an account? <signupLink>Sign up</signupLink>"
 msgstr ""
 
 #: frontend/js/src/forms/LostPassword.tsx:38
@@ -3772,15 +4765,72 @@ msgstr ""
 msgid "Allow access"
 msgstr "Permitir acesso"
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:71
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:10
+msgid "Licensing"
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:12
+msgid ""
+"Any contributions you make to any MetaBrainz service will be released "
+"into the Public Domain and/or licensed under a Creative Commons by-nc-sa "
+"license. Furthermore, you give the MetaBrainz Foundation the right to "
+"license this data for commercial use."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:17
+msgid "Please read our <licenseLink>license page</licenseLink> for more details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:34
+msgid ""
+"MetaBrainz strongly believes in the privacy of its users. Any personal "
+"information you choose to provide will not be sold or shared with anyone "
+"else."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:39
+msgid ""
+"Please read our <privacyLink>privacy policy</privacyLink> for more "
+"details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:50
+msgid "GDPR compliance"
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:52
+msgid ""
+"You may remove your personal information from our services anytime by "
+"deleting your account."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:57
+msgid ""
+"Please read our <gdprLink>GDPR compliance statement</gdprLink> for more "
+"details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:71
+msgid ""
+"Creating an account on MetaBrainz will give you access to all of our "
+"projects, such as MusicBrainz, ListenBrainz, BookBrainz, and more."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:75
+msgid ""
+"We create a placeholder account for all the MetaBrainz projects when you "
+"sign up, and you are one log-in away from activating them."
+msgstr ""
+
+#: frontend/js/src/forms/ProfileChangePassword.tsx:70
 msgid "Current Password"
 msgstr ""
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:80
+#: frontend/js/src/forms/ProfileChangePassword.tsx:79
 msgid "New Password"
 msgstr ""
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:89
+#: frontend/js/src/forms/ProfileChangePassword.tsx:88
 msgid "Confirm New Password"
 msgstr ""
 
@@ -3792,192 +4842,182 @@ msgstr ""
 msgid "Reset Password"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:38
-msgid "If you would like to support us with more than $"
+#: frontend/js/src/forms/SignupCommercial.tsx:40
+msgid ""
+"If you would like to support us with more than ${{minPledge}}, please "
+"enter the actual amount here:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:39
-msgid ", please enter the actual amount here:"
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:144
+#: frontend/js/src/forms/SignupCommercial.tsx:149
 #: frontend/js/src/forms/SignupNonCommercial.tsx:75
-#: frontend/js/src/forms/SignupUser.tsx:87
+#: frontend/js/src/forms/SignupUser.tsx:93
 msgid "Captcha is required!"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:179
+#: frontend/js/src/forms/SignupCommercial.tsx:184
 #: frontend/js/src/forms/SignupNonCommercial.tsx:110
 #: frontend/js/src/forms/SignupUser.tsx:46
 #, fuzzy
 msgid "Access all MetaBrainz projects"
 msgstr "Projetos de MetaBrainz"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:182
+#: frontend/js/src/forms/SignupCommercial.tsx:187
 msgid "Note:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:184
+#: frontend/js/src/forms/SignupCommercial.tsx:189
 msgid ""
 "Signing up for any tier other than the <italic>Stealth startup</italic> "
 "tier will publicly list your company on this web site. However, we will "
 "not publish any of your private details."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:221
+#: frontend/js/src/forms/SignupCommercial.tsx:226
 #: frontend/js/src/forms/SignupNonCommercial.tsx:145
 msgid "Account type"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:234
+#: frontend/js/src/forms/SignupCommercial.tsx:239
 msgid "Selected tier"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:242
-msgid "month and up"
+#: frontend/js/src/forms/SignupCommercial.tsx:247
+msgid "${{tierPrice}}/month and up"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:250
+#: frontend/js/src/forms/SignupCommercial.tsx:255
 msgid "Change account type or tier"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:261
+#: frontend/js/src/forms/SignupCommercial.tsx:266
 #: frontend/js/src/forms/SignupNonCommercial.tsx:166
 msgid "Your account:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:271
+#: frontend/js/src/forms/SignupCommercial.tsx:276
 #: frontend/js/src/forms/SignupNonCommercial.tsx:176
-#: frontend/js/src/forms/SignupUser.tsx:114
+#: frontend/js/src/forms/SignupUser.tsx:120
 msgid "(public)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:291
+#: frontend/js/src/forms/SignupCommercial.tsx:296
 #: frontend/js/src/forms/SignupNonCommercial.tsx:196
-#: frontend/js/src/forms/SignupUser.tsx:127
+#: frontend/js/src/forms/SignupUser.tsx:133
 msgid "E-mail address"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:295
+#: frontend/js/src/forms/SignupCommercial.tsx:300
 #: frontend/js/src/forms/SignupNonCommercial.tsx:200
-#: frontend/js/src/forms/SignupUser.tsx:131
+#: frontend/js/src/forms/SignupUser.tsx:137
 msgid "(checking...)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:314
+#: frontend/js/src/forms/SignupCommercial.tsx:319
 #: frontend/js/src/forms/SignupNonCommercial.tsx:220
-#: frontend/js/src/forms/SignupUser.tsx:163
+#: frontend/js/src/forms/SignupUser.tsx:169
 msgid "Must be at least 8 characters"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:348
+#: frontend/js/src/forms/SignupCommercial.tsx:353
 msgid ""
 "If you don't have an organization name, you probably want to become a "
 "supporter as a <nonCommercialLink>Non-commercial / "
 "Personal</nonCommercialLink> supporter."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:358
+#: frontend/js/src/forms/SignupCommercial.tsx:363
 msgid ""
 "If you don't have an organization name, you probably want to sign up as a"
 " <nonCommercialLink>Non-commercial / Personal</nonCommercialLink> user."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:378
+#: frontend/js/src/forms/SignupCommercial.tsx:383
 msgid ""
 "Please tell us a little about your company and whether you plan to use "
 "our <apiLink>API</apiLink> or to <hostLink>host your own copy</hostLink> "
 "of the data."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:404
+#: frontend/js/src/forms/SignupCommercial.tsx:408
 msgid "Logo URL"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:405
+#: frontend/js/src/forms/SignupCommercial.tsx:409
 msgid "(preferably in SVG format)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:408
+#: frontend/js/src/forms/SignupCommercial.tsx:412
 msgid ""
 "Image should be about 250 pixels wide on a white or transparent "
 "background. We will host it on our site."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:421
+#: frontend/js/src/forms/SignupCommercial.tsx:425
 msgid ""
 "URL to where developers can use your APIs using MusicBrainz IDs, if "
-"available.."
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:430
-msgid "Your project"
+"available."
 msgstr ""
 
 #: frontend/js/src/forms/SignupCommercial.tsx:434
+msgid "Your project"
+msgstr ""
+
+#: frontend/js/src/forms/SignupCommercial.tsx:438
 #: frontend/js/src/forms/SignupNonCommercial.tsx:261
 msgid "(max 150 characters)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:451
+#: frontend/js/src/forms/SignupCommercial.tsx:455
 msgid "Billing address"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:502
+#: frontend/js/src/forms/SignupCommercial.tsx:506
 msgid ""
 "I agree to support the MetaBrainz Foundation when my organization is able"
 " to do so."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:507
+#: frontend/js/src/forms/SignupCommercial.tsx:511
+#: frontend/js/src/forms/SignupNonCommercial.tsx:284
 msgid ""
-"I also agree that if I generate a Live Data Feed access token, that I "
-"treat my access token as a secret and will not share this token publicly "
-"or commit it to a source code repository."
+"I also agree that if I generate a Live Data Feed access token, then I "
+"will treat my access token as a secret and will not share this token "
+"publicly or commit it to a source code repository."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:515
+#: frontend/js/src/forms/SignupCommercial.tsx:519
 msgid ""
 "The following information will be shown publicly: organization name, "
 "logo, website and API URLs, data usage description."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:520
+#: frontend/js/src/forms/SignupCommercial.tsx:524
 msgid ""
 "We'll send you more details about payment process once your application "
 "is approved."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:552
+#: frontend/js/src/forms/SignupCommercial.tsx:556
 #: frontend/js/src/forms/SignupNonCommercial.tsx:316
-#: frontend/js/src/forms/SignupUser.tsx:224
+#: frontend/js/src/forms/SignupUser.tsx:230
 msgid "Validating..."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:564
+#: frontend/js/src/forms/SignupCommercial.tsx:568
 #: frontend/js/src/forms/SignupNonCommercial.tsx:329
 #, fuzzy
 msgid "Back to profile"
 msgstr "O seu perfil"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:569
-#: frontend/js/src/forms/SignupNonCommercial.tsx:334
-msgid "Not a supporter?"
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:570
+#: frontend/js/src/forms/SignupCommercial.tsx:574
 #: frontend/js/src/forms/SignupNonCommercial.tsx:335
-msgid "Create a user account"
+msgid "Not a supporter? <signupLink>Create a user account</signupLink>"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:573
-#: frontend/js/src/forms/SignupNonCommercial.tsx:338
-#: frontend/js/src/forms/SignupUser.tsx:231
-msgid "Already have an account?"
-msgstr ""
-
-#: frontend/js/src/forms/SignupNonCommercial.tsx:107
-msgid "non-commercial"
+#: frontend/js/src/forms/SignupCommercial.tsx:583
+#: frontend/js/src/forms/SignupNonCommercial.tsx:344
+#: frontend/js/src/forms/SignupUser.tsx:238
+msgid "Already have an account? <loginLink>Sign in</loginLink>"
 msgstr ""
 
 #: frontend/js/src/forms/SignupNonCommercial.tsx:113
@@ -4005,46 +5045,40 @@ msgid ""
 "income per year) or personal uses only."
 msgstr ""
 
-#: frontend/js/src/forms/SignupNonCommercial.tsx:284
-msgid ""
-"I also agree that if I generate a Live Data Feed access token, then I "
-"will treat my access token as a secret and will not share this token "
-"publicly or commit it to a source code repository."
-msgstr ""
-
 #: frontend/js/src/forms/SignupUser.tsx:43
 msgid "Create your account"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:50
-msgid "Registration started by"
+#: frontend/js/src/forms/SignupUser.tsx:51
+msgid "Registration started by <client />"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:69
+#: frontend/js/src/forms/SignupUser.tsx:75
+#: frontend/js/src/hooks/useEmailValidation.ts:82
 msgid "Invalid email address."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:150
+#: frontend/js/src/forms/SignupUser.tsx:156
 msgid ""
 "This username and email were provided by the app that started "
 "registration. You can change them later from MetaBrainz settings."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:182
+#: frontend/js/src/forms/SignupUser.tsx:188
 msgid ""
 "I accept that my contributions will be released into the public domain or"
 " licensed for use."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:191
+#: frontend/js/src/forms/SignupUser.tsx:197
 msgid "We will never share your personal information."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:200
+#: frontend/js/src/forms/SignupUser.tsx:206
 msgid "Click here to read more"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:224
+#: frontend/js/src/forms/SignupUser.tsx:230
 msgid "Create account"
 msgstr ""
 
@@ -4054,10 +5088,6 @@ msgstr ""
 
 #: frontend/js/src/hooks/useEmailValidation.ts:47
 msgid "Email validation failed"
-msgstr ""
-
-#: frontend/js/src/hooks/useEmailValidation.ts:82
-msgid "Invalid email address"
 msgstr ""
 
 #~ msgid "You need to specify amount!"
@@ -5324,4 +6354,96 @@ msgstr ""
 
 #~ msgid "Privacy policy"
 #~ msgstr "Política de Privacidade"
+
+#~ msgid "You need to specify website of the organization."
+#~ msgstr ""
+
+#~ msgid ""
+#~ "We are currently evaluating our overall"
+#~ " online advertising strategy. We are "
+#~ "evaluating advertising, traffic optimization,\n"
+#~ ""
+#~ "    search engine optimization and "
+#~ "software monitization technologies. If you "
+#~ "provide these professional services, please"
+#~ " provide a detailed\n"
+#~ "    deck of your comprehensive services"
+#~ " to the following email address. "
+#~ "<em>Please respect our other non-media"
+#~ " teams and do not contact us \n"
+#~ "    regarding these services on any "
+#~ "other of our email addresses. We "
+#~ "will disregard the entirety of your "
+#~ "submissions if you contact us any "
+#~ "other way!</em>"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Please come ask your questions at "
+#~ "our <a href=\"%(forums_url)s\">forums</a>! We "
+#~ "would love to\n"
+#~ "    answer any questions you may have."
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Due to the increased unreliability of"
+#~ " the US Postal Service we have "
+#~ "stopped accepting paper checks. Sorry!"
+#~ msgstr ""
+
+#~ msgid "Upgrade"
+#~ msgstr ""
+
+#~ msgid "Back to Profile"
+#~ msgstr "O seu perfil"
+
+#~ msgid ""
+#~ "Deletion of supporter accounts requires "
+#~ "manual review. Please contact us at"
+#~ msgstr ""
+
+#~ msgid "Revoke all your API tokens and access"
+#~ msgstr ""
+
+#~ msgid "Your username will be reserved and cannot be reused."
+#~ msgstr ""
+
+#~ msgid "Don't have an account?"
+#~ msgstr ""
+
+#~ msgid "If you would like to support us with more than $"
+#~ msgstr ""
+
+#~ msgid ", please enter the actual amount here:"
+#~ msgstr ""
+
+#~ msgid "month and up"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "I also agree that if I generate"
+#~ " a Live Data Feed access token, "
+#~ "that I treat my access token as"
+#~ " a secret and will not share "
+#~ "this token publicly or commit it "
+#~ "to a source code repository."
+#~ msgstr ""
+
+#~ msgid "Not a supporter?"
+#~ msgstr ""
+
+#~ msgid "Create a user account"
+#~ msgstr ""
+
+#~ msgid "Already have an account?"
+#~ msgstr ""
+
+#~ msgid "non-commercial"
+#~ msgstr ""
+
+#~ msgid "Registration started by"
+#~ msgstr ""
+
+#~ msgid "Invalid email address"
+#~ msgstr ""
 

--- a/metabrainz/translations/ru/LC_MESSAGES/messages.po
+++ b/metabrainz/translations/ru/LC_MESSAGES/messages.po
@@ -17,179 +17,263 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-07-25 16:21+0200\n"
+"POT-Creation-Date: 2026-09-08 11:18+0200\n"
 "PO-Revision-Date: 2026-07-29 07:12+0000\n"
 "Last-Translator: Libra <recreate_squall363@simplelogin.com>\n"
 "Language: ru\n"
-"Language-Team: Russian <https://translations.metabrainz.org/projects/"
-"metabrainz/website/ru/>\n"
+"Language-Team: Russian "
+"<https://translations.metabrainz.org/projects/metabrainz/website/ru/>\n"
 "Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
-"n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || "
-"(n%100>=11 && n%100<=14)? 2 : 3);\n"
+"n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) "
+"|| (n%100>=11 && n%100<=14)? 2 : 3);\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.18.0\n"
-"X-Generator: Weblate 2026.7.1\n"
 
-#: metabrainz/index/forms.py:46
+#: metabrainz/errors.py:24
+msgid "Authorization was declined."
+msgstr ""
+
+#: metabrainz/errors.py:25
+msgid "The authorization request was invalid."
+msgstr ""
+
+#: metabrainz/errors.py:26
+msgid "The application could not be authenticated."
+msgstr ""
+
+#: metabrainz/errors.py:27
+msgid "This application is not allowed to request authorization."
+msgstr ""
+
+#: metabrainz/errors.py:28
+msgid "The application asked for a response type this server does not support."
+msgstr ""
+
+#: metabrainz/errors.py:29
+msgid "The permissions requested by the application are invalid."
+msgstr ""
+
+#: metabrainz/errors.py:30
+msgid "You need to sign in to continue."
+msgstr ""
+
+#: metabrainz/errors.py:31
+msgid "Your consent is required to continue."
+msgstr ""
+
+#: metabrainz/password.py:12
+#, python-format
+msgid "Password must not exceed %(max_bytes)s bytes."
+msgstr ""
+
+#: metabrainz/index/forms.py:48
 #, python-format
 msgid "'%(value)s' is not a valid choice for this field"
 msgstr "'%(value)s' не является подходящим значением для этого поля"
 
 #: frontend/js/src/forms/ProfileEdit.tsx:27
-#: frontend/js/src/forms/SignupCommercial.tsx:154
+#: frontend/js/src/forms/SignupCommercial.tsx:159
 #: frontend/js/src/forms/SignupNonCommercial.tsx:85
-#: frontend/js/src/forms/SignupUser.tsx:70
-#: frontend/js/src/hooks/useEmailValidation.ts:78 metabrainz/index/forms.py:57
-#: metabrainz/user/forms.py:25 metabrainz/user/forms.py:57
-#: metabrainz/user/forms.py:63
+#: frontend/js/src/forms/SignupUser.tsx:76
+#: frontend/js/src/hooks/useEmailValidation.ts:78 metabrainz/index/forms.py:59
+#: metabrainz/user/forms.py:31 metabrainz/user/forms.py:70
+#: metabrainz/user/forms.py:76
 msgid "Email address is required!"
 msgstr "Укажите e-mail адрес!"
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:34
-#: metabrainz/index/forms.py:63
+#: metabrainz/index/forms.py:65
 msgid "Current password is required!"
 msgstr "Укажите текущий пароль!"
 
 #: frontend/js/src/forms/LoginUser.tsx:43
 #: frontend/js/src/forms/ProfileChangePassword.tsx:37
 #: frontend/js/src/forms/ResetPassword.tsx:39
-#: frontend/js/src/forms/SignupCommercial.tsx:156
+#: frontend/js/src/forms/SignupCommercial.tsx:161
 #: frontend/js/src/forms/SignupNonCommercial.tsx:87
-#: frontend/js/src/forms/SignupUser.tsx:72 metabrainz/index/forms.py:66
-#: metabrainz/user/forms.py:29 metabrainz/user/forms.py:46
-#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:69
+#: frontend/js/src/forms/SignupUser.tsx:78 metabrainz/index/forms.py:69
+#: metabrainz/user/forms.py:35 metabrainz/user/forms.py:54
+#: metabrainz/user/forms.py:63 metabrainz/user/forms.py:82
 msgid "Password is required!"
 msgstr "Укажите пароль!"
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:41
-#: frontend/js/src/forms/SignupCommercial.tsx:160
+#: frontend/js/src/forms/SignupCommercial.tsx:165
 #: frontend/js/src/forms/SignupNonCommercial.tsx:91
-#: frontend/js/src/forms/SignupUser.tsx:76 metabrainz/index/forms.py:70
-#: metabrainz/user/forms.py:33 metabrainz/user/forms.py:73
+#: frontend/js/src/forms/SignupUser.tsx:82 metabrainz/index/forms.py:74
+#: metabrainz/user/forms.py:40 metabrainz/user/forms.py:87
 msgid "Confirm Password is required!"
 msgstr "Подтвердите выбранный пароль!"
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:46
 #: frontend/js/src/forms/ResetPassword.tsx:48
-#: frontend/js/src/forms/SignupCommercial.tsx:165
+#: frontend/js/src/forms/SignupCommercial.tsx:170
 #: frontend/js/src/forms/SignupNonCommercial.tsx:96
-#: frontend/js/src/forms/SignupUser.tsx:81 metabrainz/index/forms.py:72
-#: metabrainz/user/forms.py:35 metabrainz/user/forms.py:75
+#: frontend/js/src/forms/SignupUser.tsx:87 metabrainz/index/forms.py:76
+#: metabrainz/user/forms.py:42 metabrainz/user/forms.py:89
 msgid "Confirm Password should match password!"
 msgstr "Подтверждение пароля и сам пароль должны совпадать!"
 
 #: frontend/js/src/Applications.tsx:56 frontend/js/src/Applications.tsx:86
 #: frontend/js/src/Profile.tsx:272 frontend/js/src/Profile.tsx:482
-#: metabrainz/index/forms.py:78
+#: metabrainz/index/forms.py:82
 msgid "Name"
 msgstr "Имя"
 
-#: metabrainz/index/forms.py:79
+#: metabrainz/index/forms.py:83
 msgid "Contact name field is empty."
 msgstr "Имя контакта не заполнено."
 
-#: metabrainz/index/views.py:234
+#: metabrainz/index/views.py:251
 msgid "Profile updated successfully."
 msgstr "Профиль успешно обновлён."
 
-#: metabrainz/index/views.py:261
+#: metabrainz/index/views.py:278
 msgid "Current password is incorrect."
 msgstr "Текущий пароль указан неверно."
 
-#: metabrainz/index/views.py:266
+#: metabrainz/index/views.py:283
 msgid "Password changed successfully."
 msgstr "Пароль успешно изменён."
 
-#: metabrainz/index/views.py:372
+#: metabrainz/index/views.py:389
 msgid "You have updated an application!"
 msgstr ""
 
-#: metabrainz/index/views.py:424
+#: metabrainz/index/views.py:441
 msgid "You have deleted an application."
 msgstr ""
 
-#: metabrainz/index/views.py:426
+#: metabrainz/index/views.py:443
 msgid "Failed to delete an application."
 msgstr ""
 
-#: metabrainz/index/views.py:449
+#: metabrainz/index/views.py:466
 msgid "Revoked tokens successfully!"
 msgstr ""
 
-#: metabrainz/index/views.py:478
+#: metabrainz/index/views.py:495
 msgid "Your account has been deleted."
 msgstr "Ваш аккаунт был удалён."
 
-#: frontend/js/src/forms/CreateApplication.tsx:106 metabrainz/oauth/forms.py:58
+#: frontend/js/src/forms/CreateApplication.tsx:106 metabrainz/oauth/forms.py:57
 msgid "Application Name"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:59
+#: metabrainz/oauth/forms.py:58
 msgid "Application name field is empty."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:60 metabrainz/oauth/forms.py:60
+#: frontend/js/src/forms/CreateApplication.tsx:60 metabrainz/oauth/forms.py:59
 msgid "Application name needs to be at least 3 characters long."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:64 metabrainz/oauth/forms.py:61
+#: frontend/js/src/forms/CreateApplication.tsx:64 metabrainz/oauth/forms.py:60
 msgid "Application name needs to be at most 64 characters long."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:114 metabrainz/oauth/forms.py:63
+#: frontend/js/src/forms/CreateApplication.tsx:114 metabrainz/oauth/forms.py:62
 #, fuzzy
 msgid "Description"
 msgstr "Описание организации"
 
-#: metabrainz/oauth/forms.py:64
+#: metabrainz/oauth/forms.py:63
 msgid "Client description field is empty."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:65
+#: metabrainz/oauth/forms.py:64
 msgid "Client description needs to be at least 3 characters long."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:66
+#: metabrainz/oauth/forms.py:65
 msgid "Client description needs to be at most 512 characters long."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:122 metabrainz/oauth/forms.py:68
+#: frontend/js/src/forms/CreateApplication.tsx:122 metabrainz/oauth/forms.py:67
 msgid "Homepage"
 msgstr "Домашняя страница"
 
-#: metabrainz/oauth/forms.py:69
+#: metabrainz/oauth/forms.py:68
 msgid "Homepage field is empty."
 msgstr "Не заполнено поле \"Домашняя страница\"."
 
-#: metabrainz/oauth/forms.py:70
+#: metabrainz/oauth/forms.py:69
 msgid "Homepage is not a valid URI."
 msgstr "URL-адрес домашней страницы указан в неверном формате."
 
-#: metabrainz/oauth/forms.py:71
+#: metabrainz/oauth/forms.py:70
 msgid "Homepage URL must use http or https"
 msgstr "Адрес домашней страницы должен содержать http или https"
 
-#: metabrainz/oauth/forms.py:73
+#: metabrainz/oauth/forms.py:72
 msgid "Authorization callback URL"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:74
+#: metabrainz/oauth/forms.py:73
 msgid "Authorization callback URL field is empty."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:75
+#: metabrainz/oauth/forms.py:74
 msgid "Authorization callback URL is invalid."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:76
+#: metabrainz/oauth/forms.py:75
 msgid "Authorization callback URL must use http or https."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:81 metabrainz/oauth/forms.py:85
+#: metabrainz/oauth/forms.py:80 metabrainz/oauth/forms.py:84
 msgid "Confirm"
 msgstr "Подтвердить"
+
+#: metabrainz/oauth/scopes.py:15
+msgid "View your public account information"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:16
+msgid "View your email address"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:17
+msgid "View and modify your private tags"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:18
+msgid "View and modify your private ratings"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:19
+msgid "View and modify your private collections"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:20
+msgid "Submit new ISRCs to the database"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:21
+msgid "Submit new barcodes to the database"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:22
+msgid "Sign you in and view your unique user id"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:23
+msgid "Submit listens to ListenBrainz."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:24
+msgid "Create and modify CritiqueBrainz reviews."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:25
+msgid "Submit and delete votes on CritiqueBrainz reviews."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:26
+msgid "Modify profile info and delete profile on CritiqueBrainz."
+msgstr ""
 
 #: metabrainz/payments/views.py:164
 msgid ""
@@ -240,185 +324,192 @@ msgid "Requested annual report was not found."
 msgstr "Запрошенный годовой отчет не найден."
 
 #: frontend/js/src/forms/ProfileEdit.tsx:30
-#: frontend/js/src/forms/SignupCommercial.tsx:139
+#: frontend/js/src/forms/SignupCommercial.tsx:144
 #: frontend/js/src/forms/SignupNonCommercial.tsx:70
-#: metabrainz/supporter/forms.py:13
+#: metabrainz/supporter/forms.py:15
 msgid "Contact name is required!"
 msgstr "Укажите имя контакта!"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:437
+#: frontend/js/src/forms/SignupCommercial.tsx:441
 #: frontend/js/src/forms/SignupNonCommercial.tsx:264
-#: metabrainz/supporter/forms.py:15
+#: metabrainz/supporter/forms.py:17
 msgid ""
 "Can you please tell us more about the project in which you'd like to use "
 "our data? Do you plan to self host the data or use our APIs?"
 msgstr ""
 "Не могли бы вы, пожалуйста, рассказать нам побольше о проекте, в котором "
-"планируете использовать наши данные? Планируете ли вы получать к ним доступ "
-"через наши API или же собираетесь селфхостить их самостоятельно?"
+"планируете использовать наши данные? Планируете ли вы получать к ним "
+"доступ через наши API или же собираетесь селфхостить их самостоятельно?"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:137
+#: frontend/js/src/forms/SignupCommercial.tsx:142
 #: frontend/js/src/forms/SignupNonCommercial.tsx:68
-#: metabrainz/supporter/forms.py:17
+#: metabrainz/supporter/forms.py:19
 msgid "Please, tell us how you (will) use our data."
 msgstr ""
 "Расскажите, пожалуйста, как вы используете (будете использовать) наши "
 "данные."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:138
+#: frontend/js/src/forms/SignupCommercial.tsx:143
 #: frontend/js/src/forms/SignupNonCommercial.tsx:69
-#: metabrainz/supporter/forms.py:18
+#: metabrainz/supporter/forms.py:20
 msgid "Please, limit usage description to 500 characters."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:141
-#: frontend/js/src/forms/SignupCommercial.tsx:142
+#: frontend/js/src/forms/SignupCommercial.tsx:146
+#: frontend/js/src/forms/SignupCommercial.tsx:147
 #: frontend/js/src/forms/SignupNonCommercial.tsx:72
 #: frontend/js/src/forms/SignupNonCommercial.tsx:73
-#: frontend/js/src/forms/SignupUser.tsx:84
-#: frontend/js/src/forms/SignupUser.tsx:85 metabrainz/supporter/forms.py:21
-#: metabrainz/user/forms.py:38
+#: frontend/js/src/forms/SignupUser.tsx:90
+#: frontend/js/src/forms/SignupUser.tsx:91 metabrainz/supporter/forms.py:23
+#: metabrainz/user/forms.py:45
 msgid "You need to accept the agreement!"
 msgstr "Вам нужно принять соглашение!"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:342
-#: metabrainz/supporter/forms.py:27
+#: frontend/js/src/forms/SignupCommercial.tsx:347
+#: metabrainz/supporter/forms.py:29
 msgid "Organization name"
 msgstr "Название организации"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:113
-#: metabrainz/supporter/forms.py:28
+#: frontend/js/src/forms/SignupCommercial.tsx:115
+#: metabrainz/supporter/forms.py:30
 msgid "You need to specify the name of your organization."
 msgstr "Необходимо указать название вашей организации."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:373
-#: metabrainz/supporter/forms.py:30
+#: frontend/js/src/forms/SignupCommercial.tsx:378
+#: metabrainz/supporter/forms.py:32
 msgid "Organization description"
 msgstr "Описание организации"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:116
-#: metabrainz/supporter/forms.py:31
+#: frontend/js/src/forms/SignupCommercial.tsx:118
+#: metabrainz/supporter/forms.py:33
 msgid "You need to provide description of your organization."
 msgstr "Вы должны предоставить описание вашей организации."
 
 #: frontend/js/src/Profile.tsx:278
-#: frontend/js/src/forms/SignupCommercial.tsx:396
-#: metabrainz/supporter/forms.py:34
+#: frontend/js/src/forms/SignupCommercial.tsx:401
+#: metabrainz/supporter/forms.py:36
 msgid "Website URL"
 msgstr "URL-адрес веб-сайта"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:119
-#: metabrainz/supporter/forms.py:35
-msgid "You need to specify website of the organization."
-msgstr "Вам необходимо указать веб-сайт организации."
+#: frontend/js/src/forms/SignupCommercial.tsx:121
+#: frontend/js/src/forms/SignupCommercial.tsx:123
+#: metabrainz/supporter/forms.py:38 metabrainz/supporter/forms.py:42
+msgid "Website URL must be a valid URL."
+msgstr ""
 
-#: metabrainz/supporter/forms.py:37
+#: metabrainz/supporter/forms.py:45
 msgid "Logo image URL"
 msgstr "URL логотипа"
 
 #: frontend/js/src/Profile.tsx:284
-#: frontend/js/src/forms/SignupCommercial.tsx:418
-#: metabrainz/supporter/forms.py:38
+#: frontend/js/src/forms/SignupCommercial.tsx:422
+#: metabrainz/supporter/forms.py:46
 msgid "API URL"
 msgstr "API URL"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:457
-#: metabrainz/supporter/forms.py:40
+#: frontend/js/src/forms/SignupCommercial.tsx:461
+#: metabrainz/supporter/forms.py:48
 msgid "Street"
 msgstr "Улица"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:123
-#: metabrainz/supporter/forms.py:41
+#: frontend/js/src/forms/SignupCommercial.tsx:128
+#: metabrainz/supporter/forms.py:49
 msgid "You need to specify street."
 msgstr "Нужно указать улицу."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:465
-#: metabrainz/supporter/forms.py:43
+#: frontend/js/src/forms/SignupCommercial.tsx:469
+#: metabrainz/supporter/forms.py:51
 msgid "City"
 msgstr "Город"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:124
-#: metabrainz/supporter/forms.py:44
+#: frontend/js/src/forms/SignupCommercial.tsx:129
+#: metabrainz/supporter/forms.py:52
 msgid "You need to specify city."
 msgstr "Нужно указать город."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:473
-#: metabrainz/supporter/forms.py:46
+#: frontend/js/src/forms/SignupCommercial.tsx:477
+#: metabrainz/supporter/forms.py:54
 msgid "State / Province"
 msgstr "Штат/область"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:126
-#: metabrainz/supporter/forms.py:47
+#: frontend/js/src/forms/SignupCommercial.tsx:131
+#: metabrainz/supporter/forms.py:55
 msgid "You need to specify state/province."
 msgstr "Необходимо указать штат/область."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:481
-#: metabrainz/supporter/forms.py:49
+#: frontend/js/src/forms/SignupCommercial.tsx:485
+#: metabrainz/supporter/forms.py:57
 msgid "Postcode"
 msgstr "Почтовый индекс"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:128
-#: metabrainz/supporter/forms.py:50
+#: frontend/js/src/forms/SignupCommercial.tsx:133
+#: metabrainz/supporter/forms.py:58
 msgid "You need to specify postcode."
 msgstr "Нужно указать почтовый индекс."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:489
-#: metabrainz/supporter/forms.py:52
+#: frontend/js/src/forms/SignupCommercial.tsx:493
+#: metabrainz/supporter/forms.py:60
 msgid "Country"
 msgstr "Страна"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:129
-#: metabrainz/supporter/forms.py:53
+#: frontend/js/src/forms/SignupCommercial.tsx:134
+#: metabrainz/supporter/forms.py:61
 msgid "You need to specify country."
 msgstr "Нужно указать страну."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:132
-#: metabrainz/supporter/forms.py:64
+#: frontend/js/src/forms/SignupCommercial.tsx:137
+#: metabrainz/supporter/forms.py:72
 msgid ""
 "Custom amount must be more than threshold amount for selected tier or "
 "equal to it!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:46 metabrainz/supporter/views.py:119
-#: metabrainz/supporter/views.py:220
+#: metabrainz/supporter/views.py:54
+msgid ""
+"The verification email could not be sent. Please request a new one from "
+"your profile."
+msgstr ""
+
+#: metabrainz/supporter/views.py:85 metabrainz/supporter/views.py:158
+#: metabrainz/supporter/views.py:260
 msgid "You are already a supporter."
 msgstr "Вы уже поддерживаете проект."
 
-#: metabrainz/supporter/views.py:61
+#: metabrainz/supporter/views.py:100
 msgid "Can't find tier with a specified ID."
 msgstr ""
 
-#: metabrainz/supporter/views.py:127
+#: metabrainz/supporter/views.py:166
 msgid "You need to choose support tier before signing up!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:137
+#: metabrainz/supporter/views.py:176
 msgid "You need to choose existing tier before signing up!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:164
+#: metabrainz/supporter/views.py:204
 msgid ""
 "Thanks for becoming a supporter! Your application will be reviewed soon. "
 "We will send you updates via email."
 msgstr ""
 
-#: metabrainz/supporter/views.py:187
+#: metabrainz/supporter/views.py:228
 msgid ""
 "Thanks for signing up! Your application will be reviewed soon. We will "
 "send you updates via email."
 msgstr ""
 
-#: metabrainz/supporter/views.py:248
+#: metabrainz/supporter/views.py:288
 msgid "Thanks for becoming a supporter!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:274
+#: metabrainz/supporter/views.py:312
 msgid "Thanks for signing up! Please check your inbox to complete verification."
 msgstr ""
-"Спасибо за регистрацию! Пожалуйста, проверьте ваши входящие, чтобы завершить "
-"верификацию."
+"Спасибо за регистрацию! Пожалуйста, проверьте ваши входящие, чтобы "
+"завершить верификацию."
 
-#: metabrainz/supporter/views.py:302
+#: metabrainz/supporter/views.py:340
 msgid "Can't generate new token unless account is active."
 msgstr ""
 
@@ -452,7 +543,7 @@ msgstr ""
 msgid "Policies"
 msgstr ""
 
-#: metabrainz/templates/base.html:55 metabrainz/templates/index/gdpr.html:178
+#: metabrainz/templates/base.html:55
 #: metabrainz/templates/index/social-contract.html:3
 #: metabrainz/templates/index/social-contract.html:6
 #: metabrainz/templates/navbar.html:34
@@ -462,14 +553,15 @@ msgstr ""
 #: metabrainz/templates/base.html:56
 #: metabrainz/templates/index/code-of-conduct.html:3
 #: metabrainz/templates/index/code-of-conduct.html:16
-#: metabrainz/templates/index/gdpr.html:181 metabrainz/templates/navbar.html:35
+#: metabrainz/templates/navbar.html:35
 msgid "Code of Conduct"
 msgstr ""
 
+#: frontend/js/src/PrivacySummary.tsx:11
 #: frontend/js/src/forms/ConditionsModal.tsx:21
-#: metabrainz/templates/base.html:57 metabrainz/templates/index/gdpr.html:184
-#: metabrainz/templates/index/privacy.html:6
+#: metabrainz/templates/base.html:57 metabrainz/templates/index/privacy.html:6
 #: metabrainz/templates/navbar.html:36
+#: metabrainz/templates/users/privacy-summary.html:3
 msgid "Privacy Policy"
 msgstr "Политика конфиденциальности"
 
@@ -503,10 +595,7 @@ msgstr "Спонсоры"
 msgid "Supporters"
 msgstr "Спонсоры"
 
-#: frontend/js/src/forms/LoginUser.tsx:103
-#: frontend/js/src/forms/SignupCommercial.tsx:574
-#: frontend/js/src/forms/SignupNonCommercial.tsx:339
-#: frontend/js/src/forms/SignupUser.tsx:232 metabrainz/templates/base.html:73
+#: frontend/js/src/forms/LoginUser.tsx:103 metabrainz/templates/base.html:73
 #: metabrainz/templates/navbar.html:66 metabrainz/templates/users/login.html:3
 msgid "Sign in"
 msgstr "Войти"
@@ -528,27 +617,27 @@ msgid "Contact us"
 msgstr "Как с нами связаться"
 
 #: metabrainz/templates/base.html:85
-#: metabrainz/templates/index/contact.html:105
+#: metabrainz/templates/index/contact.html:106
 msgid "Blog"
 msgstr "Блог"
 
-#: metabrainz/templates/base.html:86 metabrainz/templates/index/contact.html:90
+#: metabrainz/templates/base.html:86 metabrainz/templates/index/contact.html:91
 msgid "Chat"
 msgstr "Чат"
 
 #: metabrainz/templates/base.html:87
-#: metabrainz/templates/index/contact.html:106
+#: metabrainz/templates/index/contact.html:107
 #, fuzzy
 msgid "Mastodon"
 msgstr "Mastodon"
 
 #: metabrainz/templates/base.html:88
-#: metabrainz/templates/index/contact.html:107
+#: metabrainz/templates/index/contact.html:108
 msgid "Bluesky"
 msgstr "Bluesky"
 
 #: metabrainz/templates/base.html:89
-#: metabrainz/templates/index/contact.html:108
+#: metabrainz/templates/index/contact.html:109
 msgid "Instagram"
 msgstr "Instagram"
 
@@ -605,15 +694,14 @@ msgstr "Финансовые отчёты"
 msgid "Donate"
 msgstr "Пожертвовать"
 
-#: frontend/js/src/forms/LoginUser.tsx:110
-#: frontend/js/src/forms/SignupCommercial.tsx:175
-#: frontend/js/src/forms/SignupCommercial.tsx:555
+#: frontend/js/src/forms/SignupCommercial.tsx:180
+#: frontend/js/src/forms/SignupCommercial.tsx:559
 #: frontend/js/src/forms/SignupNonCommercial.tsx:106
 #: frontend/js/src/forms/SignupNonCommercial.tsx:319
 #: metabrainz/templates/navbar.html:65
-#: metabrainz/templates/supporters/account-type.html:51
-#: metabrainz/templates/supporters/account-type.html:93
-#: metabrainz/templates/supporters/account-type.html:144
+#: metabrainz/templates/supporters/account-type.html:47
+#: metabrainz/templates/supporters/account-type.html:84
+#: metabrainz/templates/supporters/account-type.html:130
 #: metabrainz/templates/users/signup.html:3
 msgid "Sign up"
 msgstr "Регистрация"
@@ -926,8 +1014,430 @@ msgstr ""
 msgid "Introduction"
 msgstr ""
 
-#: metabrainz/templates/index/conflict-policy.html:55
+#: metabrainz/templates/index/conflict-policy.html:17
+msgid ""
+"Conflicts between people arise in open source projects constantly and the"
+" projects by the \n"
+"    MetaBrainz Foundation are no different. This policy aims to establish"
+" a clear and unambiguous \n"
+"    policy for reporting and addressing conflicts in our community. In "
+"this policy we aim to \n"
+"    establish a fair practice that balances the need for confidentiality "
+"and our desire for \n"
+"    transparency in our operations."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:25
+#, python-format
+msgid ""
+"Before you continue to read this policy, we encourage you to review our "
+"existing community policies \n"
+"    including our <a href=\"%(social_contract_url)s\">Social "
+"Contract</a>, \n"
+"    <a href=\"%(code_of_conduct_url)s\">the Code of Conduct</a>, \n"
+"    and our <a href=\"%(privacy_policy_url)s\">Privacy Policy</a>. These "
+"policies establish the norms and rules for \n"
+"    participation in our projects; these policies apply equally to the "
+"contractors of the MetaBrainz \n"
+"    Foundation and any participants in our projects."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:37
+msgid ""
+"This policy divides conflicts into two categories: Private and public. "
+"Private conflicts are conflicts \n"
+"    that involve *confidential* information regarding contributors, "
+"contractors or supporters. Otherwise, any conflicts \n"
+"    that do not involve confidential information are considered to be "
+"public conflicts. For instance, a \n"
+"    conflict between a contractor and the Executive Director (aka BDFL) "
+"that involves contractor pay is \n"
+"    considered a private conflict because pay rates are confidential "
+"information. A public conflict in edit \n"
+"    notes between two editors in our community does not involve "
+"confidential information and therefore should \n"
+"    be considered a public conflict."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:47
+msgid ""
+"When conflicts arise we aim to disclose as much information as possible "
+"about the conflict in a timely \n"
+"    fashion. When conflicts contain confidential matters we will aim to "
+"disclose as much information as \n"
+"    possible, while fully respecting the confidentiality of the people "
+"involved in the conflict. With any \n"
+"    private conflict we will aim to extract the relevant lessons for the "
+"team and community in an effort to \n"
+"    evolve our policies to prevent future conflicts. Should the involved "
+"parties disagree whether a conflict \n"
+"    is private or public, the question about the nature of the conflict "
+"will be presented for the next higher \n"
+"    level in the chain of command to decide. (e.g. if a community member "
+"and the community manager disagree on \n"
+"    a conflict being public or private, the Executive Director shall "
+"decide if the conflict is public or private)."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:58
 msgid "Reporting and Response"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:61
+msgid ""
+"We aim to not have conflict in our community, but we recognize that in "
+"reality conflicts will arise and we \n"
+"    must be prepared to address them in a fair manner. When conflicts "
+"arise, we prefer to have community or team \n"
+"    members resolve the conflicts among themselves, using our existing "
+"policies as guidelines for resolving the \n"
+"    conflict."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:69
+msgid ""
+"If you do not feel comfortable resolving a conflict on your own, you "
+"should feel free to report the conflict to \n"
+"    us. How you address the conflict depends on who is involved in the "
+"conflict and your comfort level. Please see \n"
+"    the detailed sections below on how and with whom to address your "
+"conflict. We aim to address conflicts as soon \n"
+"    as possible in an effort to prevent them from escalating "
+"unnecessarily."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:75
+msgid "Direct conflict resolution"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:78
+msgid ""
+"In direct conflict resolution, the involved parties will attempt to "
+"resolve the conflict themselves without \n"
+"   involving any MetaBrainz Foundation team member. You should aim to use"
+" direct resolution when the conflict does \n"
+"   not involve the violation of one of our policies or if the conflict is"
+" minor."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:84
+#, python-format
+msgid ""
+"For instance, if a user uses a rude tone, is disruptive or flagrantly "
+"ignores our project guidelines, we suggest \n"
+"    that you use direct conflict resolution to resolve the conflict. Some"
+" resources that might give you some suggestions \n"
+"    on how to go about resolving the conflict might be this <a "
+"href=\"%(conflict_resolution_primer_url)s\">\n"
+"    conflict resolution primer</a> and <a "
+"href=\"%(difficult_conversations_url)s\">how to\n"
+"    have difficult conversations at work</a>."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:93
+msgid "Informal reporting"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:96
+msgid ""
+"You may use informal reporting of a conflict if you aim to communicate a "
+"concern or incident without \n"
+"    seeking a corrective outcome. Informal reporting may also be an "
+"option if you have not been personally \n"
+"    victimized, but you’ve witnessed a violation of our policies or where"
+" you wish to maintain confidentiality \n"
+"    throughout the entire reporting process."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:103
+msgid ""
+"For editing in MusicBrainz you may informally report a user using the "
+"“Report this user for bad behavior” \n"
+"    link from the user’s profile. For reporting bad user behavior in "
+"other of our projects, please report them to our \n"
+"    community manager by mailing <span class=\"backemail\">gro.zniarbatem"
+"@reganam-ytinummoc</span> . For conflicts \n"
+"    that involve the community manager, report them by mailing <span "
+"class=\"backemail\">gro.zniarbatem@de</span> ."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:110
+msgid ""
+"Depending the the severity of the issue, repeated informal complaints may"
+" eventually require a formal response \n"
+"    from the MetaBrainz team. If an involved party requires anonymity, "
+"the conflict becomes a private conflict. If at \n"
+"    all possible minor issues should be resolved in a public forum in "
+"order for all people to witness and learn from \n"
+"    the issue at hand."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:116
+msgid "Formal complaint process"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:119
+msgid ""
+"All complaints about conflicts should be submitted via email. To whom a "
+"complaint should be mailed and who will \n"
+"    carry out the investigation will be described in the next section."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:124
+msgid "All complaint submissions to the Foundation should include the following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:128
+msgid ""
+"Contact info, if it is different than the email used to submit the "
+"conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:129
+msgid "Who was involved in the conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:130
+msgid "Where and when the incident happened"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:131
+msgid ""
+"A description of what happened -- ideally with links (e.g. chatlogs, edit"
+" notes) that outlines what \n"
+"         happened so that the persons evaluating the conflict may "
+"understand the issue at hand"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:133
+msgid ""
+"Any related pieces of information that provide more context on the "
+"conflict (e.g. links, screenshots)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:134
+msgid "An indication if this conflict is ongoing or not"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:139
+msgid "The investigation that follows aims to determine:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:143
+msgid "The nature and severity of the incident"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:144
+msgid ""
+"Whether or not the incident is considered a violation of MetaBrainz’ "
+"conduct policies or core values"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:145
+msgid ""
+"The amount of harm experienced by the person who submitted the complaint "
+"and the broader MetaBrainz community \n"
+"         as a result of the incident"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:147
+msgid ""
+"Whether there have been prior complaints against the individual or "
+"individuals reported"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:148
+msgid "Whether the incident is ongoing"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:152
+msgid ""
+"The following potential forms of resolution may apply to any team members"
+" involved in the conflict:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:155
+#: metabrainz/templates/index/conflict-policy.html:168
+msgid "Nothing (if it has been found no violation occurred)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:156
+msgid "Creating a plan to improve the performance"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:157
+msgid "Creating a negative performance evaluation"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:158
+msgid "Mediation, an intervention by a third party to resolve the conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:159
+msgid "Suspension or forced leave"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:160
+msgid "Termination of contract"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:164
+msgid ""
+"The following potential forms of resolution may apply to non team members"
+" involved in the conflict:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:169
+msgid "A reprimand, either public or private"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:170
+msgid "Suspension of the users’ account"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:171
+msgid "Deletion of the users’ account"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:172
+msgid ""
+"Removal of user privileges (e.g. if an auto editor commits a serious "
+"offence, they may lose their auto editor status)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:175
+msgid "Filing a complaint"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:178
+msgid ""
+"NOTE: For complaints not about MetaBrainz staff, please see the "
+"<em>Informal reporting</em> section above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:182
+msgid ""
+"If the complaint does not involve the Executive Director (ED), do the "
+"following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:186
+msgid ""
+"If team member has directly violated conduct policies or engaged in "
+"otherwise harmful behavior, a formal complaint should be filed."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:187
+msgid ""
+"Mail <span class=\"backemail\">gro.zniarbatem@de</span> and include the "
+"complaint information outlined above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:188
+msgid ""
+"You should expect a response within a working day acknowledging the "
+"complaint."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:189
+msgid ""
+"The complaint will be investigated by the ED, member(s) of the board of "
+"directors or a neutral third party."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:190
+msgid ""
+"Once the investigation has been completed, the ED, with the support of "
+"others involved in the investigation will respond. The \n"
+"        ED will respond to incidents no later than 7 working days after a"
+" complaint has been filed with either a resolution or an \n"
+"        explanation of why the process must be extended."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:196
+msgid "If a complaint involves the Executive Director, do the following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:200
+msgid ""
+"If the Executive Director has directly violated conduct policies or "
+"engaged in otherwise harmful behavior, \n"
+"        a formal complaint should be filed with the board of directors."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:202
+msgid ""
+"Mail <span class=\"backemail\">gro.zniarbatem@noituloser-tcilfnoc</span> "
+"and include the complaint information outlined above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:203
+msgid ""
+"You should get a response within 5 working days acknowledging the "
+"complaint."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:204
+msgid ""
+"The complaint will be investigated by the member(s) of the board of "
+"directors, the community manager, a neutral \n"
+"        third party or a combination thereof."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:206
+msgid ""
+"Once the investigation has been completed, the board, with the support of"
+" others involved in the investigation \n"
+"        will respond. The board will aim to respond to incidents no later"
+" than 15 working days after a complaint has been filed \n"
+"        with either a resolution or an explanation of why the process "
+"must be extended."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:211
+msgid "Confidentiality"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:214
+msgid ""
+"Confidentiality is an important aspect of conflict resolution and all of "
+"the conflicts brought to the attention of the foundation \n"
+"    will be evaluated with confidentiality in mind and acted upon "
+"accordingly."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:219
+msgid ""
+"We work hard to make all of the actions of the foundation as transparent "
+"and open as possible. In cases where we cannot \n"
+"    disclose all aspects of a conflict we will disclose that a conflict "
+"is or has occurred and we will attempt to disclose the \n"
+"    appropriate amount of information about the conflict while balancing "
+"the need for confidentiality and our desire to learn \n"
+"    from conflicts so that we as a foundation and community can learn "
+"from these conflicts and improve our policies to avoid the \n"
+"    conflicts in the future."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:227
+msgid ""
+"Any breaches of confidentiality will be treated as severe breaches of our"
+" conduct policies."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:230
+msgid "Retaliation"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:233
+msgid ""
+"We will not allow retaliation for any contractor or volunteer that files "
+"a complaint or is involved in an investigation. If you \n"
+"    believe that you are being treated negatively because of your "
+"involvement in a complaint please report this complaint directly \n"
+"    to the ED at <span class=\"backemail\">gro.zniarbatem@de</span> or "
+"the board at \n"
+"    <span class=\"backemail\">gro.zniarbatem@noituloser-tcilfnoc</span>."
 msgstr ""
 
 #: metabrainz/templates/index/contact.html:3
@@ -1008,7 +1518,7 @@ msgstr ""
 msgid ""
 "We are currently evaluating our overall online advertising strategy. We "
 "are evaluating advertising, traffic optimization,\n"
-"    search engine optimization and software monitization technologies. If"
+"    search engine optimization and software monetization technologies. If"
 " you provide these professional services, please provide a detailed\n"
 "    deck of your comprehensive services to the following email address. "
 "<em>Please respect our other non-media teams and do not contact us \n"
@@ -1085,14 +1595,11 @@ msgstr "Форумы"
 #, python-format
 msgid ""
 "Please come ask your questions at our <a "
-"href=\"%(forums_url)s\">forums</a>! We would love to\n"
-"    answer any questions you may have."
+"href=\"%(forums_url)s\">forums</a>!\n"
+"    The community and the team will be more than happy to help you."
 msgstr ""
-"Пожалуйста, задавайте свои вопросы на наших <a "
-"href=\"%(forums_url)s\">форумах</a>! Мы будем рады \n"
-" ответить на любые ваши вопросы."
 
-#: metabrainz/templates/index/contact.html:92
+#: metabrainz/templates/index/contact.html:93
 #, python-format
 msgid ""
 "The MetaBrainz/MusicBrainz/ListenBrainz team and community hang out\n"
@@ -1102,15 +1609,15 @@ msgid ""
 "    <a href=\"%(chatlogs_url)s\">chat log archives</a>."
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:101
+#: metabrainz/templates/index/contact.html:102
 msgid "Social media"
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:103
+#: metabrainz/templates/index/contact.html:104
 msgid "You can follow us on these social channels:"
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:112
+#: metabrainz/templates/index/contact.html:113
 msgid "Mailing address"
 msgstr "Почтовый адрес"
 
@@ -1123,33 +1630,349 @@ msgstr ""
 msgid "GDPR Compliance Statement"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:37
+#: metabrainz/templates/index/gdpr.html:10
+msgid ""
+"The General Data Protection Regulation is a complex EU regulation that "
+"stipulates many points for protecting private data of\n"
+"    users on the Internet. Even though this is an EU regulation, it has a"
+" worldwide impact due to the nature of the Internet.\n"
+"    The MetaBrainz Foundation with its collection of projects is also "
+"affected by this regulation. We’ve been learning and adapting\n"
+"    our sites to be compliant with the GDPR – sadly this regulation isn’t"
+" entirely black and white and there is an incredible\n"
+"    amount of room left for interpretation of these rules."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:17
+msgid ""
+"The good news is that this regulation is roughly in line with our "
+"established practices: We’ve always held private information\n"
+"    in a high regard and applied the sort of rules to ourselves as we "
+"wish to have our own private data treated. Luckily, this\n"
+"    makes our compliance effort considerably easier. We’ve made two "
+"significant changes to how we treat your data and also adopted\n"
+"    terminology as used in the GDPR in order to use the same languages "
+"that many other sites are now adopting. Please keep reading\n"
+"    to find out the exact details of what we are doing to comply."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:24
+#, python-format
+msgid ""
+"However, we do ask for your compassion and help in our process of "
+"complying with the GDPR. As we already mentioned, the GDPR is\n"
+"    a complex set of rules that are not fully clarified yet. We’ve taken "
+"action on the steps that are clear to us and we’re following\n"
+"    ongoing conversations on points that are in gray zones or unclear to "
+"us. We’ve made our best initial effort on compliance and\n"
+"    promise to keep working on it as the picture becomes more clear. If "
+"you believe that we could improve our compliance, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a> and let us know what we "
+"can do to improve. It would also help us if you\n"
+"    could provide concrete discussion or examples to help us understand "
+"and take action on your suggestion."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:33
+msgid ""
+"Finally, below are the key sections of the GDPR as we understand them and"
+" how they affect your data in our ecosystem. Where\n"
+"    possible, we provide links for deeper understanding, links for you to"
+" examine our relevant code and links to tickets to follow\n"
+"    the process of improving our compliance."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:38
 msgid "Right to be forgotten"
 msgstr "Право на забвение"
 
-#: metabrainz/templates/index/gdpr.html:77
+#: metabrainz/templates/index/gdpr.html:41
+msgid ""
+"Summary: <i>Provide the user with the ability to remove their private "
+"data from our services</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:44
+msgid ""
+"The most important aspect of the right to be forgotten is the ability to "
+"delete your account. Once you request for us to delete\n"
+"    your account, we will remove any personally identifying information "
+"you may have provided us from your account (name, email\n"
+"    address, gender, biography, URL, etc.). The visible name on your "
+"account will be changed to “Deleted User #####” and effectively\n"
+"    the account will no longer be identifiable as your account."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:50
+msgid ""
+"However, given the nature of our projects where we work on collaborative "
+"databases, your contributions that are not personally\n"
+"    identifying are valuable assets to our database and these "
+"contributions will not be removed from our databases. But we will\n"
+"    ensure that these contributions no longer contain personally "
+"identifying data."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:55
+#, python-format
+msgid ""
+"Our process of automatically deleting your accounts across the MetaBrainz"
+" ecosystem is not complete yet (see below for a set of\n"
+"    tickets where you can track our progress). If you would like to "
+"delete your accounts in the MetaBrainz ecosystem or mark a\n"
+"    donation that is currently public as a private donation, please <a "
+"href=\"%(contact_url)s\">contact us</a>\n"
+"    and we will address your request as soon as possible."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:62
+#: metabrainz/templates/index/gdpr.html:182
+msgid "Links:"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:66
+#, python-format
+msgid ""
+"<a href=\"%(editor_deletion_doc_url)s\">How we delete accounts\n"
+"       in MusicBrainz</a> (warning, geek content ahead!)"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:70
+msgid ""
+"Implement sitewide user account deletion in\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/MBS-9680\">MusicBrainz</a>,"
+"\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/AB-337\">AcousticBrainz</a>,"
+"\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/BB-260\">BookBrainz</a>,\n"
+"         <a href=\"https://tickets.metabrainz.org/browse/MEB-103\">the "
+"MetaBrainz Site</a>,\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/LB-354\">ListenBrainz</a>, "
+"and\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/CB-307\">CritiqueBrainz</a>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:80
 msgid "Restriction of processing"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:110
+#: metabrainz/templates/index/gdpr.html:83
+msgid ""
+"Summary: <i>To allow the user to control how their personally identifying"
+" data is being used.</i>"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:86
+msgid ""
+"Except for the ListenBrainz and AcousticBrainz projects, we do not "
+"process personally identifying data. Any personally\n"
+"    identifying data that our projects store is for the purpose of being "
+"able to contact you about your contributions to our database\n"
+"    (email address) or for voluntarily showing information about you to "
+"other users (biography, homepage, location, etc)."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:91
+#, python-format
+msgid ""
+"The ListenBrainz project differs in that the Listens (metadata about what"
+" music you have listened to) are stored on our servers\n"
+"    and <a href=\"%(listenbrainz_data_url)s\">made available to the "
+"public</a>. We believe Listens to be personally identifying\n"
+"    data and furthermore, we have goals of creating open source "
+"recommendation engines with this data, which involves processing the\n"
+"    user’s data. These two points are fundamental goals of the "
+"ListenBrainz project and we do not see a reasonable way to reach another"
+"\n"
+"    compromise position."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:99
+msgid ""
+"Because of this, we are going to require users to either acknowledge that"
+" we may process their Listen data or alternatively to\n"
+"    delete their account, including all of their Listens. Please note "
+"that if you decide to delete your ListenBrainz account, it may\n"
+"    take up to two weeks for all of your listens to no longer be included"
+" in our efforts to build a recommendation engine."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:104
+msgid ""
+"We have always made it clear that the data in ListenBrainz was to be "
+"public and that we plan to build new tools with your data, so\n"
+"    this should not come as a surprise to our users."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:108
+msgid ""
+"The AcousticBrainz project does not track who submits data to the "
+"database. If you create an account and use our data creation\n"
+"    tools (e.g. create a dataset or participate in a challenge) then we "
+"link your participation and the things that you create to\n"
+"    your account. If you choose to delete your account then we keep the "
+"non personally identifying data that you create, but anonymize\n"
+"    it so that it cannot be linked back to you."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:114
 msgid "Right to data portability / exporting your data"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:150
+#: metabrainz/templates/index/gdpr.html:117
+msgid ""
+"Summary: <i>You have the right to access/download the data we store about"
+" you</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:120
+msgid ""
+"Except for the ListenBrainz and AcousticBrainz projects, we do not store "
+"personally identifying data beyond the\n"
+"    information that is available in your public profile on each of our "
+"projects. Since this data is plainly available in your\n"
+"    profile we do not provide a means for you to export this data."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:125
+msgid "There are the following exceptions to this:"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:129
+msgid ""
+"<b>IP addresses</b>: If you visit one of our sites the IP address of your"
+" computer is stored in our web logs for 7 days\n"
+"        before our servers automatically delete them. This data is almost"
+" never used by anyone: the only time we look at the\n"
+"        IP addresses is if our sites are adversely impacted by the "
+"actions of some unknown users. In that case, we may investigate\n"
+"        the logs to identify the IP address that needs to be blocked in "
+"order to restore the stability of our service.\n"
+"        This data is not available to anyone but the contractors of the "
+"MetaBrainz Foundation and is not available to download\n"
+"        to anyone at all."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:137
+#, python-format
+msgid ""
+"<b>ListenBrainz Listen data</b>: Users may <a "
+"href=\"%(listenbrainz_export_url)s\">export their ListenBrainz Listen\n"
+"        data</a> directly from the site. The user Listen data is also "
+"included in the <a href=\"%(listenbrainz_data_url)s\">ListenBrainz\n"
+"        data dumps</a> that are available for public download."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:146
+msgid ""
+"All of the non personally identifying data, such as your metadata "
+"contributions, are publicly visible, available for download\n"
+"    and available via the project APIs. For details about this data, "
+"downloads and APIs please check the documentation for the\n"
+"    respective projects you are interested in."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:151
+#, python-format
+msgid ""
+"Anyone wishing to get a list of financial donations they have made to the"
+" MetaBrainz Foundation, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a> and provide your "
+"MusicBrainz editor name so that we can look up\n"
+"    your donations."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:157
 msgid "Right to rectification"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:165
+#: metabrainz/templates/index/gdpr.html:160
+msgid "Summary: <i>You have the right to correct your data</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:163
+msgid ""
+"All of our projects allow their users to update their personally "
+"identifying information in their profiles. Furthermore, most\n"
+"    of our projects allow the editing of their own metadata "
+"contributions. If you find that some of your data is incorrect, please\n"
+"    feel free to edit the data since we provide the tools to do so."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:168
+#, python-format
+msgid ""
+"If anyone who has made a financial donation to the MetaBrainz Foundation "
+"would like to make their donation private, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:173
 msgid "Right to be informed"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:188
+#: metabrainz/templates/index/gdpr.html:175
+msgid ""
+"Summary: <i>You have the right to be informed about how we use your data "
+"in plain English</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:178
+msgid ""
+"Our privacy policy, as well as other policies, have always been written "
+"by humans for human consumption. We abhor legalese and\n"
+"    not speaking in direct terms."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:186
+msgid "Social contract"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:189
+msgid "Code of conduct"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:192
+msgid "Privacy policy"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:196
 msgid "Right to access"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:198
-#: metabrainz/templates/index/privacy.html:166
+#: metabrainz/templates/index/gdpr.html:199
+msgid ""
+"Summary: <i>You have the right to access the data that we collect about "
+"you</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:202
+msgid ""
+"All of our projects make all of the data we collect on your behalf, "
+"privately identifying or not, available to you. The\n"
+"    only exception to this are the IP addresses we store for 7 days – see"
+" above for details."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:206
+#: metabrainz/templates/index/privacy.html:168
 msgid "Privacy/GDPR Representative"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:209
+#, python-format
+msgid ""
+"If you have any questions about our privacy policy, please <a "
+"href=\"%(contact_url)s\">contact us</a>. To report\n"
+"   any privacy problems, violations or leaks, our GDPR representative is "
+"our Interim Executive Director Nicolás Tamargo and for\n"
+"   privacy issues contact him at <strong><a "
+"href=\"mailto:gdpr@metabrainz.org\">gdpr@metabrainz.org</a></strong>."
 msgstr ""
 
 #: metabrainz/templates/index/index.html:6
@@ -1164,11 +1987,11 @@ msgid ""
 "Creative\n"
 "        Commons licenses."
 msgstr ""
-"Фонд MetaBrainz Foundation - это НКО, которая верит в свободный и открытый "
-"доступ к данным. Он был основан с целью создать контролируемые сообществом "
-"базы данных, которые также были бы доступны широкой публике посредством их "
-"публикации в общественном достоянии или под лицензиями семейства Creative "
-"Commons."
+"Фонд MetaBrainz Foundation - это НКО, которая верит в свободный и "
+"открытый доступ к данным. Он был основан с целью создать контролируемые "
+"сообществом базы данных, которые также были бы доступны широкой публике "
+"посредством их публикации в общественном достоянии или под лицензиями "
+"семейства Creative Commons."
 
 #: metabrainz/templates/index/index.html:16
 #, python-format
@@ -1191,15 +2014,16 @@ msgid ""
 "An open music encyclopedia that collects music metadata and makes it\n"
 "              available to the public"
 msgstr ""
-"Открытая музыкальная энциклопедия, которая собирает музыкальные метаданные и "
-"делает их доступными для всех желающих."
+"Открытая музыкальная энциклопедия, которая собирает музыкальные "
+"метаданные и делает их доступными для всех желающих."
 
 #: metabrainz/templates/index/index.html:40
 #, python-format
 msgid "Sign up to use the <a href=\"%(account_type_url)s\">Live Data Feed</a>"
 msgstr ""
-"Зарегистрируйтесь, чтобы получить доступ к <a href=\"%(account_type_url)s\">"
-"ленте с динамически обновляемыми данными</a>"
+"Зарегистрируйтесь, чтобы получить доступ к <a "
+"href=\"%(account_type_url)s\">ленте с динамически обновляемыми "
+"данными</a>"
 
 #: metabrainz/templates/index/index.html:49
 msgid "A cross-platform music tagger"
@@ -1268,15 +2092,54 @@ msgid ""
 "To get more information about the foundation, go to the\n"
 "      <a href=\"%(about_url)s\">about</a> page."
 msgstr ""
-"Больше деталей о фонде вы можете узнать <a href=\"%(about_url)s\">здесь</a>."
+"Больше деталей о фонде вы можете узнать <a "
+"href=\"%(about_url)s\">здесь</a>."
 
-#: frontend/js/src/forms/ConditionsModal.tsx:43
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:32
 #: metabrainz/templates/index/privacy.html:3
 msgid "Privacy"
 msgstr "Конфиденциальность"
 
 #: metabrainz/templates/index/privacy.html:8
 msgid "Summary"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:12
+msgid ""
+"You do not have to provide any personal data to be able to browse the "
+"contents of the databases published by MetaBrainz."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:15
+msgid ""
+"You do not have to provide any personally-identifying information if you "
+"choose not to."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:18
+msgid ""
+"We will never reveal your email address on MetaBrainz controlled web "
+"sites."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:22
+msgid ""
+"In order to get maximum value out of the MetaBrainz projects, you may "
+"want to create an account and log in. \n"
+"    Doing so grants you the ability to: edit the databases, contribute "
+"your own data, communicate with other users, and keep track \n"
+"    of recently released music from artists in your MusicBrainz "
+"collection. If you choose to create an account then the minimum we \n"
+"    ask is that you: choose a unique username and password, use a web "
+"browser that accepts \"session\" cookies, and provide a verified \n"
+"    email address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:29
+msgid ""
+"If you do not create an account (or are not logged in) you will not have "
+"access to the above listed features, however, you will \n"
+"    still have full access to browse and examine the databases."
 msgstr ""
 
 #: metabrainz/templates/index/privacy.html:33
@@ -1287,39 +2150,197 @@ msgstr ""
 msgid "Cookies"
 msgstr ""
 
+#: metabrainz/templates/index/privacy.html:37
+msgid "We use two cookies that contain sensitive information:"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:42
+msgid ""
+"<b>remember_login</b>: If you choose the \"Log in permanently\" option "
+"when logging in to one of our sites; the cookie will be used to \n"
+"      remember your login details."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:46
+msgid ""
+"<b>musicbrainz_server_session, session, or connect.sid</b>: If you are "
+"logged into one of our sites, your current session ID is stored in this "
+"cookie."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:51
+msgid ""
+"We may store dynamic preference information in other cookies, but these "
+"do not contain any sensitive information."
+msgstr ""
+
 #: metabrainz/templates/index/privacy.html:54
 msgid "Web and FTP access logs"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:57
+msgid ""
+"In a practice similar to other web sites (and APIs) we keep logs of all "
+"web requests made against our servers. These logs include: your IP\n"
+"    address, your browser's (or API client's) \"User-Agent\" string, and "
+"which page (or API endpoint) you requested with which parameters. "
+"Aggregate information about web and FTP traffic is\n"
+"    made available to the public via our site usage pages."
 msgstr ""
 
 #: metabrainz/templates/index/privacy.html:62
 msgid "Third-Party content"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:92
+#: metabrainz/templates/index/privacy.html:64
+msgid ""
+"Our projects' web pages may load some third-party content. Some, but "
+"possibly not all sites are listed below:"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:69
+#, python-format
+msgid ""
+"Cover art and other images: These are provided by the various cover art "
+"sites that have given MusicBrainz permission to do so and our own \n"
+"      <a href=\"%(caa_url)s\">Cover Art Archive</a>. This means that the "
+"relevant site will know (if they want to) your IP \n"
+"      address, User-Agent string, etc., and which MusicBrainz web page "
+"you were visiting (the one which included the cover art image)."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:75
+msgid ""
+"AcoustID: Our fingerprints tab loads fingerprint information from "
+"acoustid.org."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:78
+msgid ""
+"MTCaptcha: Our account creation page loads third party content in order "
+"to prevent spammers from creating accounts."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:83
+msgid ""
+"<i>The above information assumes that you are using \"normal\" web "
+"browser settings, whereby images are always loaded and HTTP referrer \n"
+"    information is always sent.</i>"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:88
+msgid ""
+"It is impractical to constantly modify this privacy policy when "
+"MetaBrainz projects change which third party content they utilize. We "
+"will \n"
+"    aim to use common sense, respect to our community and community "
+"review when adding more content from third party sites. We will also \n"
+"    periodically review our policy to ensure that it remains current."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:93
 msgid "Applicable to account holders"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:94
+#: metabrainz/templates/index/privacy.html:95
 msgid "Account creation"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:108
+#: metabrainz/templates/index/privacy.html:97
+msgid ""
+"When creating an account with a MetaBrainz project you need to pick a "
+"unique username and choose a password, the username you pick is the \n"
+"    only name associated with your account and will be what other "
+"MetaBrainz users know you as. You may optionally also tell us other \n"
+"    information about yourself that will be displayed to other MetaBrainz"
+" users and the public."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:103
+msgid ""
+"Additionally, in order to edit the databases you will need to provide a "
+"confirmed email address. This email address will be held in \n"
+"    confidence, the only method of revealing your email address to "
+"another user is if you choose to send a message to another \n"
+"    user and enable the option to \"reveal my email address\". Changing "
+"the email address stored with your account will require you to \n"
+"    verify the new address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:109
 msgid "Edits and Notes"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:114
+#: metabrainz/templates/index/privacy.html:111
+msgid ""
+"If you make any changes to a MetaBrainz project database, such as adding "
+"any data, the details of those changes will be visible to \n"
+"    other logged-in users and the change will be associated with your "
+"username."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:115
 msgid "Subscriptions on MusicBrainz"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:131
+#: metabrainz/templates/index/privacy.html:117
+msgid ""
+"As a logged-in user you can subscribe to one or more artists, labels, "
+"collections or other editors. The act of subscribing causes \n"
+"    any edits made to (or by in the case of another editor) those "
+"entities to be emailed to you. By default, other users can see your \n"
+"    list of subscriptions, however, you can opt out of this by editing "
+"the appropriate preference."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:123
+msgid ""
+"This does not provide \"perfect\" privacy though, in some cases it will "
+"be possible to infer information about the contents of your \n"
+"    subscription list even though you have disallowed others from viewing"
+" that list directly. This imperfection arises because various \n"
+"    parts of the system behave differently depending on whether or not an"
+" entity has any subscribers; also, the number of users \n"
+"    subscribed to each artist is available via the artist pages. In the "
+"most extreme (possibly contrived) example, imagine that all \n"
+"    users have their subscriptions set to \"public\", except for exactly "
+"one user whose list is \"private\". In that case, any discrepancy \n"
+"    for a given artist between the shown list of subscribers and the "
+"total number of subscribers must be down to that one user. Thus, \n"
+"    you can infer what artists are on that user's list."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:132
 msgid "Third-party sites"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:145
-msgid "MetaBrainz donors"
+#: metabrainz/templates/index/privacy.html:134
+#, python-format
+msgid ""
+"Our code reviews are done on GitHub, which is not under the control of "
+"MetaBrainz. Participating in code reviews or other\n"
+"    tasks carried out on GitHub are subject to <a "
+"href=\"%(github_url)s\">GitHub's privacy policy</a>."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:140
+#, python-format
+msgid ""
+"Our translations platform is provided and hosted by Weblate, which has a "
+"data processing agreement with MetaBrainz.\n"
+"    Participating in translations is subject to <a "
+"href=\"%(weblate_url)s\">dedicated legal terms</a>.\n"
+"    Any translations you make will be submitted to our Git repositories "
+"and publicly associated with your username;\n"
+"    if you so choose, you can also publicly associate them with your own "
+"verified email address."
 msgstr ""
 
 #: metabrainz/templates/index/privacy.html:147
+msgid "MetaBrainz donors"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:149
 msgid ""
 "When you make a donation to the MetaBrainz Foundation, we are legally\n"
 "    required to collect your personal information and keep it in our "
@@ -1329,7 +2350,7 @@ msgid ""
 "    information to anyone else, ever."
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:153
+#: metabrainz/templates/index/privacy.html:155
 msgid ""
 "We believe in transparent finances, which means that we list all "
 "donations\n"
@@ -1339,11 +2360,34 @@ msgid ""
 "process."
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:158
+#: metabrainz/templates/index/privacy.html:160
 msgid "Exceptions"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:598
+#: metabrainz/templates/index/privacy.html:162
+msgid ""
+"<i><b>Please note</b>: Reasonable exceptions may apply to the above "
+"policy, for example to comply with applicable laws.\n"
+"    Also, members of the MetaBrainz team and other personnel contracted "
+"to provide services to MetaBrainz may have access to\n"
+"    our infrastructure and could therefore view any information contained"
+" therein. However all personnel are contractually bound\n"
+"    by non-disclosure clauses which prevent them from making any such "
+"information available to others."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:171
+#, python-format
+msgid ""
+"If you have any questions about our GDPR statement, please <a "
+"href=\"%(contact_url)s\">contact us</a>. To report\n"
+"   any privacy problems, violations or leaks, our GDPR representative is "
+"our Interim Executive Director Nicolás Tamargo and for\n"
+"   privacy issues contact him at <strong><a "
+"href=\"mailto:gdpr@metabrainz.org\">gdpr@metabrainz.org</a></strong>."
+msgstr ""
+
+#: frontend/js/src/Profile.tsx:603
 #: frontend/js/src/forms/ProfileChangePassword.tsx:22
 #: frontend/js/src/forms/ProfileChangePassword.tsx:111
 #: metabrainz/templates/index/profile-change-password.html:3
@@ -1587,6 +2631,11 @@ msgstr ""
 
 #: metabrainz/templates/index/team.html:26
 msgid "He lives on in our hearts and in open source."
+msgstr ""
+
+#: metabrainz/templates/index/team.html:29
+#: metabrainz/templates/index/team.html:315
+msgid "you’re welcome to try"
 msgstr ""
 
 #: metabrainz/templates/index/team.html:39
@@ -2087,8 +3136,10 @@ msgstr ""
 
 #: metabrainz/templates/payments/donate.html:146
 msgid ""
-"Due to the increased unreliability of the US Postal Service we have "
-"stopped accepting paper checks. Sorry!"
+"Due to the increased unreliability of the US Postal Service and the "
+"relatively large fees involved, we ask you to only send a paper check if "
+"it is the only possible option. Due to the fees, we will not cash checks "
+"for less than $25."
 msgstr ""
 
 #: metabrainz/templates/payments/donate.html:241
@@ -2974,8 +4025,8 @@ msgid "Monthly balance sheets"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:520
-#: frontend/js/src/forms/SignupCommercial.tsx:175
-#: frontend/js/src/forms/SignupCommercial.tsx:554
+#: frontend/js/src/forms/SignupCommercial.tsx:180
+#: frontend/js/src/forms/SignupCommercial.tsx:558
 #: frontend/js/src/forms/SignupNonCommercial.tsx:106
 #: frontend/js/src/forms/SignupNonCommercial.tsx:318
 #: metabrainz/templates/supporters/account-type.html:3
@@ -2996,6 +4047,7 @@ msgid "Non-commercial / Personal"
 msgstr "Некоммерческий / личный"
 
 #: frontend/js/src/Profile.tsx:235
+#: frontend/js/src/forms/SignupNonCommercial.tsx:107
 #: frontend/js/src/forms/SignupNonCommercial.tsx:151
 #: metabrainz/templates/supporters/account-type.html:42
 msgid "Non-commercial"
@@ -3009,57 +4061,46 @@ msgstr ""
 msgid "Personal or university assignment user."
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:48
-#: metabrainz/templates/supporters/account-type.html:90
-#: metabrainz/templates/supporters/account-type.html:141
-msgid "Upgrade"
-msgstr ""
-
 #: frontend/js/src/Profile.tsx:235
-#: frontend/js/src/forms/SignupCommercial.tsx:176
-#: frontend/js/src/forms/SignupCommercial.tsx:228
-#: metabrainz/templates/supporters/account-type.html:61
+#: frontend/js/src/forms/SignupCommercial.tsx:181
+#: frontend/js/src/forms/SignupCommercial.tsx:233
+#: metabrainz/templates/supporters/account-type.html:56
 msgid "Commercial"
 msgstr "Коммерческий"
 
-#: metabrainz/templates/supporters/account-type.html:83
-#: metabrainz/templates/supporters/account-type.html:135
+#: metabrainz/templates/supporters/account-type.html:78
+#: metabrainz/templates/supporters/account-type.html:125
 #, python-format
 msgid "$%(tier_price)s/month and up"
 msgstr "от $%(tier_price)s в месяц"
 
-#: metabrainz/templates/supporters/account-type.html:87
-#: metabrainz/templates/supporters/account-type.html:138
+#: metabrainz/templates/supporters/account-type.html:82
+#: metabrainz/templates/supporters/account-type.html:128
 msgid "More info"
 msgstr "Больше информации"
 
-#: metabrainz/templates/supporters/account-type.html:104
+#: metabrainz/templates/supporters/account-type.html:94
 msgid "View all tiers"
 msgstr "Просмотреть все уровни"
 
-#: metabrainz/templates/supporters/account-type.html:112
+#: metabrainz/templates/supporters/account-type.html:102
 msgid "Some of our Unicorn members"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:123
+#: metabrainz/templates/supporters/account-type.html:113
 msgid "See all our supporters"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:151
+#: metabrainz/templates/supporters/account-type.html:136
 msgid "View featured tiers"
 msgstr "Посмотреть избранные уровни"
 
-#: metabrainz/templates/supporters/account-type.html:158
+#: metabrainz/templates/supporters/account-type.html:143
 #, python-format
 msgid ""
 "If you are not sure which tier to pick, please\n"
 "      <a href=\"%(contact_url)s\">contact us</a>."
 msgstr ""
-
-#: metabrainz/templates/supporters/account-type.html:166
-#, fuzzy
-msgid "Back to Profile"
-msgstr "Ваш профиль"
 
 #: metabrainz/templates/supporters/bad-standing.html:3
 #: metabrainz/templates/supporters/bad-standing.html:6
@@ -3120,9 +4161,9 @@ msgid "Forgot your username"
 msgstr ""
 
 #: frontend/js/src/forms/ResetPassword.tsx:79
-#: frontend/js/src/forms/SignupCommercial.tsx:320
+#: frontend/js/src/forms/SignupCommercial.tsx:325
 #: frontend/js/src/forms/SignupNonCommercial.tsx:227
-#: frontend/js/src/forms/SignupUser.tsx:169
+#: frontend/js/src/forms/SignupUser.tsx:175
 #: metabrainz/templates/users/reauthenticate.html:3
 #: metabrainz/templates/users/reauthenticate.html:6
 msgid "Confirm Password"
@@ -3132,17 +4173,22 @@ msgstr ""
 msgid "Please re-enter your password to continue."
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:108
+#: frontend/js/src/ProfileDelete.tsx:110
 #: frontend/js/src/forms/DeleteApplication.tsx:53
 #: frontend/js/src/forms/OAuthPrompt.tsx:54
 #: frontend/js/src/forms/ProfileChangePassword.tsx:104
 #: frontend/js/src/forms/ProfileEdit.tsx:105
-#: metabrainz/templates/users/reauthenticate.html:23
+#: metabrainz/templates/users/reauthenticate.html:28
 msgid "Cancel"
 msgstr ""
 
-#: metabrainz/templates/users/reauthenticate.html:24
+#: metabrainz/templates/users/reauthenticate.html:29
 msgid "Continue"
+msgstr ""
+
+#: frontend/js/src/forms/utils.tsx:202
+#: metabrainz/templates/users/reauthenticate.html:40
+msgid "Password must not exceed 72 bytes."
 msgstr ""
 
 #: frontend/js/src/forms/ResetPassword.tsx:27
@@ -3150,38 +4196,38 @@ msgstr ""
 msgid "Reset your password"
 msgstr ""
 
-#: frontend/js/src/hooks/useEmailValidation.ts:41 metabrainz/user/forms.py:15
+#: frontend/js/src/hooks/useEmailValidation.ts:41 metabrainz/user/forms.py:16
 msgid "Registration from this email domain is not allowed."
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:50
 #: frontend/js/src/forms/LostPassword.tsx:45
-#: frontend/js/src/forms/SignupCommercial.tsx:270
+#: frontend/js/src/forms/SignupCommercial.tsx:275
 #: frontend/js/src/forms/SignupNonCommercial.tsx:175
-#: frontend/js/src/forms/SignupUser.tsx:114 metabrainz/user/forms.py:20
-#: metabrainz/user/forms.py:45 metabrainz/user/forms.py:62
+#: frontend/js/src/forms/SignupUser.tsx:120 metabrainz/user/forms.py:22
+#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:75
 msgid "Username"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:42
 #: frontend/js/src/forms/LostPassword.tsx:37
-#: frontend/js/src/forms/SignupCommercial.tsx:153
+#: frontend/js/src/forms/SignupCommercial.tsx:158
 #: frontend/js/src/forms/SignupNonCommercial.tsx:84
-#: frontend/js/src/forms/SignupUser.tsx:67 metabrainz/user/forms.py:21
-#: metabrainz/user/forms.py:45 metabrainz/user/forms.py:62
+#: frontend/js/src/forms/SignupUser.tsx:73 metabrainz/user/forms.py:26
+#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:75
 msgid "Username is required!"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:63
 #: frontend/js/src/forms/ResetPassword.tsx:72
-#: frontend/js/src/forms/SignupCommercial.tsx:308
+#: frontend/js/src/forms/SignupCommercial.tsx:313
 #: frontend/js/src/forms/SignupNonCommercial.tsx:214
-#: frontend/js/src/forms/SignupUser.tsx:157 metabrainz/user/forms.py:46
-#: metabrainz/user/forms.py:52
+#: frontend/js/src/forms/SignupUser.tsx:163 metabrainz/user/forms.py:53
+#: metabrainz/user/forms.py:62
 msgid "Password"
 msgstr ""
 
-#: frontend/js/src/forms/LoginUser.tsx:76 metabrainz/user/forms.py:47
+#: frontend/js/src/forms/LoginUser.tsx:76 metabrainz/user/forms.py:57
 msgid "Remember me"
 msgstr ""
 
@@ -3193,11 +4239,11 @@ msgstr ""
 msgid "Username contains invalid or invisible characters."
 msgstr ""
 
-#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:181
+#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:220
 msgid "Hide password"
 msgstr ""
 
-#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:181
+#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:220
 msgid "Show password"
 msgstr ""
 
@@ -3255,11 +4301,11 @@ msgstr ""
 msgid "Revoke access"
 msgstr ""
 
-#: frontend/js/src/OAuthError.tsx:17
+#: frontend/js/src/OAuthError.tsx:18
 msgid "OAuth2 Error"
 msgstr ""
 
-#: frontend/js/src/OAuthError.tsx:18
+#: frontend/js/src/OAuthError.tsx:19
 msgid "An error occurred during OAuth authentication process."
 msgstr ""
 
@@ -3289,8 +4335,8 @@ msgstr ""
 
 #: frontend/js/src/Profile.tsx:109
 msgid ""
-"Are you sure you want to generate new access token? Current token will be"
-" revoked!"
+"Are you sure you want to generate a new access token? The current token "
+"will be revoked!"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:118
@@ -3406,8 +4452,8 @@ msgid "Contact Information"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:310 frontend/js/src/forms/ProfileEdit.tsx:70
-#: frontend/js/src/forms/SignupCommercial.tsx:284
-#: frontend/js/src/forms/SignupCommercial.tsx:333
+#: frontend/js/src/forms/SignupCommercial.tsx:289
+#: frontend/js/src/forms/SignupCommercial.tsx:338
 #: frontend/js/src/forms/SignupNonCommercial.tsx:189
 #: frontend/js/src/forms/SignupNonCommercial.tsx:241
 msgid "Contact name"
@@ -3523,7 +4569,7 @@ msgstr ""
 msgid "Once you delete your account, there is no going back. Please be certain."
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:550 frontend/js/src/ProfileDelete.tsx:105
+#: frontend/js/src/Profile.tsx:550 frontend/js/src/ProfileDelete.tsx:107
 msgid "Delete My Account"
 msgstr ""
 
@@ -3535,39 +4581,39 @@ msgstr ""
 msgid "Need to delete your account?"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:574
+#: frontend/js/src/Profile.tsx:575
 msgid ""
 "Deletion of supporter accounts requires manual review. Please contact us "
-"at"
+"at <email />."
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:594
+#: frontend/js/src/Profile.tsx:599
 msgid "Security"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:626
+#: frontend/js/src/Profile.tsx:631
 msgid "MetaBrainz Applications"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:630
+#: frontend/js/src/Profile.tsx:635
 msgid ""
 "With your MetaBrainz account, you can access every project in the "
 "MetaBrainz family:"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:643
+#: frontend/js/src/Profile.tsx:648
 msgid "The open-source music encyclopedia"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:655
+#: frontend/js/src/Profile.tsx:660
 msgid "Track, visualise and share the music you listen to"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:667
+#: frontend/js/src/Profile.tsx:672
 msgid "The open-source book database"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:679
+#: frontend/js/src/Profile.tsx:684
 msgid "Creative Commons licensed reviews"
 msgstr ""
 
@@ -3590,7 +4636,7 @@ msgid "Permanently remove all your account information"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:64
-msgid "Revoke all your API tokens and access"
+msgid "Revoke all your tokens and access to the replication API"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:65
@@ -3602,14 +4648,16 @@ msgid "Log you out of all MetaBrainz services"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:70
-msgid "Your username will be reserved and cannot be reused."
+msgid ""
+"Your username will be reserved and cannot be reused without the "
+"intervention of an administrator."
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:82
+#: frontend/js/src/ProfileDelete.tsx:84
 msgid "To confirm, type your username '<username />' below:"
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:105
+#: frontend/js/src/ProfileDelete.tsx:107
 msgid "Deleting..."
 msgstr ""
 
@@ -3622,64 +4670,7 @@ msgstr "Ваш профиль"
 msgid "Close"
 msgstr ""
 
-#: frontend/js/src/forms/ConditionsModal.tsx:23
-msgid "Licensing"
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:25
-msgid ""
-"Any contributions you make to any MetaBrainz service will be released "
-"into the Public Domain and/or licensed under a Creative Commons by-nc-sa "
-"license. Furthermore, you give the MetaBrainz Foundation the right to "
-"license this data for commercial use."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:30
-msgid "Please read our <licenseLink>license page</licenseLink> for more details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:45
-msgid ""
-"MetaBrainz strongly believes in the privacy of its users. Any personal "
-"information you choose to provide will not be sold or shared with anyone "
-"else."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:50
-msgid ""
-"Please read our <privacyLink>privacy policy</privacyLink> for more "
-"details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:59
-msgid "GDPR compliance"
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:61
-msgid ""
-"You may remove your personal information from our services anytime by "
-"deleting your account."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:66
-msgid ""
-"Please read our <gdprLink>GDPR compliance statement</gdprLink> for more "
-"details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:78
-msgid ""
-"Creating an account on MetaBrainz will give you access to all of our "
-"projects, such as MusicBrainz, ListenBrainz, BookBrainz, and more."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:82
-msgid ""
-"We create a placeholder account for all the MetaBrainz projects when you "
-"sign up, and you are one log-in away from activating them."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:91
+#: frontend/js/src/forms/ConditionsModal.tsx:29
 msgid "Sounds good"
 msgstr ""
 
@@ -3768,8 +4759,8 @@ msgstr ""
 msgid "Forgot your password?"
 msgstr ""
 
-#: frontend/js/src/forms/LoginUser.tsx:109
-msgid "Don't have an account?"
+#: frontend/js/src/forms/LoginUser.tsx:110
+msgid "Don't have an account? <signupLink>Sign up</signupLink>"
 msgstr ""
 
 #: frontend/js/src/forms/LostPassword.tsx:38
@@ -3800,15 +4791,72 @@ msgstr ""
 msgid "Allow access"
 msgstr "Разрешить доступ"
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:71
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:10
+msgid "Licensing"
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:12
+msgid ""
+"Any contributions you make to any MetaBrainz service will be released "
+"into the Public Domain and/or licensed under a Creative Commons by-nc-sa "
+"license. Furthermore, you give the MetaBrainz Foundation the right to "
+"license this data for commercial use."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:17
+msgid "Please read our <licenseLink>license page</licenseLink> for more details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:34
+msgid ""
+"MetaBrainz strongly believes in the privacy of its users. Any personal "
+"information you choose to provide will not be sold or shared with anyone "
+"else."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:39
+msgid ""
+"Please read our <privacyLink>privacy policy</privacyLink> for more "
+"details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:50
+msgid "GDPR compliance"
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:52
+msgid ""
+"You may remove your personal information from our services anytime by "
+"deleting your account."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:57
+msgid ""
+"Please read our <gdprLink>GDPR compliance statement</gdprLink> for more "
+"details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:71
+msgid ""
+"Creating an account on MetaBrainz will give you access to all of our "
+"projects, such as MusicBrainz, ListenBrainz, BookBrainz, and more."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:75
+msgid ""
+"We create a placeholder account for all the MetaBrainz projects when you "
+"sign up, and you are one log-in away from activating them."
+msgstr ""
+
+#: frontend/js/src/forms/ProfileChangePassword.tsx:70
 msgid "Current Password"
 msgstr ""
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:80
+#: frontend/js/src/forms/ProfileChangePassword.tsx:79
 msgid "New Password"
 msgstr ""
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:89
+#: frontend/js/src/forms/ProfileChangePassword.tsx:88
 msgid "Confirm New Password"
 msgstr ""
 
@@ -3820,196 +4868,185 @@ msgstr ""
 msgid "Reset Password"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:38
-msgid "If you would like to support us with more than $"
+#: frontend/js/src/forms/SignupCommercial.tsx:40
+msgid ""
+"If you would like to support us with more than ${{minPledge}}, please "
+"enter the actual amount here:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:39
-msgid ", please enter the actual amount here:"
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:144
+#: frontend/js/src/forms/SignupCommercial.tsx:149
 #: frontend/js/src/forms/SignupNonCommercial.tsx:75
-#: frontend/js/src/forms/SignupUser.tsx:87
+#: frontend/js/src/forms/SignupUser.tsx:93
 msgid "Captcha is required!"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:179
+#: frontend/js/src/forms/SignupCommercial.tsx:184
 #: frontend/js/src/forms/SignupNonCommercial.tsx:110
 #: frontend/js/src/forms/SignupUser.tsx:46
 #, fuzzy
 msgid "Access all MetaBrainz projects"
 msgstr "Проекты MetaBrainz"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:182
+#: frontend/js/src/forms/SignupCommercial.tsx:187
 msgid "Note:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:184
+#: frontend/js/src/forms/SignupCommercial.tsx:189
 msgid ""
 "Signing up for any tier other than the <italic>Stealth startup</italic> "
 "tier will publicly list your company on this web site. However, we will "
 "not publish any of your private details."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:221
+#: frontend/js/src/forms/SignupCommercial.tsx:226
 #: frontend/js/src/forms/SignupNonCommercial.tsx:145
 #, fuzzy
 msgid "Account type"
 msgstr "Тип учетной записи"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:234
+#: frontend/js/src/forms/SignupCommercial.tsx:239
 msgid "Selected tier"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:242
-msgid "month and up"
+#: frontend/js/src/forms/SignupCommercial.tsx:247
+msgid "${{tierPrice}}/month and up"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:250
+#: frontend/js/src/forms/SignupCommercial.tsx:255
 msgid "Change account type or tier"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:261
+#: frontend/js/src/forms/SignupCommercial.tsx:266
 #: frontend/js/src/forms/SignupNonCommercial.tsx:166
 msgid "Your account:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:271
+#: frontend/js/src/forms/SignupCommercial.tsx:276
 #: frontend/js/src/forms/SignupNonCommercial.tsx:176
-#: frontend/js/src/forms/SignupUser.tsx:114
+#: frontend/js/src/forms/SignupUser.tsx:120
 msgid "(public)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:291
+#: frontend/js/src/forms/SignupCommercial.tsx:296
 #: frontend/js/src/forms/SignupNonCommercial.tsx:196
-#: frontend/js/src/forms/SignupUser.tsx:127
+#: frontend/js/src/forms/SignupUser.tsx:133
 msgid "E-mail address"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:295
+#: frontend/js/src/forms/SignupCommercial.tsx:300
 #: frontend/js/src/forms/SignupNonCommercial.tsx:200
-#: frontend/js/src/forms/SignupUser.tsx:131
+#: frontend/js/src/forms/SignupUser.tsx:137
 msgid "(checking...)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:314
+#: frontend/js/src/forms/SignupCommercial.tsx:319
 #: frontend/js/src/forms/SignupNonCommercial.tsx:220
-#: frontend/js/src/forms/SignupUser.tsx:163
+#: frontend/js/src/forms/SignupUser.tsx:169
 msgid "Must be at least 8 characters"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:348
+#: frontend/js/src/forms/SignupCommercial.tsx:353
 msgid ""
 "If you don't have an organization name, you probably want to become a "
 "supporter as a <nonCommercialLink>Non-commercial / "
 "Personal</nonCommercialLink> supporter."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:358
+#: frontend/js/src/forms/SignupCommercial.tsx:363
 msgid ""
 "If you don't have an organization name, you probably want to sign up as a"
 " <nonCommercialLink>Non-commercial / Personal</nonCommercialLink> user."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:378
+#: frontend/js/src/forms/SignupCommercial.tsx:383
 msgid ""
 "Please tell us a little about your company and whether you plan to use "
 "our <apiLink>API</apiLink> or to <hostLink>host your own copy</hostLink> "
 "of the data."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:404
+#: frontend/js/src/forms/SignupCommercial.tsx:408
 #, fuzzy
 msgid "Logo URL"
 msgstr "URL логотипа"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:405
+#: frontend/js/src/forms/SignupCommercial.tsx:409
 msgid "(preferably in SVG format)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:408
+#: frontend/js/src/forms/SignupCommercial.tsx:412
 msgid ""
 "Image should be about 250 pixels wide on a white or transparent "
 "background. We will host it on our site."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:421
+#: frontend/js/src/forms/SignupCommercial.tsx:425
 msgid ""
 "URL to where developers can use your APIs using MusicBrainz IDs, if "
-"available.."
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:430
-msgid "Your project"
+"available."
 msgstr ""
 
 #: frontend/js/src/forms/SignupCommercial.tsx:434
+msgid "Your project"
+msgstr ""
+
+#: frontend/js/src/forms/SignupCommercial.tsx:438
 #: frontend/js/src/forms/SignupNonCommercial.tsx:261
 msgid "(max 150 characters)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:451
+#: frontend/js/src/forms/SignupCommercial.tsx:455
 msgid "Billing address"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:502
+#: frontend/js/src/forms/SignupCommercial.tsx:506
 msgid ""
 "I agree to support the MetaBrainz Foundation when my organization is able"
 " to do so."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:507
+#: frontend/js/src/forms/SignupCommercial.tsx:511
+#: frontend/js/src/forms/SignupNonCommercial.tsx:284
 msgid ""
-"I also agree that if I generate a Live Data Feed access token, that I "
-"treat my access token as a secret and will not share this token publicly "
-"or commit it to a source code repository."
+"I also agree that if I generate a Live Data Feed access token, then I "
+"will treat my access token as a secret and will not share this token "
+"publicly or commit it to a source code repository."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:515
+#: frontend/js/src/forms/SignupCommercial.tsx:519
 msgid ""
 "The following information will be shown publicly: organization name, "
 "logo, website and API URLs, data usage description."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:520
+#: frontend/js/src/forms/SignupCommercial.tsx:524
 msgid ""
 "We'll send you more details about payment process once your application "
 "is approved."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:552
+#: frontend/js/src/forms/SignupCommercial.tsx:556
 #: frontend/js/src/forms/SignupNonCommercial.tsx:316
-#: frontend/js/src/forms/SignupUser.tsx:224
+#: frontend/js/src/forms/SignupUser.tsx:230
 msgid "Validating..."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:564
+#: frontend/js/src/forms/SignupCommercial.tsx:568
 #: frontend/js/src/forms/SignupNonCommercial.tsx:329
 #, fuzzy
 msgid "Back to profile"
 msgstr "Ваш профиль"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:569
-#: frontend/js/src/forms/SignupNonCommercial.tsx:334
-msgid "Not a supporter?"
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:570
+#: frontend/js/src/forms/SignupCommercial.tsx:574
 #: frontend/js/src/forms/SignupNonCommercial.tsx:335
-msgid "Create a user account"
+msgid "Not a supporter? <signupLink>Create a user account</signupLink>"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:573
-#: frontend/js/src/forms/SignupNonCommercial.tsx:338
-#: frontend/js/src/forms/SignupUser.tsx:231
-msgid "Already have an account?"
+#: frontend/js/src/forms/SignupCommercial.tsx:583
+#: frontend/js/src/forms/SignupNonCommercial.tsx:344
+#: frontend/js/src/forms/SignupUser.tsx:238
+msgid "Already have an account? <loginLink>Sign in</loginLink>"
 msgstr ""
-
-#: frontend/js/src/forms/SignupNonCommercial.tsx:107
-#, fuzzy
-msgid "non-commercial"
-msgstr "Некоммерческий"
 
 #: frontend/js/src/forms/SignupNonCommercial.tsx:113
 msgid ""
@@ -4036,46 +5073,40 @@ msgid ""
 "income per year) or personal uses only."
 msgstr ""
 
-#: frontend/js/src/forms/SignupNonCommercial.tsx:284
-msgid ""
-"I also agree that if I generate a Live Data Feed access token, then I "
-"will treat my access token as a secret and will not share this token "
-"publicly or commit it to a source code repository."
-msgstr ""
-
 #: frontend/js/src/forms/SignupUser.tsx:43
 msgid "Create your account"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:50
-msgid "Registration started by"
+#: frontend/js/src/forms/SignupUser.tsx:51
+msgid "Registration started by <client />"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:69
+#: frontend/js/src/forms/SignupUser.tsx:75
+#: frontend/js/src/hooks/useEmailValidation.ts:82
 msgid "Invalid email address."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:150
+#: frontend/js/src/forms/SignupUser.tsx:156
 msgid ""
 "This username and email were provided by the app that started "
 "registration. You can change them later from MetaBrainz settings."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:182
+#: frontend/js/src/forms/SignupUser.tsx:188
 msgid ""
 "I accept that my contributions will be released into the public domain or"
 " licensed for use."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:191
+#: frontend/js/src/forms/SignupUser.tsx:197
 msgid "We will never share your personal information."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:200
+#: frontend/js/src/forms/SignupUser.tsx:206
 msgid "Click here to read more"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:224
+#: frontend/js/src/forms/SignupUser.tsx:230
 msgid "Create account"
 msgstr ""
 
@@ -4085,10 +5116,6 @@ msgstr ""
 
 #: frontend/js/src/hooks/useEmailValidation.ts:47
 msgid "Email validation failed"
-msgstr ""
-
-#: frontend/js/src/hooks/useEmailValidation.ts:82
-msgid "Invalid email address"
 msgstr ""
 
 #~ msgid "You need to specify amount!"
@@ -4940,9 +5967,6 @@ msgstr ""
 #~ " new access token? Current token will"
 #~ " be revoked!"
 #~ msgstr ""
-#~ "Вы действительно хотите сгенерировать новый"
-#~ " ключ доступа? Текущий код будет "
-#~ "сброшен!"
 
 #~ msgid "Sign up <small>Commercial</small>"
 #~ msgstr ""
@@ -5330,3 +6354,100 @@ msgstr ""
 
 #~ msgid "Privacy policy"
 #~ msgstr "Политика конфиденциальности"
+
+#~ msgid "You need to specify website of the organization."
+#~ msgstr "Вам необходимо указать веб-сайт организации."
+
+#~ msgid ""
+#~ "We are currently evaluating our overall"
+#~ " online advertising strategy. We are "
+#~ "evaluating advertising, traffic optimization,\n"
+#~ ""
+#~ "    search engine optimization and "
+#~ "software monitization technologies. If you "
+#~ "provide these professional services, please"
+#~ " provide a detailed\n"
+#~ "    deck of your comprehensive services"
+#~ " to the following email address. "
+#~ "<em>Please respect our other non-media"
+#~ " teams and do not contact us \n"
+#~ "    regarding these services on any "
+#~ "other of our email addresses. We "
+#~ "will disregard the entirety of your "
+#~ "submissions if you contact us any "
+#~ "other way!</em>"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Please come ask your questions at "
+#~ "our <a href=\"%(forums_url)s\">forums</a>! We "
+#~ "would love to\n"
+#~ "    answer any questions you may have."
+#~ msgstr ""
+#~ "Пожалуйста, задавайте свои вопросы на "
+#~ "наших <a href=\"%(forums_url)s\">форумах</a>! Мы "
+#~ "будем рады \n"
+#~ " ответить на любые ваши вопросы."
+
+#~ msgid ""
+#~ "Due to the increased unreliability of"
+#~ " the US Postal Service we have "
+#~ "stopped accepting paper checks. Sorry!"
+#~ msgstr ""
+
+#~ msgid "Upgrade"
+#~ msgstr ""
+
+#~ msgid "Back to Profile"
+#~ msgstr "Ваш профиль"
+
+#~ msgid ""
+#~ "Deletion of supporter accounts requires "
+#~ "manual review. Please contact us at"
+#~ msgstr ""
+
+#~ msgid "Revoke all your API tokens and access"
+#~ msgstr ""
+
+#~ msgid "Your username will be reserved and cannot be reused."
+#~ msgstr ""
+
+#~ msgid "Don't have an account?"
+#~ msgstr ""
+
+#~ msgid "If you would like to support us with more than $"
+#~ msgstr ""
+
+#~ msgid ", please enter the actual amount here:"
+#~ msgstr ""
+
+#~ msgid "month and up"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "I also agree that if I generate"
+#~ " a Live Data Feed access token, "
+#~ "that I treat my access token as"
+#~ " a secret and will not share "
+#~ "this token publicly or commit it "
+#~ "to a source code repository."
+#~ msgstr ""
+
+#~ msgid "Not a supporter?"
+#~ msgstr ""
+
+#~ msgid "Create a user account"
+#~ msgstr ""
+
+#~ msgid "Already have an account?"
+#~ msgstr ""
+
+#~ msgid "non-commercial"
+#~ msgstr "Некоммерческий"
+
+#~ msgid "Registration started by"
+#~ msgstr ""
+
+#~ msgid "Invalid email address"
+#~ msgstr ""
+

--- a/metabrainz/translations/sv/LC_MESSAGES/messages.po
+++ b/metabrainz/translations/sv/LC_MESSAGES/messages.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-07-25 16:21+0200\n"
+"POT-Creation-Date: 2026-09-08 11:18+0200\n"
 "PO-Revision-Date: 2026-06-12 00:55+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: sv\n"
@@ -22,163 +22,248 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.18.0\n"
 
-#: metabrainz/index/forms.py:46
+#: metabrainz/errors.py:24
+msgid "Authorization was declined."
+msgstr ""
+
+#: metabrainz/errors.py:25
+msgid "The authorization request was invalid."
+msgstr ""
+
+#: metabrainz/errors.py:26
+msgid "The application could not be authenticated."
+msgstr ""
+
+#: metabrainz/errors.py:27
+msgid "This application is not allowed to request authorization."
+msgstr ""
+
+#: metabrainz/errors.py:28
+msgid "The application asked for a response type this server does not support."
+msgstr ""
+
+#: metabrainz/errors.py:29
+msgid "The permissions requested by the application are invalid."
+msgstr ""
+
+#: metabrainz/errors.py:30
+msgid "You need to sign in to continue."
+msgstr ""
+
+#: metabrainz/errors.py:31
+msgid "Your consent is required to continue."
+msgstr ""
+
+#: metabrainz/password.py:12
+#, python-format
+msgid "Password must not exceed %(max_bytes)s bytes."
+msgstr ""
+
+#: metabrainz/index/forms.py:48
 #, python-format
 msgid "'%(value)s' is not a valid choice for this field"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileEdit.tsx:27
-#: frontend/js/src/forms/SignupCommercial.tsx:154
+#: frontend/js/src/forms/SignupCommercial.tsx:159
 #: frontend/js/src/forms/SignupNonCommercial.tsx:85
-#: frontend/js/src/forms/SignupUser.tsx:70
-#: frontend/js/src/hooks/useEmailValidation.ts:78 metabrainz/index/forms.py:57
-#: metabrainz/user/forms.py:25 metabrainz/user/forms.py:57
-#: metabrainz/user/forms.py:63
+#: frontend/js/src/forms/SignupUser.tsx:76
+#: frontend/js/src/hooks/useEmailValidation.ts:78 metabrainz/index/forms.py:59
+#: metabrainz/user/forms.py:31 metabrainz/user/forms.py:70
+#: metabrainz/user/forms.py:76
 msgid "Email address is required!"
 msgstr "E-postadress krävs!"
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:34
-#: metabrainz/index/forms.py:63
+#: metabrainz/index/forms.py:65
 msgid "Current password is required!"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:43
 #: frontend/js/src/forms/ProfileChangePassword.tsx:37
 #: frontend/js/src/forms/ResetPassword.tsx:39
-#: frontend/js/src/forms/SignupCommercial.tsx:156
+#: frontend/js/src/forms/SignupCommercial.tsx:161
 #: frontend/js/src/forms/SignupNonCommercial.tsx:87
-#: frontend/js/src/forms/SignupUser.tsx:72 metabrainz/index/forms.py:66
-#: metabrainz/user/forms.py:29 metabrainz/user/forms.py:46
-#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:69
+#: frontend/js/src/forms/SignupUser.tsx:78 metabrainz/index/forms.py:69
+#: metabrainz/user/forms.py:35 metabrainz/user/forms.py:54
+#: metabrainz/user/forms.py:63 metabrainz/user/forms.py:82
 msgid "Password is required!"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:41
-#: frontend/js/src/forms/SignupCommercial.tsx:160
+#: frontend/js/src/forms/SignupCommercial.tsx:165
 #: frontend/js/src/forms/SignupNonCommercial.tsx:91
-#: frontend/js/src/forms/SignupUser.tsx:76 metabrainz/index/forms.py:70
-#: metabrainz/user/forms.py:33 metabrainz/user/forms.py:73
+#: frontend/js/src/forms/SignupUser.tsx:82 metabrainz/index/forms.py:74
+#: metabrainz/user/forms.py:40 metabrainz/user/forms.py:87
 msgid "Confirm Password is required!"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:46
 #: frontend/js/src/forms/ResetPassword.tsx:48
-#: frontend/js/src/forms/SignupCommercial.tsx:165
+#: frontend/js/src/forms/SignupCommercial.tsx:170
 #: frontend/js/src/forms/SignupNonCommercial.tsx:96
-#: frontend/js/src/forms/SignupUser.tsx:81 metabrainz/index/forms.py:72
-#: metabrainz/user/forms.py:35 metabrainz/user/forms.py:75
+#: frontend/js/src/forms/SignupUser.tsx:87 metabrainz/index/forms.py:76
+#: metabrainz/user/forms.py:42 metabrainz/user/forms.py:89
 msgid "Confirm Password should match password!"
 msgstr ""
 
 #: frontend/js/src/Applications.tsx:56 frontend/js/src/Applications.tsx:86
 #: frontend/js/src/Profile.tsx:272 frontend/js/src/Profile.tsx:482
-#: metabrainz/index/forms.py:78
+#: metabrainz/index/forms.py:82
 msgid "Name"
 msgstr "Namn"
 
-#: metabrainz/index/forms.py:79
+#: metabrainz/index/forms.py:83
 msgid "Contact name field is empty."
 msgstr "Kontaktnamnsfältet är tomt."
 
-#: metabrainz/index/views.py:234
+#: metabrainz/index/views.py:251
 msgid "Profile updated successfully."
 msgstr ""
 
-#: metabrainz/index/views.py:261
+#: metabrainz/index/views.py:278
 msgid "Current password is incorrect."
 msgstr ""
 
-#: metabrainz/index/views.py:266
+#: metabrainz/index/views.py:283
 msgid "Password changed successfully."
 msgstr ""
 
-#: metabrainz/index/views.py:372
+#: metabrainz/index/views.py:389
 msgid "You have updated an application!"
 msgstr ""
 
-#: metabrainz/index/views.py:424
+#: metabrainz/index/views.py:441
 msgid "You have deleted an application."
 msgstr ""
 
-#: metabrainz/index/views.py:426
+#: metabrainz/index/views.py:443
 msgid "Failed to delete an application."
 msgstr ""
 
-#: metabrainz/index/views.py:449
+#: metabrainz/index/views.py:466
 msgid "Revoked tokens successfully!"
 msgstr ""
 
-#: metabrainz/index/views.py:478
+#: metabrainz/index/views.py:495
 msgid "Your account has been deleted."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:106 metabrainz/oauth/forms.py:58
+#: frontend/js/src/forms/CreateApplication.tsx:106 metabrainz/oauth/forms.py:57
 msgid "Application Name"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:59
+#: metabrainz/oauth/forms.py:58
 msgid "Application name field is empty."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:60 metabrainz/oauth/forms.py:60
+#: frontend/js/src/forms/CreateApplication.tsx:60 metabrainz/oauth/forms.py:59
 msgid "Application name needs to be at least 3 characters long."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:64 metabrainz/oauth/forms.py:61
+#: frontend/js/src/forms/CreateApplication.tsx:64 metabrainz/oauth/forms.py:60
 msgid "Application name needs to be at most 64 characters long."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:114 metabrainz/oauth/forms.py:63
+#: frontend/js/src/forms/CreateApplication.tsx:114 metabrainz/oauth/forms.py:62
 #, fuzzy
 msgid "Description"
 msgstr "Organisationsbeskrivning"
 
-#: metabrainz/oauth/forms.py:64
+#: metabrainz/oauth/forms.py:63
 msgid "Client description field is empty."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:65
+#: metabrainz/oauth/forms.py:64
 msgid "Client description needs to be at least 3 characters long."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:66
+#: metabrainz/oauth/forms.py:65
 msgid "Client description needs to be at most 512 characters long."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:122 metabrainz/oauth/forms.py:68
+#: frontend/js/src/forms/CreateApplication.tsx:122 metabrainz/oauth/forms.py:67
 msgid "Homepage"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:69
+#: metabrainz/oauth/forms.py:68
 msgid "Homepage field is empty."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:70
+#: metabrainz/oauth/forms.py:69
 msgid "Homepage is not a valid URI."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:71
+#: metabrainz/oauth/forms.py:70
 msgid "Homepage URL must use http or https"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:73
+#: metabrainz/oauth/forms.py:72
 msgid "Authorization callback URL"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:74
+#: metabrainz/oauth/forms.py:73
 msgid "Authorization callback URL field is empty."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:75
+#: metabrainz/oauth/forms.py:74
 msgid "Authorization callback URL is invalid."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:76
+#: metabrainz/oauth/forms.py:75
 msgid "Authorization callback URL must use http or https."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:81 metabrainz/oauth/forms.py:85
+#: metabrainz/oauth/forms.py:80 metabrainz/oauth/forms.py:84
 msgid "Confirm"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:15
+msgid "View your public account information"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:16
+msgid "View your email address"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:17
+msgid "View and modify your private tags"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:18
+msgid "View and modify your private ratings"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:19
+msgid "View and modify your private collections"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:20
+msgid "Submit new ISRCs to the database"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:21
+msgid "Submit new barcodes to the database"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:22
+msgid "Sign you in and view your unique user id"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:23
+msgid "Submit listens to ListenBrainz."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:24
+msgid "Create and modify CritiqueBrainz reviews."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:25
+msgid "Submit and delete votes on CritiqueBrainz reviews."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:26
+msgid "Modify profile info and delete profile on CritiqueBrainz."
 msgstr ""
 
 #: metabrainz/payments/views.py:164
@@ -234,178 +319,185 @@ msgid "Requested annual report was not found."
 msgstr "Begärad årsrapport hittades inte."
 
 #: frontend/js/src/forms/ProfileEdit.tsx:30
-#: frontend/js/src/forms/SignupCommercial.tsx:139
+#: frontend/js/src/forms/SignupCommercial.tsx:144
 #: frontend/js/src/forms/SignupNonCommercial.tsx:70
-#: metabrainz/supporter/forms.py:13
+#: metabrainz/supporter/forms.py:15
 msgid "Contact name is required!"
 msgstr "Kontaktnamn krävs!"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:437
+#: frontend/js/src/forms/SignupCommercial.tsx:441
 #: frontend/js/src/forms/SignupNonCommercial.tsx:264
-#: metabrainz/supporter/forms.py:15
+#: metabrainz/supporter/forms.py:17
 msgid ""
 "Can you please tell us more about the project in which you'd like to use "
 "our data? Do you plan to self host the data or use our APIs?"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:137
+#: frontend/js/src/forms/SignupCommercial.tsx:142
 #: frontend/js/src/forms/SignupNonCommercial.tsx:68
-#: metabrainz/supporter/forms.py:17
+#: metabrainz/supporter/forms.py:19
 msgid "Please, tell us how you (will) use our data."
 msgstr "Berätta för oss hur du kommer använda våra data."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:138
+#: frontend/js/src/forms/SignupCommercial.tsx:143
 #: frontend/js/src/forms/SignupNonCommercial.tsx:69
-#: metabrainz/supporter/forms.py:18
+#: metabrainz/supporter/forms.py:20
 msgid "Please, limit usage description to 500 characters."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:141
-#: frontend/js/src/forms/SignupCommercial.tsx:142
+#: frontend/js/src/forms/SignupCommercial.tsx:146
+#: frontend/js/src/forms/SignupCommercial.tsx:147
 #: frontend/js/src/forms/SignupNonCommercial.tsx:72
 #: frontend/js/src/forms/SignupNonCommercial.tsx:73
-#: frontend/js/src/forms/SignupUser.tsx:84
-#: frontend/js/src/forms/SignupUser.tsx:85 metabrainz/supporter/forms.py:21
-#: metabrainz/user/forms.py:38
+#: frontend/js/src/forms/SignupUser.tsx:90
+#: frontend/js/src/forms/SignupUser.tsx:91 metabrainz/supporter/forms.py:23
+#: metabrainz/user/forms.py:45
 msgid "You need to accept the agreement!"
 msgstr "Du måste acceptera avtalet!"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:342
-#: metabrainz/supporter/forms.py:27
+#: frontend/js/src/forms/SignupCommercial.tsx:347
+#: metabrainz/supporter/forms.py:29
 msgid "Organization name"
 msgstr "Organisationsnamn"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:113
-#: metabrainz/supporter/forms.py:28
+#: frontend/js/src/forms/SignupCommercial.tsx:115
+#: metabrainz/supporter/forms.py:30
 msgid "You need to specify the name of your organization."
 msgstr "Du måste ange namnet på din organisation."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:373
-#: metabrainz/supporter/forms.py:30
+#: frontend/js/src/forms/SignupCommercial.tsx:378
+#: metabrainz/supporter/forms.py:32
 msgid "Organization description"
 msgstr "Organisationsbeskrivning"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:116
-#: metabrainz/supporter/forms.py:31
+#: frontend/js/src/forms/SignupCommercial.tsx:118
+#: metabrainz/supporter/forms.py:33
 msgid "You need to provide description of your organization."
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:278
-#: frontend/js/src/forms/SignupCommercial.tsx:396
-#: metabrainz/supporter/forms.py:34
+#: frontend/js/src/forms/SignupCommercial.tsx:401
+#: metabrainz/supporter/forms.py:36
 msgid "Website URL"
 msgstr "Webbplats-URL"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:119
-#: metabrainz/supporter/forms.py:35
-msgid "You need to specify website of the organization."
-msgstr "Du måste ange webbplats för organisationen."
+#: frontend/js/src/forms/SignupCommercial.tsx:121
+#: frontend/js/src/forms/SignupCommercial.tsx:123
+#: metabrainz/supporter/forms.py:38 metabrainz/supporter/forms.py:42
+msgid "Website URL must be a valid URL."
+msgstr ""
 
-#: metabrainz/supporter/forms.py:37
+#: metabrainz/supporter/forms.py:45
 msgid "Logo image URL"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:284
-#: frontend/js/src/forms/SignupCommercial.tsx:418
-#: metabrainz/supporter/forms.py:38
+#: frontend/js/src/forms/SignupCommercial.tsx:422
+#: metabrainz/supporter/forms.py:46
 msgid "API URL"
 msgstr "API-URL"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:457
-#: metabrainz/supporter/forms.py:40
+#: frontend/js/src/forms/SignupCommercial.tsx:461
+#: metabrainz/supporter/forms.py:48
 msgid "Street"
 msgstr "Gatuadress"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:123
-#: metabrainz/supporter/forms.py:41
+#: frontend/js/src/forms/SignupCommercial.tsx:128
+#: metabrainz/supporter/forms.py:49
 msgid "You need to specify street."
 msgstr "Du måste ange gatuadress."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:465
-#: metabrainz/supporter/forms.py:43
+#: frontend/js/src/forms/SignupCommercial.tsx:469
+#: metabrainz/supporter/forms.py:51
 msgid "City"
 msgstr "Stad"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:124
-#: metabrainz/supporter/forms.py:44
+#: frontend/js/src/forms/SignupCommercial.tsx:129
+#: metabrainz/supporter/forms.py:52
 msgid "You need to specify city."
 msgstr "Du måste ange stad."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:473
-#: metabrainz/supporter/forms.py:46
+#: frontend/js/src/forms/SignupCommercial.tsx:477
+#: metabrainz/supporter/forms.py:54
 msgid "State / Province"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:126
-#: metabrainz/supporter/forms.py:47
+#: frontend/js/src/forms/SignupCommercial.tsx:131
+#: metabrainz/supporter/forms.py:55
 msgid "You need to specify state/province."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:481
-#: metabrainz/supporter/forms.py:49
+#: frontend/js/src/forms/SignupCommercial.tsx:485
+#: metabrainz/supporter/forms.py:57
 msgid "Postcode"
 msgstr "Postnummer"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:128
-#: metabrainz/supporter/forms.py:50
+#: frontend/js/src/forms/SignupCommercial.tsx:133
+#: metabrainz/supporter/forms.py:58
 msgid "You need to specify postcode."
 msgstr "Du måste ange postnummer."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:489
-#: metabrainz/supporter/forms.py:52
+#: frontend/js/src/forms/SignupCommercial.tsx:493
+#: metabrainz/supporter/forms.py:60
 msgid "Country"
 msgstr "Land"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:129
-#: metabrainz/supporter/forms.py:53
+#: frontend/js/src/forms/SignupCommercial.tsx:134
+#: metabrainz/supporter/forms.py:61
 msgid "You need to specify country."
 msgstr "Du måste ange land."
 
-#: frontend/js/src/forms/SignupCommercial.tsx:132
-#: metabrainz/supporter/forms.py:64
+#: frontend/js/src/forms/SignupCommercial.tsx:137
+#: metabrainz/supporter/forms.py:72
 msgid ""
 "Custom amount must be more than threshold amount for selected tier or "
 "equal to it!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:46 metabrainz/supporter/views.py:119
-#: metabrainz/supporter/views.py:220
+#: metabrainz/supporter/views.py:54
+msgid ""
+"The verification email could not be sent. Please request a new one from "
+"your profile."
+msgstr ""
+
+#: metabrainz/supporter/views.py:85 metabrainz/supporter/views.py:158
+#: metabrainz/supporter/views.py:260
 msgid "You are already a supporter."
 msgstr ""
 
-#: metabrainz/supporter/views.py:61
+#: metabrainz/supporter/views.py:100
 msgid "Can't find tier with a specified ID."
 msgstr ""
 
-#: metabrainz/supporter/views.py:127
+#: metabrainz/supporter/views.py:166
 msgid "You need to choose support tier before signing up!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:137
+#: metabrainz/supporter/views.py:176
 msgid "You need to choose existing tier before signing up!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:164
+#: metabrainz/supporter/views.py:204
 msgid ""
 "Thanks for becoming a supporter! Your application will be reviewed soon. "
 "We will send you updates via email."
 msgstr ""
 
-#: metabrainz/supporter/views.py:187
+#: metabrainz/supporter/views.py:228
 msgid ""
 "Thanks for signing up! Your application will be reviewed soon. We will "
 "send you updates via email."
 msgstr ""
 
-#: metabrainz/supporter/views.py:248
+#: metabrainz/supporter/views.py:288
 msgid "Thanks for becoming a supporter!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:274
+#: metabrainz/supporter/views.py:312
 msgid "Thanks for signing up! Please check your inbox to complete verification."
 msgstr ""
 
-#: metabrainz/supporter/views.py:302
+#: metabrainz/supporter/views.py:340
 msgid "Can't generate new token unless account is active."
 msgstr ""
 
@@ -439,7 +531,7 @@ msgstr ""
 msgid "Policies"
 msgstr ""
 
-#: metabrainz/templates/base.html:55 metabrainz/templates/index/gdpr.html:178
+#: metabrainz/templates/base.html:55
 #: metabrainz/templates/index/social-contract.html:3
 #: metabrainz/templates/index/social-contract.html:6
 #: metabrainz/templates/navbar.html:34
@@ -449,14 +541,15 @@ msgstr ""
 #: metabrainz/templates/base.html:56
 #: metabrainz/templates/index/code-of-conduct.html:3
 #: metabrainz/templates/index/code-of-conduct.html:16
-#: metabrainz/templates/index/gdpr.html:181 metabrainz/templates/navbar.html:35
+#: metabrainz/templates/navbar.html:35
 msgid "Code of Conduct"
 msgstr ""
 
+#: frontend/js/src/PrivacySummary.tsx:11
 #: frontend/js/src/forms/ConditionsModal.tsx:21
-#: metabrainz/templates/base.html:57 metabrainz/templates/index/gdpr.html:184
-#: metabrainz/templates/index/privacy.html:6
+#: metabrainz/templates/base.html:57 metabrainz/templates/index/privacy.html:6
 #: metabrainz/templates/navbar.html:36
+#: metabrainz/templates/users/privacy-summary.html:3
 msgid "Privacy Policy"
 msgstr "Integritetspolicy"
 
@@ -490,10 +583,7 @@ msgstr "Sponsorer"
 msgid "Supporters"
 msgstr ""
 
-#: frontend/js/src/forms/LoginUser.tsx:103
-#: frontend/js/src/forms/SignupCommercial.tsx:574
-#: frontend/js/src/forms/SignupNonCommercial.tsx:339
-#: frontend/js/src/forms/SignupUser.tsx:232 metabrainz/templates/base.html:73
+#: frontend/js/src/forms/LoginUser.tsx:103 metabrainz/templates/base.html:73
 #: metabrainz/templates/navbar.html:66 metabrainz/templates/users/login.html:3
 msgid "Sign in"
 msgstr "Logga in"
@@ -515,26 +605,26 @@ msgid "Contact us"
 msgstr "Kontakta oss"
 
 #: metabrainz/templates/base.html:85
-#: metabrainz/templates/index/contact.html:105
+#: metabrainz/templates/index/contact.html:106
 msgid "Blog"
 msgstr "Blogg"
 
-#: metabrainz/templates/base.html:86 metabrainz/templates/index/contact.html:90
+#: metabrainz/templates/base.html:86 metabrainz/templates/index/contact.html:91
 msgid "Chat"
 msgstr ""
 
 #: metabrainz/templates/base.html:87
-#: metabrainz/templates/index/contact.html:106
+#: metabrainz/templates/index/contact.html:107
 msgid "Mastodon"
 msgstr ""
 
 #: metabrainz/templates/base.html:88
-#: metabrainz/templates/index/contact.html:107
+#: metabrainz/templates/index/contact.html:108
 msgid "Bluesky"
 msgstr ""
 
 #: metabrainz/templates/base.html:89
-#: metabrainz/templates/index/contact.html:108
+#: metabrainz/templates/index/contact.html:109
 msgid "Instagram"
 msgstr ""
 
@@ -591,15 +681,14 @@ msgstr "Finansiella rapporter"
 msgid "Donate"
 msgstr "Donera"
 
-#: frontend/js/src/forms/LoginUser.tsx:110
-#: frontend/js/src/forms/SignupCommercial.tsx:175
-#: frontend/js/src/forms/SignupCommercial.tsx:555
+#: frontend/js/src/forms/SignupCommercial.tsx:180
+#: frontend/js/src/forms/SignupCommercial.tsx:559
 #: frontend/js/src/forms/SignupNonCommercial.tsx:106
 #: frontend/js/src/forms/SignupNonCommercial.tsx:319
 #: metabrainz/templates/navbar.html:65
-#: metabrainz/templates/supporters/account-type.html:51
-#: metabrainz/templates/supporters/account-type.html:93
-#: metabrainz/templates/supporters/account-type.html:144
+#: metabrainz/templates/supporters/account-type.html:47
+#: metabrainz/templates/supporters/account-type.html:84
+#: metabrainz/templates/supporters/account-type.html:130
 #: metabrainz/templates/users/signup.html:3
 msgid "Sign up"
 msgstr "Registrera"
@@ -909,8 +998,430 @@ msgstr ""
 msgid "Introduction"
 msgstr ""
 
-#: metabrainz/templates/index/conflict-policy.html:55
+#: metabrainz/templates/index/conflict-policy.html:17
+msgid ""
+"Conflicts between people arise in open source projects constantly and the"
+" projects by the \n"
+"    MetaBrainz Foundation are no different. This policy aims to establish"
+" a clear and unambiguous \n"
+"    policy for reporting and addressing conflicts in our community. In "
+"this policy we aim to \n"
+"    establish a fair practice that balances the need for confidentiality "
+"and our desire for \n"
+"    transparency in our operations."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:25
+#, python-format
+msgid ""
+"Before you continue to read this policy, we encourage you to review our "
+"existing community policies \n"
+"    including our <a href=\"%(social_contract_url)s\">Social "
+"Contract</a>, \n"
+"    <a href=\"%(code_of_conduct_url)s\">the Code of Conduct</a>, \n"
+"    and our <a href=\"%(privacy_policy_url)s\">Privacy Policy</a>. These "
+"policies establish the norms and rules for \n"
+"    participation in our projects; these policies apply equally to the "
+"contractors of the MetaBrainz \n"
+"    Foundation and any participants in our projects."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:37
+msgid ""
+"This policy divides conflicts into two categories: Private and public. "
+"Private conflicts are conflicts \n"
+"    that involve *confidential* information regarding contributors, "
+"contractors or supporters. Otherwise, any conflicts \n"
+"    that do not involve confidential information are considered to be "
+"public conflicts. For instance, a \n"
+"    conflict between a contractor and the Executive Director (aka BDFL) "
+"that involves contractor pay is \n"
+"    considered a private conflict because pay rates are confidential "
+"information. A public conflict in edit \n"
+"    notes between two editors in our community does not involve "
+"confidential information and therefore should \n"
+"    be considered a public conflict."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:47
+msgid ""
+"When conflicts arise we aim to disclose as much information as possible "
+"about the conflict in a timely \n"
+"    fashion. When conflicts contain confidential matters we will aim to "
+"disclose as much information as \n"
+"    possible, while fully respecting the confidentiality of the people "
+"involved in the conflict. With any \n"
+"    private conflict we will aim to extract the relevant lessons for the "
+"team and community in an effort to \n"
+"    evolve our policies to prevent future conflicts. Should the involved "
+"parties disagree whether a conflict \n"
+"    is private or public, the question about the nature of the conflict "
+"will be presented for the next higher \n"
+"    level in the chain of command to decide. (e.g. if a community member "
+"and the community manager disagree on \n"
+"    a conflict being public or private, the Executive Director shall "
+"decide if the conflict is public or private)."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:58
 msgid "Reporting and Response"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:61
+msgid ""
+"We aim to not have conflict in our community, but we recognize that in "
+"reality conflicts will arise and we \n"
+"    must be prepared to address them in a fair manner. When conflicts "
+"arise, we prefer to have community or team \n"
+"    members resolve the conflicts among themselves, using our existing "
+"policies as guidelines for resolving the \n"
+"    conflict."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:69
+msgid ""
+"If you do not feel comfortable resolving a conflict on your own, you "
+"should feel free to report the conflict to \n"
+"    us. How you address the conflict depends on who is involved in the "
+"conflict and your comfort level. Please see \n"
+"    the detailed sections below on how and with whom to address your "
+"conflict. We aim to address conflicts as soon \n"
+"    as possible in an effort to prevent them from escalating "
+"unnecessarily."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:75
+msgid "Direct conflict resolution"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:78
+msgid ""
+"In direct conflict resolution, the involved parties will attempt to "
+"resolve the conflict themselves without \n"
+"   involving any MetaBrainz Foundation team member. You should aim to use"
+" direct resolution when the conflict does \n"
+"   not involve the violation of one of our policies or if the conflict is"
+" minor."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:84
+#, python-format
+msgid ""
+"For instance, if a user uses a rude tone, is disruptive or flagrantly "
+"ignores our project guidelines, we suggest \n"
+"    that you use direct conflict resolution to resolve the conflict. Some"
+" resources that might give you some suggestions \n"
+"    on how to go about resolving the conflict might be this <a "
+"href=\"%(conflict_resolution_primer_url)s\">\n"
+"    conflict resolution primer</a> and <a "
+"href=\"%(difficult_conversations_url)s\">how to\n"
+"    have difficult conversations at work</a>."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:93
+msgid "Informal reporting"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:96
+msgid ""
+"You may use informal reporting of a conflict if you aim to communicate a "
+"concern or incident without \n"
+"    seeking a corrective outcome. Informal reporting may also be an "
+"option if you have not been personally \n"
+"    victimized, but you’ve witnessed a violation of our policies or where"
+" you wish to maintain confidentiality \n"
+"    throughout the entire reporting process."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:103
+msgid ""
+"For editing in MusicBrainz you may informally report a user using the "
+"“Report this user for bad behavior” \n"
+"    link from the user’s profile. For reporting bad user behavior in "
+"other of our projects, please report them to our \n"
+"    community manager by mailing <span class=\"backemail\">gro.zniarbatem"
+"@reganam-ytinummoc</span> . For conflicts \n"
+"    that involve the community manager, report them by mailing <span "
+"class=\"backemail\">gro.zniarbatem@de</span> ."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:110
+msgid ""
+"Depending the the severity of the issue, repeated informal complaints may"
+" eventually require a formal response \n"
+"    from the MetaBrainz team. If an involved party requires anonymity, "
+"the conflict becomes a private conflict. If at \n"
+"    all possible minor issues should be resolved in a public forum in "
+"order for all people to witness and learn from \n"
+"    the issue at hand."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:116
+msgid "Formal complaint process"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:119
+msgid ""
+"All complaints about conflicts should be submitted via email. To whom a "
+"complaint should be mailed and who will \n"
+"    carry out the investigation will be described in the next section."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:124
+msgid "All complaint submissions to the Foundation should include the following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:128
+msgid ""
+"Contact info, if it is different than the email used to submit the "
+"conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:129
+msgid "Who was involved in the conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:130
+msgid "Where and when the incident happened"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:131
+msgid ""
+"A description of what happened -- ideally with links (e.g. chatlogs, edit"
+" notes) that outlines what \n"
+"         happened so that the persons evaluating the conflict may "
+"understand the issue at hand"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:133
+msgid ""
+"Any related pieces of information that provide more context on the "
+"conflict (e.g. links, screenshots)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:134
+msgid "An indication if this conflict is ongoing or not"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:139
+msgid "The investigation that follows aims to determine:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:143
+msgid "The nature and severity of the incident"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:144
+msgid ""
+"Whether or not the incident is considered a violation of MetaBrainz’ "
+"conduct policies or core values"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:145
+msgid ""
+"The amount of harm experienced by the person who submitted the complaint "
+"and the broader MetaBrainz community \n"
+"         as a result of the incident"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:147
+msgid ""
+"Whether there have been prior complaints against the individual or "
+"individuals reported"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:148
+msgid "Whether the incident is ongoing"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:152
+msgid ""
+"The following potential forms of resolution may apply to any team members"
+" involved in the conflict:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:155
+#: metabrainz/templates/index/conflict-policy.html:168
+msgid "Nothing (if it has been found no violation occurred)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:156
+msgid "Creating a plan to improve the performance"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:157
+msgid "Creating a negative performance evaluation"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:158
+msgid "Mediation, an intervention by a third party to resolve the conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:159
+msgid "Suspension or forced leave"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:160
+msgid "Termination of contract"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:164
+msgid ""
+"The following potential forms of resolution may apply to non team members"
+" involved in the conflict:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:169
+msgid "A reprimand, either public or private"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:170
+msgid "Suspension of the users’ account"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:171
+msgid "Deletion of the users’ account"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:172
+msgid ""
+"Removal of user privileges (e.g. if an auto editor commits a serious "
+"offence, they may lose their auto editor status)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:175
+msgid "Filing a complaint"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:178
+msgid ""
+"NOTE: For complaints not about MetaBrainz staff, please see the "
+"<em>Informal reporting</em> section above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:182
+msgid ""
+"If the complaint does not involve the Executive Director (ED), do the "
+"following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:186
+msgid ""
+"If team member has directly violated conduct policies or engaged in "
+"otherwise harmful behavior, a formal complaint should be filed."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:187
+msgid ""
+"Mail <span class=\"backemail\">gro.zniarbatem@de</span> and include the "
+"complaint information outlined above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:188
+msgid ""
+"You should expect a response within a working day acknowledging the "
+"complaint."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:189
+msgid ""
+"The complaint will be investigated by the ED, member(s) of the board of "
+"directors or a neutral third party."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:190
+msgid ""
+"Once the investigation has been completed, the ED, with the support of "
+"others involved in the investigation will respond. The \n"
+"        ED will respond to incidents no later than 7 working days after a"
+" complaint has been filed with either a resolution or an \n"
+"        explanation of why the process must be extended."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:196
+msgid "If a complaint involves the Executive Director, do the following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:200
+msgid ""
+"If the Executive Director has directly violated conduct policies or "
+"engaged in otherwise harmful behavior, \n"
+"        a formal complaint should be filed with the board of directors."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:202
+msgid ""
+"Mail <span class=\"backemail\">gro.zniarbatem@noituloser-tcilfnoc</span> "
+"and include the complaint information outlined above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:203
+msgid ""
+"You should get a response within 5 working days acknowledging the "
+"complaint."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:204
+msgid ""
+"The complaint will be investigated by the member(s) of the board of "
+"directors, the community manager, a neutral \n"
+"        third party or a combination thereof."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:206
+msgid ""
+"Once the investigation has been completed, the board, with the support of"
+" others involved in the investigation \n"
+"        will respond. The board will aim to respond to incidents no later"
+" than 15 working days after a complaint has been filed \n"
+"        with either a resolution or an explanation of why the process "
+"must be extended."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:211
+msgid "Confidentiality"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:214
+msgid ""
+"Confidentiality is an important aspect of conflict resolution and all of "
+"the conflicts brought to the attention of the foundation \n"
+"    will be evaluated with confidentiality in mind and acted upon "
+"accordingly."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:219
+msgid ""
+"We work hard to make all of the actions of the foundation as transparent "
+"and open as possible. In cases where we cannot \n"
+"    disclose all aspects of a conflict we will disclose that a conflict "
+"is or has occurred and we will attempt to disclose the \n"
+"    appropriate amount of information about the conflict while balancing "
+"the need for confidentiality and our desire to learn \n"
+"    from conflicts so that we as a foundation and community can learn "
+"from these conflicts and improve our policies to avoid the \n"
+"    conflicts in the future."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:227
+msgid ""
+"Any breaches of confidentiality will be treated as severe breaches of our"
+" conduct policies."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:230
+msgid "Retaliation"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:233
+msgid ""
+"We will not allow retaliation for any contractor or volunteer that files "
+"a complaint or is involved in an investigation. If you \n"
+"    believe that you are being treated negatively because of your "
+"involvement in a complaint please report this complaint directly \n"
+"    to the ED at <span class=\"backemail\">gro.zniarbatem@de</span> or "
+"the board at \n"
+"    <span class=\"backemail\">gro.zniarbatem@noituloser-tcilfnoc</span>."
 msgstr ""
 
 #: metabrainz/templates/index/contact.html:3
@@ -991,7 +1502,7 @@ msgstr ""
 msgid ""
 "We are currently evaluating our overall online advertising strategy. We "
 "are evaluating advertising, traffic optimization,\n"
-"    search engine optimization and software monitization technologies. If"
+"    search engine optimization and software monetization technologies. If"
 " you provide these professional services, please provide a detailed\n"
 "    deck of your comprehensive services to the following email address. "
 "<em>Please respect our other non-media teams and do not contact us \n"
@@ -1066,11 +1577,11 @@ msgstr "Forum"
 #, python-format
 msgid ""
 "Please come ask your questions at our <a "
-"href=\"%(forums_url)s\">forums</a>! We would love to\n"
-"    answer any questions you may have."
+"href=\"%(forums_url)s\">forums</a>!\n"
+"    The community and the team will be more than happy to help you."
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:92
+#: metabrainz/templates/index/contact.html:93
 #, python-format
 msgid ""
 "The MetaBrainz/MusicBrainz/ListenBrainz team and community hang out\n"
@@ -1080,15 +1591,15 @@ msgid ""
 "    <a href=\"%(chatlogs_url)s\">chat log archives</a>."
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:101
+#: metabrainz/templates/index/contact.html:102
 msgid "Social media"
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:103
+#: metabrainz/templates/index/contact.html:104
 msgid "You can follow us on these social channels:"
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:112
+#: metabrainz/templates/index/contact.html:113
 msgid "Mailing address"
 msgstr ""
 
@@ -1101,33 +1612,349 @@ msgstr ""
 msgid "GDPR Compliance Statement"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:37
+#: metabrainz/templates/index/gdpr.html:10
+msgid ""
+"The General Data Protection Regulation is a complex EU regulation that "
+"stipulates many points for protecting private data of\n"
+"    users on the Internet. Even though this is an EU regulation, it has a"
+" worldwide impact due to the nature of the Internet.\n"
+"    The MetaBrainz Foundation with its collection of projects is also "
+"affected by this regulation. We’ve been learning and adapting\n"
+"    our sites to be compliant with the GDPR – sadly this regulation isn’t"
+" entirely black and white and there is an incredible\n"
+"    amount of room left for interpretation of these rules."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:17
+msgid ""
+"The good news is that this regulation is roughly in line with our "
+"established practices: We’ve always held private information\n"
+"    in a high regard and applied the sort of rules to ourselves as we "
+"wish to have our own private data treated. Luckily, this\n"
+"    makes our compliance effort considerably easier. We’ve made two "
+"significant changes to how we treat your data and also adopted\n"
+"    terminology as used in the GDPR in order to use the same languages "
+"that many other sites are now adopting. Please keep reading\n"
+"    to find out the exact details of what we are doing to comply."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:24
+#, python-format
+msgid ""
+"However, we do ask for your compassion and help in our process of "
+"complying with the GDPR. As we already mentioned, the GDPR is\n"
+"    a complex set of rules that are not fully clarified yet. We’ve taken "
+"action on the steps that are clear to us and we’re following\n"
+"    ongoing conversations on points that are in gray zones or unclear to "
+"us. We’ve made our best initial effort on compliance and\n"
+"    promise to keep working on it as the picture becomes more clear. If "
+"you believe that we could improve our compliance, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a> and let us know what we "
+"can do to improve. It would also help us if you\n"
+"    could provide concrete discussion or examples to help us understand "
+"and take action on your suggestion."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:33
+msgid ""
+"Finally, below are the key sections of the GDPR as we understand them and"
+" how they affect your data in our ecosystem. Where\n"
+"    possible, we provide links for deeper understanding, links for you to"
+" examine our relevant code and links to tickets to follow\n"
+"    the process of improving our compliance."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:38
 msgid "Right to be forgotten"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:77
+#: metabrainz/templates/index/gdpr.html:41
+msgid ""
+"Summary: <i>Provide the user with the ability to remove their private "
+"data from our services</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:44
+msgid ""
+"The most important aspect of the right to be forgotten is the ability to "
+"delete your account. Once you request for us to delete\n"
+"    your account, we will remove any personally identifying information "
+"you may have provided us from your account (name, email\n"
+"    address, gender, biography, URL, etc.). The visible name on your "
+"account will be changed to “Deleted User #####” and effectively\n"
+"    the account will no longer be identifiable as your account."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:50
+msgid ""
+"However, given the nature of our projects where we work on collaborative "
+"databases, your contributions that are not personally\n"
+"    identifying are valuable assets to our database and these "
+"contributions will not be removed from our databases. But we will\n"
+"    ensure that these contributions no longer contain personally "
+"identifying data."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:55
+#, python-format
+msgid ""
+"Our process of automatically deleting your accounts across the MetaBrainz"
+" ecosystem is not complete yet (see below for a set of\n"
+"    tickets where you can track our progress). If you would like to "
+"delete your accounts in the MetaBrainz ecosystem or mark a\n"
+"    donation that is currently public as a private donation, please <a "
+"href=\"%(contact_url)s\">contact us</a>\n"
+"    and we will address your request as soon as possible."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:62
+#: metabrainz/templates/index/gdpr.html:182
+msgid "Links:"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:66
+#, python-format
+msgid ""
+"<a href=\"%(editor_deletion_doc_url)s\">How we delete accounts\n"
+"       in MusicBrainz</a> (warning, geek content ahead!)"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:70
+msgid ""
+"Implement sitewide user account deletion in\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/MBS-9680\">MusicBrainz</a>,"
+"\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/AB-337\">AcousticBrainz</a>,"
+"\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/BB-260\">BookBrainz</a>,\n"
+"         <a href=\"https://tickets.metabrainz.org/browse/MEB-103\">the "
+"MetaBrainz Site</a>,\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/LB-354\">ListenBrainz</a>, "
+"and\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/CB-307\">CritiqueBrainz</a>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:80
 msgid "Restriction of processing"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:110
+#: metabrainz/templates/index/gdpr.html:83
+msgid ""
+"Summary: <i>To allow the user to control how their personally identifying"
+" data is being used.</i>"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:86
+msgid ""
+"Except for the ListenBrainz and AcousticBrainz projects, we do not "
+"process personally identifying data. Any personally\n"
+"    identifying data that our projects store is for the purpose of being "
+"able to contact you about your contributions to our database\n"
+"    (email address) or for voluntarily showing information about you to "
+"other users (biography, homepage, location, etc)."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:91
+#, python-format
+msgid ""
+"The ListenBrainz project differs in that the Listens (metadata about what"
+" music you have listened to) are stored on our servers\n"
+"    and <a href=\"%(listenbrainz_data_url)s\">made available to the "
+"public</a>. We believe Listens to be personally identifying\n"
+"    data and furthermore, we have goals of creating open source "
+"recommendation engines with this data, which involves processing the\n"
+"    user’s data. These two points are fundamental goals of the "
+"ListenBrainz project and we do not see a reasonable way to reach another"
+"\n"
+"    compromise position."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:99
+msgid ""
+"Because of this, we are going to require users to either acknowledge that"
+" we may process their Listen data or alternatively to\n"
+"    delete their account, including all of their Listens. Please note "
+"that if you decide to delete your ListenBrainz account, it may\n"
+"    take up to two weeks for all of your listens to no longer be included"
+" in our efforts to build a recommendation engine."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:104
+msgid ""
+"We have always made it clear that the data in ListenBrainz was to be "
+"public and that we plan to build new tools with your data, so\n"
+"    this should not come as a surprise to our users."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:108
+msgid ""
+"The AcousticBrainz project does not track who submits data to the "
+"database. If you create an account and use our data creation\n"
+"    tools (e.g. create a dataset or participate in a challenge) then we "
+"link your participation and the things that you create to\n"
+"    your account. If you choose to delete your account then we keep the "
+"non personally identifying data that you create, but anonymize\n"
+"    it so that it cannot be linked back to you."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:114
 msgid "Right to data portability / exporting your data"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:150
+#: metabrainz/templates/index/gdpr.html:117
+msgid ""
+"Summary: <i>You have the right to access/download the data we store about"
+" you</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:120
+msgid ""
+"Except for the ListenBrainz and AcousticBrainz projects, we do not store "
+"personally identifying data beyond the\n"
+"    information that is available in your public profile on each of our "
+"projects. Since this data is plainly available in your\n"
+"    profile we do not provide a means for you to export this data."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:125
+msgid "There are the following exceptions to this:"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:129
+msgid ""
+"<b>IP addresses</b>: If you visit one of our sites the IP address of your"
+" computer is stored in our web logs for 7 days\n"
+"        before our servers automatically delete them. This data is almost"
+" never used by anyone: the only time we look at the\n"
+"        IP addresses is if our sites are adversely impacted by the "
+"actions of some unknown users. In that case, we may investigate\n"
+"        the logs to identify the IP address that needs to be blocked in "
+"order to restore the stability of our service.\n"
+"        This data is not available to anyone but the contractors of the "
+"MetaBrainz Foundation and is not available to download\n"
+"        to anyone at all."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:137
+#, python-format
+msgid ""
+"<b>ListenBrainz Listen data</b>: Users may <a "
+"href=\"%(listenbrainz_export_url)s\">export their ListenBrainz Listen\n"
+"        data</a> directly from the site. The user Listen data is also "
+"included in the <a href=\"%(listenbrainz_data_url)s\">ListenBrainz\n"
+"        data dumps</a> that are available for public download."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:146
+msgid ""
+"All of the non personally identifying data, such as your metadata "
+"contributions, are publicly visible, available for download\n"
+"    and available via the project APIs. For details about this data, "
+"downloads and APIs please check the documentation for the\n"
+"    respective projects you are interested in."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:151
+#, python-format
+msgid ""
+"Anyone wishing to get a list of financial donations they have made to the"
+" MetaBrainz Foundation, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a> and provide your "
+"MusicBrainz editor name so that we can look up\n"
+"    your donations."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:157
 msgid "Right to rectification"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:165
+#: metabrainz/templates/index/gdpr.html:160
+msgid "Summary: <i>You have the right to correct your data</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:163
+msgid ""
+"All of our projects allow their users to update their personally "
+"identifying information in their profiles. Furthermore, most\n"
+"    of our projects allow the editing of their own metadata "
+"contributions. If you find that some of your data is incorrect, please\n"
+"    feel free to edit the data since we provide the tools to do so."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:168
+#, python-format
+msgid ""
+"If anyone who has made a financial donation to the MetaBrainz Foundation "
+"would like to make their donation private, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:173
 msgid "Right to be informed"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:188
+#: metabrainz/templates/index/gdpr.html:175
+msgid ""
+"Summary: <i>You have the right to be informed about how we use your data "
+"in plain English</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:178
+msgid ""
+"Our privacy policy, as well as other policies, have always been written "
+"by humans for human consumption. We abhor legalese and\n"
+"    not speaking in direct terms."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:186
+msgid "Social contract"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:189
+msgid "Code of conduct"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:192
+msgid "Privacy policy"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:196
 msgid "Right to access"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:198
-#: metabrainz/templates/index/privacy.html:166
+#: metabrainz/templates/index/gdpr.html:199
+msgid ""
+"Summary: <i>You have the right to access the data that we collect about "
+"you</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:202
+msgid ""
+"All of our projects make all of the data we collect on your behalf, "
+"privately identifying or not, available to you. The\n"
+"    only exception to this are the IP addresses we store for 7 days – see"
+" above for details."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:206
+#: metabrainz/templates/index/privacy.html:168
 msgid "Privacy/GDPR Representative"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:209
+#, python-format
+msgid ""
+"If you have any questions about our privacy policy, please <a "
+"href=\"%(contact_url)s\">contact us</a>. To report\n"
+"   any privacy problems, violations or leaks, our GDPR representative is "
+"our Interim Executive Director Nicolás Tamargo and for\n"
+"   privacy issues contact him at <strong><a "
+"href=\"mailto:gdpr@metabrainz.org\">gdpr@metabrainz.org</a></strong>."
 msgstr ""
 
 #: metabrainz/templates/index/index.html:6
@@ -1232,7 +2059,7 @@ msgid ""
 "      <a href=\"%(about_url)s\">about</a> page."
 msgstr ""
 
-#: frontend/js/src/forms/ConditionsModal.tsx:43
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:32
 #: metabrainz/templates/index/privacy.html:3
 msgid "Privacy"
 msgstr "Sekretess"
@@ -1240,6 +2067,44 @@ msgstr "Sekretess"
 #: metabrainz/templates/index/privacy.html:8
 msgid "Summary"
 msgstr "Sammanfattning"
+
+#: metabrainz/templates/index/privacy.html:12
+msgid ""
+"You do not have to provide any personal data to be able to browse the "
+"contents of the databases published by MetaBrainz."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:15
+msgid ""
+"You do not have to provide any personally-identifying information if you "
+"choose not to."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:18
+msgid ""
+"We will never reveal your email address on MetaBrainz controlled web "
+"sites."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:22
+msgid ""
+"In order to get maximum value out of the MetaBrainz projects, you may "
+"want to create an account and log in. \n"
+"    Doing so grants you the ability to: edit the databases, contribute "
+"your own data, communicate with other users, and keep track \n"
+"    of recently released music from artists in your MusicBrainz "
+"collection. If you choose to create an account then the minimum we \n"
+"    ask is that you: choose a unique username and password, use a web "
+"browser that accepts \"session\" cookies, and provide a verified \n"
+"    email address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:29
+msgid ""
+"If you do not create an account (or are not logged in) you will not have "
+"access to the above listed features, however, you will \n"
+"    still have full access to browse and examine the databases."
+msgstr ""
 
 #: metabrainz/templates/index/privacy.html:33
 msgid "Applicable to all users"
@@ -1249,40 +2114,198 @@ msgstr ""
 msgid "Cookies"
 msgstr ""
 
+#: metabrainz/templates/index/privacy.html:37
+msgid "We use two cookies that contain sensitive information:"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:42
+msgid ""
+"<b>remember_login</b>: If you choose the \"Log in permanently\" option "
+"when logging in to one of our sites; the cookie will be used to \n"
+"      remember your login details."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:46
+msgid ""
+"<b>musicbrainz_server_session, session, or connect.sid</b>: If you are "
+"logged into one of our sites, your current session ID is stored in this "
+"cookie."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:51
+msgid ""
+"We may store dynamic preference information in other cookies, but these "
+"do not contain any sensitive information."
+msgstr ""
+
 #: metabrainz/templates/index/privacy.html:54
 #, fuzzy
 msgid "Web and FTP access logs"
 msgstr "Webb- och FTP-åtkomstloggar (alla användare)"
 
+#: metabrainz/templates/index/privacy.html:57
+msgid ""
+"In a practice similar to other web sites (and APIs) we keep logs of all "
+"web requests made against our servers. These logs include: your IP\n"
+"    address, your browser's (or API client's) \"User-Agent\" string, and "
+"which page (or API endpoint) you requested with which parameters. "
+"Aggregate information about web and FTP traffic is\n"
+"    made available to the public via our site usage pages."
+msgstr ""
+
 #: metabrainz/templates/index/privacy.html:62
 msgid "Third-Party content"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:92
+#: metabrainz/templates/index/privacy.html:64
+msgid ""
+"Our projects' web pages may load some third-party content. Some, but "
+"possibly not all sites are listed below:"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:69
+#, python-format
+msgid ""
+"Cover art and other images: These are provided by the various cover art "
+"sites that have given MusicBrainz permission to do so and our own \n"
+"      <a href=\"%(caa_url)s\">Cover Art Archive</a>. This means that the "
+"relevant site will know (if they want to) your IP \n"
+"      address, User-Agent string, etc., and which MusicBrainz web page "
+"you were visiting (the one which included the cover art image)."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:75
+msgid ""
+"AcoustID: Our fingerprints tab loads fingerprint information from "
+"acoustid.org."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:78
+msgid ""
+"MTCaptcha: Our account creation page loads third party content in order "
+"to prevent spammers from creating accounts."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:83
+msgid ""
+"<i>The above information assumes that you are using \"normal\" web "
+"browser settings, whereby images are always loaded and HTTP referrer \n"
+"    information is always sent.</i>"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:88
+msgid ""
+"It is impractical to constantly modify this privacy policy when "
+"MetaBrainz projects change which third party content they utilize. We "
+"will \n"
+"    aim to use common sense, respect to our community and community "
+"review when adding more content from third party sites. We will also \n"
+"    periodically review our policy to ensure that it remains current."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:93
 msgid "Applicable to account holders"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:94
+#: metabrainz/templates/index/privacy.html:95
 msgid "Account creation"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:108
+#: metabrainz/templates/index/privacy.html:97
+msgid ""
+"When creating an account with a MetaBrainz project you need to pick a "
+"unique username and choose a password, the username you pick is the \n"
+"    only name associated with your account and will be what other "
+"MetaBrainz users know you as. You may optionally also tell us other \n"
+"    information about yourself that will be displayed to other MetaBrainz"
+" users and the public."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:103
+msgid ""
+"Additionally, in order to edit the databases you will need to provide a "
+"confirmed email address. This email address will be held in \n"
+"    confidence, the only method of revealing your email address to "
+"another user is if you choose to send a message to another \n"
+"    user and enable the option to \"reveal my email address\". Changing "
+"the email address stored with your account will require you to \n"
+"    verify the new address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:109
 msgid "Edits and Notes"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:114
+#: metabrainz/templates/index/privacy.html:111
+msgid ""
+"If you make any changes to a MetaBrainz project database, such as adding "
+"any data, the details of those changes will be visible to \n"
+"    other logged-in users and the change will be associated with your "
+"username."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:115
 msgid "Subscriptions on MusicBrainz"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:131
+#: metabrainz/templates/index/privacy.html:117
+msgid ""
+"As a logged-in user you can subscribe to one or more artists, labels, "
+"collections or other editors. The act of subscribing causes \n"
+"    any edits made to (or by in the case of another editor) those "
+"entities to be emailed to you. By default, other users can see your \n"
+"    list of subscriptions, however, you can opt out of this by editing "
+"the appropriate preference."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:123
+msgid ""
+"This does not provide \"perfect\" privacy though, in some cases it will "
+"be possible to infer information about the contents of your \n"
+"    subscription list even though you have disallowed others from viewing"
+" that list directly. This imperfection arises because various \n"
+"    parts of the system behave differently depending on whether or not an"
+" entity has any subscribers; also, the number of users \n"
+"    subscribed to each artist is available via the artist pages. In the "
+"most extreme (possibly contrived) example, imagine that all \n"
+"    users have their subscriptions set to \"public\", except for exactly "
+"one user whose list is \"private\". In that case, any discrepancy \n"
+"    for a given artist between the shown list of subscribers and the "
+"total number of subscribers must be down to that one user. Thus, \n"
+"    you can infer what artists are on that user's list."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:132
 msgid "Third-party sites"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:145
-msgid "MetaBrainz donors"
+#: metabrainz/templates/index/privacy.html:134
+#, python-format
+msgid ""
+"Our code reviews are done on GitHub, which is not under the control of "
+"MetaBrainz. Participating in code reviews or other\n"
+"    tasks carried out on GitHub are subject to <a "
+"href=\"%(github_url)s\">GitHub's privacy policy</a>."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:140
+#, python-format
+msgid ""
+"Our translations platform is provided and hosted by Weblate, which has a "
+"data processing agreement with MetaBrainz.\n"
+"    Participating in translations is subject to <a "
+"href=\"%(weblate_url)s\">dedicated legal terms</a>.\n"
+"    Any translations you make will be submitted to our Git repositories "
+"and publicly associated with your username;\n"
+"    if you so choose, you can also publicly associate them with your own "
+"verified email address."
 msgstr ""
 
 #: metabrainz/templates/index/privacy.html:147
+msgid "MetaBrainz donors"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:149
 msgid ""
 "When you make a donation to the MetaBrainz Foundation, we are legally\n"
 "    required to collect your personal information and keep it in our "
@@ -1292,7 +2315,7 @@ msgid ""
 "    information to anyone else, ever."
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:153
+#: metabrainz/templates/index/privacy.html:155
 msgid ""
 "We believe in transparent finances, which means that we list all "
 "donations\n"
@@ -1302,11 +2325,34 @@ msgid ""
 "process."
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:158
+#: metabrainz/templates/index/privacy.html:160
 msgid "Exceptions"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:598
+#: metabrainz/templates/index/privacy.html:162
+msgid ""
+"<i><b>Please note</b>: Reasonable exceptions may apply to the above "
+"policy, for example to comply with applicable laws.\n"
+"    Also, members of the MetaBrainz team and other personnel contracted "
+"to provide services to MetaBrainz may have access to\n"
+"    our infrastructure and could therefore view any information contained"
+" therein. However all personnel are contractually bound\n"
+"    by non-disclosure clauses which prevent them from making any such "
+"information available to others."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:171
+#, python-format
+msgid ""
+"If you have any questions about our GDPR statement, please <a "
+"href=\"%(contact_url)s\">contact us</a>. To report\n"
+"   any privacy problems, violations or leaks, our GDPR representative is "
+"our Interim Executive Director Nicolás Tamargo and for\n"
+"   privacy issues contact him at <strong><a "
+"href=\"mailto:gdpr@metabrainz.org\">gdpr@metabrainz.org</a></strong>."
+msgstr ""
+
+#: frontend/js/src/Profile.tsx:603
 #: frontend/js/src/forms/ProfileChangePassword.tsx:22
 #: frontend/js/src/forms/ProfileChangePassword.tsx:111
 #: metabrainz/templates/index/profile-change-password.html:3
@@ -1550,6 +2596,11 @@ msgstr ""
 
 #: metabrainz/templates/index/team.html:26
 msgid "He lives on in our hearts and in open source."
+msgstr ""
+
+#: metabrainz/templates/index/team.html:29
+#: metabrainz/templates/index/team.html:315
+msgid "you’re welcome to try"
 msgstr ""
 
 #: metabrainz/templates/index/team.html:39
@@ -2050,8 +3101,10 @@ msgstr ""
 
 #: metabrainz/templates/payments/donate.html:146
 msgid ""
-"Due to the increased unreliability of the US Postal Service we have "
-"stopped accepting paper checks. Sorry!"
+"Due to the increased unreliability of the US Postal Service and the "
+"relatively large fees involved, we ask you to only send a paper check if "
+"it is the only possible option. Due to the fees, we will not cash checks "
+"for less than $25."
 msgstr ""
 
 #: metabrainz/templates/payments/donate.html:241
@@ -2937,8 +3990,8 @@ msgid "Monthly balance sheets"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:520
-#: frontend/js/src/forms/SignupCommercial.tsx:175
-#: frontend/js/src/forms/SignupCommercial.tsx:554
+#: frontend/js/src/forms/SignupCommercial.tsx:180
+#: frontend/js/src/forms/SignupCommercial.tsx:558
 #: frontend/js/src/forms/SignupNonCommercial.tsx:106
 #: frontend/js/src/forms/SignupNonCommercial.tsx:318
 #: metabrainz/templates/supporters/account-type.html:3
@@ -2959,6 +4012,7 @@ msgid "Non-commercial / Personal"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:235
+#: frontend/js/src/forms/SignupNonCommercial.tsx:107
 #: frontend/js/src/forms/SignupNonCommercial.tsx:151
 #: metabrainz/templates/supporters/account-type.html:42
 msgid "Non-commercial"
@@ -2972,57 +4026,46 @@ msgstr ""
 msgid "Personal or university assignment user."
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:48
-#: metabrainz/templates/supporters/account-type.html:90
-#: metabrainz/templates/supporters/account-type.html:141
-msgid "Upgrade"
-msgstr ""
-
 #: frontend/js/src/Profile.tsx:235
-#: frontend/js/src/forms/SignupCommercial.tsx:176
-#: frontend/js/src/forms/SignupCommercial.tsx:228
-#: metabrainz/templates/supporters/account-type.html:61
+#: frontend/js/src/forms/SignupCommercial.tsx:181
+#: frontend/js/src/forms/SignupCommercial.tsx:233
+#: metabrainz/templates/supporters/account-type.html:56
 msgid "Commercial"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:83
-#: metabrainz/templates/supporters/account-type.html:135
+#: metabrainz/templates/supporters/account-type.html:78
+#: metabrainz/templates/supporters/account-type.html:125
 #, python-format
 msgid "$%(tier_price)s/month and up"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:87
-#: metabrainz/templates/supporters/account-type.html:138
+#: metabrainz/templates/supporters/account-type.html:82
+#: metabrainz/templates/supporters/account-type.html:128
 msgid "More info"
 msgstr "Mer information"
 
-#: metabrainz/templates/supporters/account-type.html:104
+#: metabrainz/templates/supporters/account-type.html:94
 msgid "View all tiers"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:112
+#: metabrainz/templates/supporters/account-type.html:102
 msgid "Some of our Unicorn members"
 msgstr "Några av våra enhörningsmedlemmar"
 
-#: metabrainz/templates/supporters/account-type.html:123
+#: metabrainz/templates/supporters/account-type.html:113
 msgid "See all our supporters"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:151
+#: metabrainz/templates/supporters/account-type.html:136
 msgid "View featured tiers"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:158
+#: metabrainz/templates/supporters/account-type.html:143
 #, python-format
 msgid ""
 "If you are not sure which tier to pick, please\n"
 "      <a href=\"%(contact_url)s\">contact us</a>."
 msgstr ""
-
-#: metabrainz/templates/supporters/account-type.html:166
-#, fuzzy
-msgid "Back to Profile"
-msgstr "Din profil"
 
 #: metabrainz/templates/supporters/bad-standing.html:3
 #: metabrainz/templates/supporters/bad-standing.html:6
@@ -3083,9 +4126,9 @@ msgid "Forgot your username"
 msgstr ""
 
 #: frontend/js/src/forms/ResetPassword.tsx:79
-#: frontend/js/src/forms/SignupCommercial.tsx:320
+#: frontend/js/src/forms/SignupCommercial.tsx:325
 #: frontend/js/src/forms/SignupNonCommercial.tsx:227
-#: frontend/js/src/forms/SignupUser.tsx:169
+#: frontend/js/src/forms/SignupUser.tsx:175
 #: metabrainz/templates/users/reauthenticate.html:3
 #: metabrainz/templates/users/reauthenticate.html:6
 msgid "Confirm Password"
@@ -3095,17 +4138,22 @@ msgstr ""
 msgid "Please re-enter your password to continue."
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:108
+#: frontend/js/src/ProfileDelete.tsx:110
 #: frontend/js/src/forms/DeleteApplication.tsx:53
 #: frontend/js/src/forms/OAuthPrompt.tsx:54
 #: frontend/js/src/forms/ProfileChangePassword.tsx:104
 #: frontend/js/src/forms/ProfileEdit.tsx:105
-#: metabrainz/templates/users/reauthenticate.html:23
+#: metabrainz/templates/users/reauthenticate.html:28
 msgid "Cancel"
 msgstr ""
 
-#: metabrainz/templates/users/reauthenticate.html:24
+#: metabrainz/templates/users/reauthenticate.html:29
 msgid "Continue"
+msgstr ""
+
+#: frontend/js/src/forms/utils.tsx:202
+#: metabrainz/templates/users/reauthenticate.html:40
+msgid "Password must not exceed 72 bytes."
 msgstr ""
 
 #: frontend/js/src/forms/ResetPassword.tsx:27
@@ -3113,38 +4161,38 @@ msgstr ""
 msgid "Reset your password"
 msgstr ""
 
-#: frontend/js/src/hooks/useEmailValidation.ts:41 metabrainz/user/forms.py:15
+#: frontend/js/src/hooks/useEmailValidation.ts:41 metabrainz/user/forms.py:16
 msgid "Registration from this email domain is not allowed."
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:50
 #: frontend/js/src/forms/LostPassword.tsx:45
-#: frontend/js/src/forms/SignupCommercial.tsx:270
+#: frontend/js/src/forms/SignupCommercial.tsx:275
 #: frontend/js/src/forms/SignupNonCommercial.tsx:175
-#: frontend/js/src/forms/SignupUser.tsx:114 metabrainz/user/forms.py:20
-#: metabrainz/user/forms.py:45 metabrainz/user/forms.py:62
+#: frontend/js/src/forms/SignupUser.tsx:120 metabrainz/user/forms.py:22
+#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:75
 msgid "Username"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:42
 #: frontend/js/src/forms/LostPassword.tsx:37
-#: frontend/js/src/forms/SignupCommercial.tsx:153
+#: frontend/js/src/forms/SignupCommercial.tsx:158
 #: frontend/js/src/forms/SignupNonCommercial.tsx:84
-#: frontend/js/src/forms/SignupUser.tsx:67 metabrainz/user/forms.py:21
-#: metabrainz/user/forms.py:45 metabrainz/user/forms.py:62
+#: frontend/js/src/forms/SignupUser.tsx:73 metabrainz/user/forms.py:26
+#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:75
 msgid "Username is required!"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:63
 #: frontend/js/src/forms/ResetPassword.tsx:72
-#: frontend/js/src/forms/SignupCommercial.tsx:308
+#: frontend/js/src/forms/SignupCommercial.tsx:313
 #: frontend/js/src/forms/SignupNonCommercial.tsx:214
-#: frontend/js/src/forms/SignupUser.tsx:157 metabrainz/user/forms.py:46
-#: metabrainz/user/forms.py:52
+#: frontend/js/src/forms/SignupUser.tsx:163 metabrainz/user/forms.py:53
+#: metabrainz/user/forms.py:62
 msgid "Password"
 msgstr ""
 
-#: frontend/js/src/forms/LoginUser.tsx:76 metabrainz/user/forms.py:47
+#: frontend/js/src/forms/LoginUser.tsx:76 metabrainz/user/forms.py:57
 msgid "Remember me"
 msgstr ""
 
@@ -3156,11 +4204,11 @@ msgstr ""
 msgid "Username contains invalid or invisible characters."
 msgstr ""
 
-#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:181
+#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:220
 msgid "Hide password"
 msgstr ""
 
-#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:181
+#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:220
 msgid "Show password"
 msgstr ""
 
@@ -3218,11 +4266,11 @@ msgstr ""
 msgid "Revoke access"
 msgstr ""
 
-#: frontend/js/src/OAuthError.tsx:17
+#: frontend/js/src/OAuthError.tsx:18
 msgid "OAuth2 Error"
 msgstr ""
 
-#: frontend/js/src/OAuthError.tsx:18
+#: frontend/js/src/OAuthError.tsx:19
 msgid "An error occurred during OAuth authentication process."
 msgstr ""
 
@@ -3252,8 +4300,8 @@ msgstr ""
 
 #: frontend/js/src/Profile.tsx:109
 msgid ""
-"Are you sure you want to generate new access token? Current token will be"
-" revoked!"
+"Are you sure you want to generate a new access token? The current token "
+"will be revoked!"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:118
@@ -3368,8 +4416,8 @@ msgid "Contact Information"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:310 frontend/js/src/forms/ProfileEdit.tsx:70
-#: frontend/js/src/forms/SignupCommercial.tsx:284
-#: frontend/js/src/forms/SignupCommercial.tsx:333
+#: frontend/js/src/forms/SignupCommercial.tsx:289
+#: frontend/js/src/forms/SignupCommercial.tsx:338
 #: frontend/js/src/forms/SignupNonCommercial.tsx:189
 #: frontend/js/src/forms/SignupNonCommercial.tsx:241
 msgid "Contact name"
@@ -3484,7 +4532,7 @@ msgstr ""
 msgid "Once you delete your account, there is no going back. Please be certain."
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:550 frontend/js/src/ProfileDelete.tsx:105
+#: frontend/js/src/Profile.tsx:550 frontend/js/src/ProfileDelete.tsx:107
 msgid "Delete My Account"
 msgstr ""
 
@@ -3496,39 +4544,39 @@ msgstr ""
 msgid "Need to delete your account?"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:574
+#: frontend/js/src/Profile.tsx:575
 msgid ""
 "Deletion of supporter accounts requires manual review. Please contact us "
-"at"
+"at <email />."
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:594
+#: frontend/js/src/Profile.tsx:599
 msgid "Security"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:626
+#: frontend/js/src/Profile.tsx:631
 msgid "MetaBrainz Applications"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:630
+#: frontend/js/src/Profile.tsx:635
 msgid ""
 "With your MetaBrainz account, you can access every project in the "
 "MetaBrainz family:"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:643
+#: frontend/js/src/Profile.tsx:648
 msgid "The open-source music encyclopedia"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:655
+#: frontend/js/src/Profile.tsx:660
 msgid "Track, visualise and share the music you listen to"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:667
+#: frontend/js/src/Profile.tsx:672
 msgid "The open-source book database"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:679
+#: frontend/js/src/Profile.tsx:684
 msgid "Creative Commons licensed reviews"
 msgstr ""
 
@@ -3551,7 +4599,7 @@ msgid "Permanently remove all your account information"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:64
-msgid "Revoke all your API tokens and access"
+msgid "Revoke all your tokens and access to the replication API"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:65
@@ -3563,14 +4611,16 @@ msgid "Log you out of all MetaBrainz services"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:70
-msgid "Your username will be reserved and cannot be reused."
+msgid ""
+"Your username will be reserved and cannot be reused without the "
+"intervention of an administrator."
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:82
+#: frontend/js/src/ProfileDelete.tsx:84
 msgid "To confirm, type your username '<username />' below:"
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:105
+#: frontend/js/src/ProfileDelete.tsx:107
 msgid "Deleting..."
 msgstr ""
 
@@ -3583,64 +4633,7 @@ msgstr "Din profil"
 msgid "Close"
 msgstr ""
 
-#: frontend/js/src/forms/ConditionsModal.tsx:23
-msgid "Licensing"
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:25
-msgid ""
-"Any contributions you make to any MetaBrainz service will be released "
-"into the Public Domain and/or licensed under a Creative Commons by-nc-sa "
-"license. Furthermore, you give the MetaBrainz Foundation the right to "
-"license this data for commercial use."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:30
-msgid "Please read our <licenseLink>license page</licenseLink> for more details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:45
-msgid ""
-"MetaBrainz strongly believes in the privacy of its users. Any personal "
-"information you choose to provide will not be sold or shared with anyone "
-"else."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:50
-msgid ""
-"Please read our <privacyLink>privacy policy</privacyLink> for more "
-"details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:59
-msgid "GDPR compliance"
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:61
-msgid ""
-"You may remove your personal information from our services anytime by "
-"deleting your account."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:66
-msgid ""
-"Please read our <gdprLink>GDPR compliance statement</gdprLink> for more "
-"details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:78
-msgid ""
-"Creating an account on MetaBrainz will give you access to all of our "
-"projects, such as MusicBrainz, ListenBrainz, BookBrainz, and more."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:82
-msgid ""
-"We create a placeholder account for all the MetaBrainz projects when you "
-"sign up, and you are one log-in away from activating them."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:91
+#: frontend/js/src/forms/ConditionsModal.tsx:29
 msgid "Sounds good"
 msgstr ""
 
@@ -3729,8 +4722,8 @@ msgstr ""
 msgid "Forgot your password?"
 msgstr ""
 
-#: frontend/js/src/forms/LoginUser.tsx:109
-msgid "Don't have an account?"
+#: frontend/js/src/forms/LoginUser.tsx:110
+msgid "Don't have an account? <signupLink>Sign up</signupLink>"
 msgstr ""
 
 #: frontend/js/src/forms/LostPassword.tsx:38
@@ -3761,15 +4754,72 @@ msgstr ""
 msgid "Allow access"
 msgstr "Tillåt åtkomst"
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:71
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:10
+msgid "Licensing"
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:12
+msgid ""
+"Any contributions you make to any MetaBrainz service will be released "
+"into the Public Domain and/or licensed under a Creative Commons by-nc-sa "
+"license. Furthermore, you give the MetaBrainz Foundation the right to "
+"license this data for commercial use."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:17
+msgid "Please read our <licenseLink>license page</licenseLink> for more details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:34
+msgid ""
+"MetaBrainz strongly believes in the privacy of its users. Any personal "
+"information you choose to provide will not be sold or shared with anyone "
+"else."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:39
+msgid ""
+"Please read our <privacyLink>privacy policy</privacyLink> for more "
+"details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:50
+msgid "GDPR compliance"
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:52
+msgid ""
+"You may remove your personal information from our services anytime by "
+"deleting your account."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:57
+msgid ""
+"Please read our <gdprLink>GDPR compliance statement</gdprLink> for more "
+"details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:71
+msgid ""
+"Creating an account on MetaBrainz will give you access to all of our "
+"projects, such as MusicBrainz, ListenBrainz, BookBrainz, and more."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:75
+msgid ""
+"We create a placeholder account for all the MetaBrainz projects when you "
+"sign up, and you are one log-in away from activating them."
+msgstr ""
+
+#: frontend/js/src/forms/ProfileChangePassword.tsx:70
 msgid "Current Password"
 msgstr ""
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:80
+#: frontend/js/src/forms/ProfileChangePassword.tsx:79
 msgid "New Password"
 msgstr ""
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:89
+#: frontend/js/src/forms/ProfileChangePassword.tsx:88
 msgid "Confirm New Password"
 msgstr ""
 
@@ -3781,193 +4831,183 @@ msgstr ""
 msgid "Reset Password"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:38
-msgid "If you would like to support us with more than $"
+#: frontend/js/src/forms/SignupCommercial.tsx:40
+msgid ""
+"If you would like to support us with more than ${{minPledge}}, please "
+"enter the actual amount here:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:39
-msgid ", please enter the actual amount here:"
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:144
+#: frontend/js/src/forms/SignupCommercial.tsx:149
 #: frontend/js/src/forms/SignupNonCommercial.tsx:75
-#: frontend/js/src/forms/SignupUser.tsx:87
+#: frontend/js/src/forms/SignupUser.tsx:93
 msgid "Captcha is required!"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:179
+#: frontend/js/src/forms/SignupCommercial.tsx:184
 #: frontend/js/src/forms/SignupNonCommercial.tsx:110
 #: frontend/js/src/forms/SignupUser.tsx:46
 #, fuzzy
 msgid "Access all MetaBrainz projects"
 msgstr "MetaBrainz-projekt"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:182
+#: frontend/js/src/forms/SignupCommercial.tsx:187
 msgid "Note:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:184
+#: frontend/js/src/forms/SignupCommercial.tsx:189
 msgid ""
 "Signing up for any tier other than the <italic>Stealth startup</italic> "
 "tier will publicly list your company on this web site. However, we will "
 "not publish any of your private details."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:221
+#: frontend/js/src/forms/SignupCommercial.tsx:226
 #: frontend/js/src/forms/SignupNonCommercial.tsx:145
 #, fuzzy
 msgid "Account type"
 msgstr "Kontotyp"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:234
+#: frontend/js/src/forms/SignupCommercial.tsx:239
 msgid "Selected tier"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:242
-msgid "month and up"
+#: frontend/js/src/forms/SignupCommercial.tsx:247
+msgid "${{tierPrice}}/month and up"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:250
+#: frontend/js/src/forms/SignupCommercial.tsx:255
 msgid "Change account type or tier"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:261
+#: frontend/js/src/forms/SignupCommercial.tsx:266
 #: frontend/js/src/forms/SignupNonCommercial.tsx:166
 msgid "Your account:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:271
+#: frontend/js/src/forms/SignupCommercial.tsx:276
 #: frontend/js/src/forms/SignupNonCommercial.tsx:176
-#: frontend/js/src/forms/SignupUser.tsx:114
+#: frontend/js/src/forms/SignupUser.tsx:120
 msgid "(public)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:291
+#: frontend/js/src/forms/SignupCommercial.tsx:296
 #: frontend/js/src/forms/SignupNonCommercial.tsx:196
-#: frontend/js/src/forms/SignupUser.tsx:127
+#: frontend/js/src/forms/SignupUser.tsx:133
 msgid "E-mail address"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:295
+#: frontend/js/src/forms/SignupCommercial.tsx:300
 #: frontend/js/src/forms/SignupNonCommercial.tsx:200
-#: frontend/js/src/forms/SignupUser.tsx:131
+#: frontend/js/src/forms/SignupUser.tsx:137
 msgid "(checking...)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:314
+#: frontend/js/src/forms/SignupCommercial.tsx:319
 #: frontend/js/src/forms/SignupNonCommercial.tsx:220
-#: frontend/js/src/forms/SignupUser.tsx:163
+#: frontend/js/src/forms/SignupUser.tsx:169
 msgid "Must be at least 8 characters"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:348
+#: frontend/js/src/forms/SignupCommercial.tsx:353
 msgid ""
 "If you don't have an organization name, you probably want to become a "
 "supporter as a <nonCommercialLink>Non-commercial / "
 "Personal</nonCommercialLink> supporter."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:358
+#: frontend/js/src/forms/SignupCommercial.tsx:363
 msgid ""
 "If you don't have an organization name, you probably want to sign up as a"
 " <nonCommercialLink>Non-commercial / Personal</nonCommercialLink> user."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:378
+#: frontend/js/src/forms/SignupCommercial.tsx:383
 msgid ""
 "Please tell us a little about your company and whether you plan to use "
 "our <apiLink>API</apiLink> or to <hostLink>host your own copy</hostLink> "
 "of the data."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:404
+#: frontend/js/src/forms/SignupCommercial.tsx:408
 msgid "Logo URL"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:405
+#: frontend/js/src/forms/SignupCommercial.tsx:409
 msgid "(preferably in SVG format)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:408
+#: frontend/js/src/forms/SignupCommercial.tsx:412
 msgid ""
 "Image should be about 250 pixels wide on a white or transparent "
 "background. We will host it on our site."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:421
+#: frontend/js/src/forms/SignupCommercial.tsx:425
 msgid ""
 "URL to where developers can use your APIs using MusicBrainz IDs, if "
-"available.."
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:430
-msgid "Your project"
+"available."
 msgstr ""
 
 #: frontend/js/src/forms/SignupCommercial.tsx:434
+msgid "Your project"
+msgstr ""
+
+#: frontend/js/src/forms/SignupCommercial.tsx:438
 #: frontend/js/src/forms/SignupNonCommercial.tsx:261
 msgid "(max 150 characters)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:451
+#: frontend/js/src/forms/SignupCommercial.tsx:455
 msgid "Billing address"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:502
+#: frontend/js/src/forms/SignupCommercial.tsx:506
 msgid ""
 "I agree to support the MetaBrainz Foundation when my organization is able"
 " to do so."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:507
+#: frontend/js/src/forms/SignupCommercial.tsx:511
+#: frontend/js/src/forms/SignupNonCommercial.tsx:284
 msgid ""
-"I also agree that if I generate a Live Data Feed access token, that I "
-"treat my access token as a secret and will not share this token publicly "
-"or commit it to a source code repository."
+"I also agree that if I generate a Live Data Feed access token, then I "
+"will treat my access token as a secret and will not share this token "
+"publicly or commit it to a source code repository."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:515
+#: frontend/js/src/forms/SignupCommercial.tsx:519
 msgid ""
 "The following information will be shown publicly: organization name, "
 "logo, website and API URLs, data usage description."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:520
+#: frontend/js/src/forms/SignupCommercial.tsx:524
 msgid ""
 "We'll send you more details about payment process once your application "
 "is approved."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:552
+#: frontend/js/src/forms/SignupCommercial.tsx:556
 #: frontend/js/src/forms/SignupNonCommercial.tsx:316
-#: frontend/js/src/forms/SignupUser.tsx:224
+#: frontend/js/src/forms/SignupUser.tsx:230
 msgid "Validating..."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:564
+#: frontend/js/src/forms/SignupCommercial.tsx:568
 #: frontend/js/src/forms/SignupNonCommercial.tsx:329
 #, fuzzy
 msgid "Back to profile"
 msgstr "Din profil"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:569
-#: frontend/js/src/forms/SignupNonCommercial.tsx:334
-msgid "Not a supporter?"
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:570
+#: frontend/js/src/forms/SignupCommercial.tsx:574
 #: frontend/js/src/forms/SignupNonCommercial.tsx:335
-msgid "Create a user account"
+msgid "Not a supporter? <signupLink>Create a user account</signupLink>"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:573
-#: frontend/js/src/forms/SignupNonCommercial.tsx:338
-#: frontend/js/src/forms/SignupUser.tsx:231
-msgid "Already have an account?"
-msgstr ""
-
-#: frontend/js/src/forms/SignupNonCommercial.tsx:107
-msgid "non-commercial"
+#: frontend/js/src/forms/SignupCommercial.tsx:583
+#: frontend/js/src/forms/SignupNonCommercial.tsx:344
+#: frontend/js/src/forms/SignupUser.tsx:238
+msgid "Already have an account? <loginLink>Sign in</loginLink>"
 msgstr ""
 
 #: frontend/js/src/forms/SignupNonCommercial.tsx:113
@@ -3995,46 +5035,40 @@ msgid ""
 "income per year) or personal uses only."
 msgstr ""
 
-#: frontend/js/src/forms/SignupNonCommercial.tsx:284
-msgid ""
-"I also agree that if I generate a Live Data Feed access token, then I "
-"will treat my access token as a secret and will not share this token "
-"publicly or commit it to a source code repository."
-msgstr ""
-
 #: frontend/js/src/forms/SignupUser.tsx:43
 msgid "Create your account"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:50
-msgid "Registration started by"
+#: frontend/js/src/forms/SignupUser.tsx:51
+msgid "Registration started by <client />"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:69
+#: frontend/js/src/forms/SignupUser.tsx:75
+#: frontend/js/src/hooks/useEmailValidation.ts:82
 msgid "Invalid email address."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:150
+#: frontend/js/src/forms/SignupUser.tsx:156
 msgid ""
 "This username and email were provided by the app that started "
 "registration. You can change them later from MetaBrainz settings."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:182
+#: frontend/js/src/forms/SignupUser.tsx:188
 msgid ""
 "I accept that my contributions will be released into the public domain or"
 " licensed for use."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:191
+#: frontend/js/src/forms/SignupUser.tsx:197
 msgid "We will never share your personal information."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:200
+#: frontend/js/src/forms/SignupUser.tsx:206
 msgid "Click here to read more"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:224
+#: frontend/js/src/forms/SignupUser.tsx:230
 msgid "Create account"
 msgstr ""
 
@@ -4044,10 +5078,6 @@ msgstr ""
 
 #: frontend/js/src/hooks/useEmailValidation.ts:47
 msgid "Email validation failed"
-msgstr ""
-
-#: frontend/js/src/hooks/useEmailValidation.ts:82
-msgid "Invalid email address"
 msgstr ""
 
 #~ msgid "You need to specify amount!"
@@ -5298,4 +6328,96 @@ msgstr ""
 
 #~ msgid "Privacy policy"
 #~ msgstr "Integritetspolicy"
+
+#~ msgid "You need to specify website of the organization."
+#~ msgstr "Du måste ange webbplats för organisationen."
+
+#~ msgid ""
+#~ "We are currently evaluating our overall"
+#~ " online advertising strategy. We are "
+#~ "evaluating advertising, traffic optimization,\n"
+#~ ""
+#~ "    search engine optimization and "
+#~ "software monitization technologies. If you "
+#~ "provide these professional services, please"
+#~ " provide a detailed\n"
+#~ "    deck of your comprehensive services"
+#~ " to the following email address. "
+#~ "<em>Please respect our other non-media"
+#~ " teams and do not contact us \n"
+#~ "    regarding these services on any "
+#~ "other of our email addresses. We "
+#~ "will disregard the entirety of your "
+#~ "submissions if you contact us any "
+#~ "other way!</em>"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Please come ask your questions at "
+#~ "our <a href=\"%(forums_url)s\">forums</a>! We "
+#~ "would love to\n"
+#~ "    answer any questions you may have."
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Due to the increased unreliability of"
+#~ " the US Postal Service we have "
+#~ "stopped accepting paper checks. Sorry!"
+#~ msgstr ""
+
+#~ msgid "Upgrade"
+#~ msgstr ""
+
+#~ msgid "Back to Profile"
+#~ msgstr "Din profil"
+
+#~ msgid ""
+#~ "Deletion of supporter accounts requires "
+#~ "manual review. Please contact us at"
+#~ msgstr ""
+
+#~ msgid "Revoke all your API tokens and access"
+#~ msgstr ""
+
+#~ msgid "Your username will be reserved and cannot be reused."
+#~ msgstr ""
+
+#~ msgid "Don't have an account?"
+#~ msgstr ""
+
+#~ msgid "If you would like to support us with more than $"
+#~ msgstr ""
+
+#~ msgid ", please enter the actual amount here:"
+#~ msgstr ""
+
+#~ msgid "month and up"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "I also agree that if I generate"
+#~ " a Live Data Feed access token, "
+#~ "that I treat my access token as"
+#~ " a secret and will not share "
+#~ "this token publicly or commit it "
+#~ "to a source code repository."
+#~ msgstr ""
+
+#~ msgid "Not a supporter?"
+#~ msgstr ""
+
+#~ msgid "Create a user account"
+#~ msgstr ""
+
+#~ msgid "Already have an account?"
+#~ msgstr ""
+
+#~ msgid "non-commercial"
+#~ msgstr ""
+
+#~ msgid "Registration started by"
+#~ msgstr ""
+
+#~ msgid "Invalid email address"
+#~ msgstr ""
 

--- a/metabrainz/translations/zh_CN/LC_MESSAGES/messages.po
+++ b/metabrainz/translations/zh_CN/LC_MESSAGES/messages.po
@@ -15,176 +15,261 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-07-25 16:21+0200\n"
+"POT-Creation-Date: 2026-09-08 11:18+0200\n"
 "PO-Revision-Date: 2026-07-29 11:24+0000\n"
 "Last-Translator: nullpinter <fanng233@gmail.com>\n"
 "Language: zh_CN\n"
-"Language-Team: Chinese (Simplified Han script) <https://"
-"translations.metabrainz.org/projects/metabrainz/website/zh_Hans/>\n"
+"Language-Team: Chinese (Simplified Han script) "
+"<https://translations.metabrainz.org/projects/metabrainz/website/zh_Hans/>"
+"\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.18.0\n"
-"X-Generator: Weblate 2026.7.1\n"
 
-#: metabrainz/index/forms.py:46
+#: metabrainz/errors.py:24
+msgid "Authorization was declined."
+msgstr ""
+
+#: metabrainz/errors.py:25
+msgid "The authorization request was invalid."
+msgstr ""
+
+#: metabrainz/errors.py:26
+msgid "The application could not be authenticated."
+msgstr ""
+
+#: metabrainz/errors.py:27
+msgid "This application is not allowed to request authorization."
+msgstr ""
+
+#: metabrainz/errors.py:28
+msgid "The application asked for a response type this server does not support."
+msgstr ""
+
+#: metabrainz/errors.py:29
+msgid "The permissions requested by the application are invalid."
+msgstr ""
+
+#: metabrainz/errors.py:30
+msgid "You need to sign in to continue."
+msgstr ""
+
+#: metabrainz/errors.py:31
+msgid "Your consent is required to continue."
+msgstr ""
+
+#: metabrainz/password.py:12
+#, python-format
+msgid "Password must not exceed %(max_bytes)s bytes."
+msgstr ""
+
+#: metabrainz/index/forms.py:48
 #, python-format
 msgid "'%(value)s' is not a valid choice for this field"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileEdit.tsx:27
-#: frontend/js/src/forms/SignupCommercial.tsx:154
+#: frontend/js/src/forms/SignupCommercial.tsx:159
 #: frontend/js/src/forms/SignupNonCommercial.tsx:85
-#: frontend/js/src/forms/SignupUser.tsx:70
-#: frontend/js/src/hooks/useEmailValidation.ts:78 metabrainz/index/forms.py:57
-#: metabrainz/user/forms.py:25 metabrainz/user/forms.py:57
-#: metabrainz/user/forms.py:63
+#: frontend/js/src/forms/SignupUser.tsx:76
+#: frontend/js/src/hooks/useEmailValidation.ts:78 metabrainz/index/forms.py:59
+#: metabrainz/user/forms.py:31 metabrainz/user/forms.py:70
+#: metabrainz/user/forms.py:76
 msgid "Email address is required!"
 msgstr "请提供邮箱地址！"
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:34
-#: metabrainz/index/forms.py:63
+#: metabrainz/index/forms.py:65
 msgid "Current password is required!"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:43
 #: frontend/js/src/forms/ProfileChangePassword.tsx:37
 #: frontend/js/src/forms/ResetPassword.tsx:39
-#: frontend/js/src/forms/SignupCommercial.tsx:156
+#: frontend/js/src/forms/SignupCommercial.tsx:161
 #: frontend/js/src/forms/SignupNonCommercial.tsx:87
-#: frontend/js/src/forms/SignupUser.tsx:72 metabrainz/index/forms.py:66
-#: metabrainz/user/forms.py:29 metabrainz/user/forms.py:46
-#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:69
+#: frontend/js/src/forms/SignupUser.tsx:78 metabrainz/index/forms.py:69
+#: metabrainz/user/forms.py:35 metabrainz/user/forms.py:54
+#: metabrainz/user/forms.py:63 metabrainz/user/forms.py:82
 msgid "Password is required!"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:41
-#: frontend/js/src/forms/SignupCommercial.tsx:160
+#: frontend/js/src/forms/SignupCommercial.tsx:165
 #: frontend/js/src/forms/SignupNonCommercial.tsx:91
-#: frontend/js/src/forms/SignupUser.tsx:76 metabrainz/index/forms.py:70
-#: metabrainz/user/forms.py:33 metabrainz/user/forms.py:73
+#: frontend/js/src/forms/SignupUser.tsx:82 metabrainz/index/forms.py:74
+#: metabrainz/user/forms.py:40 metabrainz/user/forms.py:87
 msgid "Confirm Password is required!"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:46
 #: frontend/js/src/forms/ResetPassword.tsx:48
-#: frontend/js/src/forms/SignupCommercial.tsx:165
+#: frontend/js/src/forms/SignupCommercial.tsx:170
 #: frontend/js/src/forms/SignupNonCommercial.tsx:96
-#: frontend/js/src/forms/SignupUser.tsx:81 metabrainz/index/forms.py:72
-#: metabrainz/user/forms.py:35 metabrainz/user/forms.py:75
+#: frontend/js/src/forms/SignupUser.tsx:87 metabrainz/index/forms.py:76
+#: metabrainz/user/forms.py:42 metabrainz/user/forms.py:89
 msgid "Confirm Password should match password!"
 msgstr ""
 
 #: frontend/js/src/Applications.tsx:56 frontend/js/src/Applications.tsx:86
 #: frontend/js/src/Profile.tsx:272 frontend/js/src/Profile.tsx:482
-#: metabrainz/index/forms.py:78
+#: metabrainz/index/forms.py:82
 msgid "Name"
 msgstr "姓名"
 
-#: metabrainz/index/forms.py:79
+#: metabrainz/index/forms.py:83
 msgid "Contact name field is empty."
 msgstr "请输入姓名。"
 
-#: metabrainz/index/views.py:234
+#: metabrainz/index/views.py:251
 msgid "Profile updated successfully."
 msgstr "个人资料已成功更新。"
 
-#: metabrainz/index/views.py:261
+#: metabrainz/index/views.py:278
 msgid "Current password is incorrect."
 msgstr "当前密码不正确。"
 
-#: metabrainz/index/views.py:266
+#: metabrainz/index/views.py:283
 msgid "Password changed successfully."
 msgstr "已成功更改密码。"
 
-#: metabrainz/index/views.py:372
+#: metabrainz/index/views.py:389
 msgid "You have updated an application!"
 msgstr ""
 
-#: metabrainz/index/views.py:424
+#: metabrainz/index/views.py:441
 msgid "You have deleted an application."
 msgstr ""
 
-#: metabrainz/index/views.py:426
+#: metabrainz/index/views.py:443
 msgid "Failed to delete an application."
 msgstr ""
 
-#: metabrainz/index/views.py:449
+#: metabrainz/index/views.py:466
 msgid "Revoked tokens successfully!"
 msgstr ""
 
-#: metabrainz/index/views.py:478
+#: metabrainz/index/views.py:495
 msgid "Your account has been deleted."
 msgstr "您的账户已被删除。"
 
-#: frontend/js/src/forms/CreateApplication.tsx:106 metabrainz/oauth/forms.py:58
+#: frontend/js/src/forms/CreateApplication.tsx:106 metabrainz/oauth/forms.py:57
 msgid "Application Name"
 msgstr "应用名称"
 
-#: metabrainz/oauth/forms.py:59
+#: metabrainz/oauth/forms.py:58
 msgid "Application name field is empty."
 msgstr "应用名称字段为空。"
 
-#: frontend/js/src/forms/CreateApplication.tsx:60 metabrainz/oauth/forms.py:60
+#: frontend/js/src/forms/CreateApplication.tsx:60 metabrainz/oauth/forms.py:59
 msgid "Application name needs to be at least 3 characters long."
 msgstr "应用名称长度应长于三个字符。"
 
-#: frontend/js/src/forms/CreateApplication.tsx:64 metabrainz/oauth/forms.py:61
+#: frontend/js/src/forms/CreateApplication.tsx:64 metabrainz/oauth/forms.py:60
 msgid "Application name needs to be at most 64 characters long."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:114 metabrainz/oauth/forms.py:63
+#: frontend/js/src/forms/CreateApplication.tsx:114 metabrainz/oauth/forms.py:62
 msgid "Description"
 msgstr "描述"
 
-#: metabrainz/oauth/forms.py:64
+#: metabrainz/oauth/forms.py:63
 msgid "Client description field is empty."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:65
+#: metabrainz/oauth/forms.py:64
 msgid "Client description needs to be at least 3 characters long."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:66
+#: metabrainz/oauth/forms.py:65
 msgid "Client description needs to be at most 512 characters long."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:122 metabrainz/oauth/forms.py:68
+#: frontend/js/src/forms/CreateApplication.tsx:122 metabrainz/oauth/forms.py:67
 msgid "Homepage"
 msgstr "主页"
 
-#: metabrainz/oauth/forms.py:69
+#: metabrainz/oauth/forms.py:68
 msgid "Homepage field is empty."
 msgstr "主页字段为空。"
 
-#: metabrainz/oauth/forms.py:70
+#: metabrainz/oauth/forms.py:69
 msgid "Homepage is not a valid URI."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:71
+#: metabrainz/oauth/forms.py:70
 msgid "Homepage URL must use http or https"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:73
+#: metabrainz/oauth/forms.py:72
 msgid "Authorization callback URL"
 msgstr "验证回调URL"
 
-#: metabrainz/oauth/forms.py:74
+#: metabrainz/oauth/forms.py:73
 msgid "Authorization callback URL field is empty."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:75
+#: metabrainz/oauth/forms.py:74
 msgid "Authorization callback URL is invalid."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:76
+#: metabrainz/oauth/forms.py:75
 msgid "Authorization callback URL must use http or https."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:81 metabrainz/oauth/forms.py:85
+#: metabrainz/oauth/forms.py:80 metabrainz/oauth/forms.py:84
 msgid "Confirm"
 msgstr "确认"
+
+#: metabrainz/oauth/scopes.py:15
+msgid "View your public account information"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:16
+msgid "View your email address"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:17
+msgid "View and modify your private tags"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:18
+msgid "View and modify your private ratings"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:19
+msgid "View and modify your private collections"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:20
+msgid "Submit new ISRCs to the database"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:21
+msgid "Submit new barcodes to the database"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:22
+msgid "Sign you in and view your unique user id"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:23
+msgid "Submit listens to ListenBrainz."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:24
+msgid "Create and modify CritiqueBrainz reviews."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:25
+msgid "Submit and delete votes on CritiqueBrainz reviews."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:26
+msgid "Modify profile info and delete profile on CritiqueBrainz."
+msgstr ""
 
 #: metabrainz/payments/views.py:164
 msgid ""
@@ -228,180 +313,187 @@ msgid "Requested annual report was not found."
 msgstr "未找到所请求的年度报告。"
 
 #: frontend/js/src/forms/ProfileEdit.tsx:30
-#: frontend/js/src/forms/SignupCommercial.tsx:139
+#: frontend/js/src/forms/SignupCommercial.tsx:144
 #: frontend/js/src/forms/SignupNonCommercial.tsx:70
-#: metabrainz/supporter/forms.py:13
+#: metabrainz/supporter/forms.py:15
 msgid "Contact name is required!"
 msgstr "联系人姓名为必填项！"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:437
+#: frontend/js/src/forms/SignupCommercial.tsx:441
 #: frontend/js/src/forms/SignupNonCommercial.tsx:264
-#: metabrainz/supporter/forms.py:15
+#: metabrainz/supporter/forms.py:17
 msgid ""
 "Can you please tell us more about the project in which you'd like to use "
 "our data? Do you plan to self host the data or use our APIs?"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:137
+#: frontend/js/src/forms/SignupCommercial.tsx:142
 #: frontend/js/src/forms/SignupNonCommercial.tsx:68
-#: metabrainz/supporter/forms.py:17
+#: metabrainz/supporter/forms.py:19
 msgid "Please, tell us how you (will) use our data."
 msgstr "请告诉我们您（未来）会如何使用我们的数据。"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:138
+#: frontend/js/src/forms/SignupCommercial.tsx:143
 #: frontend/js/src/forms/SignupNonCommercial.tsx:69
-#: metabrainz/supporter/forms.py:18
+#: metabrainz/supporter/forms.py:20
 msgid "Please, limit usage description to 500 characters."
 msgstr "请将描述字段文字长度控制在500字符以内。"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:141
-#: frontend/js/src/forms/SignupCommercial.tsx:142
+#: frontend/js/src/forms/SignupCommercial.tsx:146
+#: frontend/js/src/forms/SignupCommercial.tsx:147
 #: frontend/js/src/forms/SignupNonCommercial.tsx:72
 #: frontend/js/src/forms/SignupNonCommercial.tsx:73
-#: frontend/js/src/forms/SignupUser.tsx:84
-#: frontend/js/src/forms/SignupUser.tsx:85 metabrainz/supporter/forms.py:21
-#: metabrainz/user/forms.py:38
+#: frontend/js/src/forms/SignupUser.tsx:90
+#: frontend/js/src/forms/SignupUser.tsx:91 metabrainz/supporter/forms.py:23
+#: metabrainz/user/forms.py:45
 msgid "You need to accept the agreement!"
 msgstr "请接受协议！"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:342
-#: metabrainz/supporter/forms.py:27
+#: frontend/js/src/forms/SignupCommercial.tsx:347
+#: metabrainz/supporter/forms.py:29
 msgid "Organization name"
 msgstr "机构名称"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:113
-#: metabrainz/supporter/forms.py:28
+#: frontend/js/src/forms/SignupCommercial.tsx:115
+#: metabrainz/supporter/forms.py:30
 msgid "You need to specify the name of your organization."
 msgstr "请输入您的机构名称。"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:373
-#: metabrainz/supporter/forms.py:30
+#: frontend/js/src/forms/SignupCommercial.tsx:378
+#: metabrainz/supporter/forms.py:32
 msgid "Organization description"
 msgstr "机构描述"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:116
-#: metabrainz/supporter/forms.py:31
+#: frontend/js/src/forms/SignupCommercial.tsx:118
+#: metabrainz/supporter/forms.py:33
 msgid "You need to provide description of your organization."
 msgstr "请提供您的机构描述。"
 
 #: frontend/js/src/Profile.tsx:278
-#: frontend/js/src/forms/SignupCommercial.tsx:396
-#: metabrainz/supporter/forms.py:34
+#: frontend/js/src/forms/SignupCommercial.tsx:401
+#: metabrainz/supporter/forms.py:36
 msgid "Website URL"
 msgstr "网站 URL"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:119
-#: metabrainz/supporter/forms.py:35
-msgid "You need to specify website of the organization."
-msgstr "请输入机构网站。"
+#: frontend/js/src/forms/SignupCommercial.tsx:121
+#: frontend/js/src/forms/SignupCommercial.tsx:123
+#: metabrainz/supporter/forms.py:38 metabrainz/supporter/forms.py:42
+msgid "Website URL must be a valid URL."
+msgstr ""
 
-#: metabrainz/supporter/forms.py:37
+#: metabrainz/supporter/forms.py:45
 msgid "Logo image URL"
 msgstr "Logo 图片 URL"
 
 #: frontend/js/src/Profile.tsx:284
-#: frontend/js/src/forms/SignupCommercial.tsx:418
-#: metabrainz/supporter/forms.py:38
+#: frontend/js/src/forms/SignupCommercial.tsx:422
+#: metabrainz/supporter/forms.py:46
 msgid "API URL"
 msgstr "API URL"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:457
-#: metabrainz/supporter/forms.py:40
+#: frontend/js/src/forms/SignupCommercial.tsx:461
+#: metabrainz/supporter/forms.py:48
 msgid "Street"
 msgstr "街道"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:123
-#: metabrainz/supporter/forms.py:41
+#: frontend/js/src/forms/SignupCommercial.tsx:128
+#: metabrainz/supporter/forms.py:49
 msgid "You need to specify street."
 msgstr "请输入街道！"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:465
-#: metabrainz/supporter/forms.py:43
+#: frontend/js/src/forms/SignupCommercial.tsx:469
+#: metabrainz/supporter/forms.py:51
 msgid "City"
 msgstr "城市"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:124
-#: metabrainz/supporter/forms.py:44
+#: frontend/js/src/forms/SignupCommercial.tsx:129
+#: metabrainz/supporter/forms.py:52
 msgid "You need to specify city."
 msgstr "请输入城市！"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:473
-#: metabrainz/supporter/forms.py:46
+#: frontend/js/src/forms/SignupCommercial.tsx:477
+#: metabrainz/supporter/forms.py:54
 msgid "State / Province"
 msgstr "省份"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:126
-#: metabrainz/supporter/forms.py:47
+#: frontend/js/src/forms/SignupCommercial.tsx:131
+#: metabrainz/supporter/forms.py:55
 msgid "You need to specify state/province."
 msgstr "请输入省份！"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:481
-#: metabrainz/supporter/forms.py:49
+#: frontend/js/src/forms/SignupCommercial.tsx:485
+#: metabrainz/supporter/forms.py:57
 msgid "Postcode"
 msgstr "邮政编码"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:128
-#: metabrainz/supporter/forms.py:50
+#: frontend/js/src/forms/SignupCommercial.tsx:133
+#: metabrainz/supporter/forms.py:58
 msgid "You need to specify postcode."
 msgstr "请输入邮政编码。"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:489
-#: metabrainz/supporter/forms.py:52
+#: frontend/js/src/forms/SignupCommercial.tsx:493
+#: metabrainz/supporter/forms.py:60
 msgid "Country"
 msgstr "国家"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:129
-#: metabrainz/supporter/forms.py:53
+#: frontend/js/src/forms/SignupCommercial.tsx:134
+#: metabrainz/supporter/forms.py:61
 msgid "You need to specify country."
 msgstr "请输入国家。"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:132
-#: metabrainz/supporter/forms.py:64
+#: frontend/js/src/forms/SignupCommercial.tsx:137
+#: metabrainz/supporter/forms.py:72
 #, fuzzy
 msgid ""
 "Custom amount must be more than threshold amount for selected tier or "
 "equal to it!"
 msgstr "自定义金额必须大于或等于所选等级的起点金额。"
 
-#: metabrainz/supporter/views.py:46 metabrainz/supporter/views.py:119
-#: metabrainz/supporter/views.py:220
+#: metabrainz/supporter/views.py:54
+msgid ""
+"The verification email could not be sent. Please request a new one from "
+"your profile."
+msgstr ""
+
+#: metabrainz/supporter/views.py:85 metabrainz/supporter/views.py:158
+#: metabrainz/supporter/views.py:260
 msgid "You are already a supporter."
 msgstr ""
 
-#: metabrainz/supporter/views.py:61
+#: metabrainz/supporter/views.py:100
 msgid "Can't find tier with a specified ID."
 msgstr "无法找到指定ID的等级。"
 
-#: metabrainz/supporter/views.py:127
+#: metabrainz/supporter/views.py:166
 msgid "You need to choose support tier before signing up!"
 msgstr "您需要在注册前选择支持的等级！"
 
-#: metabrainz/supporter/views.py:137
+#: metabrainz/supporter/views.py:176
 msgid "You need to choose existing tier before signing up!"
 msgstr "您需要在注册前选择当前的等级！"
 
-#: metabrainz/supporter/views.py:164
+#: metabrainz/supporter/views.py:204
 #, fuzzy
 msgid ""
 "Thanks for becoming a supporter! Your application will be reviewed soon. "
 "We will send you updates via email."
 msgstr "感谢您的注册！您的申请将很快得到审核。我们会通过电子邮件向您发送最新消息。"
 
-#: metabrainz/supporter/views.py:187
+#: metabrainz/supporter/views.py:228
 msgid ""
 "Thanks for signing up! Your application will be reviewed soon. We will "
 "send you updates via email."
 msgstr "感谢您的注册！您的申请将很快得到审核。我们会通过电子邮件向您发送最新消息。"
 
-#: metabrainz/supporter/views.py:248
+#: metabrainz/supporter/views.py:288
 msgid "Thanks for becoming a supporter!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:274
+#: metabrainz/supporter/views.py:312
 msgid "Thanks for signing up! Please check your inbox to complete verification."
 msgstr ""
 
-#: metabrainz/supporter/views.py:302
+#: metabrainz/supporter/views.py:340
 msgid "Can't generate new token unless account is active."
 msgstr "无法为不活跃的账号生成新凭据。"
 
@@ -435,7 +527,7 @@ msgstr ""
 msgid "Policies"
 msgstr ""
 
-#: metabrainz/templates/base.html:55 metabrainz/templates/index/gdpr.html:178
+#: metabrainz/templates/base.html:55
 #: metabrainz/templates/index/social-contract.html:3
 #: metabrainz/templates/index/social-contract.html:6
 #: metabrainz/templates/navbar.html:34
@@ -445,14 +537,15 @@ msgstr ""
 #: metabrainz/templates/base.html:56
 #: metabrainz/templates/index/code-of-conduct.html:3
 #: metabrainz/templates/index/code-of-conduct.html:16
-#: metabrainz/templates/index/gdpr.html:181 metabrainz/templates/navbar.html:35
+#: metabrainz/templates/navbar.html:35
 msgid "Code of Conduct"
 msgstr ""
 
+#: frontend/js/src/PrivacySummary.tsx:11
 #: frontend/js/src/forms/ConditionsModal.tsx:21
-#: metabrainz/templates/base.html:57 metabrainz/templates/index/gdpr.html:184
-#: metabrainz/templates/index/privacy.html:6
+#: metabrainz/templates/base.html:57 metabrainz/templates/index/privacy.html:6
 #: metabrainz/templates/navbar.html:36
+#: metabrainz/templates/users/privacy-summary.html:3
 msgid "Privacy Policy"
 msgstr "隐私政策"
 
@@ -486,10 +579,7 @@ msgstr "赞助商"
 msgid "Supporters"
 msgstr "支持者"
 
-#: frontend/js/src/forms/LoginUser.tsx:103
-#: frontend/js/src/forms/SignupCommercial.tsx:574
-#: frontend/js/src/forms/SignupNonCommercial.tsx:339
-#: frontend/js/src/forms/SignupUser.tsx:232 metabrainz/templates/base.html:73
+#: frontend/js/src/forms/LoginUser.tsx:103 metabrainz/templates/base.html:73
 #: metabrainz/templates/navbar.html:66 metabrainz/templates/users/login.html:3
 msgid "Sign in"
 msgstr "登录"
@@ -511,26 +601,26 @@ msgid "Contact us"
 msgstr "联系我们"
 
 #: metabrainz/templates/base.html:85
-#: metabrainz/templates/index/contact.html:105
+#: metabrainz/templates/index/contact.html:106
 msgid "Blog"
 msgstr "博客"
 
-#: metabrainz/templates/base.html:86 metabrainz/templates/index/contact.html:90
+#: metabrainz/templates/base.html:86 metabrainz/templates/index/contact.html:91
 msgid "Chat"
 msgstr ""
 
 #: metabrainz/templates/base.html:87
-#: metabrainz/templates/index/contact.html:106
+#: metabrainz/templates/index/contact.html:107
 msgid "Mastodon"
 msgstr ""
 
 #: metabrainz/templates/base.html:88
-#: metabrainz/templates/index/contact.html:107
+#: metabrainz/templates/index/contact.html:108
 msgid "Bluesky"
 msgstr ""
 
 #: metabrainz/templates/base.html:89
-#: metabrainz/templates/index/contact.html:108
+#: metabrainz/templates/index/contact.html:109
 msgid "Instagram"
 msgstr ""
 
@@ -588,15 +678,14 @@ msgstr "财务报告"
 msgid "Donate"
 msgstr "捐赠"
 
-#: frontend/js/src/forms/LoginUser.tsx:110
-#: frontend/js/src/forms/SignupCommercial.tsx:175
-#: frontend/js/src/forms/SignupCommercial.tsx:555
+#: frontend/js/src/forms/SignupCommercial.tsx:180
+#: frontend/js/src/forms/SignupCommercial.tsx:559
 #: frontend/js/src/forms/SignupNonCommercial.tsx:106
 #: frontend/js/src/forms/SignupNonCommercial.tsx:319
 #: metabrainz/templates/navbar.html:65
-#: metabrainz/templates/supporters/account-type.html:51
-#: metabrainz/templates/supporters/account-type.html:93
-#: metabrainz/templates/supporters/account-type.html:144
+#: metabrainz/templates/supporters/account-type.html:47
+#: metabrainz/templates/supporters/account-type.html:84
+#: metabrainz/templates/supporters/account-type.html:130
 #: metabrainz/templates/users/signup.html:3
 msgid "Sign up"
 msgstr "注册"
@@ -927,8 +1016,430 @@ msgstr "……或许，我们正在游说某公司去做“正确的事”……
 msgid "Introduction"
 msgstr ""
 
-#: metabrainz/templates/index/conflict-policy.html:55
+#: metabrainz/templates/index/conflict-policy.html:17
+msgid ""
+"Conflicts between people arise in open source projects constantly and the"
+" projects by the \n"
+"    MetaBrainz Foundation are no different. This policy aims to establish"
+" a clear and unambiguous \n"
+"    policy for reporting and addressing conflicts in our community. In "
+"this policy we aim to \n"
+"    establish a fair practice that balances the need for confidentiality "
+"and our desire for \n"
+"    transparency in our operations."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:25
+#, python-format
+msgid ""
+"Before you continue to read this policy, we encourage you to review our "
+"existing community policies \n"
+"    including our <a href=\"%(social_contract_url)s\">Social "
+"Contract</a>, \n"
+"    <a href=\"%(code_of_conduct_url)s\">the Code of Conduct</a>, \n"
+"    and our <a href=\"%(privacy_policy_url)s\">Privacy Policy</a>. These "
+"policies establish the norms and rules for \n"
+"    participation in our projects; these policies apply equally to the "
+"contractors of the MetaBrainz \n"
+"    Foundation and any participants in our projects."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:37
+msgid ""
+"This policy divides conflicts into two categories: Private and public. "
+"Private conflicts are conflicts \n"
+"    that involve *confidential* information regarding contributors, "
+"contractors or supporters. Otherwise, any conflicts \n"
+"    that do not involve confidential information are considered to be "
+"public conflicts. For instance, a \n"
+"    conflict between a contractor and the Executive Director (aka BDFL) "
+"that involves contractor pay is \n"
+"    considered a private conflict because pay rates are confidential "
+"information. A public conflict in edit \n"
+"    notes between two editors in our community does not involve "
+"confidential information and therefore should \n"
+"    be considered a public conflict."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:47
+msgid ""
+"When conflicts arise we aim to disclose as much information as possible "
+"about the conflict in a timely \n"
+"    fashion. When conflicts contain confidential matters we will aim to "
+"disclose as much information as \n"
+"    possible, while fully respecting the confidentiality of the people "
+"involved in the conflict. With any \n"
+"    private conflict we will aim to extract the relevant lessons for the "
+"team and community in an effort to \n"
+"    evolve our policies to prevent future conflicts. Should the involved "
+"parties disagree whether a conflict \n"
+"    is private or public, the question about the nature of the conflict "
+"will be presented for the next higher \n"
+"    level in the chain of command to decide. (e.g. if a community member "
+"and the community manager disagree on \n"
+"    a conflict being public or private, the Executive Director shall "
+"decide if the conflict is public or private)."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:58
 msgid "Reporting and Response"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:61
+msgid ""
+"We aim to not have conflict in our community, but we recognize that in "
+"reality conflicts will arise and we \n"
+"    must be prepared to address them in a fair manner. When conflicts "
+"arise, we prefer to have community or team \n"
+"    members resolve the conflicts among themselves, using our existing "
+"policies as guidelines for resolving the \n"
+"    conflict."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:69
+msgid ""
+"If you do not feel comfortable resolving a conflict on your own, you "
+"should feel free to report the conflict to \n"
+"    us. How you address the conflict depends on who is involved in the "
+"conflict and your comfort level. Please see \n"
+"    the detailed sections below on how and with whom to address your "
+"conflict. We aim to address conflicts as soon \n"
+"    as possible in an effort to prevent them from escalating "
+"unnecessarily."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:75
+msgid "Direct conflict resolution"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:78
+msgid ""
+"In direct conflict resolution, the involved parties will attempt to "
+"resolve the conflict themselves without \n"
+"   involving any MetaBrainz Foundation team member. You should aim to use"
+" direct resolution when the conflict does \n"
+"   not involve the violation of one of our policies or if the conflict is"
+" minor."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:84
+#, python-format
+msgid ""
+"For instance, if a user uses a rude tone, is disruptive or flagrantly "
+"ignores our project guidelines, we suggest \n"
+"    that you use direct conflict resolution to resolve the conflict. Some"
+" resources that might give you some suggestions \n"
+"    on how to go about resolving the conflict might be this <a "
+"href=\"%(conflict_resolution_primer_url)s\">\n"
+"    conflict resolution primer</a> and <a "
+"href=\"%(difficult_conversations_url)s\">how to\n"
+"    have difficult conversations at work</a>."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:93
+msgid "Informal reporting"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:96
+msgid ""
+"You may use informal reporting of a conflict if you aim to communicate a "
+"concern or incident without \n"
+"    seeking a corrective outcome. Informal reporting may also be an "
+"option if you have not been personally \n"
+"    victimized, but you’ve witnessed a violation of our policies or where"
+" you wish to maintain confidentiality \n"
+"    throughout the entire reporting process."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:103
+msgid ""
+"For editing in MusicBrainz you may informally report a user using the "
+"“Report this user for bad behavior” \n"
+"    link from the user’s profile. For reporting bad user behavior in "
+"other of our projects, please report them to our \n"
+"    community manager by mailing <span class=\"backemail\">gro.zniarbatem"
+"@reganam-ytinummoc</span> . For conflicts \n"
+"    that involve the community manager, report them by mailing <span "
+"class=\"backemail\">gro.zniarbatem@de</span> ."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:110
+msgid ""
+"Depending the the severity of the issue, repeated informal complaints may"
+" eventually require a formal response \n"
+"    from the MetaBrainz team. If an involved party requires anonymity, "
+"the conflict becomes a private conflict. If at \n"
+"    all possible minor issues should be resolved in a public forum in "
+"order for all people to witness and learn from \n"
+"    the issue at hand."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:116
+msgid "Formal complaint process"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:119
+msgid ""
+"All complaints about conflicts should be submitted via email. To whom a "
+"complaint should be mailed and who will \n"
+"    carry out the investigation will be described in the next section."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:124
+msgid "All complaint submissions to the Foundation should include the following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:128
+msgid ""
+"Contact info, if it is different than the email used to submit the "
+"conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:129
+msgid "Who was involved in the conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:130
+msgid "Where and when the incident happened"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:131
+msgid ""
+"A description of what happened -- ideally with links (e.g. chatlogs, edit"
+" notes) that outlines what \n"
+"         happened so that the persons evaluating the conflict may "
+"understand the issue at hand"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:133
+msgid ""
+"Any related pieces of information that provide more context on the "
+"conflict (e.g. links, screenshots)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:134
+msgid "An indication if this conflict is ongoing or not"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:139
+msgid "The investigation that follows aims to determine:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:143
+msgid "The nature and severity of the incident"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:144
+msgid ""
+"Whether or not the incident is considered a violation of MetaBrainz’ "
+"conduct policies or core values"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:145
+msgid ""
+"The amount of harm experienced by the person who submitted the complaint "
+"and the broader MetaBrainz community \n"
+"         as a result of the incident"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:147
+msgid ""
+"Whether there have been prior complaints against the individual or "
+"individuals reported"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:148
+msgid "Whether the incident is ongoing"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:152
+msgid ""
+"The following potential forms of resolution may apply to any team members"
+" involved in the conflict:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:155
+#: metabrainz/templates/index/conflict-policy.html:168
+msgid "Nothing (if it has been found no violation occurred)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:156
+msgid "Creating a plan to improve the performance"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:157
+msgid "Creating a negative performance evaluation"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:158
+msgid "Mediation, an intervention by a third party to resolve the conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:159
+msgid "Suspension or forced leave"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:160
+msgid "Termination of contract"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:164
+msgid ""
+"The following potential forms of resolution may apply to non team members"
+" involved in the conflict:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:169
+msgid "A reprimand, either public or private"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:170
+msgid "Suspension of the users’ account"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:171
+msgid "Deletion of the users’ account"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:172
+msgid ""
+"Removal of user privileges (e.g. if an auto editor commits a serious "
+"offence, they may lose their auto editor status)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:175
+msgid "Filing a complaint"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:178
+msgid ""
+"NOTE: For complaints not about MetaBrainz staff, please see the "
+"<em>Informal reporting</em> section above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:182
+msgid ""
+"If the complaint does not involve the Executive Director (ED), do the "
+"following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:186
+msgid ""
+"If team member has directly violated conduct policies or engaged in "
+"otherwise harmful behavior, a formal complaint should be filed."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:187
+msgid ""
+"Mail <span class=\"backemail\">gro.zniarbatem@de</span> and include the "
+"complaint information outlined above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:188
+msgid ""
+"You should expect a response within a working day acknowledging the "
+"complaint."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:189
+msgid ""
+"The complaint will be investigated by the ED, member(s) of the board of "
+"directors or a neutral third party."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:190
+msgid ""
+"Once the investigation has been completed, the ED, with the support of "
+"others involved in the investigation will respond. The \n"
+"        ED will respond to incidents no later than 7 working days after a"
+" complaint has been filed with either a resolution or an \n"
+"        explanation of why the process must be extended."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:196
+msgid "If a complaint involves the Executive Director, do the following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:200
+msgid ""
+"If the Executive Director has directly violated conduct policies or "
+"engaged in otherwise harmful behavior, \n"
+"        a formal complaint should be filed with the board of directors."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:202
+msgid ""
+"Mail <span class=\"backemail\">gro.zniarbatem@noituloser-tcilfnoc</span> "
+"and include the complaint information outlined above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:203
+msgid ""
+"You should get a response within 5 working days acknowledging the "
+"complaint."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:204
+msgid ""
+"The complaint will be investigated by the member(s) of the board of "
+"directors, the community manager, a neutral \n"
+"        third party or a combination thereof."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:206
+msgid ""
+"Once the investigation has been completed, the board, with the support of"
+" others involved in the investigation \n"
+"        will respond. The board will aim to respond to incidents no later"
+" than 15 working days after a complaint has been filed \n"
+"        with either a resolution or an explanation of why the process "
+"must be extended."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:211
+msgid "Confidentiality"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:214
+msgid ""
+"Confidentiality is an important aspect of conflict resolution and all of "
+"the conflicts brought to the attention of the foundation \n"
+"    will be evaluated with confidentiality in mind and acted upon "
+"accordingly."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:219
+msgid ""
+"We work hard to make all of the actions of the foundation as transparent "
+"and open as possible. In cases where we cannot \n"
+"    disclose all aspects of a conflict we will disclose that a conflict "
+"is or has occurred and we will attempt to disclose the \n"
+"    appropriate amount of information about the conflict while balancing "
+"the need for confidentiality and our desire to learn \n"
+"    from conflicts so that we as a foundation and community can learn "
+"from these conflicts and improve our policies to avoid the \n"
+"    conflicts in the future."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:227
+msgid ""
+"Any breaches of confidentiality will be treated as severe breaches of our"
+" conduct policies."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:230
+msgid "Retaliation"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:233
+msgid ""
+"We will not allow retaliation for any contractor or volunteer that files "
+"a complaint or is involved in an investigation. If you \n"
+"    believe that you are being treated negatively because of your "
+"involvement in a complaint please report this complaint directly \n"
+"    to the ED at <span class=\"backemail\">gro.zniarbatem@de</span> or "
+"the board at \n"
+"    <span class=\"backemail\">gro.zniarbatem@noituloser-tcilfnoc</span>."
 msgstr ""
 
 #: metabrainz/templates/index/contact.html:3
@@ -1023,7 +1534,7 @@ msgstr ""
 msgid ""
 "We are currently evaluating our overall online advertising strategy. We "
 "are evaluating advertising, traffic optimization,\n"
-"    search engine optimization and software monitization technologies. If"
+"    search engine optimization and software monetization technologies. If"
 " you provide these professional services, please provide a detailed\n"
 "    deck of your comprehensive services to the following email address. "
 "<em>Please respect our other non-media teams and do not contact us \n"
@@ -1098,13 +1609,11 @@ msgstr "论坛"
 #, python-format
 msgid ""
 "Please come ask your questions at our <a "
-"href=\"%(forums_url)s\">forums</a>! We would love to\n"
-"    answer any questions you may have."
+"href=\"%(forums_url)s\">forums</a>!\n"
+"    The community and the team will be more than happy to help you."
 msgstr ""
-"欢迎到我们的<a href=\"%(forums_url)s\">论坛</a>互动！\n"
-"我们将很乐意解答您的问题。"
 
-#: metabrainz/templates/index/contact.html:92
+#: metabrainz/templates/index/contact.html:93
 #, python-format
 msgid ""
 "The MetaBrainz/MusicBrainz/ListenBrainz team and community hang out\n"
@@ -1114,15 +1623,15 @@ msgid ""
 "    <a href=\"%(chatlogs_url)s\">chat log archives</a>."
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:101
+#: metabrainz/templates/index/contact.html:102
 msgid "Social media"
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:103
+#: metabrainz/templates/index/contact.html:104
 msgid "You can follow us on these social channels:"
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:112
+#: metabrainz/templates/index/contact.html:113
 msgid "Mailing address"
 msgstr "邮寄地址"
 
@@ -1135,33 +1644,349 @@ msgstr ""
 msgid "GDPR Compliance Statement"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:37
+#: metabrainz/templates/index/gdpr.html:10
+msgid ""
+"The General Data Protection Regulation is a complex EU regulation that "
+"stipulates many points for protecting private data of\n"
+"    users on the Internet. Even though this is an EU regulation, it has a"
+" worldwide impact due to the nature of the Internet.\n"
+"    The MetaBrainz Foundation with its collection of projects is also "
+"affected by this regulation. We’ve been learning and adapting\n"
+"    our sites to be compliant with the GDPR – sadly this regulation isn’t"
+" entirely black and white and there is an incredible\n"
+"    amount of room left for interpretation of these rules."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:17
+msgid ""
+"The good news is that this regulation is roughly in line with our "
+"established practices: We’ve always held private information\n"
+"    in a high regard and applied the sort of rules to ourselves as we "
+"wish to have our own private data treated. Luckily, this\n"
+"    makes our compliance effort considerably easier. We’ve made two "
+"significant changes to how we treat your data and also adopted\n"
+"    terminology as used in the GDPR in order to use the same languages "
+"that many other sites are now adopting. Please keep reading\n"
+"    to find out the exact details of what we are doing to comply."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:24
+#, python-format
+msgid ""
+"However, we do ask for your compassion and help in our process of "
+"complying with the GDPR. As we already mentioned, the GDPR is\n"
+"    a complex set of rules that are not fully clarified yet. We’ve taken "
+"action on the steps that are clear to us and we’re following\n"
+"    ongoing conversations on points that are in gray zones or unclear to "
+"us. We’ve made our best initial effort on compliance and\n"
+"    promise to keep working on it as the picture becomes more clear. If "
+"you believe that we could improve our compliance, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a> and let us know what we "
+"can do to improve. It would also help us if you\n"
+"    could provide concrete discussion or examples to help us understand "
+"and take action on your suggestion."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:33
+msgid ""
+"Finally, below are the key sections of the GDPR as we understand them and"
+" how they affect your data in our ecosystem. Where\n"
+"    possible, we provide links for deeper understanding, links for you to"
+" examine our relevant code and links to tickets to follow\n"
+"    the process of improving our compliance."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:38
 msgid "Right to be forgotten"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:77
+#: metabrainz/templates/index/gdpr.html:41
+msgid ""
+"Summary: <i>Provide the user with the ability to remove their private "
+"data from our services</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:44
+msgid ""
+"The most important aspect of the right to be forgotten is the ability to "
+"delete your account. Once you request for us to delete\n"
+"    your account, we will remove any personally identifying information "
+"you may have provided us from your account (name, email\n"
+"    address, gender, biography, URL, etc.). The visible name on your "
+"account will be changed to “Deleted User #####” and effectively\n"
+"    the account will no longer be identifiable as your account."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:50
+msgid ""
+"However, given the nature of our projects where we work on collaborative "
+"databases, your contributions that are not personally\n"
+"    identifying are valuable assets to our database and these "
+"contributions will not be removed from our databases. But we will\n"
+"    ensure that these contributions no longer contain personally "
+"identifying data."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:55
+#, python-format
+msgid ""
+"Our process of automatically deleting your accounts across the MetaBrainz"
+" ecosystem is not complete yet (see below for a set of\n"
+"    tickets where you can track our progress). If you would like to "
+"delete your accounts in the MetaBrainz ecosystem or mark a\n"
+"    donation that is currently public as a private donation, please <a "
+"href=\"%(contact_url)s\">contact us</a>\n"
+"    and we will address your request as soon as possible."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:62
+#: metabrainz/templates/index/gdpr.html:182
+msgid "Links:"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:66
+#, python-format
+msgid ""
+"<a href=\"%(editor_deletion_doc_url)s\">How we delete accounts\n"
+"       in MusicBrainz</a> (warning, geek content ahead!)"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:70
+msgid ""
+"Implement sitewide user account deletion in\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/MBS-9680\">MusicBrainz</a>,"
+"\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/AB-337\">AcousticBrainz</a>,"
+"\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/BB-260\">BookBrainz</a>,\n"
+"         <a href=\"https://tickets.metabrainz.org/browse/MEB-103\">the "
+"MetaBrainz Site</a>,\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/LB-354\">ListenBrainz</a>, "
+"and\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/CB-307\">CritiqueBrainz</a>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:80
 msgid "Restriction of processing"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:110
+#: metabrainz/templates/index/gdpr.html:83
+msgid ""
+"Summary: <i>To allow the user to control how their personally identifying"
+" data is being used.</i>"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:86
+msgid ""
+"Except for the ListenBrainz and AcousticBrainz projects, we do not "
+"process personally identifying data. Any personally\n"
+"    identifying data that our projects store is for the purpose of being "
+"able to contact you about your contributions to our database\n"
+"    (email address) or for voluntarily showing information about you to "
+"other users (biography, homepage, location, etc)."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:91
+#, python-format
+msgid ""
+"The ListenBrainz project differs in that the Listens (metadata about what"
+" music you have listened to) are stored on our servers\n"
+"    and <a href=\"%(listenbrainz_data_url)s\">made available to the "
+"public</a>. We believe Listens to be personally identifying\n"
+"    data and furthermore, we have goals of creating open source "
+"recommendation engines with this data, which involves processing the\n"
+"    user’s data. These two points are fundamental goals of the "
+"ListenBrainz project and we do not see a reasonable way to reach another"
+"\n"
+"    compromise position."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:99
+msgid ""
+"Because of this, we are going to require users to either acknowledge that"
+" we may process their Listen data or alternatively to\n"
+"    delete their account, including all of their Listens. Please note "
+"that if you decide to delete your ListenBrainz account, it may\n"
+"    take up to two weeks for all of your listens to no longer be included"
+" in our efforts to build a recommendation engine."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:104
+msgid ""
+"We have always made it clear that the data in ListenBrainz was to be "
+"public and that we plan to build new tools with your data, so\n"
+"    this should not come as a surprise to our users."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:108
+msgid ""
+"The AcousticBrainz project does not track who submits data to the "
+"database. If you create an account and use our data creation\n"
+"    tools (e.g. create a dataset or participate in a challenge) then we "
+"link your participation and the things that you create to\n"
+"    your account. If you choose to delete your account then we keep the "
+"non personally identifying data that you create, but anonymize\n"
+"    it so that it cannot be linked back to you."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:114
 msgid "Right to data portability / exporting your data"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:150
+#: metabrainz/templates/index/gdpr.html:117
+msgid ""
+"Summary: <i>You have the right to access/download the data we store about"
+" you</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:120
+msgid ""
+"Except for the ListenBrainz and AcousticBrainz projects, we do not store "
+"personally identifying data beyond the\n"
+"    information that is available in your public profile on each of our "
+"projects. Since this data is plainly available in your\n"
+"    profile we do not provide a means for you to export this data."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:125
+msgid "There are the following exceptions to this:"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:129
+msgid ""
+"<b>IP addresses</b>: If you visit one of our sites the IP address of your"
+" computer is stored in our web logs for 7 days\n"
+"        before our servers automatically delete them. This data is almost"
+" never used by anyone: the only time we look at the\n"
+"        IP addresses is if our sites are adversely impacted by the "
+"actions of some unknown users. In that case, we may investigate\n"
+"        the logs to identify the IP address that needs to be blocked in "
+"order to restore the stability of our service.\n"
+"        This data is not available to anyone but the contractors of the "
+"MetaBrainz Foundation and is not available to download\n"
+"        to anyone at all."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:137
+#, python-format
+msgid ""
+"<b>ListenBrainz Listen data</b>: Users may <a "
+"href=\"%(listenbrainz_export_url)s\">export their ListenBrainz Listen\n"
+"        data</a> directly from the site. The user Listen data is also "
+"included in the <a href=\"%(listenbrainz_data_url)s\">ListenBrainz\n"
+"        data dumps</a> that are available for public download."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:146
+msgid ""
+"All of the non personally identifying data, such as your metadata "
+"contributions, are publicly visible, available for download\n"
+"    and available via the project APIs. For details about this data, "
+"downloads and APIs please check the documentation for the\n"
+"    respective projects you are interested in."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:151
+#, python-format
+msgid ""
+"Anyone wishing to get a list of financial donations they have made to the"
+" MetaBrainz Foundation, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a> and provide your "
+"MusicBrainz editor name so that we can look up\n"
+"    your donations."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:157
 msgid "Right to rectification"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:165
+#: metabrainz/templates/index/gdpr.html:160
+msgid "Summary: <i>You have the right to correct your data</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:163
+msgid ""
+"All of our projects allow their users to update their personally "
+"identifying information in their profiles. Furthermore, most\n"
+"    of our projects allow the editing of their own metadata "
+"contributions. If you find that some of your data is incorrect, please\n"
+"    feel free to edit the data since we provide the tools to do so."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:168
+#, python-format
+msgid ""
+"If anyone who has made a financial donation to the MetaBrainz Foundation "
+"would like to make their donation private, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:173
 msgid "Right to be informed"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:188
+#: metabrainz/templates/index/gdpr.html:175
+msgid ""
+"Summary: <i>You have the right to be informed about how we use your data "
+"in plain English</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:178
+msgid ""
+"Our privacy policy, as well as other policies, have always been written "
+"by humans for human consumption. We abhor legalese and\n"
+"    not speaking in direct terms."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:186
+msgid "Social contract"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:189
+msgid "Code of conduct"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:192
+msgid "Privacy policy"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:196
 msgid "Right to access"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:198
-#: metabrainz/templates/index/privacy.html:166
+#: metabrainz/templates/index/gdpr.html:199
+msgid ""
+"Summary: <i>You have the right to access the data that we collect about "
+"you</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:202
+msgid ""
+"All of our projects make all of the data we collect on your behalf, "
+"privately identifying or not, available to you. The\n"
+"    only exception to this are the IP addresses we store for 7 days – see"
+" above for details."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:206
+#: metabrainz/templates/index/privacy.html:168
 msgid "Privacy/GDPR Representative"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:209
+#, python-format
+msgid ""
+"If you have any questions about our privacy policy, please <a "
+"href=\"%(contact_url)s\">contact us</a>. To report\n"
+"   any privacy problems, violations or leaks, our GDPR representative is "
+"our Interim Executive Director Nicolás Tamargo and for\n"
+"   privacy issues contact him at <strong><a "
+"href=\"mailto:gdpr@metabrainz.org\">gdpr@metabrainz.org</a></strong>."
 msgstr ""
 
 #: metabrainz/templates/index/index.html:6
@@ -1274,7 +2099,7 @@ msgid ""
 "      <a href=\"%(about_url)s\">about</a> page."
 msgstr ""
 
-#: frontend/js/src/forms/ConditionsModal.tsx:43
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:32
 #: metabrainz/templates/index/privacy.html:3
 msgid "Privacy"
 msgstr "隐私"
@@ -1282,6 +2107,44 @@ msgstr "隐私"
 #: metabrainz/templates/index/privacy.html:8
 msgid "Summary"
 msgstr "概要"
+
+#: metabrainz/templates/index/privacy.html:12
+msgid ""
+"You do not have to provide any personal data to be able to browse the "
+"contents of the databases published by MetaBrainz."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:15
+msgid ""
+"You do not have to provide any personally-identifying information if you "
+"choose not to."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:18
+msgid ""
+"We will never reveal your email address on MetaBrainz controlled web "
+"sites."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:22
+msgid ""
+"In order to get maximum value out of the MetaBrainz projects, you may "
+"want to create an account and log in. \n"
+"    Doing so grants you the ability to: edit the databases, contribute "
+"your own data, communicate with other users, and keep track \n"
+"    of recently released music from artists in your MusicBrainz "
+"collection. If you choose to create an account then the minimum we \n"
+"    ask is that you: choose a unique username and password, use a web "
+"browser that accepts \"session\" cookies, and provide a verified \n"
+"    email address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:29
+msgid ""
+"If you do not create an account (or are not logged in) you will not have "
+"access to the above listed features, however, you will \n"
+"    still have full access to browse and examine the databases."
+msgstr ""
 
 #: metabrainz/templates/index/privacy.html:33
 msgid "Applicable to all users"
@@ -1291,39 +2154,197 @@ msgstr ""
 msgid "Cookies"
 msgstr ""
 
+#: metabrainz/templates/index/privacy.html:37
+msgid "We use two cookies that contain sensitive information:"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:42
+msgid ""
+"<b>remember_login</b>: If you choose the \"Log in permanently\" option "
+"when logging in to one of our sites; the cookie will be used to \n"
+"      remember your login details."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:46
+msgid ""
+"<b>musicbrainz_server_session, session, or connect.sid</b>: If you are "
+"logged into one of our sites, your current session ID is stored in this "
+"cookie."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:51
+msgid ""
+"We may store dynamic preference information in other cookies, but these "
+"do not contain any sensitive information."
+msgstr ""
+
 #: metabrainz/templates/index/privacy.html:54
 msgid "Web and FTP access logs"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:57
+msgid ""
+"In a practice similar to other web sites (and APIs) we keep logs of all "
+"web requests made against our servers. These logs include: your IP\n"
+"    address, your browser's (or API client's) \"User-Agent\" string, and "
+"which page (or API endpoint) you requested with which parameters. "
+"Aggregate information about web and FTP traffic is\n"
+"    made available to the public via our site usage pages."
 msgstr ""
 
 #: metabrainz/templates/index/privacy.html:62
 msgid "Third-Party content"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:92
+#: metabrainz/templates/index/privacy.html:64
+msgid ""
+"Our projects' web pages may load some third-party content. Some, but "
+"possibly not all sites are listed below:"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:69
+#, python-format
+msgid ""
+"Cover art and other images: These are provided by the various cover art "
+"sites that have given MusicBrainz permission to do so and our own \n"
+"      <a href=\"%(caa_url)s\">Cover Art Archive</a>. This means that the "
+"relevant site will know (if they want to) your IP \n"
+"      address, User-Agent string, etc., and which MusicBrainz web page "
+"you were visiting (the one which included the cover art image)."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:75
+msgid ""
+"AcoustID: Our fingerprints tab loads fingerprint information from "
+"acoustid.org."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:78
+msgid ""
+"MTCaptcha: Our account creation page loads third party content in order "
+"to prevent spammers from creating accounts."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:83
+msgid ""
+"<i>The above information assumes that you are using \"normal\" web "
+"browser settings, whereby images are always loaded and HTTP referrer \n"
+"    information is always sent.</i>"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:88
+msgid ""
+"It is impractical to constantly modify this privacy policy when "
+"MetaBrainz projects change which third party content they utilize. We "
+"will \n"
+"    aim to use common sense, respect to our community and community "
+"review when adding more content from third party sites. We will also \n"
+"    periodically review our policy to ensure that it remains current."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:93
 msgid "Applicable to account holders"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:94
+#: metabrainz/templates/index/privacy.html:95
 msgid "Account creation"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:108
+#: metabrainz/templates/index/privacy.html:97
+msgid ""
+"When creating an account with a MetaBrainz project you need to pick a "
+"unique username and choose a password, the username you pick is the \n"
+"    only name associated with your account and will be what other "
+"MetaBrainz users know you as. You may optionally also tell us other \n"
+"    information about yourself that will be displayed to other MetaBrainz"
+" users and the public."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:103
+msgid ""
+"Additionally, in order to edit the databases you will need to provide a "
+"confirmed email address. This email address will be held in \n"
+"    confidence, the only method of revealing your email address to "
+"another user is if you choose to send a message to another \n"
+"    user and enable the option to \"reveal my email address\". Changing "
+"the email address stored with your account will require you to \n"
+"    verify the new address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:109
 msgid "Edits and Notes"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:114
+#: metabrainz/templates/index/privacy.html:111
+msgid ""
+"If you make any changes to a MetaBrainz project database, such as adding "
+"any data, the details of those changes will be visible to \n"
+"    other logged-in users and the change will be associated with your "
+"username."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:115
 msgid "Subscriptions on MusicBrainz"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:131
+#: metabrainz/templates/index/privacy.html:117
+msgid ""
+"As a logged-in user you can subscribe to one or more artists, labels, "
+"collections or other editors. The act of subscribing causes \n"
+"    any edits made to (or by in the case of another editor) those "
+"entities to be emailed to you. By default, other users can see your \n"
+"    list of subscriptions, however, you can opt out of this by editing "
+"the appropriate preference."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:123
+msgid ""
+"This does not provide \"perfect\" privacy though, in some cases it will "
+"be possible to infer information about the contents of your \n"
+"    subscription list even though you have disallowed others from viewing"
+" that list directly. This imperfection arises because various \n"
+"    parts of the system behave differently depending on whether or not an"
+" entity has any subscribers; also, the number of users \n"
+"    subscribed to each artist is available via the artist pages. In the "
+"most extreme (possibly contrived) example, imagine that all \n"
+"    users have their subscriptions set to \"public\", except for exactly "
+"one user whose list is \"private\". In that case, any discrepancy \n"
+"    for a given artist between the shown list of subscribers and the "
+"total number of subscribers must be down to that one user. Thus, \n"
+"    you can infer what artists are on that user's list."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:132
 msgid "Third-party sites"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:145
+#: metabrainz/templates/index/privacy.html:134
+#, python-format
+msgid ""
+"Our code reviews are done on GitHub, which is not under the control of "
+"MetaBrainz. Participating in code reviews or other\n"
+"    tasks carried out on GitHub are subject to <a "
+"href=\"%(github_url)s\">GitHub's privacy policy</a>."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:140
+#, python-format
+msgid ""
+"Our translations platform is provided and hosted by Weblate, which has a "
+"data processing agreement with MetaBrainz.\n"
+"    Participating in translations is subject to <a "
+"href=\"%(weblate_url)s\">dedicated legal terms</a>.\n"
+"    Any translations you make will be submitted to our Git repositories "
+"and publicly associated with your username;\n"
+"    if you so choose, you can also publicly associate them with your own "
+"verified email address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:147
 msgid "MetaBrainz donors"
 msgstr "MetaBrainz 捐赠者"
 
-#: metabrainz/templates/index/privacy.html:147
+#: metabrainz/templates/index/privacy.html:149
 msgid ""
 "When you make a donation to the MetaBrainz Foundation, we are legally\n"
 "    required to collect your personal information and keep it in our "
@@ -1333,7 +2354,7 @@ msgid ""
 "    information to anyone else, ever."
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:153
+#: metabrainz/templates/index/privacy.html:155
 msgid ""
 "We believe in transparent finances, which means that we list all "
 "donations\n"
@@ -1343,11 +2364,34 @@ msgid ""
 "process."
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:158
+#: metabrainz/templates/index/privacy.html:160
 msgid "Exceptions"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:598
+#: metabrainz/templates/index/privacy.html:162
+msgid ""
+"<i><b>Please note</b>: Reasonable exceptions may apply to the above "
+"policy, for example to comply with applicable laws.\n"
+"    Also, members of the MetaBrainz team and other personnel contracted "
+"to provide services to MetaBrainz may have access to\n"
+"    our infrastructure and could therefore view any information contained"
+" therein. However all personnel are contractually bound\n"
+"    by non-disclosure clauses which prevent them from making any such "
+"information available to others."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:171
+#, python-format
+msgid ""
+"If you have any questions about our GDPR statement, please <a "
+"href=\"%(contact_url)s\">contact us</a>. To report\n"
+"   any privacy problems, violations or leaks, our GDPR representative is "
+"our Interim Executive Director Nicolás Tamargo and for\n"
+"   privacy issues contact him at <strong><a "
+"href=\"mailto:gdpr@metabrainz.org\">gdpr@metabrainz.org</a></strong>."
+msgstr ""
+
+#: frontend/js/src/Profile.tsx:603
 #: frontend/js/src/forms/ProfileChangePassword.tsx:22
 #: frontend/js/src/forms/ProfileChangePassword.tsx:111
 #: metabrainz/templates/index/profile-change-password.html:3
@@ -1592,6 +2636,11 @@ msgstr ""
 
 #: metabrainz/templates/index/team.html:26
 msgid "He lives on in our hearts and in open source."
+msgstr ""
+
+#: metabrainz/templates/index/team.html:29
+#: metabrainz/templates/index/team.html:315
+msgid "you’re welcome to try"
 msgstr ""
 
 #: metabrainz/templates/index/team.html:39
@@ -2091,8 +3140,10 @@ msgstr "美国支票"
 
 #: metabrainz/templates/payments/donate.html:146
 msgid ""
-"Due to the increased unreliability of the US Postal Service we have "
-"stopped accepting paper checks. Sorry!"
+"Due to the increased unreliability of the US Postal Service and the "
+"relatively large fees involved, we ask you to only send a paper check if "
+"it is the only possible option. Due to the fees, we will not cash checks "
+"for less than $25."
 msgstr ""
 
 #: metabrainz/templates/payments/donate.html:241
@@ -2980,8 +4031,8 @@ msgid "Monthly balance sheets"
 msgstr "月度资产负债表"
 
 #: frontend/js/src/Profile.tsx:520
-#: frontend/js/src/forms/SignupCommercial.tsx:175
-#: frontend/js/src/forms/SignupCommercial.tsx:554
+#: frontend/js/src/forms/SignupCommercial.tsx:180
+#: frontend/js/src/forms/SignupCommercial.tsx:558
 #: frontend/js/src/forms/SignupNonCommercial.tsx:106
 #: frontend/js/src/forms/SignupNonCommercial.tsx:318
 #: metabrainz/templates/supporters/account-type.html:3
@@ -3002,6 +4053,7 @@ msgid "Non-commercial / Personal"
 msgstr "非商业 / 个人"
 
 #: frontend/js/src/Profile.tsx:235
+#: frontend/js/src/forms/SignupNonCommercial.tsx:107
 #: frontend/js/src/forms/SignupNonCommercial.tsx:151
 #: metabrainz/templates/supporters/account-type.html:42
 msgid "Non-commercial"
@@ -3015,57 +4067,46 @@ msgstr ""
 msgid "Personal or university assignment user."
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:48
-#: metabrainz/templates/supporters/account-type.html:90
-#: metabrainz/templates/supporters/account-type.html:141
-msgid "Upgrade"
-msgstr ""
-
 #: frontend/js/src/Profile.tsx:235
-#: frontend/js/src/forms/SignupCommercial.tsx:176
-#: frontend/js/src/forms/SignupCommercial.tsx:228
-#: metabrainz/templates/supporters/account-type.html:61
+#: frontend/js/src/forms/SignupCommercial.tsx:181
+#: frontend/js/src/forms/SignupCommercial.tsx:233
+#: metabrainz/templates/supporters/account-type.html:56
 msgid "Commercial"
 msgstr "商业"
 
-#: metabrainz/templates/supporters/account-type.html:83
-#: metabrainz/templates/supporters/account-type.html:135
+#: metabrainz/templates/supporters/account-type.html:78
+#: metabrainz/templates/supporters/account-type.html:125
 #, python-format
 msgid "$%(tier_price)s/month and up"
 msgstr "$%(tier_price)s及以上/月"
 
-#: metabrainz/templates/supporters/account-type.html:87
-#: metabrainz/templates/supporters/account-type.html:138
+#: metabrainz/templates/supporters/account-type.html:82
+#: metabrainz/templates/supporters/account-type.html:128
 msgid "More info"
 msgstr "更多信息"
 
-#: metabrainz/templates/supporters/account-type.html:104
+#: metabrainz/templates/supporters/account-type.html:94
 msgid "View all tiers"
 msgstr "显示所有等级"
 
-#: metabrainz/templates/supporters/account-type.html:112
+#: metabrainz/templates/supporters/account-type.html:102
 msgid "Some of our Unicorn members"
 msgstr "我们的部分独角兽成员"
 
-#: metabrainz/templates/supporters/account-type.html:123
+#: metabrainz/templates/supporters/account-type.html:113
 msgid "See all our supporters"
 msgstr "查看我们的所有支持者"
 
-#: metabrainz/templates/supporters/account-type.html:151
+#: metabrainz/templates/supporters/account-type.html:136
 msgid "View featured tiers"
 msgstr "显示特色等级"
 
-#: metabrainz/templates/supporters/account-type.html:158
+#: metabrainz/templates/supporters/account-type.html:143
 #, python-format
 msgid ""
 "If you are not sure which tier to pick, please\n"
 "      <a href=\"%(contact_url)s\">contact us</a>."
 msgstr "如果您不确定应该选择那一等级，请<a href=\"%(contact_url)s\">联系我们</a>"
-
-#: metabrainz/templates/supporters/account-type.html:166
-#, fuzzy
-msgid "Back to Profile"
-msgstr "您的资料"
 
 #: metabrainz/templates/supporters/bad-standing.html:3
 #: metabrainz/templates/supporters/bad-standing.html:6
@@ -3128,9 +4169,9 @@ msgid "Forgot your username"
 msgstr ""
 
 #: frontend/js/src/forms/ResetPassword.tsx:79
-#: frontend/js/src/forms/SignupCommercial.tsx:320
+#: frontend/js/src/forms/SignupCommercial.tsx:325
 #: frontend/js/src/forms/SignupNonCommercial.tsx:227
-#: frontend/js/src/forms/SignupUser.tsx:169
+#: frontend/js/src/forms/SignupUser.tsx:175
 #: metabrainz/templates/users/reauthenticate.html:3
 #: metabrainz/templates/users/reauthenticate.html:6
 msgid "Confirm Password"
@@ -3140,17 +4181,22 @@ msgstr ""
 msgid "Please re-enter your password to continue."
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:108
+#: frontend/js/src/ProfileDelete.tsx:110
 #: frontend/js/src/forms/DeleteApplication.tsx:53
 #: frontend/js/src/forms/OAuthPrompt.tsx:54
 #: frontend/js/src/forms/ProfileChangePassword.tsx:104
 #: frontend/js/src/forms/ProfileEdit.tsx:105
-#: metabrainz/templates/users/reauthenticate.html:23
+#: metabrainz/templates/users/reauthenticate.html:28
 msgid "Cancel"
 msgstr ""
 
-#: metabrainz/templates/users/reauthenticate.html:24
+#: metabrainz/templates/users/reauthenticate.html:29
 msgid "Continue"
+msgstr ""
+
+#: frontend/js/src/forms/utils.tsx:202
+#: metabrainz/templates/users/reauthenticate.html:40
+msgid "Password must not exceed 72 bytes."
 msgstr ""
 
 #: frontend/js/src/forms/ResetPassword.tsx:27
@@ -3158,38 +4204,38 @@ msgstr ""
 msgid "Reset your password"
 msgstr ""
 
-#: frontend/js/src/hooks/useEmailValidation.ts:41 metabrainz/user/forms.py:15
+#: frontend/js/src/hooks/useEmailValidation.ts:41 metabrainz/user/forms.py:16
 msgid "Registration from this email domain is not allowed."
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:50
 #: frontend/js/src/forms/LostPassword.tsx:45
-#: frontend/js/src/forms/SignupCommercial.tsx:270
+#: frontend/js/src/forms/SignupCommercial.tsx:275
 #: frontend/js/src/forms/SignupNonCommercial.tsx:175
-#: frontend/js/src/forms/SignupUser.tsx:114 metabrainz/user/forms.py:20
-#: metabrainz/user/forms.py:45 metabrainz/user/forms.py:62
+#: frontend/js/src/forms/SignupUser.tsx:120 metabrainz/user/forms.py:22
+#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:75
 msgid "Username"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:42
 #: frontend/js/src/forms/LostPassword.tsx:37
-#: frontend/js/src/forms/SignupCommercial.tsx:153
+#: frontend/js/src/forms/SignupCommercial.tsx:158
 #: frontend/js/src/forms/SignupNonCommercial.tsx:84
-#: frontend/js/src/forms/SignupUser.tsx:67 metabrainz/user/forms.py:21
-#: metabrainz/user/forms.py:45 metabrainz/user/forms.py:62
+#: frontend/js/src/forms/SignupUser.tsx:73 metabrainz/user/forms.py:26
+#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:75
 msgid "Username is required!"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:63
 #: frontend/js/src/forms/ResetPassword.tsx:72
-#: frontend/js/src/forms/SignupCommercial.tsx:308
+#: frontend/js/src/forms/SignupCommercial.tsx:313
 #: frontend/js/src/forms/SignupNonCommercial.tsx:214
-#: frontend/js/src/forms/SignupUser.tsx:157 metabrainz/user/forms.py:46
-#: metabrainz/user/forms.py:52
+#: frontend/js/src/forms/SignupUser.tsx:163 metabrainz/user/forms.py:53
+#: metabrainz/user/forms.py:62
 msgid "Password"
 msgstr ""
 
-#: frontend/js/src/forms/LoginUser.tsx:76 metabrainz/user/forms.py:47
+#: frontend/js/src/forms/LoginUser.tsx:76 metabrainz/user/forms.py:57
 msgid "Remember me"
 msgstr ""
 
@@ -3201,11 +4247,11 @@ msgstr ""
 msgid "Username contains invalid or invisible characters."
 msgstr ""
 
-#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:181
+#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:220
 msgid "Hide password"
 msgstr ""
 
-#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:181
+#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:220
 msgid "Show password"
 msgstr ""
 
@@ -3264,11 +4310,11 @@ msgstr ""
 msgid "Revoke access"
 msgstr ""
 
-#: frontend/js/src/OAuthError.tsx:17
+#: frontend/js/src/OAuthError.tsx:18
 msgid "OAuth2 Error"
 msgstr ""
 
-#: frontend/js/src/OAuthError.tsx:18
+#: frontend/js/src/OAuthError.tsx:19
 msgid "An error occurred during OAuth authentication process."
 msgstr ""
 
@@ -3298,8 +4344,8 @@ msgstr ""
 
 #: frontend/js/src/Profile.tsx:109
 msgid ""
-"Are you sure you want to generate new access token? Current token will be"
-" revoked!"
+"Are you sure you want to generate a new access token? The current token "
+"will be revoked!"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:118
@@ -3415,8 +4461,8 @@ msgid "Contact Information"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:310 frontend/js/src/forms/ProfileEdit.tsx:70
-#: frontend/js/src/forms/SignupCommercial.tsx:284
-#: frontend/js/src/forms/SignupCommercial.tsx:333
+#: frontend/js/src/forms/SignupCommercial.tsx:289
+#: frontend/js/src/forms/SignupCommercial.tsx:338
 #: frontend/js/src/forms/SignupNonCommercial.tsx:189
 #: frontend/js/src/forms/SignupNonCommercial.tsx:241
 msgid "Contact name"
@@ -3532,7 +4578,7 @@ msgstr ""
 msgid "Once you delete your account, there is no going back. Please be certain."
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:550 frontend/js/src/ProfileDelete.tsx:105
+#: frontend/js/src/Profile.tsx:550 frontend/js/src/ProfileDelete.tsx:107
 msgid "Delete My Account"
 msgstr ""
 
@@ -3544,39 +4590,39 @@ msgstr ""
 msgid "Need to delete your account?"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:574
+#: frontend/js/src/Profile.tsx:575
 msgid ""
 "Deletion of supporter accounts requires manual review. Please contact us "
-"at"
+"at <email />."
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:594
+#: frontend/js/src/Profile.tsx:599
 msgid "Security"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:626
+#: frontend/js/src/Profile.tsx:631
 msgid "MetaBrainz Applications"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:630
+#: frontend/js/src/Profile.tsx:635
 msgid ""
 "With your MetaBrainz account, you can access every project in the "
 "MetaBrainz family:"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:643
+#: frontend/js/src/Profile.tsx:648
 msgid "The open-source music encyclopedia"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:655
+#: frontend/js/src/Profile.tsx:660
 msgid "Track, visualise and share the music you listen to"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:667
+#: frontend/js/src/Profile.tsx:672
 msgid "The open-source book database"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:679
+#: frontend/js/src/Profile.tsx:684
 msgid "Creative Commons licensed reviews"
 msgstr ""
 
@@ -3599,7 +4645,7 @@ msgid "Permanently remove all your account information"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:64
-msgid "Revoke all your API tokens and access"
+msgid "Revoke all your tokens and access to the replication API"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:65
@@ -3611,14 +4657,16 @@ msgid "Log you out of all MetaBrainz services"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:70
-msgid "Your username will be reserved and cannot be reused."
+msgid ""
+"Your username will be reserved and cannot be reused without the "
+"intervention of an administrator."
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:82
+#: frontend/js/src/ProfileDelete.tsx:84
 msgid "To confirm, type your username '<username />' below:"
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:105
+#: frontend/js/src/ProfileDelete.tsx:107
 msgid "Deleting..."
 msgstr ""
 
@@ -3631,64 +4679,7 @@ msgstr "您的资料"
 msgid "Close"
 msgstr ""
 
-#: frontend/js/src/forms/ConditionsModal.tsx:23
-msgid "Licensing"
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:25
-msgid ""
-"Any contributions you make to any MetaBrainz service will be released "
-"into the Public Domain and/or licensed under a Creative Commons by-nc-sa "
-"license. Furthermore, you give the MetaBrainz Foundation the right to "
-"license this data for commercial use."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:30
-msgid "Please read our <licenseLink>license page</licenseLink> for more details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:45
-msgid ""
-"MetaBrainz strongly believes in the privacy of its users. Any personal "
-"information you choose to provide will not be sold or shared with anyone "
-"else."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:50
-msgid ""
-"Please read our <privacyLink>privacy policy</privacyLink> for more "
-"details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:59
-msgid "GDPR compliance"
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:61
-msgid ""
-"You may remove your personal information from our services anytime by "
-"deleting your account."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:66
-msgid ""
-"Please read our <gdprLink>GDPR compliance statement</gdprLink> for more "
-"details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:78
-msgid ""
-"Creating an account on MetaBrainz will give you access to all of our "
-"projects, such as MusicBrainz, ListenBrainz, BookBrainz, and more."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:82
-msgid ""
-"We create a placeholder account for all the MetaBrainz projects when you "
-"sign up, and you are one log-in away from activating them."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:91
+#: frontend/js/src/forms/ConditionsModal.tsx:29
 msgid "Sounds good"
 msgstr ""
 
@@ -3777,8 +4768,8 @@ msgstr ""
 msgid "Forgot your password?"
 msgstr ""
 
-#: frontend/js/src/forms/LoginUser.tsx:109
-msgid "Don't have an account?"
+#: frontend/js/src/forms/LoginUser.tsx:110
+msgid "Don't have an account? <signupLink>Sign up</signupLink>"
 msgstr ""
 
 #: frontend/js/src/forms/LostPassword.tsx:38
@@ -3809,15 +4800,72 @@ msgstr ""
 msgid "Allow access"
 msgstr "允许访问"
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:71
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:10
+msgid "Licensing"
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:12
+msgid ""
+"Any contributions you make to any MetaBrainz service will be released "
+"into the Public Domain and/or licensed under a Creative Commons by-nc-sa "
+"license. Furthermore, you give the MetaBrainz Foundation the right to "
+"license this data for commercial use."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:17
+msgid "Please read our <licenseLink>license page</licenseLink> for more details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:34
+msgid ""
+"MetaBrainz strongly believes in the privacy of its users. Any personal "
+"information you choose to provide will not be sold or shared with anyone "
+"else."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:39
+msgid ""
+"Please read our <privacyLink>privacy policy</privacyLink> for more "
+"details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:50
+msgid "GDPR compliance"
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:52
+msgid ""
+"You may remove your personal information from our services anytime by "
+"deleting your account."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:57
+msgid ""
+"Please read our <gdprLink>GDPR compliance statement</gdprLink> for more "
+"details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:71
+msgid ""
+"Creating an account on MetaBrainz will give you access to all of our "
+"projects, such as MusicBrainz, ListenBrainz, BookBrainz, and more."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:75
+msgid ""
+"We create a placeholder account for all the MetaBrainz projects when you "
+"sign up, and you are one log-in away from activating them."
+msgstr ""
+
+#: frontend/js/src/forms/ProfileChangePassword.tsx:70
 msgid "Current Password"
 msgstr ""
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:80
+#: frontend/js/src/forms/ProfileChangePassword.tsx:79
 msgid "New Password"
 msgstr ""
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:89
+#: frontend/js/src/forms/ProfileChangePassword.tsx:88
 msgid "Confirm New Password"
 msgstr ""
 
@@ -3829,196 +4877,185 @@ msgstr ""
 msgid "Reset Password"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:38
-msgid "If you would like to support us with more than $"
+#: frontend/js/src/forms/SignupCommercial.tsx:40
+msgid ""
+"If you would like to support us with more than ${{minPledge}}, please "
+"enter the actual amount here:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:39
-msgid ", please enter the actual amount here:"
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:144
+#: frontend/js/src/forms/SignupCommercial.tsx:149
 #: frontend/js/src/forms/SignupNonCommercial.tsx:75
-#: frontend/js/src/forms/SignupUser.tsx:87
+#: frontend/js/src/forms/SignupUser.tsx:93
 msgid "Captcha is required!"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:179
+#: frontend/js/src/forms/SignupCommercial.tsx:184
 #: frontend/js/src/forms/SignupNonCommercial.tsx:110
 #: frontend/js/src/forms/SignupUser.tsx:46
 #, fuzzy
 msgid "Access all MetaBrainz projects"
 msgstr "MetaBrainz 项目"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:182
+#: frontend/js/src/forms/SignupCommercial.tsx:187
 msgid "Note:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:184
+#: frontend/js/src/forms/SignupCommercial.tsx:189
 msgid ""
 "Signing up for any tier other than the <italic>Stealth startup</italic> "
 "tier will publicly list your company on this web site. However, we will "
 "not publish any of your private details."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:221
+#: frontend/js/src/forms/SignupCommercial.tsx:226
 #: frontend/js/src/forms/SignupNonCommercial.tsx:145
 #, fuzzy
 msgid "Account type"
 msgstr "账号类型"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:234
+#: frontend/js/src/forms/SignupCommercial.tsx:239
 msgid "Selected tier"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:242
-msgid "month and up"
+#: frontend/js/src/forms/SignupCommercial.tsx:247
+msgid "${{tierPrice}}/month and up"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:250
+#: frontend/js/src/forms/SignupCommercial.tsx:255
 msgid "Change account type or tier"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:261
+#: frontend/js/src/forms/SignupCommercial.tsx:266
 #: frontend/js/src/forms/SignupNonCommercial.tsx:166
 msgid "Your account:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:271
+#: frontend/js/src/forms/SignupCommercial.tsx:276
 #: frontend/js/src/forms/SignupNonCommercial.tsx:176
-#: frontend/js/src/forms/SignupUser.tsx:114
+#: frontend/js/src/forms/SignupUser.tsx:120
 msgid "(public)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:291
+#: frontend/js/src/forms/SignupCommercial.tsx:296
 #: frontend/js/src/forms/SignupNonCommercial.tsx:196
-#: frontend/js/src/forms/SignupUser.tsx:127
+#: frontend/js/src/forms/SignupUser.tsx:133
 msgid "E-mail address"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:295
+#: frontend/js/src/forms/SignupCommercial.tsx:300
 #: frontend/js/src/forms/SignupNonCommercial.tsx:200
-#: frontend/js/src/forms/SignupUser.tsx:131
+#: frontend/js/src/forms/SignupUser.tsx:137
 msgid "(checking...)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:314
+#: frontend/js/src/forms/SignupCommercial.tsx:319
 #: frontend/js/src/forms/SignupNonCommercial.tsx:220
-#: frontend/js/src/forms/SignupUser.tsx:163
+#: frontend/js/src/forms/SignupUser.tsx:169
 msgid "Must be at least 8 characters"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:348
+#: frontend/js/src/forms/SignupCommercial.tsx:353
 msgid ""
 "If you don't have an organization name, you probably want to become a "
 "supporter as a <nonCommercialLink>Non-commercial / "
 "Personal</nonCommercialLink> supporter."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:358
+#: frontend/js/src/forms/SignupCommercial.tsx:363
 msgid ""
 "If you don't have an organization name, you probably want to sign up as a"
 " <nonCommercialLink>Non-commercial / Personal</nonCommercialLink> user."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:378
+#: frontend/js/src/forms/SignupCommercial.tsx:383
 msgid ""
 "Please tell us a little about your company and whether you plan to use "
 "our <apiLink>API</apiLink> or to <hostLink>host your own copy</hostLink> "
 "of the data."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:404
+#: frontend/js/src/forms/SignupCommercial.tsx:408
 #, fuzzy
 msgid "Logo URL"
 msgstr "Logo 图片 URL"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:405
+#: frontend/js/src/forms/SignupCommercial.tsx:409
 msgid "(preferably in SVG format)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:408
+#: frontend/js/src/forms/SignupCommercial.tsx:412
 msgid ""
 "Image should be about 250 pixels wide on a white or transparent "
 "background. We will host it on our site."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:421
+#: frontend/js/src/forms/SignupCommercial.tsx:425
 msgid ""
 "URL to where developers can use your APIs using MusicBrainz IDs, if "
-"available.."
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:430
-msgid "Your project"
+"available."
 msgstr ""
 
 #: frontend/js/src/forms/SignupCommercial.tsx:434
+msgid "Your project"
+msgstr ""
+
+#: frontend/js/src/forms/SignupCommercial.tsx:438
 #: frontend/js/src/forms/SignupNonCommercial.tsx:261
 msgid "(max 150 characters)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:451
+#: frontend/js/src/forms/SignupCommercial.tsx:455
 msgid "Billing address"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:502
+#: frontend/js/src/forms/SignupCommercial.tsx:506
 msgid ""
 "I agree to support the MetaBrainz Foundation when my organization is able"
 " to do so."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:507
+#: frontend/js/src/forms/SignupCommercial.tsx:511
+#: frontend/js/src/forms/SignupNonCommercial.tsx:284
 msgid ""
-"I also agree that if I generate a Live Data Feed access token, that I "
-"treat my access token as a secret and will not share this token publicly "
-"or commit it to a source code repository."
+"I also agree that if I generate a Live Data Feed access token, then I "
+"will treat my access token as a secret and will not share this token "
+"publicly or commit it to a source code repository."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:515
+#: frontend/js/src/forms/SignupCommercial.tsx:519
 msgid ""
 "The following information will be shown publicly: organization name, "
 "logo, website and API URLs, data usage description."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:520
+#: frontend/js/src/forms/SignupCommercial.tsx:524
 msgid ""
 "We'll send you more details about payment process once your application "
 "is approved."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:552
+#: frontend/js/src/forms/SignupCommercial.tsx:556
 #: frontend/js/src/forms/SignupNonCommercial.tsx:316
-#: frontend/js/src/forms/SignupUser.tsx:224
+#: frontend/js/src/forms/SignupUser.tsx:230
 msgid "Validating..."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:564
+#: frontend/js/src/forms/SignupCommercial.tsx:568
 #: frontend/js/src/forms/SignupNonCommercial.tsx:329
 #, fuzzy
 msgid "Back to profile"
 msgstr "您的资料"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:569
-#: frontend/js/src/forms/SignupNonCommercial.tsx:334
-msgid "Not a supporter?"
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:570
+#: frontend/js/src/forms/SignupCommercial.tsx:574
 #: frontend/js/src/forms/SignupNonCommercial.tsx:335
-msgid "Create a user account"
+msgid "Not a supporter? <signupLink>Create a user account</signupLink>"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:573
-#: frontend/js/src/forms/SignupNonCommercial.tsx:338
-#: frontend/js/src/forms/SignupUser.tsx:231
-msgid "Already have an account?"
+#: frontend/js/src/forms/SignupCommercial.tsx:583
+#: frontend/js/src/forms/SignupNonCommercial.tsx:344
+#: frontend/js/src/forms/SignupUser.tsx:238
+msgid "Already have an account? <loginLink>Sign in</loginLink>"
 msgstr ""
-
-#: frontend/js/src/forms/SignupNonCommercial.tsx:107
-#, fuzzy
-msgid "non-commercial"
-msgstr "非商业"
 
 #: frontend/js/src/forms/SignupNonCommercial.tsx:113
 msgid ""
@@ -4045,46 +5082,40 @@ msgid ""
 "income per year) or personal uses only."
 msgstr ""
 
-#: frontend/js/src/forms/SignupNonCommercial.tsx:284
-msgid ""
-"I also agree that if I generate a Live Data Feed access token, then I "
-"will treat my access token as a secret and will not share this token "
-"publicly or commit it to a source code repository."
-msgstr ""
-
 #: frontend/js/src/forms/SignupUser.tsx:43
 msgid "Create your account"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:50
-msgid "Registration started by"
+#: frontend/js/src/forms/SignupUser.tsx:51
+msgid "Registration started by <client />"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:69
+#: frontend/js/src/forms/SignupUser.tsx:75
+#: frontend/js/src/hooks/useEmailValidation.ts:82
 msgid "Invalid email address."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:150
+#: frontend/js/src/forms/SignupUser.tsx:156
 msgid ""
 "This username and email were provided by the app that started "
 "registration. You can change them later from MetaBrainz settings."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:182
+#: frontend/js/src/forms/SignupUser.tsx:188
 msgid ""
 "I accept that my contributions will be released into the public domain or"
 " licensed for use."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:191
+#: frontend/js/src/forms/SignupUser.tsx:197
 msgid "We will never share your personal information."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:200
+#: frontend/js/src/forms/SignupUser.tsx:206
 msgid "Click here to read more"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:224
+#: frontend/js/src/forms/SignupUser.tsx:230
 msgid "Create account"
 msgstr ""
 
@@ -4094,10 +5125,6 @@ msgstr ""
 
 #: frontend/js/src/hooks/useEmailValidation.ts:47
 msgid "Email validation failed"
-msgstr ""
-
-#: frontend/js/src/hooks/useEmailValidation.ts:82
-msgid "Invalid email address"
 msgstr ""
 
 #~ msgid "You need to specify amount!"
@@ -4888,7 +5915,7 @@ msgstr ""
 #~ "Are you sure you want to generate"
 #~ " new access token? Current token will"
 #~ " be revoked!"
-#~ msgstr "您确定要生成新的访问令牌吗?当前令牌将被撤销！"
+#~ msgstr ""
 
 #~ msgid "Sign up <small>Commercial</small>"
 #~ msgstr "<small>商用</small>注册"
@@ -5231,3 +6258,98 @@ msgstr ""
 
 #~ msgid "Privacy policy"
 #~ msgstr "隐私政策"
+
+#~ msgid "You need to specify website of the organization."
+#~ msgstr "请输入机构网站。"
+
+#~ msgid ""
+#~ "We are currently evaluating our overall"
+#~ " online advertising strategy. We are "
+#~ "evaluating advertising, traffic optimization,\n"
+#~ ""
+#~ "    search engine optimization and "
+#~ "software monitization technologies. If you "
+#~ "provide these professional services, please"
+#~ " provide a detailed\n"
+#~ "    deck of your comprehensive services"
+#~ " to the following email address. "
+#~ "<em>Please respect our other non-media"
+#~ " teams and do not contact us \n"
+#~ "    regarding these services on any "
+#~ "other of our email addresses. We "
+#~ "will disregard the entirety of your "
+#~ "submissions if you contact us any "
+#~ "other way!</em>"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Please come ask your questions at "
+#~ "our <a href=\"%(forums_url)s\">forums</a>! We "
+#~ "would love to\n"
+#~ "    answer any questions you may have."
+#~ msgstr ""
+#~ "欢迎到我们的<a href=\"%(forums_url)s\">论坛</a>互动！\n"
+#~ "我们将很乐意解答您的问题。"
+
+#~ msgid ""
+#~ "Due to the increased unreliability of"
+#~ " the US Postal Service we have "
+#~ "stopped accepting paper checks. Sorry!"
+#~ msgstr ""
+
+#~ msgid "Upgrade"
+#~ msgstr ""
+
+#~ msgid "Back to Profile"
+#~ msgstr "您的资料"
+
+#~ msgid ""
+#~ "Deletion of supporter accounts requires "
+#~ "manual review. Please contact us at"
+#~ msgstr ""
+
+#~ msgid "Revoke all your API tokens and access"
+#~ msgstr ""
+
+#~ msgid "Your username will be reserved and cannot be reused."
+#~ msgstr ""
+
+#~ msgid "Don't have an account?"
+#~ msgstr ""
+
+#~ msgid "If you would like to support us with more than $"
+#~ msgstr ""
+
+#~ msgid ", please enter the actual amount here:"
+#~ msgstr ""
+
+#~ msgid "month and up"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "I also agree that if I generate"
+#~ " a Live Data Feed access token, "
+#~ "that I treat my access token as"
+#~ " a secret and will not share "
+#~ "this token publicly or commit it "
+#~ "to a source code repository."
+#~ msgstr ""
+
+#~ msgid "Not a supporter?"
+#~ msgstr ""
+
+#~ msgid "Create a user account"
+#~ msgstr ""
+
+#~ msgid "Already have an account?"
+#~ msgstr ""
+
+#~ msgid "non-commercial"
+#~ msgstr "非商业"
+
+#~ msgid "Registration started by"
+#~ msgstr ""
+
+#~ msgid "Invalid email address"
+#~ msgstr ""
+

--- a/metabrainz/translations/zh_HK/LC_MESSAGES/messages.po
+++ b/metabrainz/translations/zh_HK/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-07-25 16:21+0200\n"
+"POT-Creation-Date: 2026-09-08 11:18+0200\n"
 "PO-Revision-Date: 2026-06-12 00:55+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: zh_HK\n"
@@ -21,162 +21,247 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.18.0\n"
 
-#: metabrainz/index/forms.py:46
+#: metabrainz/errors.py:24
+msgid "Authorization was declined."
+msgstr ""
+
+#: metabrainz/errors.py:25
+msgid "The authorization request was invalid."
+msgstr ""
+
+#: metabrainz/errors.py:26
+msgid "The application could not be authenticated."
+msgstr ""
+
+#: metabrainz/errors.py:27
+msgid "This application is not allowed to request authorization."
+msgstr ""
+
+#: metabrainz/errors.py:28
+msgid "The application asked for a response type this server does not support."
+msgstr ""
+
+#: metabrainz/errors.py:29
+msgid "The permissions requested by the application are invalid."
+msgstr ""
+
+#: metabrainz/errors.py:30
+msgid "You need to sign in to continue."
+msgstr ""
+
+#: metabrainz/errors.py:31
+msgid "Your consent is required to continue."
+msgstr ""
+
+#: metabrainz/password.py:12
+#, python-format
+msgid "Password must not exceed %(max_bytes)s bytes."
+msgstr ""
+
+#: metabrainz/index/forms.py:48
 #, python-format
 msgid "'%(value)s' is not a valid choice for this field"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileEdit.tsx:27
-#: frontend/js/src/forms/SignupCommercial.tsx:154
+#: frontend/js/src/forms/SignupCommercial.tsx:159
 #: frontend/js/src/forms/SignupNonCommercial.tsx:85
-#: frontend/js/src/forms/SignupUser.tsx:70
-#: frontend/js/src/hooks/useEmailValidation.ts:78 metabrainz/index/forms.py:57
-#: metabrainz/user/forms.py:25 metabrainz/user/forms.py:57
-#: metabrainz/user/forms.py:63
+#: frontend/js/src/forms/SignupUser.tsx:76
+#: frontend/js/src/hooks/useEmailValidation.ts:78 metabrainz/index/forms.py:59
+#: metabrainz/user/forms.py:31 metabrainz/user/forms.py:70
+#: metabrainz/user/forms.py:76
 msgid "Email address is required!"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:34
-#: metabrainz/index/forms.py:63
+#: metabrainz/index/forms.py:65
 msgid "Current password is required!"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:43
 #: frontend/js/src/forms/ProfileChangePassword.tsx:37
 #: frontend/js/src/forms/ResetPassword.tsx:39
-#: frontend/js/src/forms/SignupCommercial.tsx:156
+#: frontend/js/src/forms/SignupCommercial.tsx:161
 #: frontend/js/src/forms/SignupNonCommercial.tsx:87
-#: frontend/js/src/forms/SignupUser.tsx:72 metabrainz/index/forms.py:66
-#: metabrainz/user/forms.py:29 metabrainz/user/forms.py:46
-#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:69
+#: frontend/js/src/forms/SignupUser.tsx:78 metabrainz/index/forms.py:69
+#: metabrainz/user/forms.py:35 metabrainz/user/forms.py:54
+#: metabrainz/user/forms.py:63 metabrainz/user/forms.py:82
 msgid "Password is required!"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:41
-#: frontend/js/src/forms/SignupCommercial.tsx:160
+#: frontend/js/src/forms/SignupCommercial.tsx:165
 #: frontend/js/src/forms/SignupNonCommercial.tsx:91
-#: frontend/js/src/forms/SignupUser.tsx:76 metabrainz/index/forms.py:70
-#: metabrainz/user/forms.py:33 metabrainz/user/forms.py:73
+#: frontend/js/src/forms/SignupUser.tsx:82 metabrainz/index/forms.py:74
+#: metabrainz/user/forms.py:40 metabrainz/user/forms.py:87
 msgid "Confirm Password is required!"
 msgstr ""
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:46
 #: frontend/js/src/forms/ResetPassword.tsx:48
-#: frontend/js/src/forms/SignupCommercial.tsx:165
+#: frontend/js/src/forms/SignupCommercial.tsx:170
 #: frontend/js/src/forms/SignupNonCommercial.tsx:96
-#: frontend/js/src/forms/SignupUser.tsx:81 metabrainz/index/forms.py:72
-#: metabrainz/user/forms.py:35 metabrainz/user/forms.py:75
+#: frontend/js/src/forms/SignupUser.tsx:87 metabrainz/index/forms.py:76
+#: metabrainz/user/forms.py:42 metabrainz/user/forms.py:89
 msgid "Confirm Password should match password!"
 msgstr ""
 
 #: frontend/js/src/Applications.tsx:56 frontend/js/src/Applications.tsx:86
 #: frontend/js/src/Profile.tsx:272 frontend/js/src/Profile.tsx:482
-#: metabrainz/index/forms.py:78
+#: metabrainz/index/forms.py:82
 msgid "Name"
 msgstr ""
 
-#: metabrainz/index/forms.py:79
+#: metabrainz/index/forms.py:83
 msgid "Contact name field is empty."
 msgstr ""
 
-#: metabrainz/index/views.py:234
+#: metabrainz/index/views.py:251
 msgid "Profile updated successfully."
 msgstr ""
 
-#: metabrainz/index/views.py:261
+#: metabrainz/index/views.py:278
 msgid "Current password is incorrect."
 msgstr ""
 
-#: metabrainz/index/views.py:266
+#: metabrainz/index/views.py:283
 msgid "Password changed successfully."
 msgstr ""
 
-#: metabrainz/index/views.py:372
+#: metabrainz/index/views.py:389
 msgid "You have updated an application!"
 msgstr ""
 
-#: metabrainz/index/views.py:424
+#: metabrainz/index/views.py:441
 msgid "You have deleted an application."
 msgstr ""
 
-#: metabrainz/index/views.py:426
+#: metabrainz/index/views.py:443
 msgid "Failed to delete an application."
 msgstr ""
 
-#: metabrainz/index/views.py:449
+#: metabrainz/index/views.py:466
 msgid "Revoked tokens successfully!"
 msgstr ""
 
-#: metabrainz/index/views.py:478
+#: metabrainz/index/views.py:495
 msgid "Your account has been deleted."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:106 metabrainz/oauth/forms.py:58
+#: frontend/js/src/forms/CreateApplication.tsx:106 metabrainz/oauth/forms.py:57
 msgid "Application Name"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:59
+#: metabrainz/oauth/forms.py:58
 msgid "Application name field is empty."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:60 metabrainz/oauth/forms.py:60
+#: frontend/js/src/forms/CreateApplication.tsx:60 metabrainz/oauth/forms.py:59
 msgid "Application name needs to be at least 3 characters long."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:64 metabrainz/oauth/forms.py:61
+#: frontend/js/src/forms/CreateApplication.tsx:64 metabrainz/oauth/forms.py:60
 msgid "Application name needs to be at most 64 characters long."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:114 metabrainz/oauth/forms.py:63
+#: frontend/js/src/forms/CreateApplication.tsx:114 metabrainz/oauth/forms.py:62
 msgid "Description"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:64
+#: metabrainz/oauth/forms.py:63
 msgid "Client description field is empty."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:65
+#: metabrainz/oauth/forms.py:64
 msgid "Client description needs to be at least 3 characters long."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:66
+#: metabrainz/oauth/forms.py:65
 msgid "Client description needs to be at most 512 characters long."
 msgstr ""
 
-#: frontend/js/src/forms/CreateApplication.tsx:122 metabrainz/oauth/forms.py:68
+#: frontend/js/src/forms/CreateApplication.tsx:122 metabrainz/oauth/forms.py:67
 msgid "Homepage"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:69
+#: metabrainz/oauth/forms.py:68
 msgid "Homepage field is empty."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:70
+#: metabrainz/oauth/forms.py:69
 msgid "Homepage is not a valid URI."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:71
+#: metabrainz/oauth/forms.py:70
 msgid "Homepage URL must use http or https"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:73
+#: metabrainz/oauth/forms.py:72
 msgid "Authorization callback URL"
 msgstr ""
 
-#: metabrainz/oauth/forms.py:74
+#: metabrainz/oauth/forms.py:73
 msgid "Authorization callback URL field is empty."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:75
+#: metabrainz/oauth/forms.py:74
 msgid "Authorization callback URL is invalid."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:76
+#: metabrainz/oauth/forms.py:75
 msgid "Authorization callback URL must use http or https."
 msgstr ""
 
-#: metabrainz/oauth/forms.py:81 metabrainz/oauth/forms.py:85
+#: metabrainz/oauth/forms.py:80 metabrainz/oauth/forms.py:84
 msgid "Confirm"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:15
+msgid "View your public account information"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:16
+msgid "View your email address"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:17
+msgid "View and modify your private tags"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:18
+msgid "View and modify your private ratings"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:19
+msgid "View and modify your private collections"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:20
+msgid "Submit new ISRCs to the database"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:21
+msgid "Submit new barcodes to the database"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:22
+msgid "Sign you in and view your unique user id"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:23
+msgid "Submit listens to ListenBrainz."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:24
+msgid "Create and modify CritiqueBrainz reviews."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:25
+msgid "Submit and delete votes on CritiqueBrainz reviews."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:26
+msgid "Modify profile info and delete profile on CritiqueBrainz."
 msgstr ""
 
 #: metabrainz/payments/views.py:164
@@ -221,178 +306,185 @@ msgid "Requested annual report was not found."
 msgstr ""
 
 #: frontend/js/src/forms/ProfileEdit.tsx:30
-#: frontend/js/src/forms/SignupCommercial.tsx:139
+#: frontend/js/src/forms/SignupCommercial.tsx:144
 #: frontend/js/src/forms/SignupNonCommercial.tsx:70
-#: metabrainz/supporter/forms.py:13
+#: metabrainz/supporter/forms.py:15
 msgid "Contact name is required!"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:437
+#: frontend/js/src/forms/SignupCommercial.tsx:441
 #: frontend/js/src/forms/SignupNonCommercial.tsx:264
-#: metabrainz/supporter/forms.py:15
+#: metabrainz/supporter/forms.py:17
 msgid ""
 "Can you please tell us more about the project in which you'd like to use "
 "our data? Do you plan to self host the data or use our APIs?"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:137
+#: frontend/js/src/forms/SignupCommercial.tsx:142
 #: frontend/js/src/forms/SignupNonCommercial.tsx:68
-#: metabrainz/supporter/forms.py:17
+#: metabrainz/supporter/forms.py:19
 msgid "Please, tell us how you (will) use our data."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:138
+#: frontend/js/src/forms/SignupCommercial.tsx:143
 #: frontend/js/src/forms/SignupNonCommercial.tsx:69
-#: metabrainz/supporter/forms.py:18
+#: metabrainz/supporter/forms.py:20
 msgid "Please, limit usage description to 500 characters."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:141
-#: frontend/js/src/forms/SignupCommercial.tsx:142
+#: frontend/js/src/forms/SignupCommercial.tsx:146
+#: frontend/js/src/forms/SignupCommercial.tsx:147
 #: frontend/js/src/forms/SignupNonCommercial.tsx:72
 #: frontend/js/src/forms/SignupNonCommercial.tsx:73
-#: frontend/js/src/forms/SignupUser.tsx:84
-#: frontend/js/src/forms/SignupUser.tsx:85 metabrainz/supporter/forms.py:21
-#: metabrainz/user/forms.py:38
+#: frontend/js/src/forms/SignupUser.tsx:90
+#: frontend/js/src/forms/SignupUser.tsx:91 metabrainz/supporter/forms.py:23
+#: metabrainz/user/forms.py:45
 msgid "You need to accept the agreement!"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:342
-#: metabrainz/supporter/forms.py:27
+#: frontend/js/src/forms/SignupCommercial.tsx:347
+#: metabrainz/supporter/forms.py:29
 msgid "Organization name"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:113
-#: metabrainz/supporter/forms.py:28
+#: frontend/js/src/forms/SignupCommercial.tsx:115
+#: metabrainz/supporter/forms.py:30
 msgid "You need to specify the name of your organization."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:373
-#: metabrainz/supporter/forms.py:30
+#: frontend/js/src/forms/SignupCommercial.tsx:378
+#: metabrainz/supporter/forms.py:32
 msgid "Organization description"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:116
-#: metabrainz/supporter/forms.py:31
+#: frontend/js/src/forms/SignupCommercial.tsx:118
+#: metabrainz/supporter/forms.py:33
 msgid "You need to provide description of your organization."
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:278
-#: frontend/js/src/forms/SignupCommercial.tsx:396
-#: metabrainz/supporter/forms.py:34
+#: frontend/js/src/forms/SignupCommercial.tsx:401
+#: metabrainz/supporter/forms.py:36
 msgid "Website URL"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:119
-#: metabrainz/supporter/forms.py:35
-msgid "You need to specify website of the organization."
+#: frontend/js/src/forms/SignupCommercial.tsx:121
+#: frontend/js/src/forms/SignupCommercial.tsx:123
+#: metabrainz/supporter/forms.py:38 metabrainz/supporter/forms.py:42
+msgid "Website URL must be a valid URL."
 msgstr ""
 
-#: metabrainz/supporter/forms.py:37
+#: metabrainz/supporter/forms.py:45
 msgid "Logo image URL"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:284
-#: frontend/js/src/forms/SignupCommercial.tsx:418
-#: metabrainz/supporter/forms.py:38
+#: frontend/js/src/forms/SignupCommercial.tsx:422
+#: metabrainz/supporter/forms.py:46
 msgid "API URL"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:457
-#: metabrainz/supporter/forms.py:40
+#: frontend/js/src/forms/SignupCommercial.tsx:461
+#: metabrainz/supporter/forms.py:48
 msgid "Street"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:123
-#: metabrainz/supporter/forms.py:41
+#: frontend/js/src/forms/SignupCommercial.tsx:128
+#: metabrainz/supporter/forms.py:49
 msgid "You need to specify street."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:465
-#: metabrainz/supporter/forms.py:43
+#: frontend/js/src/forms/SignupCommercial.tsx:469
+#: metabrainz/supporter/forms.py:51
 msgid "City"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:124
-#: metabrainz/supporter/forms.py:44
+#: frontend/js/src/forms/SignupCommercial.tsx:129
+#: metabrainz/supporter/forms.py:52
 msgid "You need to specify city."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:473
-#: metabrainz/supporter/forms.py:46
+#: frontend/js/src/forms/SignupCommercial.tsx:477
+#: metabrainz/supporter/forms.py:54
 msgid "State / Province"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:126
-#: metabrainz/supporter/forms.py:47
+#: frontend/js/src/forms/SignupCommercial.tsx:131
+#: metabrainz/supporter/forms.py:55
 msgid "You need to specify state/province."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:481
-#: metabrainz/supporter/forms.py:49
+#: frontend/js/src/forms/SignupCommercial.tsx:485
+#: metabrainz/supporter/forms.py:57
 msgid "Postcode"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:128
-#: metabrainz/supporter/forms.py:50
+#: frontend/js/src/forms/SignupCommercial.tsx:133
+#: metabrainz/supporter/forms.py:58
 msgid "You need to specify postcode."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:489
-#: metabrainz/supporter/forms.py:52
+#: frontend/js/src/forms/SignupCommercial.tsx:493
+#: metabrainz/supporter/forms.py:60
 msgid "Country"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:129
-#: metabrainz/supporter/forms.py:53
+#: frontend/js/src/forms/SignupCommercial.tsx:134
+#: metabrainz/supporter/forms.py:61
 msgid "You need to specify country."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:132
-#: metabrainz/supporter/forms.py:64
+#: frontend/js/src/forms/SignupCommercial.tsx:137
+#: metabrainz/supporter/forms.py:72
 msgid ""
 "Custom amount must be more than threshold amount for selected tier or "
 "equal to it!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:46 metabrainz/supporter/views.py:119
-#: metabrainz/supporter/views.py:220
+#: metabrainz/supporter/views.py:54
+msgid ""
+"The verification email could not be sent. Please request a new one from "
+"your profile."
+msgstr ""
+
+#: metabrainz/supporter/views.py:85 metabrainz/supporter/views.py:158
+#: metabrainz/supporter/views.py:260
 msgid "You are already a supporter."
 msgstr ""
 
-#: metabrainz/supporter/views.py:61
+#: metabrainz/supporter/views.py:100
 msgid "Can't find tier with a specified ID."
 msgstr ""
 
-#: metabrainz/supporter/views.py:127
+#: metabrainz/supporter/views.py:166
 msgid "You need to choose support tier before signing up!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:137
+#: metabrainz/supporter/views.py:176
 msgid "You need to choose existing tier before signing up!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:164
+#: metabrainz/supporter/views.py:204
 msgid ""
 "Thanks for becoming a supporter! Your application will be reviewed soon. "
 "We will send you updates via email."
 msgstr ""
 
-#: metabrainz/supporter/views.py:187
+#: metabrainz/supporter/views.py:228
 msgid ""
 "Thanks for signing up! Your application will be reviewed soon. We will "
 "send you updates via email."
 msgstr ""
 
-#: metabrainz/supporter/views.py:248
+#: metabrainz/supporter/views.py:288
 msgid "Thanks for becoming a supporter!"
 msgstr ""
 
-#: metabrainz/supporter/views.py:274
+#: metabrainz/supporter/views.py:312
 msgid "Thanks for signing up! Please check your inbox to complete verification."
 msgstr ""
 
-#: metabrainz/supporter/views.py:302
+#: metabrainz/supporter/views.py:340
 msgid "Can't generate new token unless account is active."
 msgstr ""
 
@@ -426,7 +518,7 @@ msgstr ""
 msgid "Policies"
 msgstr ""
 
-#: metabrainz/templates/base.html:55 metabrainz/templates/index/gdpr.html:178
+#: metabrainz/templates/base.html:55
 #: metabrainz/templates/index/social-contract.html:3
 #: metabrainz/templates/index/social-contract.html:6
 #: metabrainz/templates/navbar.html:34
@@ -436,14 +528,15 @@ msgstr ""
 #: metabrainz/templates/base.html:56
 #: metabrainz/templates/index/code-of-conduct.html:3
 #: metabrainz/templates/index/code-of-conduct.html:16
-#: metabrainz/templates/index/gdpr.html:181 metabrainz/templates/navbar.html:35
+#: metabrainz/templates/navbar.html:35
 msgid "Code of Conduct"
 msgstr ""
 
+#: frontend/js/src/PrivacySummary.tsx:11
 #: frontend/js/src/forms/ConditionsModal.tsx:21
-#: metabrainz/templates/base.html:57 metabrainz/templates/index/gdpr.html:184
-#: metabrainz/templates/index/privacy.html:6
+#: metabrainz/templates/base.html:57 metabrainz/templates/index/privacy.html:6
 #: metabrainz/templates/navbar.html:36
+#: metabrainz/templates/users/privacy-summary.html:3
 msgid "Privacy Policy"
 msgstr ""
 
@@ -476,10 +569,7 @@ msgstr ""
 msgid "Supporters"
 msgstr ""
 
-#: frontend/js/src/forms/LoginUser.tsx:103
-#: frontend/js/src/forms/SignupCommercial.tsx:574
-#: frontend/js/src/forms/SignupNonCommercial.tsx:339
-#: frontend/js/src/forms/SignupUser.tsx:232 metabrainz/templates/base.html:73
+#: frontend/js/src/forms/LoginUser.tsx:103 metabrainz/templates/base.html:73
 #: metabrainz/templates/navbar.html:66 metabrainz/templates/users/login.html:3
 msgid "Sign in"
 msgstr ""
@@ -501,26 +591,26 @@ msgid "Contact us"
 msgstr ""
 
 #: metabrainz/templates/base.html:85
-#: metabrainz/templates/index/contact.html:105
+#: metabrainz/templates/index/contact.html:106
 msgid "Blog"
 msgstr ""
 
-#: metabrainz/templates/base.html:86 metabrainz/templates/index/contact.html:90
+#: metabrainz/templates/base.html:86 metabrainz/templates/index/contact.html:91
 msgid "Chat"
 msgstr ""
 
 #: metabrainz/templates/base.html:87
-#: metabrainz/templates/index/contact.html:106
+#: metabrainz/templates/index/contact.html:107
 msgid "Mastodon"
 msgstr ""
 
 #: metabrainz/templates/base.html:88
-#: metabrainz/templates/index/contact.html:107
+#: metabrainz/templates/index/contact.html:108
 msgid "Bluesky"
 msgstr ""
 
 #: metabrainz/templates/base.html:89
-#: metabrainz/templates/index/contact.html:108
+#: metabrainz/templates/index/contact.html:109
 msgid "Instagram"
 msgstr ""
 
@@ -576,15 +666,14 @@ msgstr ""
 msgid "Donate"
 msgstr ""
 
-#: frontend/js/src/forms/LoginUser.tsx:110
-#: frontend/js/src/forms/SignupCommercial.tsx:175
-#: frontend/js/src/forms/SignupCommercial.tsx:555
+#: frontend/js/src/forms/SignupCommercial.tsx:180
+#: frontend/js/src/forms/SignupCommercial.tsx:559
 #: frontend/js/src/forms/SignupNonCommercial.tsx:106
 #: frontend/js/src/forms/SignupNonCommercial.tsx:319
 #: metabrainz/templates/navbar.html:65
-#: metabrainz/templates/supporters/account-type.html:51
-#: metabrainz/templates/supporters/account-type.html:93
-#: metabrainz/templates/supporters/account-type.html:144
+#: metabrainz/templates/supporters/account-type.html:47
+#: metabrainz/templates/supporters/account-type.html:84
+#: metabrainz/templates/supporters/account-type.html:130
 #: metabrainz/templates/users/signup.html:3
 msgid "Sign up"
 msgstr ""
@@ -891,8 +980,430 @@ msgstr ""
 msgid "Introduction"
 msgstr ""
 
-#: metabrainz/templates/index/conflict-policy.html:55
+#: metabrainz/templates/index/conflict-policy.html:17
+msgid ""
+"Conflicts between people arise in open source projects constantly and the"
+" projects by the \n"
+"    MetaBrainz Foundation are no different. This policy aims to establish"
+" a clear and unambiguous \n"
+"    policy for reporting and addressing conflicts in our community. In "
+"this policy we aim to \n"
+"    establish a fair practice that balances the need for confidentiality "
+"and our desire for \n"
+"    transparency in our operations."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:25
+#, python-format
+msgid ""
+"Before you continue to read this policy, we encourage you to review our "
+"existing community policies \n"
+"    including our <a href=\"%(social_contract_url)s\">Social "
+"Contract</a>, \n"
+"    <a href=\"%(code_of_conduct_url)s\">the Code of Conduct</a>, \n"
+"    and our <a href=\"%(privacy_policy_url)s\">Privacy Policy</a>. These "
+"policies establish the norms and rules for \n"
+"    participation in our projects; these policies apply equally to the "
+"contractors of the MetaBrainz \n"
+"    Foundation and any participants in our projects."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:37
+msgid ""
+"This policy divides conflicts into two categories: Private and public. "
+"Private conflicts are conflicts \n"
+"    that involve *confidential* information regarding contributors, "
+"contractors or supporters. Otherwise, any conflicts \n"
+"    that do not involve confidential information are considered to be "
+"public conflicts. For instance, a \n"
+"    conflict between a contractor and the Executive Director (aka BDFL) "
+"that involves contractor pay is \n"
+"    considered a private conflict because pay rates are confidential "
+"information. A public conflict in edit \n"
+"    notes between two editors in our community does not involve "
+"confidential information and therefore should \n"
+"    be considered a public conflict."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:47
+msgid ""
+"When conflicts arise we aim to disclose as much information as possible "
+"about the conflict in a timely \n"
+"    fashion. When conflicts contain confidential matters we will aim to "
+"disclose as much information as \n"
+"    possible, while fully respecting the confidentiality of the people "
+"involved in the conflict. With any \n"
+"    private conflict we will aim to extract the relevant lessons for the "
+"team and community in an effort to \n"
+"    evolve our policies to prevent future conflicts. Should the involved "
+"parties disagree whether a conflict \n"
+"    is private or public, the question about the nature of the conflict "
+"will be presented for the next higher \n"
+"    level in the chain of command to decide. (e.g. if a community member "
+"and the community manager disagree on \n"
+"    a conflict being public or private, the Executive Director shall "
+"decide if the conflict is public or private)."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:58
 msgid "Reporting and Response"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:61
+msgid ""
+"We aim to not have conflict in our community, but we recognize that in "
+"reality conflicts will arise and we \n"
+"    must be prepared to address them in a fair manner. When conflicts "
+"arise, we prefer to have community or team \n"
+"    members resolve the conflicts among themselves, using our existing "
+"policies as guidelines for resolving the \n"
+"    conflict."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:69
+msgid ""
+"If you do not feel comfortable resolving a conflict on your own, you "
+"should feel free to report the conflict to \n"
+"    us. How you address the conflict depends on who is involved in the "
+"conflict and your comfort level. Please see \n"
+"    the detailed sections below on how and with whom to address your "
+"conflict. We aim to address conflicts as soon \n"
+"    as possible in an effort to prevent them from escalating "
+"unnecessarily."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:75
+msgid "Direct conflict resolution"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:78
+msgid ""
+"In direct conflict resolution, the involved parties will attempt to "
+"resolve the conflict themselves without \n"
+"   involving any MetaBrainz Foundation team member. You should aim to use"
+" direct resolution when the conflict does \n"
+"   not involve the violation of one of our policies or if the conflict is"
+" minor."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:84
+#, python-format
+msgid ""
+"For instance, if a user uses a rude tone, is disruptive or flagrantly "
+"ignores our project guidelines, we suggest \n"
+"    that you use direct conflict resolution to resolve the conflict. Some"
+" resources that might give you some suggestions \n"
+"    on how to go about resolving the conflict might be this <a "
+"href=\"%(conflict_resolution_primer_url)s\">\n"
+"    conflict resolution primer</a> and <a "
+"href=\"%(difficult_conversations_url)s\">how to\n"
+"    have difficult conversations at work</a>."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:93
+msgid "Informal reporting"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:96
+msgid ""
+"You may use informal reporting of a conflict if you aim to communicate a "
+"concern or incident without \n"
+"    seeking a corrective outcome. Informal reporting may also be an "
+"option if you have not been personally \n"
+"    victimized, but you’ve witnessed a violation of our policies or where"
+" you wish to maintain confidentiality \n"
+"    throughout the entire reporting process."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:103
+msgid ""
+"For editing in MusicBrainz you may informally report a user using the "
+"“Report this user for bad behavior” \n"
+"    link from the user’s profile. For reporting bad user behavior in "
+"other of our projects, please report them to our \n"
+"    community manager by mailing <span class=\"backemail\">gro.zniarbatem"
+"@reganam-ytinummoc</span> . For conflicts \n"
+"    that involve the community manager, report them by mailing <span "
+"class=\"backemail\">gro.zniarbatem@de</span> ."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:110
+msgid ""
+"Depending the the severity of the issue, repeated informal complaints may"
+" eventually require a formal response \n"
+"    from the MetaBrainz team. If an involved party requires anonymity, "
+"the conflict becomes a private conflict. If at \n"
+"    all possible minor issues should be resolved in a public forum in "
+"order for all people to witness and learn from \n"
+"    the issue at hand."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:116
+msgid "Formal complaint process"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:119
+msgid ""
+"All complaints about conflicts should be submitted via email. To whom a "
+"complaint should be mailed and who will \n"
+"    carry out the investigation will be described in the next section."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:124
+msgid "All complaint submissions to the Foundation should include the following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:128
+msgid ""
+"Contact info, if it is different than the email used to submit the "
+"conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:129
+msgid "Who was involved in the conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:130
+msgid "Where and when the incident happened"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:131
+msgid ""
+"A description of what happened -- ideally with links (e.g. chatlogs, edit"
+" notes) that outlines what \n"
+"         happened so that the persons evaluating the conflict may "
+"understand the issue at hand"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:133
+msgid ""
+"Any related pieces of information that provide more context on the "
+"conflict (e.g. links, screenshots)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:134
+msgid "An indication if this conflict is ongoing or not"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:139
+msgid "The investigation that follows aims to determine:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:143
+msgid "The nature and severity of the incident"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:144
+msgid ""
+"Whether or not the incident is considered a violation of MetaBrainz’ "
+"conduct policies or core values"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:145
+msgid ""
+"The amount of harm experienced by the person who submitted the complaint "
+"and the broader MetaBrainz community \n"
+"         as a result of the incident"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:147
+msgid ""
+"Whether there have been prior complaints against the individual or "
+"individuals reported"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:148
+msgid "Whether the incident is ongoing"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:152
+msgid ""
+"The following potential forms of resolution may apply to any team members"
+" involved in the conflict:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:155
+#: metabrainz/templates/index/conflict-policy.html:168
+msgid "Nothing (if it has been found no violation occurred)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:156
+msgid "Creating a plan to improve the performance"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:157
+msgid "Creating a negative performance evaluation"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:158
+msgid "Mediation, an intervention by a third party to resolve the conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:159
+msgid "Suspension or forced leave"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:160
+msgid "Termination of contract"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:164
+msgid ""
+"The following potential forms of resolution may apply to non team members"
+" involved in the conflict:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:169
+msgid "A reprimand, either public or private"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:170
+msgid "Suspension of the users’ account"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:171
+msgid "Deletion of the users’ account"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:172
+msgid ""
+"Removal of user privileges (e.g. if an auto editor commits a serious "
+"offence, they may lose their auto editor status)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:175
+msgid "Filing a complaint"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:178
+msgid ""
+"NOTE: For complaints not about MetaBrainz staff, please see the "
+"<em>Informal reporting</em> section above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:182
+msgid ""
+"If the complaint does not involve the Executive Director (ED), do the "
+"following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:186
+msgid ""
+"If team member has directly violated conduct policies or engaged in "
+"otherwise harmful behavior, a formal complaint should be filed."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:187
+msgid ""
+"Mail <span class=\"backemail\">gro.zniarbatem@de</span> and include the "
+"complaint information outlined above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:188
+msgid ""
+"You should expect a response within a working day acknowledging the "
+"complaint."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:189
+msgid ""
+"The complaint will be investigated by the ED, member(s) of the board of "
+"directors or a neutral third party."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:190
+msgid ""
+"Once the investigation has been completed, the ED, with the support of "
+"others involved in the investigation will respond. The \n"
+"        ED will respond to incidents no later than 7 working days after a"
+" complaint has been filed with either a resolution or an \n"
+"        explanation of why the process must be extended."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:196
+msgid "If a complaint involves the Executive Director, do the following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:200
+msgid ""
+"If the Executive Director has directly violated conduct policies or "
+"engaged in otherwise harmful behavior, \n"
+"        a formal complaint should be filed with the board of directors."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:202
+msgid ""
+"Mail <span class=\"backemail\">gro.zniarbatem@noituloser-tcilfnoc</span> "
+"and include the complaint information outlined above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:203
+msgid ""
+"You should get a response within 5 working days acknowledging the "
+"complaint."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:204
+msgid ""
+"The complaint will be investigated by the member(s) of the board of "
+"directors, the community manager, a neutral \n"
+"        third party or a combination thereof."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:206
+msgid ""
+"Once the investigation has been completed, the board, with the support of"
+" others involved in the investigation \n"
+"        will respond. The board will aim to respond to incidents no later"
+" than 15 working days after a complaint has been filed \n"
+"        with either a resolution or an explanation of why the process "
+"must be extended."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:211
+msgid "Confidentiality"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:214
+msgid ""
+"Confidentiality is an important aspect of conflict resolution and all of "
+"the conflicts brought to the attention of the foundation \n"
+"    will be evaluated with confidentiality in mind and acted upon "
+"accordingly."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:219
+msgid ""
+"We work hard to make all of the actions of the foundation as transparent "
+"and open as possible. In cases where we cannot \n"
+"    disclose all aspects of a conflict we will disclose that a conflict "
+"is or has occurred and we will attempt to disclose the \n"
+"    appropriate amount of information about the conflict while balancing "
+"the need for confidentiality and our desire to learn \n"
+"    from conflicts so that we as a foundation and community can learn "
+"from these conflicts and improve our policies to avoid the \n"
+"    conflicts in the future."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:227
+msgid ""
+"Any breaches of confidentiality will be treated as severe breaches of our"
+" conduct policies."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:230
+msgid "Retaliation"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:233
+msgid ""
+"We will not allow retaliation for any contractor or volunteer that files "
+"a complaint or is involved in an investigation. If you \n"
+"    believe that you are being treated negatively because of your "
+"involvement in a complaint please report this complaint directly \n"
+"    to the ED at <span class=\"backemail\">gro.zniarbatem@de</span> or "
+"the board at \n"
+"    <span class=\"backemail\">gro.zniarbatem@noituloser-tcilfnoc</span>."
 msgstr ""
 
 #: metabrainz/templates/index/contact.html:3
@@ -973,7 +1484,7 @@ msgstr ""
 msgid ""
 "We are currently evaluating our overall online advertising strategy. We "
 "are evaluating advertising, traffic optimization,\n"
-"    search engine optimization and software monitization technologies. If"
+"    search engine optimization and software monetization technologies. If"
 " you provide these professional services, please provide a detailed\n"
 "    deck of your comprehensive services to the following email address. "
 "<em>Please respect our other non-media teams and do not contact us \n"
@@ -1048,11 +1559,11 @@ msgstr ""
 #, python-format
 msgid ""
 "Please come ask your questions at our <a "
-"href=\"%(forums_url)s\">forums</a>! We would love to\n"
-"    answer any questions you may have."
+"href=\"%(forums_url)s\">forums</a>!\n"
+"    The community and the team will be more than happy to help you."
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:92
+#: metabrainz/templates/index/contact.html:93
 #, python-format
 msgid ""
 "The MetaBrainz/MusicBrainz/ListenBrainz team and community hang out\n"
@@ -1062,15 +1573,15 @@ msgid ""
 "    <a href=\"%(chatlogs_url)s\">chat log archives</a>."
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:101
+#: metabrainz/templates/index/contact.html:102
 msgid "Social media"
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:103
+#: metabrainz/templates/index/contact.html:104
 msgid "You can follow us on these social channels:"
 msgstr ""
 
-#: metabrainz/templates/index/contact.html:112
+#: metabrainz/templates/index/contact.html:113
 msgid "Mailing address"
 msgstr ""
 
@@ -1083,33 +1594,349 @@ msgstr ""
 msgid "GDPR Compliance Statement"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:37
+#: metabrainz/templates/index/gdpr.html:10
+msgid ""
+"The General Data Protection Regulation is a complex EU regulation that "
+"stipulates many points for protecting private data of\n"
+"    users on the Internet. Even though this is an EU regulation, it has a"
+" worldwide impact due to the nature of the Internet.\n"
+"    The MetaBrainz Foundation with its collection of projects is also "
+"affected by this regulation. We’ve been learning and adapting\n"
+"    our sites to be compliant with the GDPR – sadly this regulation isn’t"
+" entirely black and white and there is an incredible\n"
+"    amount of room left for interpretation of these rules."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:17
+msgid ""
+"The good news is that this regulation is roughly in line with our "
+"established practices: We’ve always held private information\n"
+"    in a high regard and applied the sort of rules to ourselves as we "
+"wish to have our own private data treated. Luckily, this\n"
+"    makes our compliance effort considerably easier. We’ve made two "
+"significant changes to how we treat your data and also adopted\n"
+"    terminology as used in the GDPR in order to use the same languages "
+"that many other sites are now adopting. Please keep reading\n"
+"    to find out the exact details of what we are doing to comply."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:24
+#, python-format
+msgid ""
+"However, we do ask for your compassion and help in our process of "
+"complying with the GDPR. As we already mentioned, the GDPR is\n"
+"    a complex set of rules that are not fully clarified yet. We’ve taken "
+"action on the steps that are clear to us and we’re following\n"
+"    ongoing conversations on points that are in gray zones or unclear to "
+"us. We’ve made our best initial effort on compliance and\n"
+"    promise to keep working on it as the picture becomes more clear. If "
+"you believe that we could improve our compliance, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a> and let us know what we "
+"can do to improve. It would also help us if you\n"
+"    could provide concrete discussion or examples to help us understand "
+"and take action on your suggestion."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:33
+msgid ""
+"Finally, below are the key sections of the GDPR as we understand them and"
+" how they affect your data in our ecosystem. Where\n"
+"    possible, we provide links for deeper understanding, links for you to"
+" examine our relevant code and links to tickets to follow\n"
+"    the process of improving our compliance."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:38
 msgid "Right to be forgotten"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:77
+#: metabrainz/templates/index/gdpr.html:41
+msgid ""
+"Summary: <i>Provide the user with the ability to remove their private "
+"data from our services</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:44
+msgid ""
+"The most important aspect of the right to be forgotten is the ability to "
+"delete your account. Once you request for us to delete\n"
+"    your account, we will remove any personally identifying information "
+"you may have provided us from your account (name, email\n"
+"    address, gender, biography, URL, etc.). The visible name on your "
+"account will be changed to “Deleted User #####” and effectively\n"
+"    the account will no longer be identifiable as your account."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:50
+msgid ""
+"However, given the nature of our projects where we work on collaborative "
+"databases, your contributions that are not personally\n"
+"    identifying are valuable assets to our database and these "
+"contributions will not be removed from our databases. But we will\n"
+"    ensure that these contributions no longer contain personally "
+"identifying data."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:55
+#, python-format
+msgid ""
+"Our process of automatically deleting your accounts across the MetaBrainz"
+" ecosystem is not complete yet (see below for a set of\n"
+"    tickets where you can track our progress). If you would like to "
+"delete your accounts in the MetaBrainz ecosystem or mark a\n"
+"    donation that is currently public as a private donation, please <a "
+"href=\"%(contact_url)s\">contact us</a>\n"
+"    and we will address your request as soon as possible."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:62
+#: metabrainz/templates/index/gdpr.html:182
+msgid "Links:"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:66
+#, python-format
+msgid ""
+"<a href=\"%(editor_deletion_doc_url)s\">How we delete accounts\n"
+"       in MusicBrainz</a> (warning, geek content ahead!)"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:70
+msgid ""
+"Implement sitewide user account deletion in\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/MBS-9680\">MusicBrainz</a>,"
+"\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/AB-337\">AcousticBrainz</a>,"
+"\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/BB-260\">BookBrainz</a>,\n"
+"         <a href=\"https://tickets.metabrainz.org/browse/MEB-103\">the "
+"MetaBrainz Site</a>,\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/LB-354\">ListenBrainz</a>, "
+"and\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/CB-307\">CritiqueBrainz</a>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:80
 msgid "Restriction of processing"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:110
+#: metabrainz/templates/index/gdpr.html:83
+msgid ""
+"Summary: <i>To allow the user to control how their personally identifying"
+" data is being used.</i>"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:86
+msgid ""
+"Except for the ListenBrainz and AcousticBrainz projects, we do not "
+"process personally identifying data. Any personally\n"
+"    identifying data that our projects store is for the purpose of being "
+"able to contact you about your contributions to our database\n"
+"    (email address) or for voluntarily showing information about you to "
+"other users (biography, homepage, location, etc)."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:91
+#, python-format
+msgid ""
+"The ListenBrainz project differs in that the Listens (metadata about what"
+" music you have listened to) are stored on our servers\n"
+"    and <a href=\"%(listenbrainz_data_url)s\">made available to the "
+"public</a>. We believe Listens to be personally identifying\n"
+"    data and furthermore, we have goals of creating open source "
+"recommendation engines with this data, which involves processing the\n"
+"    user’s data. These two points are fundamental goals of the "
+"ListenBrainz project and we do not see a reasonable way to reach another"
+"\n"
+"    compromise position."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:99
+msgid ""
+"Because of this, we are going to require users to either acknowledge that"
+" we may process their Listen data or alternatively to\n"
+"    delete their account, including all of their Listens. Please note "
+"that if you decide to delete your ListenBrainz account, it may\n"
+"    take up to two weeks for all of your listens to no longer be included"
+" in our efforts to build a recommendation engine."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:104
+msgid ""
+"We have always made it clear that the data in ListenBrainz was to be "
+"public and that we plan to build new tools with your data, so\n"
+"    this should not come as a surprise to our users."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:108
+msgid ""
+"The AcousticBrainz project does not track who submits data to the "
+"database. If you create an account and use our data creation\n"
+"    tools (e.g. create a dataset or participate in a challenge) then we "
+"link your participation and the things that you create to\n"
+"    your account. If you choose to delete your account then we keep the "
+"non personally identifying data that you create, but anonymize\n"
+"    it so that it cannot be linked back to you."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:114
 msgid "Right to data portability / exporting your data"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:150
+#: metabrainz/templates/index/gdpr.html:117
+msgid ""
+"Summary: <i>You have the right to access/download the data we store about"
+" you</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:120
+msgid ""
+"Except for the ListenBrainz and AcousticBrainz projects, we do not store "
+"personally identifying data beyond the\n"
+"    information that is available in your public profile on each of our "
+"projects. Since this data is plainly available in your\n"
+"    profile we do not provide a means for you to export this data."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:125
+msgid "There are the following exceptions to this:"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:129
+msgid ""
+"<b>IP addresses</b>: If you visit one of our sites the IP address of your"
+" computer is stored in our web logs for 7 days\n"
+"        before our servers automatically delete them. This data is almost"
+" never used by anyone: the only time we look at the\n"
+"        IP addresses is if our sites are adversely impacted by the "
+"actions of some unknown users. In that case, we may investigate\n"
+"        the logs to identify the IP address that needs to be blocked in "
+"order to restore the stability of our service.\n"
+"        This data is not available to anyone but the contractors of the "
+"MetaBrainz Foundation and is not available to download\n"
+"        to anyone at all."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:137
+#, python-format
+msgid ""
+"<b>ListenBrainz Listen data</b>: Users may <a "
+"href=\"%(listenbrainz_export_url)s\">export their ListenBrainz Listen\n"
+"        data</a> directly from the site. The user Listen data is also "
+"included in the <a href=\"%(listenbrainz_data_url)s\">ListenBrainz\n"
+"        data dumps</a> that are available for public download."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:146
+msgid ""
+"All of the non personally identifying data, such as your metadata "
+"contributions, are publicly visible, available for download\n"
+"    and available via the project APIs. For details about this data, "
+"downloads and APIs please check the documentation for the\n"
+"    respective projects you are interested in."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:151
+#, python-format
+msgid ""
+"Anyone wishing to get a list of financial donations they have made to the"
+" MetaBrainz Foundation, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a> and provide your "
+"MusicBrainz editor name so that we can look up\n"
+"    your donations."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:157
 msgid "Right to rectification"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:165
+#: metabrainz/templates/index/gdpr.html:160
+msgid "Summary: <i>You have the right to correct your data</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:163
+msgid ""
+"All of our projects allow their users to update their personally "
+"identifying information in their profiles. Furthermore, most\n"
+"    of our projects allow the editing of their own metadata "
+"contributions. If you find that some of your data is incorrect, please\n"
+"    feel free to edit the data since we provide the tools to do so."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:168
+#, python-format
+msgid ""
+"If anyone who has made a financial donation to the MetaBrainz Foundation "
+"would like to make their donation private, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:173
 msgid "Right to be informed"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:188
+#: metabrainz/templates/index/gdpr.html:175
+msgid ""
+"Summary: <i>You have the right to be informed about how we use your data "
+"in plain English</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:178
+msgid ""
+"Our privacy policy, as well as other policies, have always been written "
+"by humans for human consumption. We abhor legalese and\n"
+"    not speaking in direct terms."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:186
+msgid "Social contract"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:189
+msgid "Code of conduct"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:192
+msgid "Privacy policy"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:196
 msgid "Right to access"
 msgstr ""
 
-#: metabrainz/templates/index/gdpr.html:198
-#: metabrainz/templates/index/privacy.html:166
+#: metabrainz/templates/index/gdpr.html:199
+msgid ""
+"Summary: <i>You have the right to access the data that we collect about "
+"you</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:202
+msgid ""
+"All of our projects make all of the data we collect on your behalf, "
+"privately identifying or not, available to you. The\n"
+"    only exception to this are the IP addresses we store for 7 days – see"
+" above for details."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:206
+#: metabrainz/templates/index/privacy.html:168
 msgid "Privacy/GDPR Representative"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:209
+#, python-format
+msgid ""
+"If you have any questions about our privacy policy, please <a "
+"href=\"%(contact_url)s\">contact us</a>. To report\n"
+"   any privacy problems, violations or leaks, our GDPR representative is "
+"our Interim Executive Director Nicolás Tamargo and for\n"
+"   privacy issues contact him at <strong><a "
+"href=\"mailto:gdpr@metabrainz.org\">gdpr@metabrainz.org</a></strong>."
 msgstr ""
 
 #: metabrainz/templates/index/index.html:6
@@ -1214,13 +2041,51 @@ msgid ""
 "      <a href=\"%(about_url)s\">about</a> page."
 msgstr ""
 
-#: frontend/js/src/forms/ConditionsModal.tsx:43
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:32
 #: metabrainz/templates/index/privacy.html:3
 msgid "Privacy"
 msgstr ""
 
 #: metabrainz/templates/index/privacy.html:8
 msgid "Summary"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:12
+msgid ""
+"You do not have to provide any personal data to be able to browse the "
+"contents of the databases published by MetaBrainz."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:15
+msgid ""
+"You do not have to provide any personally-identifying information if you "
+"choose not to."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:18
+msgid ""
+"We will never reveal your email address on MetaBrainz controlled web "
+"sites."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:22
+msgid ""
+"In order to get maximum value out of the MetaBrainz projects, you may "
+"want to create an account and log in. \n"
+"    Doing so grants you the ability to: edit the databases, contribute "
+"your own data, communicate with other users, and keep track \n"
+"    of recently released music from artists in your MusicBrainz "
+"collection. If you choose to create an account then the minimum we \n"
+"    ask is that you: choose a unique username and password, use a web "
+"browser that accepts \"session\" cookies, and provide a verified \n"
+"    email address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:29
+msgid ""
+"If you do not create an account (or are not logged in) you will not have "
+"access to the above listed features, however, you will \n"
+"    still have full access to browse and examine the databases."
 msgstr ""
 
 #: metabrainz/templates/index/privacy.html:33
@@ -1231,39 +2096,197 @@ msgstr ""
 msgid "Cookies"
 msgstr ""
 
+#: metabrainz/templates/index/privacy.html:37
+msgid "We use two cookies that contain sensitive information:"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:42
+msgid ""
+"<b>remember_login</b>: If you choose the \"Log in permanently\" option "
+"when logging in to one of our sites; the cookie will be used to \n"
+"      remember your login details."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:46
+msgid ""
+"<b>musicbrainz_server_session, session, or connect.sid</b>: If you are "
+"logged into one of our sites, your current session ID is stored in this "
+"cookie."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:51
+msgid ""
+"We may store dynamic preference information in other cookies, but these "
+"do not contain any sensitive information."
+msgstr ""
+
 #: metabrainz/templates/index/privacy.html:54
 msgid "Web and FTP access logs"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:57
+msgid ""
+"In a practice similar to other web sites (and APIs) we keep logs of all "
+"web requests made against our servers. These logs include: your IP\n"
+"    address, your browser's (or API client's) \"User-Agent\" string, and "
+"which page (or API endpoint) you requested with which parameters. "
+"Aggregate information about web and FTP traffic is\n"
+"    made available to the public via our site usage pages."
 msgstr ""
 
 #: metabrainz/templates/index/privacy.html:62
 msgid "Third-Party content"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:92
+#: metabrainz/templates/index/privacy.html:64
+msgid ""
+"Our projects' web pages may load some third-party content. Some, but "
+"possibly not all sites are listed below:"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:69
+#, python-format
+msgid ""
+"Cover art and other images: These are provided by the various cover art "
+"sites that have given MusicBrainz permission to do so and our own \n"
+"      <a href=\"%(caa_url)s\">Cover Art Archive</a>. This means that the "
+"relevant site will know (if they want to) your IP \n"
+"      address, User-Agent string, etc., and which MusicBrainz web page "
+"you were visiting (the one which included the cover art image)."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:75
+msgid ""
+"AcoustID: Our fingerprints tab loads fingerprint information from "
+"acoustid.org."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:78
+msgid ""
+"MTCaptcha: Our account creation page loads third party content in order "
+"to prevent spammers from creating accounts."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:83
+msgid ""
+"<i>The above information assumes that you are using \"normal\" web "
+"browser settings, whereby images are always loaded and HTTP referrer \n"
+"    information is always sent.</i>"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:88
+msgid ""
+"It is impractical to constantly modify this privacy policy when "
+"MetaBrainz projects change which third party content they utilize. We "
+"will \n"
+"    aim to use common sense, respect to our community and community "
+"review when adding more content from third party sites. We will also \n"
+"    periodically review our policy to ensure that it remains current."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:93
 msgid "Applicable to account holders"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:94
+#: metabrainz/templates/index/privacy.html:95
 msgid "Account creation"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:108
+#: metabrainz/templates/index/privacy.html:97
+msgid ""
+"When creating an account with a MetaBrainz project you need to pick a "
+"unique username and choose a password, the username you pick is the \n"
+"    only name associated with your account and will be what other "
+"MetaBrainz users know you as. You may optionally also tell us other \n"
+"    information about yourself that will be displayed to other MetaBrainz"
+" users and the public."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:103
+msgid ""
+"Additionally, in order to edit the databases you will need to provide a "
+"confirmed email address. This email address will be held in \n"
+"    confidence, the only method of revealing your email address to "
+"another user is if you choose to send a message to another \n"
+"    user and enable the option to \"reveal my email address\". Changing "
+"the email address stored with your account will require you to \n"
+"    verify the new address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:109
 msgid "Edits and Notes"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:114
+#: metabrainz/templates/index/privacy.html:111
+msgid ""
+"If you make any changes to a MetaBrainz project database, such as adding "
+"any data, the details of those changes will be visible to \n"
+"    other logged-in users and the change will be associated with your "
+"username."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:115
 msgid "Subscriptions on MusicBrainz"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:131
+#: metabrainz/templates/index/privacy.html:117
+msgid ""
+"As a logged-in user you can subscribe to one or more artists, labels, "
+"collections or other editors. The act of subscribing causes \n"
+"    any edits made to (or by in the case of another editor) those "
+"entities to be emailed to you. By default, other users can see your \n"
+"    list of subscriptions, however, you can opt out of this by editing "
+"the appropriate preference."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:123
+msgid ""
+"This does not provide \"perfect\" privacy though, in some cases it will "
+"be possible to infer information about the contents of your \n"
+"    subscription list even though you have disallowed others from viewing"
+" that list directly. This imperfection arises because various \n"
+"    parts of the system behave differently depending on whether or not an"
+" entity has any subscribers; also, the number of users \n"
+"    subscribed to each artist is available via the artist pages. In the "
+"most extreme (possibly contrived) example, imagine that all \n"
+"    users have their subscriptions set to \"public\", except for exactly "
+"one user whose list is \"private\". In that case, any discrepancy \n"
+"    for a given artist between the shown list of subscribers and the "
+"total number of subscribers must be down to that one user. Thus, \n"
+"    you can infer what artists are on that user's list."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:132
 msgid "Third-party sites"
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:145
-msgid "MetaBrainz donors"
+#: metabrainz/templates/index/privacy.html:134
+#, python-format
+msgid ""
+"Our code reviews are done on GitHub, which is not under the control of "
+"MetaBrainz. Participating in code reviews or other\n"
+"    tasks carried out on GitHub are subject to <a "
+"href=\"%(github_url)s\">GitHub's privacy policy</a>."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:140
+#, python-format
+msgid ""
+"Our translations platform is provided and hosted by Weblate, which has a "
+"data processing agreement with MetaBrainz.\n"
+"    Participating in translations is subject to <a "
+"href=\"%(weblate_url)s\">dedicated legal terms</a>.\n"
+"    Any translations you make will be submitted to our Git repositories "
+"and publicly associated with your username;\n"
+"    if you so choose, you can also publicly associate them with your own "
+"verified email address."
 msgstr ""
 
 #: metabrainz/templates/index/privacy.html:147
+msgid "MetaBrainz donors"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:149
 msgid ""
 "When you make a donation to the MetaBrainz Foundation, we are legally\n"
 "    required to collect your personal information and keep it in our "
@@ -1273,7 +2296,7 @@ msgid ""
 "    information to anyone else, ever."
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:153
+#: metabrainz/templates/index/privacy.html:155
 msgid ""
 "We believe in transparent finances, which means that we list all "
 "donations\n"
@@ -1283,11 +2306,34 @@ msgid ""
 "process."
 msgstr ""
 
-#: metabrainz/templates/index/privacy.html:158
+#: metabrainz/templates/index/privacy.html:160
 msgid "Exceptions"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:598
+#: metabrainz/templates/index/privacy.html:162
+msgid ""
+"<i><b>Please note</b>: Reasonable exceptions may apply to the above "
+"policy, for example to comply with applicable laws.\n"
+"    Also, members of the MetaBrainz team and other personnel contracted "
+"to provide services to MetaBrainz may have access to\n"
+"    our infrastructure and could therefore view any information contained"
+" therein. However all personnel are contractually bound\n"
+"    by non-disclosure clauses which prevent them from making any such "
+"information available to others."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:171
+#, python-format
+msgid ""
+"If you have any questions about our GDPR statement, please <a "
+"href=\"%(contact_url)s\">contact us</a>. To report\n"
+"   any privacy problems, violations or leaks, our GDPR representative is "
+"our Interim Executive Director Nicolás Tamargo and for\n"
+"   privacy issues contact him at <strong><a "
+"href=\"mailto:gdpr@metabrainz.org\">gdpr@metabrainz.org</a></strong>."
+msgstr ""
+
+#: frontend/js/src/Profile.tsx:603
 #: frontend/js/src/forms/ProfileChangePassword.tsx:22
 #: frontend/js/src/forms/ProfileChangePassword.tsx:111
 #: metabrainz/templates/index/profile-change-password.html:3
@@ -1531,6 +2577,11 @@ msgstr ""
 
 #: metabrainz/templates/index/team.html:26
 msgid "He lives on in our hearts and in open source."
+msgstr ""
+
+#: metabrainz/templates/index/team.html:29
+#: metabrainz/templates/index/team.html:315
+msgid "you’re welcome to try"
 msgstr ""
 
 #: metabrainz/templates/index/team.html:39
@@ -2028,8 +3079,10 @@ msgstr ""
 
 #: metabrainz/templates/payments/donate.html:146
 msgid ""
-"Due to the increased unreliability of the US Postal Service we have "
-"stopped accepting paper checks. Sorry!"
+"Due to the increased unreliability of the US Postal Service and the "
+"relatively large fees involved, we ask you to only send a paper check if "
+"it is the only possible option. Due to the fees, we will not cash checks "
+"for less than $25."
 msgstr ""
 
 #: metabrainz/templates/payments/donate.html:241
@@ -2913,8 +3966,8 @@ msgid "Monthly balance sheets"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:520
-#: frontend/js/src/forms/SignupCommercial.tsx:175
-#: frontend/js/src/forms/SignupCommercial.tsx:554
+#: frontend/js/src/forms/SignupCommercial.tsx:180
+#: frontend/js/src/forms/SignupCommercial.tsx:558
 #: frontend/js/src/forms/SignupNonCommercial.tsx:106
 #: frontend/js/src/forms/SignupNonCommercial.tsx:318
 #: metabrainz/templates/supporters/account-type.html:3
@@ -2935,6 +3988,7 @@ msgid "Non-commercial / Personal"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:235
+#: frontend/js/src/forms/SignupNonCommercial.tsx:107
 #: frontend/js/src/forms/SignupNonCommercial.tsx:151
 #: metabrainz/templates/supporters/account-type.html:42
 msgid "Non-commercial"
@@ -2948,55 +4002,45 @@ msgstr ""
 msgid "Personal or university assignment user."
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:48
-#: metabrainz/templates/supporters/account-type.html:90
-#: metabrainz/templates/supporters/account-type.html:141
-msgid "Upgrade"
-msgstr ""
-
 #: frontend/js/src/Profile.tsx:235
-#: frontend/js/src/forms/SignupCommercial.tsx:176
-#: frontend/js/src/forms/SignupCommercial.tsx:228
-#: metabrainz/templates/supporters/account-type.html:61
+#: frontend/js/src/forms/SignupCommercial.tsx:181
+#: frontend/js/src/forms/SignupCommercial.tsx:233
+#: metabrainz/templates/supporters/account-type.html:56
 msgid "Commercial"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:83
-#: metabrainz/templates/supporters/account-type.html:135
+#: metabrainz/templates/supporters/account-type.html:78
+#: metabrainz/templates/supporters/account-type.html:125
 #, python-format
 msgid "$%(tier_price)s/month and up"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:87
-#: metabrainz/templates/supporters/account-type.html:138
+#: metabrainz/templates/supporters/account-type.html:82
+#: metabrainz/templates/supporters/account-type.html:128
 msgid "More info"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:104
+#: metabrainz/templates/supporters/account-type.html:94
 msgid "View all tiers"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:112
+#: metabrainz/templates/supporters/account-type.html:102
 msgid "Some of our Unicorn members"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:123
+#: metabrainz/templates/supporters/account-type.html:113
 msgid "See all our supporters"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:151
+#: metabrainz/templates/supporters/account-type.html:136
 msgid "View featured tiers"
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:158
+#: metabrainz/templates/supporters/account-type.html:143
 #, python-format
 msgid ""
 "If you are not sure which tier to pick, please\n"
 "      <a href=\"%(contact_url)s\">contact us</a>."
-msgstr ""
-
-#: metabrainz/templates/supporters/account-type.html:166
-msgid "Back to Profile"
 msgstr ""
 
 #: metabrainz/templates/supporters/bad-standing.html:3
@@ -3058,9 +4102,9 @@ msgid "Forgot your username"
 msgstr ""
 
 #: frontend/js/src/forms/ResetPassword.tsx:79
-#: frontend/js/src/forms/SignupCommercial.tsx:320
+#: frontend/js/src/forms/SignupCommercial.tsx:325
 #: frontend/js/src/forms/SignupNonCommercial.tsx:227
-#: frontend/js/src/forms/SignupUser.tsx:169
+#: frontend/js/src/forms/SignupUser.tsx:175
 #: metabrainz/templates/users/reauthenticate.html:3
 #: metabrainz/templates/users/reauthenticate.html:6
 msgid "Confirm Password"
@@ -3070,17 +4114,22 @@ msgstr ""
 msgid "Please re-enter your password to continue."
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:108
+#: frontend/js/src/ProfileDelete.tsx:110
 #: frontend/js/src/forms/DeleteApplication.tsx:53
 #: frontend/js/src/forms/OAuthPrompt.tsx:54
 #: frontend/js/src/forms/ProfileChangePassword.tsx:104
 #: frontend/js/src/forms/ProfileEdit.tsx:105
-#: metabrainz/templates/users/reauthenticate.html:23
+#: metabrainz/templates/users/reauthenticate.html:28
 msgid "Cancel"
 msgstr ""
 
-#: metabrainz/templates/users/reauthenticate.html:24
+#: metabrainz/templates/users/reauthenticate.html:29
 msgid "Continue"
+msgstr ""
+
+#: frontend/js/src/forms/utils.tsx:202
+#: metabrainz/templates/users/reauthenticate.html:40
+msgid "Password must not exceed 72 bytes."
 msgstr ""
 
 #: frontend/js/src/forms/ResetPassword.tsx:27
@@ -3088,38 +4137,38 @@ msgstr ""
 msgid "Reset your password"
 msgstr ""
 
-#: frontend/js/src/hooks/useEmailValidation.ts:41 metabrainz/user/forms.py:15
+#: frontend/js/src/hooks/useEmailValidation.ts:41 metabrainz/user/forms.py:16
 msgid "Registration from this email domain is not allowed."
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:50
 #: frontend/js/src/forms/LostPassword.tsx:45
-#: frontend/js/src/forms/SignupCommercial.tsx:270
+#: frontend/js/src/forms/SignupCommercial.tsx:275
 #: frontend/js/src/forms/SignupNonCommercial.tsx:175
-#: frontend/js/src/forms/SignupUser.tsx:114 metabrainz/user/forms.py:20
-#: metabrainz/user/forms.py:45 metabrainz/user/forms.py:62
+#: frontend/js/src/forms/SignupUser.tsx:120 metabrainz/user/forms.py:22
+#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:75
 msgid "Username"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:42
 #: frontend/js/src/forms/LostPassword.tsx:37
-#: frontend/js/src/forms/SignupCommercial.tsx:153
+#: frontend/js/src/forms/SignupCommercial.tsx:158
 #: frontend/js/src/forms/SignupNonCommercial.tsx:84
-#: frontend/js/src/forms/SignupUser.tsx:67 metabrainz/user/forms.py:21
-#: metabrainz/user/forms.py:45 metabrainz/user/forms.py:62
+#: frontend/js/src/forms/SignupUser.tsx:73 metabrainz/user/forms.py:26
+#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:75
 msgid "Username is required!"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:63
 #: frontend/js/src/forms/ResetPassword.tsx:72
-#: frontend/js/src/forms/SignupCommercial.tsx:308
+#: frontend/js/src/forms/SignupCommercial.tsx:313
 #: frontend/js/src/forms/SignupNonCommercial.tsx:214
-#: frontend/js/src/forms/SignupUser.tsx:157 metabrainz/user/forms.py:46
-#: metabrainz/user/forms.py:52
+#: frontend/js/src/forms/SignupUser.tsx:163 metabrainz/user/forms.py:53
+#: metabrainz/user/forms.py:62
 msgid "Password"
 msgstr ""
 
-#: frontend/js/src/forms/LoginUser.tsx:76 metabrainz/user/forms.py:47
+#: frontend/js/src/forms/LoginUser.tsx:76 metabrainz/user/forms.py:57
 msgid "Remember me"
 msgstr ""
 
@@ -3131,11 +4180,11 @@ msgstr ""
 msgid "Username contains invalid or invisible characters."
 msgstr ""
 
-#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:181
+#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:220
 msgid "Hide password"
 msgstr ""
 
-#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:181
+#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:220
 msgid "Show password"
 msgstr ""
 
@@ -3192,11 +4241,11 @@ msgstr ""
 msgid "Revoke access"
 msgstr ""
 
-#: frontend/js/src/OAuthError.tsx:17
+#: frontend/js/src/OAuthError.tsx:18
 msgid "OAuth2 Error"
 msgstr ""
 
-#: frontend/js/src/OAuthError.tsx:18
+#: frontend/js/src/OAuthError.tsx:19
 msgid "An error occurred during OAuth authentication process."
 msgstr ""
 
@@ -3226,8 +4275,8 @@ msgstr ""
 
 #: frontend/js/src/Profile.tsx:109
 msgid ""
-"Are you sure you want to generate new access token? Current token will be"
-" revoked!"
+"Are you sure you want to generate a new access token? The current token "
+"will be revoked!"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:118
@@ -3342,8 +4391,8 @@ msgid "Contact Information"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:310 frontend/js/src/forms/ProfileEdit.tsx:70
-#: frontend/js/src/forms/SignupCommercial.tsx:284
-#: frontend/js/src/forms/SignupCommercial.tsx:333
+#: frontend/js/src/forms/SignupCommercial.tsx:289
+#: frontend/js/src/forms/SignupCommercial.tsx:338
 #: frontend/js/src/forms/SignupNonCommercial.tsx:189
 #: frontend/js/src/forms/SignupNonCommercial.tsx:241
 msgid "Contact name"
@@ -3458,7 +4507,7 @@ msgstr ""
 msgid "Once you delete your account, there is no going back. Please be certain."
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:550 frontend/js/src/ProfileDelete.tsx:105
+#: frontend/js/src/Profile.tsx:550 frontend/js/src/ProfileDelete.tsx:107
 msgid "Delete My Account"
 msgstr ""
 
@@ -3470,39 +4519,39 @@ msgstr ""
 msgid "Need to delete your account?"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:574
+#: frontend/js/src/Profile.tsx:575
 msgid ""
 "Deletion of supporter accounts requires manual review. Please contact us "
-"at"
+"at <email />."
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:594
+#: frontend/js/src/Profile.tsx:599
 msgid "Security"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:626
+#: frontend/js/src/Profile.tsx:631
 msgid "MetaBrainz Applications"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:630
+#: frontend/js/src/Profile.tsx:635
 msgid ""
 "With your MetaBrainz account, you can access every project in the "
 "MetaBrainz family:"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:643
+#: frontend/js/src/Profile.tsx:648
 msgid "The open-source music encyclopedia"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:655
+#: frontend/js/src/Profile.tsx:660
 msgid "Track, visualise and share the music you listen to"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:667
+#: frontend/js/src/Profile.tsx:672
 msgid "The open-source book database"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:679
+#: frontend/js/src/Profile.tsx:684
 msgid "Creative Commons licensed reviews"
 msgstr ""
 
@@ -3525,7 +4574,7 @@ msgid "Permanently remove all your account information"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:64
-msgid "Revoke all your API tokens and access"
+msgid "Revoke all your tokens and access to the replication API"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:65
@@ -3537,14 +4586,16 @@ msgid "Log you out of all MetaBrainz services"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:70
-msgid "Your username will be reserved and cannot be reused."
+msgid ""
+"Your username will be reserved and cannot be reused without the "
+"intervention of an administrator."
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:82
+#: frontend/js/src/ProfileDelete.tsx:84
 msgid "To confirm, type your username '<username />' below:"
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:105
+#: frontend/js/src/ProfileDelete.tsx:107
 msgid "Deleting..."
 msgstr ""
 
@@ -3556,64 +4607,7 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: frontend/js/src/forms/ConditionsModal.tsx:23
-msgid "Licensing"
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:25
-msgid ""
-"Any contributions you make to any MetaBrainz service will be released "
-"into the Public Domain and/or licensed under a Creative Commons by-nc-sa "
-"license. Furthermore, you give the MetaBrainz Foundation the right to "
-"license this data for commercial use."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:30
-msgid "Please read our <licenseLink>license page</licenseLink> for more details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:45
-msgid ""
-"MetaBrainz strongly believes in the privacy of its users. Any personal "
-"information you choose to provide will not be sold or shared with anyone "
-"else."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:50
-msgid ""
-"Please read our <privacyLink>privacy policy</privacyLink> for more "
-"details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:59
-msgid "GDPR compliance"
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:61
-msgid ""
-"You may remove your personal information from our services anytime by "
-"deleting your account."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:66
-msgid ""
-"Please read our <gdprLink>GDPR compliance statement</gdprLink> for more "
-"details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:78
-msgid ""
-"Creating an account on MetaBrainz will give you access to all of our "
-"projects, such as MusicBrainz, ListenBrainz, BookBrainz, and more."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:82
-msgid ""
-"We create a placeholder account for all the MetaBrainz projects when you "
-"sign up, and you are one log-in away from activating them."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:91
+#: frontend/js/src/forms/ConditionsModal.tsx:29
 msgid "Sounds good"
 msgstr ""
 
@@ -3699,8 +4693,8 @@ msgstr ""
 msgid "Forgot your password?"
 msgstr ""
 
-#: frontend/js/src/forms/LoginUser.tsx:109
-msgid "Don't have an account?"
+#: frontend/js/src/forms/LoginUser.tsx:110
+msgid "Don't have an account? <signupLink>Sign up</signupLink>"
 msgstr ""
 
 #: frontend/js/src/forms/LostPassword.tsx:38
@@ -3729,15 +4723,72 @@ msgstr ""
 msgid "Allow access"
 msgstr ""
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:71
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:10
+msgid "Licensing"
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:12
+msgid ""
+"Any contributions you make to any MetaBrainz service will be released "
+"into the Public Domain and/or licensed under a Creative Commons by-nc-sa "
+"license. Furthermore, you give the MetaBrainz Foundation the right to "
+"license this data for commercial use."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:17
+msgid "Please read our <licenseLink>license page</licenseLink> for more details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:34
+msgid ""
+"MetaBrainz strongly believes in the privacy of its users. Any personal "
+"information you choose to provide will not be sold or shared with anyone "
+"else."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:39
+msgid ""
+"Please read our <privacyLink>privacy policy</privacyLink> for more "
+"details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:50
+msgid "GDPR compliance"
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:52
+msgid ""
+"You may remove your personal information from our services anytime by "
+"deleting your account."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:57
+msgid ""
+"Please read our <gdprLink>GDPR compliance statement</gdprLink> for more "
+"details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:71
+msgid ""
+"Creating an account on MetaBrainz will give you access to all of our "
+"projects, such as MusicBrainz, ListenBrainz, BookBrainz, and more."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:75
+msgid ""
+"We create a placeholder account for all the MetaBrainz projects when you "
+"sign up, and you are one log-in away from activating them."
+msgstr ""
+
+#: frontend/js/src/forms/ProfileChangePassword.tsx:70
 msgid "Current Password"
 msgstr ""
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:80
+#: frontend/js/src/forms/ProfileChangePassword.tsx:79
 msgid "New Password"
 msgstr ""
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:89
+#: frontend/js/src/forms/ProfileChangePassword.tsx:88
 msgid "Confirm New Password"
 msgstr ""
 
@@ -3749,190 +4800,180 @@ msgstr ""
 msgid "Reset Password"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:38
-msgid "If you would like to support us with more than $"
+#: frontend/js/src/forms/SignupCommercial.tsx:40
+msgid ""
+"If you would like to support us with more than ${{minPledge}}, please "
+"enter the actual amount here:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:39
-msgid ", please enter the actual amount here:"
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:144
+#: frontend/js/src/forms/SignupCommercial.tsx:149
 #: frontend/js/src/forms/SignupNonCommercial.tsx:75
-#: frontend/js/src/forms/SignupUser.tsx:87
+#: frontend/js/src/forms/SignupUser.tsx:93
 msgid "Captcha is required!"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:179
+#: frontend/js/src/forms/SignupCommercial.tsx:184
 #: frontend/js/src/forms/SignupNonCommercial.tsx:110
 #: frontend/js/src/forms/SignupUser.tsx:46
 msgid "Access all MetaBrainz projects"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:182
+#: frontend/js/src/forms/SignupCommercial.tsx:187
 msgid "Note:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:184
+#: frontend/js/src/forms/SignupCommercial.tsx:189
 msgid ""
 "Signing up for any tier other than the <italic>Stealth startup</italic> "
 "tier will publicly list your company on this web site. However, we will "
 "not publish any of your private details."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:221
+#: frontend/js/src/forms/SignupCommercial.tsx:226
 #: frontend/js/src/forms/SignupNonCommercial.tsx:145
 msgid "Account type"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:234
+#: frontend/js/src/forms/SignupCommercial.tsx:239
 msgid "Selected tier"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:242
-msgid "month and up"
+#: frontend/js/src/forms/SignupCommercial.tsx:247
+msgid "${{tierPrice}}/month and up"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:250
+#: frontend/js/src/forms/SignupCommercial.tsx:255
 msgid "Change account type or tier"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:261
+#: frontend/js/src/forms/SignupCommercial.tsx:266
 #: frontend/js/src/forms/SignupNonCommercial.tsx:166
 msgid "Your account:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:271
+#: frontend/js/src/forms/SignupCommercial.tsx:276
 #: frontend/js/src/forms/SignupNonCommercial.tsx:176
-#: frontend/js/src/forms/SignupUser.tsx:114
+#: frontend/js/src/forms/SignupUser.tsx:120
 msgid "(public)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:291
+#: frontend/js/src/forms/SignupCommercial.tsx:296
 #: frontend/js/src/forms/SignupNonCommercial.tsx:196
-#: frontend/js/src/forms/SignupUser.tsx:127
+#: frontend/js/src/forms/SignupUser.tsx:133
 msgid "E-mail address"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:295
+#: frontend/js/src/forms/SignupCommercial.tsx:300
 #: frontend/js/src/forms/SignupNonCommercial.tsx:200
-#: frontend/js/src/forms/SignupUser.tsx:131
+#: frontend/js/src/forms/SignupUser.tsx:137
 msgid "(checking...)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:314
+#: frontend/js/src/forms/SignupCommercial.tsx:319
 #: frontend/js/src/forms/SignupNonCommercial.tsx:220
-#: frontend/js/src/forms/SignupUser.tsx:163
+#: frontend/js/src/forms/SignupUser.tsx:169
 msgid "Must be at least 8 characters"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:348
+#: frontend/js/src/forms/SignupCommercial.tsx:353
 msgid ""
 "If you don't have an organization name, you probably want to become a "
 "supporter as a <nonCommercialLink>Non-commercial / "
 "Personal</nonCommercialLink> supporter."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:358
+#: frontend/js/src/forms/SignupCommercial.tsx:363
 msgid ""
 "If you don't have an organization name, you probably want to sign up as a"
 " <nonCommercialLink>Non-commercial / Personal</nonCommercialLink> user."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:378
+#: frontend/js/src/forms/SignupCommercial.tsx:383
 msgid ""
 "Please tell us a little about your company and whether you plan to use "
 "our <apiLink>API</apiLink> or to <hostLink>host your own copy</hostLink> "
 "of the data."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:404
+#: frontend/js/src/forms/SignupCommercial.tsx:408
 msgid "Logo URL"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:405
+#: frontend/js/src/forms/SignupCommercial.tsx:409
 msgid "(preferably in SVG format)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:408
+#: frontend/js/src/forms/SignupCommercial.tsx:412
 msgid ""
 "Image should be about 250 pixels wide on a white or transparent "
 "background. We will host it on our site."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:421
+#: frontend/js/src/forms/SignupCommercial.tsx:425
 msgid ""
 "URL to where developers can use your APIs using MusicBrainz IDs, if "
-"available.."
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:430
-msgid "Your project"
+"available."
 msgstr ""
 
 #: frontend/js/src/forms/SignupCommercial.tsx:434
+msgid "Your project"
+msgstr ""
+
+#: frontend/js/src/forms/SignupCommercial.tsx:438
 #: frontend/js/src/forms/SignupNonCommercial.tsx:261
 msgid "(max 150 characters)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:451
+#: frontend/js/src/forms/SignupCommercial.tsx:455
 msgid "Billing address"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:502
+#: frontend/js/src/forms/SignupCommercial.tsx:506
 msgid ""
 "I agree to support the MetaBrainz Foundation when my organization is able"
 " to do so."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:507
+#: frontend/js/src/forms/SignupCommercial.tsx:511
+#: frontend/js/src/forms/SignupNonCommercial.tsx:284
 msgid ""
-"I also agree that if I generate a Live Data Feed access token, that I "
-"treat my access token as a secret and will not share this token publicly "
-"or commit it to a source code repository."
+"I also agree that if I generate a Live Data Feed access token, then I "
+"will treat my access token as a secret and will not share this token "
+"publicly or commit it to a source code repository."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:515
+#: frontend/js/src/forms/SignupCommercial.tsx:519
 msgid ""
 "The following information will be shown publicly: organization name, "
 "logo, website and API URLs, data usage description."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:520
+#: frontend/js/src/forms/SignupCommercial.tsx:524
 msgid ""
 "We'll send you more details about payment process once your application "
 "is approved."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:552
+#: frontend/js/src/forms/SignupCommercial.tsx:556
 #: frontend/js/src/forms/SignupNonCommercial.tsx:316
-#: frontend/js/src/forms/SignupUser.tsx:224
+#: frontend/js/src/forms/SignupUser.tsx:230
 msgid "Validating..."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:564
+#: frontend/js/src/forms/SignupCommercial.tsx:568
 #: frontend/js/src/forms/SignupNonCommercial.tsx:329
 msgid "Back to profile"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:569
-#: frontend/js/src/forms/SignupNonCommercial.tsx:334
-msgid "Not a supporter?"
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:570
+#: frontend/js/src/forms/SignupCommercial.tsx:574
 #: frontend/js/src/forms/SignupNonCommercial.tsx:335
-msgid "Create a user account"
+msgid "Not a supporter? <signupLink>Create a user account</signupLink>"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:573
-#: frontend/js/src/forms/SignupNonCommercial.tsx:338
-#: frontend/js/src/forms/SignupUser.tsx:231
-msgid "Already have an account?"
-msgstr ""
-
-#: frontend/js/src/forms/SignupNonCommercial.tsx:107
-msgid "non-commercial"
+#: frontend/js/src/forms/SignupCommercial.tsx:583
+#: frontend/js/src/forms/SignupNonCommercial.tsx:344
+#: frontend/js/src/forms/SignupUser.tsx:238
+msgid "Already have an account? <loginLink>Sign in</loginLink>"
 msgstr ""
 
 #: frontend/js/src/forms/SignupNonCommercial.tsx:113
@@ -3960,46 +5001,40 @@ msgid ""
 "income per year) or personal uses only."
 msgstr ""
 
-#: frontend/js/src/forms/SignupNonCommercial.tsx:284
-msgid ""
-"I also agree that if I generate a Live Data Feed access token, then I "
-"will treat my access token as a secret and will not share this token "
-"publicly or commit it to a source code repository."
-msgstr ""
-
 #: frontend/js/src/forms/SignupUser.tsx:43
 msgid "Create your account"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:50
-msgid "Registration started by"
+#: frontend/js/src/forms/SignupUser.tsx:51
+msgid "Registration started by <client />"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:69
+#: frontend/js/src/forms/SignupUser.tsx:75
+#: frontend/js/src/hooks/useEmailValidation.ts:82
 msgid "Invalid email address."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:150
+#: frontend/js/src/forms/SignupUser.tsx:156
 msgid ""
 "This username and email were provided by the app that started "
 "registration. You can change them later from MetaBrainz settings."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:182
+#: frontend/js/src/forms/SignupUser.tsx:188
 msgid ""
 "I accept that my contributions will be released into the public domain or"
 " licensed for use."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:191
+#: frontend/js/src/forms/SignupUser.tsx:197
 msgid "We will never share your personal information."
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:200
+#: frontend/js/src/forms/SignupUser.tsx:206
 msgid "Click here to read more"
 msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:224
+#: frontend/js/src/forms/SignupUser.tsx:230
 msgid "Create account"
 msgstr ""
 
@@ -4009,10 +5044,6 @@ msgstr ""
 
 #: frontend/js/src/hooks/useEmailValidation.ts:47
 msgid "Email validation failed"
-msgstr ""
-
-#: frontend/js/src/hooks/useEmailValidation.ts:82
-msgid "Invalid email address"
 msgstr ""
 
 #~ msgid "You need to specify amount!"
@@ -5317,5 +6348,97 @@ msgstr ""
 #~ msgstr ""
 
 #~ msgid "Privacy policy"
+#~ msgstr ""
+
+#~ msgid "You need to specify website of the organization."
+#~ msgstr ""
+
+#~ msgid ""
+#~ "We are currently evaluating our overall"
+#~ " online advertising strategy. We are "
+#~ "evaluating advertising, traffic optimization,\n"
+#~ ""
+#~ "    search engine optimization and "
+#~ "software monitization technologies. If you "
+#~ "provide these professional services, please"
+#~ " provide a detailed\n"
+#~ "    deck of your comprehensive services"
+#~ " to the following email address. "
+#~ "<em>Please respect our other non-media"
+#~ " teams and do not contact us \n"
+#~ "    regarding these services on any "
+#~ "other of our email addresses. We "
+#~ "will disregard the entirety of your "
+#~ "submissions if you contact us any "
+#~ "other way!</em>"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Please come ask your questions at "
+#~ "our <a href=\"%(forums_url)s\">forums</a>! We "
+#~ "would love to\n"
+#~ "    answer any questions you may have."
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Due to the increased unreliability of"
+#~ " the US Postal Service we have "
+#~ "stopped accepting paper checks. Sorry!"
+#~ msgstr ""
+
+#~ msgid "Upgrade"
+#~ msgstr ""
+
+#~ msgid "Back to Profile"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Deletion of supporter accounts requires "
+#~ "manual review. Please contact us at"
+#~ msgstr ""
+
+#~ msgid "Revoke all your API tokens and access"
+#~ msgstr ""
+
+#~ msgid "Your username will be reserved and cannot be reused."
+#~ msgstr ""
+
+#~ msgid "Don't have an account?"
+#~ msgstr ""
+
+#~ msgid "If you would like to support us with more than $"
+#~ msgstr ""
+
+#~ msgid ", please enter the actual amount here:"
+#~ msgstr ""
+
+#~ msgid "month and up"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "I also agree that if I generate"
+#~ " a Live Data Feed access token, "
+#~ "that I treat my access token as"
+#~ " a secret and will not share "
+#~ "this token publicly or commit it "
+#~ "to a source code repository."
+#~ msgstr ""
+
+#~ msgid "Not a supporter?"
+#~ msgstr ""
+
+#~ msgid "Create a user account"
+#~ msgstr ""
+
+#~ msgid "Already have an account?"
+#~ msgstr ""
+
+#~ msgid "non-commercial"
+#~ msgstr ""
+
+#~ msgid "Registration started by"
+#~ msgstr ""
+
+#~ msgid "Invalid email address"
 #~ msgstr ""
 

--- a/metabrainz/translations/zh_TW/LC_MESSAGES/messages.po
+++ b/metabrainz/translations/zh_TW/LC_MESSAGES/messages.po
@@ -10,186 +10,269 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-07-25 16:21+0200\n"
+"POT-Creation-Date: 2026-09-08 11:18+0200\n"
 "PO-Revision-Date: 2026-07-29 07:12+0000\n"
 "Last-Translator: silentbird "
 "<silentbird@users.noreply.translations.metabrainz.org>\n"
 "Language: zh_TW\n"
-"Language-Team: Chinese (Traditional Han script) <https://"
-"translations.metabrainz.org/projects/metabrainz/website/zh_Hant/>\n"
+"Language-Team: Chinese (Traditional Han script) "
+"<https://translations.metabrainz.org/projects/metabrainz/website/zh_Hant/>"
+"\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.18.0\n"
-"X-Generator: Weblate 2026.7.1\n"
 
-#: metabrainz/index/forms.py:46
+#: metabrainz/errors.py:24
+msgid "Authorization was declined."
+msgstr ""
+
+#: metabrainz/errors.py:25
+msgid "The authorization request was invalid."
+msgstr ""
+
+#: metabrainz/errors.py:26
+msgid "The application could not be authenticated."
+msgstr ""
+
+#: metabrainz/errors.py:27
+msgid "This application is not allowed to request authorization."
+msgstr ""
+
+#: metabrainz/errors.py:28
+msgid "The application asked for a response type this server does not support."
+msgstr ""
+
+#: metabrainz/errors.py:29
+msgid "The permissions requested by the application are invalid."
+msgstr ""
+
+#: metabrainz/errors.py:30
+msgid "You need to sign in to continue."
+msgstr ""
+
+#: metabrainz/errors.py:31
+msgid "Your consent is required to continue."
+msgstr ""
+
+#: metabrainz/password.py:12
+#, python-format
+msgid "Password must not exceed %(max_bytes)s bytes."
+msgstr ""
+
+#: metabrainz/index/forms.py:48
 #, python-format
 msgid "'%(value)s' is not a valid choice for this field"
 msgstr "「%(value)s」不是有效選項"
 
 #: frontend/js/src/forms/ProfileEdit.tsx:27
-#: frontend/js/src/forms/SignupCommercial.tsx:154
+#: frontend/js/src/forms/SignupCommercial.tsx:159
 #: frontend/js/src/forms/SignupNonCommercial.tsx:85
-#: frontend/js/src/forms/SignupUser.tsx:70
-#: frontend/js/src/hooks/useEmailValidation.ts:78 metabrainz/index/forms.py:57
-#: metabrainz/user/forms.py:25 metabrainz/user/forms.py:57
-#: metabrainz/user/forms.py:63
+#: frontend/js/src/forms/SignupUser.tsx:76
+#: frontend/js/src/hooks/useEmailValidation.ts:78 metabrainz/index/forms.py:59
+#: metabrainz/user/forms.py:31 metabrainz/user/forms.py:70
+#: metabrainz/user/forms.py:76
 msgid "Email address is required!"
 msgstr "請提供電子信箱地址！"
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:34
-#: metabrainz/index/forms.py:63
+#: metabrainz/index/forms.py:65
 msgid "Current password is required!"
 msgstr "請提供目前密碼！"
 
 #: frontend/js/src/forms/LoginUser.tsx:43
 #: frontend/js/src/forms/ProfileChangePassword.tsx:37
 #: frontend/js/src/forms/ResetPassword.tsx:39
-#: frontend/js/src/forms/SignupCommercial.tsx:156
+#: frontend/js/src/forms/SignupCommercial.tsx:161
 #: frontend/js/src/forms/SignupNonCommercial.tsx:87
-#: frontend/js/src/forms/SignupUser.tsx:72 metabrainz/index/forms.py:66
-#: metabrainz/user/forms.py:29 metabrainz/user/forms.py:46
-#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:69
+#: frontend/js/src/forms/SignupUser.tsx:78 metabrainz/index/forms.py:69
+#: metabrainz/user/forms.py:35 metabrainz/user/forms.py:54
+#: metabrainz/user/forms.py:63 metabrainz/user/forms.py:82
 msgid "Password is required!"
 msgstr "請提供密碼！"
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:41
-#: frontend/js/src/forms/SignupCommercial.tsx:160
+#: frontend/js/src/forms/SignupCommercial.tsx:165
 #: frontend/js/src/forms/SignupNonCommercial.tsx:91
-#: frontend/js/src/forms/SignupUser.tsx:76 metabrainz/index/forms.py:70
-#: metabrainz/user/forms.py:33 metabrainz/user/forms.py:73
+#: frontend/js/src/forms/SignupUser.tsx:82 metabrainz/index/forms.py:74
+#: metabrainz/user/forms.py:40 metabrainz/user/forms.py:87
 msgid "Confirm Password is required!"
 msgstr "請確認密碼！"
 
 #: frontend/js/src/forms/ProfileChangePassword.tsx:46
 #: frontend/js/src/forms/ResetPassword.tsx:48
-#: frontend/js/src/forms/SignupCommercial.tsx:165
+#: frontend/js/src/forms/SignupCommercial.tsx:170
 #: frontend/js/src/forms/SignupNonCommercial.tsx:96
-#: frontend/js/src/forms/SignupUser.tsx:81 metabrainz/index/forms.py:72
-#: metabrainz/user/forms.py:35 metabrainz/user/forms.py:75
+#: frontend/js/src/forms/SignupUser.tsx:87 metabrainz/index/forms.py:76
+#: metabrainz/user/forms.py:42 metabrainz/user/forms.py:89
 msgid "Confirm Password should match password!"
 msgstr "確認密碼須與密碼相符！"
 
 #: frontend/js/src/Applications.tsx:56 frontend/js/src/Applications.tsx:86
 #: frontend/js/src/Profile.tsx:272 frontend/js/src/Profile.tsx:482
-#: metabrainz/index/forms.py:78
+#: metabrainz/index/forms.py:82
 msgid "Name"
 msgstr "名稱"
 
-#: metabrainz/index/forms.py:79
+#: metabrainz/index/forms.py:83
 msgid "Contact name field is empty."
 msgstr "請提供聯絡人名稱。"
 
-#: metabrainz/index/views.py:234
+#: metabrainz/index/views.py:251
 msgid "Profile updated successfully."
 msgstr "個人資訊已更新。"
 
-#: metabrainz/index/views.py:261
+#: metabrainz/index/views.py:278
 msgid "Current password is incorrect."
 msgstr "目前密碼有誤。"
 
-#: metabrainz/index/views.py:266
+#: metabrainz/index/views.py:283
 msgid "Password changed successfully."
 msgstr "密碼已變更。"
 
-#: metabrainz/index/views.py:372
+#: metabrainz/index/views.py:389
 msgid "You have updated an application!"
 msgstr "應用程式已更新！"
 
-#: metabrainz/index/views.py:424
+#: metabrainz/index/views.py:441
 msgid "You have deleted an application."
 msgstr "應用程式已刪除。"
 
-#: metabrainz/index/views.py:426
+#: metabrainz/index/views.py:443
 msgid "Failed to delete an application."
 msgstr "未能刪除應用程式。"
 
-#: metabrainz/index/views.py:449
+#: metabrainz/index/views.py:466
 msgid "Revoked tokens successfully!"
 msgstr "權杖已撤銷！"
 
-#: metabrainz/index/views.py:478
+#: metabrainz/index/views.py:495
 msgid "Your account has been deleted."
 msgstr "您的帳號已刪除。"
 
-#: frontend/js/src/forms/CreateApplication.tsx:106 metabrainz/oauth/forms.py:58
+#: frontend/js/src/forms/CreateApplication.tsx:106 metabrainz/oauth/forms.py:57
 msgid "Application Name"
 msgstr "應用程式名稱"
 
-#: metabrainz/oauth/forms.py:59
+#: metabrainz/oauth/forms.py:58
 msgid "Application name field is empty."
 msgstr "請提供應用程式名稱。"
 
-#: frontend/js/src/forms/CreateApplication.tsx:60 metabrainz/oauth/forms.py:60
+#: frontend/js/src/forms/CreateApplication.tsx:60 metabrainz/oauth/forms.py:59
 msgid "Application name needs to be at least 3 characters long."
 msgstr "應用程式名稱不可短於三個字元。"
 
-#: frontend/js/src/forms/CreateApplication.tsx:64 metabrainz/oauth/forms.py:61
+#: frontend/js/src/forms/CreateApplication.tsx:64 metabrainz/oauth/forms.py:60
 msgid "Application name needs to be at most 64 characters long."
 msgstr "應用程式名稱不可長於64個字元。"
 
-#: frontend/js/src/forms/CreateApplication.tsx:114 metabrainz/oauth/forms.py:63
+#: frontend/js/src/forms/CreateApplication.tsx:114 metabrainz/oauth/forms.py:62
 msgid "Description"
 msgstr "描述"
 
-#: metabrainz/oauth/forms.py:64
+#: metabrainz/oauth/forms.py:63
 msgid "Client description field is empty."
 msgstr "請描述應用程式。"
 
-#: metabrainz/oauth/forms.py:65
+#: metabrainz/oauth/forms.py:64
 msgid "Client description needs to be at least 3 characters long."
 msgstr "應用程式的描述不可短於三個字元。"
 
-#: metabrainz/oauth/forms.py:66
+#: metabrainz/oauth/forms.py:65
 msgid "Client description needs to be at most 512 characters long."
 msgstr "應用程式的描述不可長於512個字元。"
 
-#: frontend/js/src/forms/CreateApplication.tsx:122 metabrainz/oauth/forms.py:68
+#: frontend/js/src/forms/CreateApplication.tsx:122 metabrainz/oauth/forms.py:67
 msgid "Homepage"
 msgstr "主頁"
 
-#: metabrainz/oauth/forms.py:69
+#: metabrainz/oauth/forms.py:68
 msgid "Homepage field is empty."
 msgstr "請提供主頁。"
 
-#: metabrainz/oauth/forms.py:70
+#: metabrainz/oauth/forms.py:69
 msgid "Homepage is not a valid URI."
 msgstr "主頁地址無效。"
 
-#: metabrainz/oauth/forms.py:71
+#: metabrainz/oauth/forms.py:70
 msgid "Homepage URL must use http or https"
 msgstr "主頁地址必須使用http或https"
 
-#: metabrainz/oauth/forms.py:73
+#: metabrainz/oauth/forms.py:72
 msgid "Authorization callback URL"
 msgstr "授權回呼地址"
 
-#: metabrainz/oauth/forms.py:74
+#: metabrainz/oauth/forms.py:73
 msgid "Authorization callback URL field is empty."
 msgstr "請提供授權回呼地址。"
 
-#: metabrainz/oauth/forms.py:75
+#: metabrainz/oauth/forms.py:74
 msgid "Authorization callback URL is invalid."
 msgstr "授權回呼地址無效。"
 
-#: metabrainz/oauth/forms.py:76
+#: metabrainz/oauth/forms.py:75
 msgid "Authorization callback URL must use http or https."
 msgstr "授權回呼地址必須使用http或https。"
 
-#: metabrainz/oauth/forms.py:81 metabrainz/oauth/forms.py:85
+#: metabrainz/oauth/forms.py:80 metabrainz/oauth/forms.py:84
 msgid "Confirm"
 msgstr "確定"
+
+#: metabrainz/oauth/scopes.py:15
+msgid "View your public account information"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:16
+msgid "View your email address"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:17
+msgid "View and modify your private tags"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:18
+msgid "View and modify your private ratings"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:19
+msgid "View and modify your private collections"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:20
+msgid "Submit new ISRCs to the database"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:21
+msgid "Submit new barcodes to the database"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:22
+msgid "Sign you in and view your unique user id"
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:23
+msgid "Submit listens to ListenBrainz."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:24
+msgid "Create and modify CritiqueBrainz reviews."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:25
+msgid "Submit and delete votes on CritiqueBrainz reviews."
+msgstr ""
+
+#: metabrainz/oauth/scopes.py:26
+msgid "Modify profile info and delete profile on CritiqueBrainz."
+msgstr ""
 
 #: metabrainz/payments/views.py:164
 msgid ""
 "Thank you for making a donation to the MetaBrainz Foundation. Your "
 "support is greatly appreciated! It may take some time before your "
 "donation appears in the list due to processing delays."
-msgstr ""
-"您已向MetaBrainz基金會捐款。非常感謝您的支持！由於我們還要處理捐款，所以您的"
-"名字可能要過一段時間才會出現在列表中。"
+msgstr "您已向MetaBrainz基金會捐款。非常感謝您的支持！由於我們還要處理捐款，所以您的名字可能要過一段時間才會出現在列表中。"
 
 #: metabrainz/payments/views.py:171
 msgid ""
@@ -226,182 +309,185 @@ msgid "Requested annual report was not found."
 msgstr "找不到所要的年度報告。"
 
 #: frontend/js/src/forms/ProfileEdit.tsx:30
-#: frontend/js/src/forms/SignupCommercial.tsx:139
+#: frontend/js/src/forms/SignupCommercial.tsx:144
 #: frontend/js/src/forms/SignupNonCommercial.tsx:70
-#: metabrainz/supporter/forms.py:13
+#: metabrainz/supporter/forms.py:15
 msgid "Contact name is required!"
 msgstr "請提供聯絡人名稱！"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:437
+#: frontend/js/src/forms/SignupCommercial.tsx:441
 #: frontend/js/src/forms/SignupNonCommercial.tsx:264
-#: metabrainz/supporter/forms.py:15
+#: metabrainz/supporter/forms.py:17
 msgid ""
 "Can you please tell us more about the project in which you'd like to use "
 "our data? Do you plan to self host the data or use our APIs?"
-msgstr ""
-"請說明您打算如何在應用程式中使用我們的資料。您打算將資料儲存在主機還是使用我"
-"們的API？"
+msgstr "請說明您打算如何在應用程式中使用我們的資料。您打算將資料儲存在主機還是使用我們的API？"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:137
+#: frontend/js/src/forms/SignupCommercial.tsx:142
 #: frontend/js/src/forms/SignupNonCommercial.tsx:68
-#: metabrainz/supporter/forms.py:17
+#: metabrainz/supporter/forms.py:19
 msgid "Please, tell us how you (will) use our data."
 msgstr "請說明您將如何使用我們的數據。"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:138
+#: frontend/js/src/forms/SignupCommercial.tsx:143
 #: frontend/js/src/forms/SignupNonCommercial.tsx:69
-#: metabrainz/supporter/forms.py:18
+#: metabrainz/supporter/forms.py:20
 msgid "Please, limit usage description to 500 characters."
 msgstr "描述不可長於500個字元。"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:141
-#: frontend/js/src/forms/SignupCommercial.tsx:142
+#: frontend/js/src/forms/SignupCommercial.tsx:146
+#: frontend/js/src/forms/SignupCommercial.tsx:147
 #: frontend/js/src/forms/SignupNonCommercial.tsx:72
 #: frontend/js/src/forms/SignupNonCommercial.tsx:73
-#: frontend/js/src/forms/SignupUser.tsx:84
-#: frontend/js/src/forms/SignupUser.tsx:85 metabrainz/supporter/forms.py:21
-#: metabrainz/user/forms.py:38
+#: frontend/js/src/forms/SignupUser.tsx:90
+#: frontend/js/src/forms/SignupUser.tsx:91 metabrainz/supporter/forms.py:23
+#: metabrainz/user/forms.py:45
 msgid "You need to accept the agreement!"
 msgstr "請接受協議！"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:342
-#: metabrainz/supporter/forms.py:27
+#: frontend/js/src/forms/SignupCommercial.tsx:347
+#: metabrainz/supporter/forms.py:29
 msgid "Organization name"
 msgstr "組織名稱"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:113
-#: metabrainz/supporter/forms.py:28
+#: frontend/js/src/forms/SignupCommercial.tsx:115
+#: metabrainz/supporter/forms.py:30
 msgid "You need to specify the name of your organization."
 msgstr "請提供機構的名稱。"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:373
-#: metabrainz/supporter/forms.py:30
+#: frontend/js/src/forms/SignupCommercial.tsx:378
+#: metabrainz/supporter/forms.py:32
 msgid "Organization description"
 msgstr "組織描述"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:116
-#: metabrainz/supporter/forms.py:31
+#: frontend/js/src/forms/SignupCommercial.tsx:118
+#: metabrainz/supporter/forms.py:33
 msgid "You need to provide description of your organization."
 msgstr "請描述組織。"
 
 #: frontend/js/src/Profile.tsx:278
-#: frontend/js/src/forms/SignupCommercial.tsx:396
-#: metabrainz/supporter/forms.py:34
+#: frontend/js/src/forms/SignupCommercial.tsx:401
+#: metabrainz/supporter/forms.py:36
 msgid "Website URL"
 msgstr "網站地址"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:119
-#: metabrainz/supporter/forms.py:35
-msgid "You need to specify website of the organization."
-msgstr "請提供組織網址。"
+#: frontend/js/src/forms/SignupCommercial.tsx:121
+#: frontend/js/src/forms/SignupCommercial.tsx:123
+#: metabrainz/supporter/forms.py:38 metabrainz/supporter/forms.py:42
+msgid "Website URL must be a valid URL."
+msgstr ""
 
-#: metabrainz/supporter/forms.py:37
+#: metabrainz/supporter/forms.py:45
 msgid "Logo image URL"
 msgstr "標誌圖片網址"
 
 #: frontend/js/src/Profile.tsx:284
-#: frontend/js/src/forms/SignupCommercial.tsx:418
-#: metabrainz/supporter/forms.py:38
+#: frontend/js/src/forms/SignupCommercial.tsx:422
+#: metabrainz/supporter/forms.py:46
 msgid "API URL"
 msgstr "API網址"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:457
-#: metabrainz/supporter/forms.py:40
+#: frontend/js/src/forms/SignupCommercial.tsx:461
+#: metabrainz/supporter/forms.py:48
 msgid "Street"
 msgstr "街道"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:123
-#: metabrainz/supporter/forms.py:41
+#: frontend/js/src/forms/SignupCommercial.tsx:128
+#: metabrainz/supporter/forms.py:49
 msgid "You need to specify street."
 msgstr "請輸入街道。"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:465
-#: metabrainz/supporter/forms.py:43
+#: frontend/js/src/forms/SignupCommercial.tsx:469
+#: metabrainz/supporter/forms.py:51
 msgid "City"
 msgstr "城市"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:124
-#: metabrainz/supporter/forms.py:44
+#: frontend/js/src/forms/SignupCommercial.tsx:129
+#: metabrainz/supporter/forms.py:52
 msgid "You need to specify city."
 msgstr "請輸入城市。"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:473
-#: metabrainz/supporter/forms.py:46
+#: frontend/js/src/forms/SignupCommercial.tsx:477
+#: metabrainz/supporter/forms.py:54
 msgid "State / Province"
 msgstr "州／省"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:126
-#: metabrainz/supporter/forms.py:47
+#: frontend/js/src/forms/SignupCommercial.tsx:131
+#: metabrainz/supporter/forms.py:55
 msgid "You need to specify state/province."
 msgstr "請輸入州或省。"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:481
-#: metabrainz/supporter/forms.py:49
+#: frontend/js/src/forms/SignupCommercial.tsx:485
+#: metabrainz/supporter/forms.py:57
 msgid "Postcode"
 msgstr "郵遞區號"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:128
-#: metabrainz/supporter/forms.py:50
+#: frontend/js/src/forms/SignupCommercial.tsx:133
+#: metabrainz/supporter/forms.py:58
 msgid "You need to specify postcode."
 msgstr "請輸入郵遞區號。"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:489
-#: metabrainz/supporter/forms.py:52
+#: frontend/js/src/forms/SignupCommercial.tsx:493
+#: metabrainz/supporter/forms.py:60
 msgid "Country"
 msgstr "國家"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:129
-#: metabrainz/supporter/forms.py:53
+#: frontend/js/src/forms/SignupCommercial.tsx:134
+#: metabrainz/supporter/forms.py:61
 msgid "You need to specify country."
 msgstr "請輸入國家。"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:132
-#: metabrainz/supporter/forms.py:64
+#: frontend/js/src/forms/SignupCommercial.tsx:137
+#: metabrainz/supporter/forms.py:72
 msgid ""
 "Custom amount must be more than threshold amount for selected tier or "
 "equal to it!"
 msgstr "自訂金額必須等同或多於已選等級之最低金額。"
 
-#: metabrainz/supporter/views.py:46 metabrainz/supporter/views.py:119
-#: metabrainz/supporter/views.py:220
+#: metabrainz/supporter/views.py:54
+msgid ""
+"The verification email could not be sent. Please request a new one from "
+"your profile."
+msgstr ""
+
+#: metabrainz/supporter/views.py:85 metabrainz/supporter/views.py:158
+#: metabrainz/supporter/views.py:260
 msgid "You are already a supporter."
 msgstr "您已經是支持者。"
 
-#: metabrainz/supporter/views.py:61
+#: metabrainz/supporter/views.py:100
 msgid "Can't find tier with a specified ID."
 msgstr "未能找到指定ID的等級。"
 
-#: metabrainz/supporter/views.py:127
+#: metabrainz/supporter/views.py:166
 msgid "You need to choose support tier before signing up!"
 msgstr "請先選擇支持等級！"
 
-#: metabrainz/supporter/views.py:137
+#: metabrainz/supporter/views.py:176
 msgid "You need to choose existing tier before signing up!"
 msgstr "請先選擇現有的等級！"
 
-#: metabrainz/supporter/views.py:164
+#: metabrainz/supporter/views.py:204
 msgid ""
 "Thanks for becoming a supporter! Your application will be reviewed soon. "
 "We will send you updates via email."
-msgstr ""
-"感謝註冊成為支持者！我們很快就會審視您的申請，並透過電子郵件讓您了解審視進度"
-"。"
+msgstr "感謝註冊成為支持者！我們很快就會審視您的申請，並透過電子郵件讓您了解審視進度。"
 
-#: metabrainz/supporter/views.py:187
+#: metabrainz/supporter/views.py:228
 msgid ""
 "Thanks for signing up! Your application will be reviewed soon. We will "
 "send you updates via email."
 msgstr "感謝註冊！我們很快就會審視您的申請，並透過電子郵件讓您了解審視進度。"
 
-#: metabrainz/supporter/views.py:248
+#: metabrainz/supporter/views.py:288
 msgid "Thanks for becoming a supporter!"
 msgstr "感謝您註冊為支持者！"
 
-#: metabrainz/supporter/views.py:274
+#: metabrainz/supporter/views.py:312
 msgid "Thanks for signing up! Please check your inbox to complete verification."
 msgstr "感謝註冊！請檢查收件匣，並完成確認程序。"
 
-#: metabrainz/supporter/views.py:302
+#: metabrainz/supporter/views.py:340
 msgid "Can't generate new token unless account is active."
 msgstr "只可為活躍的帳號產生新權杖。"
 
@@ -435,7 +521,7 @@ msgstr "商店"
 msgid "Policies"
 msgstr "政策"
 
-#: metabrainz/templates/base.html:55 metabrainz/templates/index/gdpr.html:178
+#: metabrainz/templates/base.html:55
 #: metabrainz/templates/index/social-contract.html:3
 #: metabrainz/templates/index/social-contract.html:6
 #: metabrainz/templates/navbar.html:34
@@ -445,14 +531,15 @@ msgstr "社會契約"
 #: metabrainz/templates/base.html:56
 #: metabrainz/templates/index/code-of-conduct.html:3
 #: metabrainz/templates/index/code-of-conduct.html:16
-#: metabrainz/templates/index/gdpr.html:181 metabrainz/templates/navbar.html:35
+#: metabrainz/templates/navbar.html:35
 msgid "Code of Conduct"
 msgstr "行為準則"
 
+#: frontend/js/src/PrivacySummary.tsx:11
 #: frontend/js/src/forms/ConditionsModal.tsx:21
-#: metabrainz/templates/base.html:57 metabrainz/templates/index/gdpr.html:184
-#: metabrainz/templates/index/privacy.html:6
+#: metabrainz/templates/base.html:57 metabrainz/templates/index/privacy.html:6
 #: metabrainz/templates/navbar.html:36
+#: metabrainz/templates/users/privacy-summary.html:3
 msgid "Privacy Policy"
 msgstr "隱私政策"
 
@@ -485,10 +572,7 @@ msgstr "贊助商"
 msgid "Supporters"
 msgstr "支持者"
 
-#: frontend/js/src/forms/LoginUser.tsx:103
-#: frontend/js/src/forms/SignupCommercial.tsx:574
-#: frontend/js/src/forms/SignupNonCommercial.tsx:339
-#: frontend/js/src/forms/SignupUser.tsx:232 metabrainz/templates/base.html:73
+#: frontend/js/src/forms/LoginUser.tsx:103 metabrainz/templates/base.html:73
 #: metabrainz/templates/navbar.html:66 metabrainz/templates/users/login.html:3
 msgid "Sign in"
 msgstr "登入"
@@ -510,26 +594,26 @@ msgid "Contact us"
 msgstr "聯絡我們"
 
 #: metabrainz/templates/base.html:85
-#: metabrainz/templates/index/contact.html:105
+#: metabrainz/templates/index/contact.html:106
 msgid "Blog"
 msgstr "部落格"
 
-#: metabrainz/templates/base.html:86 metabrainz/templates/index/contact.html:90
+#: metabrainz/templates/base.html:86 metabrainz/templates/index/contact.html:91
 msgid "Chat"
 msgstr "聊天室"
 
 #: metabrainz/templates/base.html:87
-#: metabrainz/templates/index/contact.html:106
+#: metabrainz/templates/index/contact.html:107
 msgid "Mastodon"
 msgstr "Mastodon"
 
 #: metabrainz/templates/base.html:88
-#: metabrainz/templates/index/contact.html:107
+#: metabrainz/templates/index/contact.html:108
 msgid "Bluesky"
 msgstr ""
 
 #: metabrainz/templates/base.html:89
-#: metabrainz/templates/index/contact.html:108
+#: metabrainz/templates/index/contact.html:109
 msgid "Instagram"
 msgstr ""
 
@@ -585,15 +669,14 @@ msgstr "財務報告"
 msgid "Donate"
 msgstr "捐款"
 
-#: frontend/js/src/forms/LoginUser.tsx:110
-#: frontend/js/src/forms/SignupCommercial.tsx:175
-#: frontend/js/src/forms/SignupCommercial.tsx:555
+#: frontend/js/src/forms/SignupCommercial.tsx:180
+#: frontend/js/src/forms/SignupCommercial.tsx:559
 #: frontend/js/src/forms/SignupNonCommercial.tsx:106
 #: frontend/js/src/forms/SignupNonCommercial.tsx:319
 #: metabrainz/templates/navbar.html:65
-#: metabrainz/templates/supporters/account-type.html:51
-#: metabrainz/templates/supporters/account-type.html:93
-#: metabrainz/templates/supporters/account-type.html:144
+#: metabrainz/templates/supporters/account-type.html:47
+#: metabrainz/templates/supporters/account-type.html:84
+#: metabrainz/templates/supporters/account-type.html:130
 #: metabrainz/templates/users/signup.html:3
 msgid "Sign up"
 msgstr "註冊"
@@ -624,9 +707,7 @@ msgstr "MetaBrainz API"
 msgid ""
 "All endpoints require an access token which you can get from your\n"
 "    <a href=\"%(profile_url)s\">profile page</a>."
-msgstr ""
-"所有終端都需要訪問權杖，權杖可以從<a href=\"%(profile_url)s\">個人資料頁</a>"
-"取得。"
+msgstr "所有終端都需要訪問權杖，權杖可以從<a href=\"%(profile_url)s\">個人資料頁</a>取得。"
 
 #: metabrainz/templates/api/info.html:15
 msgid "MusicBrainz Live Data Feed"
@@ -645,9 +726,7 @@ msgid ""
 "It is possible to get a signature for each replication packet. Just "
 "replace\n"
 "      <code>.tar.bz2</code> with <code>.tar.bz2.asc</code>."
-msgstr ""
-"如要取得每個複製封包的簽章，請將<code>.tar.bz2</code>替代為<code>"
-".tar.bz2.asc</code>。"
+msgstr "如要取得每個複製封包的簽章，請將<code>.tar.bz2</code>替代為<code>.tar.bz2.asc</code>。"
 
 #: metabrainz/templates/api/info.html:34
 msgid "You can find the latest replication packet number from this endpoint:"
@@ -664,8 +743,8 @@ msgid ""
 "instrument, label, place, recording, release, release-group, series, or "
 "work."
 msgstr ""
-"JSON傾印按實體分類，<code>&lt;ENTITY_NAME&gt;</code>可以是area、artist、event"
-"、instrument、label、place、recording、release、release-group、series或work。"
+"JSON傾印按實體分類，<code>&lt;ENTITY_NAME&gt;</code>可以是area、artist、event、instrument、label、place、recording、release"
+"、release-group、series或work。"
 
 #: metabrainz/templates/api/info.html:61
 msgid ""
@@ -678,17 +757,13 @@ msgid ""
 "Each dump contains a file named <code>mbdump/&lt;ENTITY_NAME&gt;</code>. "
 "This file must be read line-by-line; each line contains one changed "
 "entity in JSON format."
-msgstr ""
-"每個傾印包含一個名為<code>mbdump/&lt;ENTITY_NAME&gt;</code>的檔案，此檔案必須"
-"每行讀取，因為每一行均以JSON格式列出一個經更改的實體。"
+msgstr "每個傾印包含一個名為<code>mbdump/&lt;ENTITY_NAME&gt;</code>的檔案，此檔案必須每行讀取，因為每一行均以JSON格式列出一個經更改的實體。"
 
 #: metabrainz/templates/api/info.html:67
 msgid ""
 "As with replication packets, you can obtain a file signature by replacing"
 " <code>.tar.xz</code> with <code>.tar.xz.asc</code>."
-msgstr ""
-"如複製封包一樣，如要取得檔案簽章，請將<code>.tar.xz</code>替代為<code>"
-".tar.xz.asc</code>。"
+msgstr "如複製封包一樣，如要取得檔案簽章，請將<code>.tar.xz</code>替代為<code>.tar.xz.asc</code>。"
 
 #: metabrainz/templates/errors/base.html:8
 msgid "Back to home page"
@@ -713,10 +788,9 @@ msgid ""
 "        collaborating together to build and maintain the MetaBrainz "
 "comprehensive datasets."
 msgstr ""
-"MetaBrainz基金會是個全球社群，負責建立和維護載有音樂藝術詮釋資料的開放百科全"
-"書。在創立初期，我們僅是音樂收藏家的一個資源網；到了現在，我們推動志工、藝術"
-"家和行業領袖之間協作，已經有<a href=\"%(editors_url)s\">數十萬計</a>、來自五"
-"湖四海的編輯加入我們社群，協力建設和維護MetaBrainz廣博的資料集。"
+"MetaBrainz基金會是個全球社群，負責建立和維護載有音樂藝術詮釋資料的開放百科全書。在創立初期，我們僅是音樂收藏家的一個資源網；到了現在，我們推動志工、藝術家和行業領袖之間協作，已經有<a"
+" "
+"href=\"%(editors_url)s\">數十萬計</a>、來自五湖四海的編輯加入我們社群，協力建設和維護MetaBrainz廣博的資料集。"
 
 #: metabrainz/templates/index/about.html:22
 #, python-format
@@ -779,8 +853,8 @@ msgid ""
 "href=\"%(internet_ecosys_url)s\">Internet &amp; Digital Ecosystem "
 "Alliance</a>"
 msgstr ""
-"Nick Ashton-Hart董事兼秘書，<a href=\"%(internet_ecosys_url)s\">Internet "
-"&amp; Digital Ecosystem Alliance</a>的執行董事"
+"Nick Ashton-Hart董事兼秘書，<a href=\"%(internet_ecosys_url)s\">Internet &amp; "
+"Digital Ecosystem Alliance</a>的執行董事"
 
 #: metabrainz/templates/index/about.html:54
 #, python-format
@@ -793,8 +867,8 @@ msgid ""
 "Director <a href=\"%(matthew_url)s\">Matthew Hawn</a> of <a "
 "href=\"%(compass_url)s\">Compass, Map & Key</a>"
 msgstr ""
-"<a href=\"%(matthew_url)s\">Matthew Hawn</a>董事，<a href=\"%(compass_url)"
-"s\">Compass, Map & Key</a>"
+"<a href=\"%(matthew_url)s\">Matthew Hawn</a>董事，<a "
+"href=\"%(compass_url)s\">Compass, Map & Key</a>"
 
 #: metabrainz/templates/index/about.html:56
 #, python-format
@@ -818,8 +892,8 @@ msgid ""
 "Director <a href=\"%(hazel_url)s\">Hazel Savage</a> of <a "
 "href=\"%(leeds_url)s\">Leeds Angels</a>"
 msgstr ""
-"<a href=\"%(hazel_url)s\">Hazel Savage</a>董事，<a href=\"%(leeds_url)s\">"
-"Leeds Angels</a>"
+"<a href=\"%(hazel_url)s\">Hazel Savage</a>董事，<a "
+"href=\"%(leeds_url)s\">Leeds Angels</a>"
 
 #: metabrainz/templates/index/about.html:62
 msgid "Advisor"
@@ -880,10 +954,7 @@ msgid ""
 "business should provide financial\n"
 "      support so that we may continue to cover our expenses and pay our "
 "staff."
-msgstr ""
-"我們所有專案都需要來自終端使用者的捐贈和商業使用者的支援。我們的免費資料集，"
-"對這些公司來說價值龐大，創造不少商業優勢。我們認為，使用我們的資料來拓展業務"
-"的公司，應該支持我們的財務，讓我們能夠應對業務支出和發放員工的薪水。"
+msgstr "我們所有專案都需要來自終端使用者的捐贈和商業使用者的支援。我們的免費資料集，對這些公司來說價值龐大，創造不少商業優勢。我們認為，使用我們的資料來拓展業務的公司，應該支持我們的財務，讓我們能夠應對業務支出和發放員工的薪水。"
 
 #: metabrainz/templates/index/bad-customers.html:20
 #, python-format
@@ -896,9 +967,8 @@ msgid ""
 "href=\"%(account_type_url)s\">signing up\n"
 "      for support</a>."
 msgstr ""
-"如果您喜愛的公司出現在名單中，請聯絡該公司，詢問他們為什麼會拒絕支援我們。如"
-"果您是以下公司的員工，且希望從列表中除名，請<a href=\"%(account_type_url)s\">"
-"註冊成為支持者</a>。"
+"如果您喜愛的公司出現在名單中，請聯絡該公司，詢問他們為什麼會拒絕支援我們。如果您是以下公司的員工，且希望從列表中除名，請<a "
+"href=\"%(account_type_url)s\">註冊成為支持者</a>。"
 
 #: metabrainz/templates/index/bad-customers.html:26
 #, python-format
@@ -930,9 +1000,431 @@ msgstr "……或許，我們正在遊說某企業去做「應做的事」……
 msgid "Introduction"
 msgstr "前言"
 
-#: metabrainz/templates/index/conflict-policy.html:55
+#: metabrainz/templates/index/conflict-policy.html:17
+msgid ""
+"Conflicts between people arise in open source projects constantly and the"
+" projects by the \n"
+"    MetaBrainz Foundation are no different. This policy aims to establish"
+" a clear and unambiguous \n"
+"    policy for reporting and addressing conflicts in our community. In "
+"this policy we aim to \n"
+"    establish a fair practice that balances the need for confidentiality "
+"and our desire for \n"
+"    transparency in our operations."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:25
+#, python-format
+msgid ""
+"Before you continue to read this policy, we encourage you to review our "
+"existing community policies \n"
+"    including our <a href=\"%(social_contract_url)s\">Social "
+"Contract</a>, \n"
+"    <a href=\"%(code_of_conduct_url)s\">the Code of Conduct</a>, \n"
+"    and our <a href=\"%(privacy_policy_url)s\">Privacy Policy</a>. These "
+"policies establish the norms and rules for \n"
+"    participation in our projects; these policies apply equally to the "
+"contractors of the MetaBrainz \n"
+"    Foundation and any participants in our projects."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:37
+msgid ""
+"This policy divides conflicts into two categories: Private and public. "
+"Private conflicts are conflicts \n"
+"    that involve *confidential* information regarding contributors, "
+"contractors or supporters. Otherwise, any conflicts \n"
+"    that do not involve confidential information are considered to be "
+"public conflicts. For instance, a \n"
+"    conflict between a contractor and the Executive Director (aka BDFL) "
+"that involves contractor pay is \n"
+"    considered a private conflict because pay rates are confidential "
+"information. A public conflict in edit \n"
+"    notes between two editors in our community does not involve "
+"confidential information and therefore should \n"
+"    be considered a public conflict."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:47
+msgid ""
+"When conflicts arise we aim to disclose as much information as possible "
+"about the conflict in a timely \n"
+"    fashion. When conflicts contain confidential matters we will aim to "
+"disclose as much information as \n"
+"    possible, while fully respecting the confidentiality of the people "
+"involved in the conflict. With any \n"
+"    private conflict we will aim to extract the relevant lessons for the "
+"team and community in an effort to \n"
+"    evolve our policies to prevent future conflicts. Should the involved "
+"parties disagree whether a conflict \n"
+"    is private or public, the question about the nature of the conflict "
+"will be presented for the next higher \n"
+"    level in the chain of command to decide. (e.g. if a community member "
+"and the community manager disagree on \n"
+"    a conflict being public or private, the Executive Director shall "
+"decide if the conflict is public or private)."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:58
 msgid "Reporting and Response"
 msgstr "檢舉與處理程序"
+
+#: metabrainz/templates/index/conflict-policy.html:61
+msgid ""
+"We aim to not have conflict in our community, but we recognize that in "
+"reality conflicts will arise and we \n"
+"    must be prepared to address them in a fair manner. When conflicts "
+"arise, we prefer to have community or team \n"
+"    members resolve the conflicts among themselves, using our existing "
+"policies as guidelines for resolving the \n"
+"    conflict."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:69
+msgid ""
+"If you do not feel comfortable resolving a conflict on your own, you "
+"should feel free to report the conflict to \n"
+"    us. How you address the conflict depends on who is involved in the "
+"conflict and your comfort level. Please see \n"
+"    the detailed sections below on how and with whom to address your "
+"conflict. We aim to address conflicts as soon \n"
+"    as possible in an effort to prevent them from escalating "
+"unnecessarily."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:75
+msgid "Direct conflict resolution"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:78
+msgid ""
+"In direct conflict resolution, the involved parties will attempt to "
+"resolve the conflict themselves without \n"
+"   involving any MetaBrainz Foundation team member. You should aim to use"
+" direct resolution when the conflict does \n"
+"   not involve the violation of one of our policies or if the conflict is"
+" minor."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:84
+#, python-format
+msgid ""
+"For instance, if a user uses a rude tone, is disruptive or flagrantly "
+"ignores our project guidelines, we suggest \n"
+"    that you use direct conflict resolution to resolve the conflict. Some"
+" resources that might give you some suggestions \n"
+"    on how to go about resolving the conflict might be this <a "
+"href=\"%(conflict_resolution_primer_url)s\">\n"
+"    conflict resolution primer</a> and <a "
+"href=\"%(difficult_conversations_url)s\">how to\n"
+"    have difficult conversations at work</a>."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:93
+msgid "Informal reporting"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:96
+msgid ""
+"You may use informal reporting of a conflict if you aim to communicate a "
+"concern or incident without \n"
+"    seeking a corrective outcome. Informal reporting may also be an "
+"option if you have not been personally \n"
+"    victimized, but you’ve witnessed a violation of our policies or where"
+" you wish to maintain confidentiality \n"
+"    throughout the entire reporting process."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:103
+msgid ""
+"For editing in MusicBrainz you may informally report a user using the "
+"“Report this user for bad behavior” \n"
+"    link from the user’s profile. For reporting bad user behavior in "
+"other of our projects, please report them to our \n"
+"    community manager by mailing <span class=\"backemail\">gro.zniarbatem"
+"@reganam-ytinummoc</span> . For conflicts \n"
+"    that involve the community manager, report them by mailing <span "
+"class=\"backemail\">gro.zniarbatem@de</span> ."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:110
+msgid ""
+"Depending the the severity of the issue, repeated informal complaints may"
+" eventually require a formal response \n"
+"    from the MetaBrainz team. If an involved party requires anonymity, "
+"the conflict becomes a private conflict. If at \n"
+"    all possible minor issues should be resolved in a public forum in "
+"order for all people to witness and learn from \n"
+"    the issue at hand."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:116
+msgid "Formal complaint process"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:119
+msgid ""
+"All complaints about conflicts should be submitted via email. To whom a "
+"complaint should be mailed and who will \n"
+"    carry out the investigation will be described in the next section."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:124
+msgid "All complaint submissions to the Foundation should include the following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:128
+msgid ""
+"Contact info, if it is different than the email used to submit the "
+"conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:129
+msgid "Who was involved in the conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:130
+msgid "Where and when the incident happened"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:131
+msgid ""
+"A description of what happened -- ideally with links (e.g. chatlogs, edit"
+" notes) that outlines what \n"
+"         happened so that the persons evaluating the conflict may "
+"understand the issue at hand"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:133
+msgid ""
+"Any related pieces of information that provide more context on the "
+"conflict (e.g. links, screenshots)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:134
+msgid "An indication if this conflict is ongoing or not"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:139
+msgid "The investigation that follows aims to determine:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:143
+msgid "The nature and severity of the incident"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:144
+msgid ""
+"Whether or not the incident is considered a violation of MetaBrainz’ "
+"conduct policies or core values"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:145
+msgid ""
+"The amount of harm experienced by the person who submitted the complaint "
+"and the broader MetaBrainz community \n"
+"         as a result of the incident"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:147
+msgid ""
+"Whether there have been prior complaints against the individual or "
+"individuals reported"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:148
+msgid "Whether the incident is ongoing"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:152
+msgid ""
+"The following potential forms of resolution may apply to any team members"
+" involved in the conflict:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:155
+#: metabrainz/templates/index/conflict-policy.html:168
+msgid "Nothing (if it has been found no violation occurred)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:156
+msgid "Creating a plan to improve the performance"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:157
+msgid "Creating a negative performance evaluation"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:158
+msgid "Mediation, an intervention by a third party to resolve the conflict"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:159
+msgid "Suspension or forced leave"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:160
+msgid "Termination of contract"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:164
+msgid ""
+"The following potential forms of resolution may apply to non team members"
+" involved in the conflict:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:169
+msgid "A reprimand, either public or private"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:170
+msgid "Suspension of the users’ account"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:171
+msgid "Deletion of the users’ account"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:172
+msgid ""
+"Removal of user privileges (e.g. if an auto editor commits a serious "
+"offence, they may lose their auto editor status)"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:175
+msgid "Filing a complaint"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:178
+msgid ""
+"NOTE: For complaints not about MetaBrainz staff, please see the "
+"<em>Informal reporting</em> section above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:182
+msgid ""
+"If the complaint does not involve the Executive Director (ED), do the "
+"following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:186
+msgid ""
+"If team member has directly violated conduct policies or engaged in "
+"otherwise harmful behavior, a formal complaint should be filed."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:187
+msgid ""
+"Mail <span class=\"backemail\">gro.zniarbatem@de</span> and include the "
+"complaint information outlined above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:188
+msgid ""
+"You should expect a response within a working day acknowledging the "
+"complaint."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:189
+msgid ""
+"The complaint will be investigated by the ED, member(s) of the board of "
+"directors or a neutral third party."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:190
+msgid ""
+"Once the investigation has been completed, the ED, with the support of "
+"others involved in the investigation will respond. The \n"
+"        ED will respond to incidents no later than 7 working days after a"
+" complaint has been filed with either a resolution or an \n"
+"        explanation of why the process must be extended."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:196
+msgid "If a complaint involves the Executive Director, do the following:"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:200
+msgid ""
+"If the Executive Director has directly violated conduct policies or "
+"engaged in otherwise harmful behavior, \n"
+"        a formal complaint should be filed with the board of directors."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:202
+msgid ""
+"Mail <span class=\"backemail\">gro.zniarbatem@noituloser-tcilfnoc</span> "
+"and include the complaint information outlined above."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:203
+msgid ""
+"You should get a response within 5 working days acknowledging the "
+"complaint."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:204
+msgid ""
+"The complaint will be investigated by the member(s) of the board of "
+"directors, the community manager, a neutral \n"
+"        third party or a combination thereof."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:206
+msgid ""
+"Once the investigation has been completed, the board, with the support of"
+" others involved in the investigation \n"
+"        will respond. The board will aim to respond to incidents no later"
+" than 15 working days after a complaint has been filed \n"
+"        with either a resolution or an explanation of why the process "
+"must be extended."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:211
+msgid "Confidentiality"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:214
+msgid ""
+"Confidentiality is an important aspect of conflict resolution and all of "
+"the conflicts brought to the attention of the foundation \n"
+"    will be evaluated with confidentiality in mind and acted upon "
+"accordingly."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:219
+msgid ""
+"We work hard to make all of the actions of the foundation as transparent "
+"and open as possible. In cases where we cannot \n"
+"    disclose all aspects of a conflict we will disclose that a conflict "
+"is or has occurred and we will attempt to disclose the \n"
+"    appropriate amount of information about the conflict while balancing "
+"the need for confidentiality and our desire to learn \n"
+"    from conflicts so that we as a foundation and community can learn "
+"from these conflicts and improve our policies to avoid the \n"
+"    conflicts in the future."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:227
+msgid ""
+"Any breaches of confidentiality will be treated as severe breaches of our"
+" conduct policies."
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:230
+msgid "Retaliation"
+msgstr ""
+
+#: metabrainz/templates/index/conflict-policy.html:233
+msgid ""
+"We will not allow retaliation for any contractor or volunteer that files "
+"a complaint or is involved in an investigation. If you \n"
+"    believe that you are being treated negatively because of your "
+"involvement in a complaint please report this complaint directly \n"
+"    to the ED at <span class=\"backemail\">gro.zniarbatem@de</span> or "
+"the board at \n"
+"    <span class=\"backemail\">gro.zniarbatem@noituloser-tcilfnoc</span>."
+msgstr ""
 
 #: metabrainz/templates/index/contact.html:3
 #: metabrainz/templates/index/contact.html:6
@@ -954,9 +1446,8 @@ msgid ""
 "such as what happened, what you expected\n"
 "    to happen, and the URLs of any pages involved."
 msgstr ""
-"您是否找到一個失效的連結或其他預期之外的行為？您可以在<a href=\"%"
-"(bug_tracker_url)s\">錯誤通報系統</a>中回報，也可以透過聊天室、電子郵件通知我"
-"們。請在報告中描述事發經過、預期的行為、相關網址等細節。"
+"您是否找到一個失效的連結或其他預期之外的行為？您可以在<a "
+"href=\"%(bug_tracker_url)s\">錯誤通報系統</a>中回報，也可以透過聊天室、電子郵件通知我們。請在報告中描述事發經過、預期的行為、相關網址等細節。"
 
 #: metabrainz/templates/index/contact.html:16
 msgid "Have a question about MusicBrainz?"
@@ -973,10 +1464,10 @@ msgid ""
 "    Picard</a>, check its <a "
 "href=\"%(picard_troubleshooting)s\">troubleshooting page</a>."
 msgstr ""
-"請先閱覽<a href=\"%(general_faq_url)s\">一般常見問答集</a>或其他<a href=\"%"
-"(faq_url)s\">常見問答集</a>，或許您的問題已經得到解答了。如果您是<a href=\"%"
-"(picard_homepage)s\">MusicBrainz Picard</a>的使用者，請參見MusicBrainz Picard"
-"的<a href=\"%(picard_troubleshooting)s\">疑難排解頁</a>。"
+"請先閱覽<a href=\"%(general_faq_url)s\">一般常見問答集</a>或其他<a "
+"href=\"%(faq_url)s\">常見問答集</a>，或許您的問題已經得到解答了。如果您是<a "
+"href=\"%(picard_homepage)s\">MusicBrainz Picard</a>的使用者，請參見MusicBrainz "
+"Picard的<a href=\"%(picard_troubleshooting)s\">疑難排解頁</a>。"
 
 #: metabrainz/templates/index/contact.html:25
 msgid "Data removal requests"
@@ -990,8 +1481,8 @@ msgid ""
 "    <a href=\"%(dr_policy_url)s\">data removal policy</a> for more "
 "information."
 msgstr ""
-"MusicBrainz不會按要求編輯或刪除真實資料。想瞭解更多，請閱覽我們的<a href=\"%"
-"(dr_policy_url)s\">資料移除政策</a>。"
+"MusicBrainz不會按要求編輯或刪除真實資料。想瞭解更多，請閱覽我們的<a "
+"href=\"%(dr_policy_url)s\">資料移除政策</a>。"
 
 #: metabrainz/templates/index/contact.html:30
 msgid "Copyright issues"
@@ -1012,12 +1503,10 @@ msgid ""
 "    the infringing material from our website. If you cannot provide us a "
 "link, we cannot help you."
 msgstr ""
-"如果您認為MusicBrainz侵犯了您的著作權，您可以向我們<a href=\"%"
-"(cr_violation_url)s\">檢舉侵權</a>。請注意，MusicBrainz提供音樂的資料，而<i>"
-"不是音樂本身</i>。 如果您在MusicBrainz找到您的音樂，<b>這不代表我們提供或持有"
-"該音樂的檔案</b>。如果您仍然認為我們侵犯了您的著作權，您必須提供一個連結，以"
-"示您能夠在我們的網站下載侵權資料。如果您未能提供連結，我們不可為您提供任何幫"
-"助。"
+"如果您認為MusicBrainz侵犯了您的著作權，您可以向我們<a "
+"href=\"%(cr_violation_url)s\">檢舉侵權</a>。請注意，MusicBrainz提供音樂的資料，而<i>不是音樂本身</i>。"
+" "
+"如果您在MusicBrainz找到您的音樂，<b>這不代表我們提供或持有該音樂的檔案</b>。如果您仍然認為我們侵犯了您的著作權，您必須提供一個連結，以示您能夠在我們的網站下載侵權資料。如果您未能提供連結，我們不可為您提供任何幫助。"
 
 #: metabrainz/templates/index/contact.html:40
 msgid "Advertising requests"
@@ -1027,7 +1516,7 @@ msgstr "廣告事項"
 msgid ""
 "We are currently evaluating our overall online advertising strategy. We "
 "are evaluating advertising, traffic optimization,\n"
-"    search engine optimization and software monitization technologies. If"
+"    search engine optimization and software monetization technologies. If"
 " you provide these professional services, please provide a detailed\n"
 "    deck of your comprehensive services to the following email address. "
 "<em>Please respect our other non-media teams and do not contact us \n"
@@ -1035,10 +1524,6 @@ msgid ""
 " disregard the entirety of your submissions if you contact us any other "
 "way!</em>"
 msgstr ""
-"我們正在評估網路廣告的整體策略，包括廣告投放、流量優化、搜尋引擎優化和軟體獲"
-"利科技等方面。如果您能就上述方面提供專業服務，請向以下電子信箱寄出關於該服務"
-"的詳盡簡報。<em>請尊重我們的非媒體部門，不要向我們其他郵箱寄出有關於廣告服務"
-"的電子郵件，否則我們將不會理會您公司的所有來函。</em>"
 
 #: metabrainz/templates/index/contact.html:52
 #, python-format
@@ -1058,9 +1543,7 @@ msgid ""
 "We cannot license any of the music listed in MusicBrainz, since we have "
 "neither the music itself nor the\n"
 "        rights to license the music."
-msgstr ""
-"我們未能為列在MusicBrainz中的音樂提供授權，因為我們不持有該音樂，也沒有權力授"
-"權該音樂。"
+msgstr "我們未能為列在MusicBrainz中的音樂提供授權，因為我們不持有該音樂，也沒有權力授權該音樂。"
 
 #: metabrainz/templates/index/contact.html:60
 msgid "We are not distributing any of the music listed in MusicBrainz."
@@ -1108,13 +1591,11 @@ msgstr "討論區"
 #, python-format
 msgid ""
 "Please come ask your questions at our <a "
-"href=\"%(forums_url)s\">forums</a>! We would love to\n"
-"    answer any questions you may have."
+"href=\"%(forums_url)s\">forums</a>!\n"
+"    The community and the team will be more than happy to help you."
 msgstr ""
-"歡迎到我們的<a href=\"%(forums_url)s\">討論區</a>發問！我們非常樂意解答您的疑"
-"問。"
 
-#: metabrainz/templates/index/contact.html:92
+#: metabrainz/templates/index/contact.html:93
 #, python-format
 msgid ""
 "The MetaBrainz/MusicBrainz/ListenBrainz team and community hang out\n"
@@ -1129,15 +1610,15 @@ msgstr ""
 "    您也可以瀏覽\n"
 "    <a href=\"%(chatlogs_url)s\">聊天紀錄</a>。"
 
-#: metabrainz/templates/index/contact.html:101
+#: metabrainz/templates/index/contact.html:102
 msgid "Social media"
 msgstr "社群媒體"
 
-#: metabrainz/templates/index/contact.html:103
+#: metabrainz/templates/index/contact.html:104
 msgid "You can follow us on these social channels:"
 msgstr "您可以在這些社群媒體關注我們："
 
-#: metabrainz/templates/index/contact.html:112
+#: metabrainz/templates/index/contact.html:113
 msgid "Mailing address"
 msgstr "地址"
 
@@ -1150,34 +1631,350 @@ msgstr "MetaBrainz資料集"
 msgid "GDPR Compliance Statement"
 msgstr "GDPR法遵聲明"
 
-#: metabrainz/templates/index/gdpr.html:37
+#: metabrainz/templates/index/gdpr.html:10
+msgid ""
+"The General Data Protection Regulation is a complex EU regulation that "
+"stipulates many points for protecting private data of\n"
+"    users on the Internet. Even though this is an EU regulation, it has a"
+" worldwide impact due to the nature of the Internet.\n"
+"    The MetaBrainz Foundation with its collection of projects is also "
+"affected by this regulation. We’ve been learning and adapting\n"
+"    our sites to be compliant with the GDPR – sadly this regulation isn’t"
+" entirely black and white and there is an incredible\n"
+"    amount of room left for interpretation of these rules."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:17
+msgid ""
+"The good news is that this regulation is roughly in line with our "
+"established practices: We’ve always held private information\n"
+"    in a high regard and applied the sort of rules to ourselves as we "
+"wish to have our own private data treated. Luckily, this\n"
+"    makes our compliance effort considerably easier. We’ve made two "
+"significant changes to how we treat your data and also adopted\n"
+"    terminology as used in the GDPR in order to use the same languages "
+"that many other sites are now adopting. Please keep reading\n"
+"    to find out the exact details of what we are doing to comply."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:24
+#, python-format
+msgid ""
+"However, we do ask for your compassion and help in our process of "
+"complying with the GDPR. As we already mentioned, the GDPR is\n"
+"    a complex set of rules that are not fully clarified yet. We’ve taken "
+"action on the steps that are clear to us and we’re following\n"
+"    ongoing conversations on points that are in gray zones or unclear to "
+"us. We’ve made our best initial effort on compliance and\n"
+"    promise to keep working on it as the picture becomes more clear. If "
+"you believe that we could improve our compliance, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a> and let us know what we "
+"can do to improve. It would also help us if you\n"
+"    could provide concrete discussion or examples to help us understand "
+"and take action on your suggestion."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:33
+msgid ""
+"Finally, below are the key sections of the GDPR as we understand them and"
+" how they affect your data in our ecosystem. Where\n"
+"    possible, we provide links for deeper understanding, links for you to"
+" examine our relevant code and links to tickets to follow\n"
+"    the process of improving our compliance."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:38
 msgid "Right to be forgotten"
 msgstr "被遺忘權"
 
-#: metabrainz/templates/index/gdpr.html:77
+#: metabrainz/templates/index/gdpr.html:41
+msgid ""
+"Summary: <i>Provide the user with the ability to remove their private "
+"data from our services</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:44
+msgid ""
+"The most important aspect of the right to be forgotten is the ability to "
+"delete your account. Once you request for us to delete\n"
+"    your account, we will remove any personally identifying information "
+"you may have provided us from your account (name, email\n"
+"    address, gender, biography, URL, etc.). The visible name on your "
+"account will be changed to “Deleted User #####” and effectively\n"
+"    the account will no longer be identifiable as your account."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:50
+msgid ""
+"However, given the nature of our projects where we work on collaborative "
+"databases, your contributions that are not personally\n"
+"    identifying are valuable assets to our database and these "
+"contributions will not be removed from our databases. But we will\n"
+"    ensure that these contributions no longer contain personally "
+"identifying data."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:55
+#, python-format
+msgid ""
+"Our process of automatically deleting your accounts across the MetaBrainz"
+" ecosystem is not complete yet (see below for a set of\n"
+"    tickets where you can track our progress). If you would like to "
+"delete your accounts in the MetaBrainz ecosystem or mark a\n"
+"    donation that is currently public as a private donation, please <a "
+"href=\"%(contact_url)s\">contact us</a>\n"
+"    and we will address your request as soon as possible."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:62
+#: metabrainz/templates/index/gdpr.html:182
+msgid "Links:"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:66
+#, python-format
+msgid ""
+"<a href=\"%(editor_deletion_doc_url)s\">How we delete accounts\n"
+"       in MusicBrainz</a> (warning, geek content ahead!)"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:70
+msgid ""
+"Implement sitewide user account deletion in\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/MBS-9680\">MusicBrainz</a>,"
+"\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/AB-337\">AcousticBrainz</a>,"
+"\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/BB-260\">BookBrainz</a>,\n"
+"         <a href=\"https://tickets.metabrainz.org/browse/MEB-103\">the "
+"MetaBrainz Site</a>,\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/LB-354\">ListenBrainz</a>, "
+"and\n"
+"         <a "
+"href=\"https://tickets.metabrainz.org/browse/CB-307\">CritiqueBrainz</a>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:80
 msgid "Restriction of processing"
 msgstr "運用資料的限制"
 
-#: metabrainz/templates/index/gdpr.html:110
+#: metabrainz/templates/index/gdpr.html:83
+msgid ""
+"Summary: <i>To allow the user to control how their personally identifying"
+" data is being used.</i>"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:86
+msgid ""
+"Except for the ListenBrainz and AcousticBrainz projects, we do not "
+"process personally identifying data. Any personally\n"
+"    identifying data that our projects store is for the purpose of being "
+"able to contact you about your contributions to our database\n"
+"    (email address) or for voluntarily showing information about you to "
+"other users (biography, homepage, location, etc)."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:91
+#, python-format
+msgid ""
+"The ListenBrainz project differs in that the Listens (metadata about what"
+" music you have listened to) are stored on our servers\n"
+"    and <a href=\"%(listenbrainz_data_url)s\">made available to the "
+"public</a>. We believe Listens to be personally identifying\n"
+"    data and furthermore, we have goals of creating open source "
+"recommendation engines with this data, which involves processing the\n"
+"    user’s data. These two points are fundamental goals of the "
+"ListenBrainz project and we do not see a reasonable way to reach another"
+"\n"
+"    compromise position."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:99
+msgid ""
+"Because of this, we are going to require users to either acknowledge that"
+" we may process their Listen data or alternatively to\n"
+"    delete their account, including all of their Listens. Please note "
+"that if you decide to delete your ListenBrainz account, it may\n"
+"    take up to two weeks for all of your listens to no longer be included"
+" in our efforts to build a recommendation engine."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:104
+msgid ""
+"We have always made it clear that the data in ListenBrainz was to be "
+"public and that we plan to build new tools with your data, so\n"
+"    this should not come as a surprise to our users."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:108
+msgid ""
+"The AcousticBrainz project does not track who submits data to the "
+"database. If you create an account and use our data creation\n"
+"    tools (e.g. create a dataset or participate in a challenge) then we "
+"link your participation and the things that you create to\n"
+"    your account. If you choose to delete your account then we keep the "
+"non personally identifying data that you create, but anonymize\n"
+"    it so that it cannot be linked back to you."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:114
 msgid "Right to data portability / exporting your data"
 msgstr "資料可攜性／匯出您的資料"
 
-#: metabrainz/templates/index/gdpr.html:150
+#: metabrainz/templates/index/gdpr.html:117
+msgid ""
+"Summary: <i>You have the right to access/download the data we store about"
+" you</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:120
+msgid ""
+"Except for the ListenBrainz and AcousticBrainz projects, we do not store "
+"personally identifying data beyond the\n"
+"    information that is available in your public profile on each of our "
+"projects. Since this data is plainly available in your\n"
+"    profile we do not provide a means for you to export this data."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:125
+msgid "There are the following exceptions to this:"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:129
+msgid ""
+"<b>IP addresses</b>: If you visit one of our sites the IP address of your"
+" computer is stored in our web logs for 7 days\n"
+"        before our servers automatically delete them. This data is almost"
+" never used by anyone: the only time we look at the\n"
+"        IP addresses is if our sites are adversely impacted by the "
+"actions of some unknown users. In that case, we may investigate\n"
+"        the logs to identify the IP address that needs to be blocked in "
+"order to restore the stability of our service.\n"
+"        This data is not available to anyone but the contractors of the "
+"MetaBrainz Foundation and is not available to download\n"
+"        to anyone at all."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:137
+#, python-format
+msgid ""
+"<b>ListenBrainz Listen data</b>: Users may <a "
+"href=\"%(listenbrainz_export_url)s\">export their ListenBrainz Listen\n"
+"        data</a> directly from the site. The user Listen data is also "
+"included in the <a href=\"%(listenbrainz_data_url)s\">ListenBrainz\n"
+"        data dumps</a> that are available for public download."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:146
+msgid ""
+"All of the non personally identifying data, such as your metadata "
+"contributions, are publicly visible, available for download\n"
+"    and available via the project APIs. For details about this data, "
+"downloads and APIs please check the documentation for the\n"
+"    respective projects you are interested in."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:151
+#, python-format
+msgid ""
+"Anyone wishing to get a list of financial donations they have made to the"
+" MetaBrainz Foundation, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a> and provide your "
+"MusicBrainz editor name so that we can look up\n"
+"    your donations."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:157
 msgid "Right to rectification"
 msgstr "修改權"
 
-#: metabrainz/templates/index/gdpr.html:165
+#: metabrainz/templates/index/gdpr.html:160
+msgid "Summary: <i>You have the right to correct your data</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:163
+msgid ""
+"All of our projects allow their users to update their personally "
+"identifying information in their profiles. Furthermore, most\n"
+"    of our projects allow the editing of their own metadata "
+"contributions. If you find that some of your data is incorrect, please\n"
+"    feel free to edit the data since we provide the tools to do so."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:168
+#, python-format
+msgid ""
+"If anyone who has made a financial donation to the MetaBrainz Foundation "
+"would like to make their donation private, please\n"
+"    <a href=\"%(contact_url)s\">contact us</a>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:173
 msgid "Right to be informed"
 msgstr "知情權"
 
-#: metabrainz/templates/index/gdpr.html:188
+#: metabrainz/templates/index/gdpr.html:175
+msgid ""
+"Summary: <i>You have the right to be informed about how we use your data "
+"in plain English</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:178
+msgid ""
+"Our privacy policy, as well as other policies, have always been written "
+"by humans for human consumption. We abhor legalese and\n"
+"    not speaking in direct terms."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:186
+msgid "Social contract"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:189
+msgid "Code of conduct"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:192
+msgid "Privacy policy"
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:196
 msgid "Right to access"
 msgstr "近用權"
 
-#: metabrainz/templates/index/gdpr.html:198
-#: metabrainz/templates/index/privacy.html:166
+#: metabrainz/templates/index/gdpr.html:199
+msgid ""
+"Summary: <i>You have the right to access the data that we collect about "
+"you</i>."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:202
+msgid ""
+"All of our projects make all of the data we collect on your behalf, "
+"privately identifying or not, available to you. The\n"
+"    only exception to this are the IP addresses we store for 7 days – see"
+" above for details."
+msgstr ""
+
+#: metabrainz/templates/index/gdpr.html:206
+#: metabrainz/templates/index/privacy.html:168
 msgid "Privacy/GDPR Representative"
 msgstr "隱私／GDPR代理人"
+
+#: metabrainz/templates/index/gdpr.html:209
+#, python-format
+msgid ""
+"If you have any questions about our privacy policy, please <a "
+"href=\"%(contact_url)s\">contact us</a>. To report\n"
+"   any privacy problems, violations or leaks, our GDPR representative is "
+"our Interim Executive Director Nicolás Tamargo and for\n"
+"   privacy issues contact him at <strong><a "
+"href=\"mailto:gdpr@metabrainz.org\">gdpr@metabrainz.org</a></strong>."
+msgstr ""
 
 #: metabrainz/templates/index/index.html:6
 msgid "Welcome to MetaBrainz!"
@@ -1190,9 +1987,7 @@ msgid ""
 "        databases and make them available in the public domain or under "
 "Creative\n"
 "        Commons licenses."
-msgstr ""
-"MetaBrainz基金會是一個非營利機構，深信大眾應可以自由和開放地使用資料。基金會"
-"旨在設立由社區管理的資料庫，並在公眾領域或以創用CC條款發布。"
+msgstr "MetaBrainz基金會是一個非營利機構，深信大眾應可以自由和開放地使用資料。基金會旨在設立由社區管理的資料庫，並在公眾領域或以創用CC條款發布。"
 
 #: metabrainz/templates/index/index.html:16
 #, python-format
@@ -1209,11 +2004,10 @@ msgid ""
 "gathering process so\n"
 "        that our data can be as comprehensive as possible."
 msgstr ""
-"我們的資料大部分經志願者蒐集，透過相互評審以確保資料一貫和準確。資料可免費"
-"作<a href=\"%(account_type_url)s\">非商業用途</a>，但我們要求<a href=\"%"
-"(account_type_url)s\">商業用戶</a><a href=\"%(account_type_url)s\">支持我們</"
-"a>，以讓我們能夠繼續營運各專案。我們鼓勵所有資料使用者參與蒐集資料，好使我們"
-"的資料變得更全面。"
+"我們的資料大部分經志願者蒐集，透過相互評審以確保資料一貫和準確。資料可免費作<a "
+"href=\"%(account_type_url)s\">非商業用途</a>，但我們要求<a "
+"href=\"%(account_type_url)s\">商業用戶</a><a "
+"href=\"%(account_type_url)s\">支持我們</a>，以讓我們能夠繼續營運各專案。我們鼓勵所有資料使用者參與蒐集資料，好使我們的資料變得更全面。"
 
 #: metabrainz/templates/index/index.html:38
 msgid ""
@@ -1270,11 +2064,11 @@ msgid ""
 "supporters</a>\n"
 "        who make use of our data sets."
 msgstr ""
-"MetaBrainz基金會認為，<a href=\"%(financial_reports_url)s\">財政透明</a>是非"
-"常重要的。基金會接受來自<a href=\"%(donations_url)s\">使用者</a>和<a href=\"%"
-"(sponsors_url)s\">贊助商</a>的資金，以確保基金會能夠達到其設立的目標。此外"
-"，<a href=\"%(supporters_url)s\">商業支持者</a>也透過使用我們的資料，支持基金"
-"會的運作。"
+"MetaBrainz基金會認為，<a "
+"href=\"%(financial_reports_url)s\">財政透明</a>是非常重要的。基金會接受來自<a "
+"href=\"%(donations_url)s\">使用者</a>和<a "
+"href=\"%(sponsors_url)s\">贊助商</a>的資金，以確保基金會能夠達到其設立的目標。此外，<a "
+"href=\"%(supporters_url)s\">商業支持者</a>也透過使用我們的資料，支持基金會的運作。"
 
 #: metabrainz/templates/index/index.html:133
 #, python-format
@@ -1296,7 +2090,7 @@ msgid ""
 "      <a href=\"%(about_url)s\">about</a> page."
 msgstr "如要取得更多關於基金會的資訊，請參見<a href=\"%(about_url)s\">關於我們</a>。"
 
-#: frontend/js/src/forms/ConditionsModal.tsx:43
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:32
 #: metabrainz/templates/index/privacy.html:3
 msgid "Privacy"
 msgstr "隱私"
@@ -1304,6 +2098,44 @@ msgstr "隱私"
 #: metabrainz/templates/index/privacy.html:8
 msgid "Summary"
 msgstr "摘要"
+
+#: metabrainz/templates/index/privacy.html:12
+msgid ""
+"You do not have to provide any personal data to be able to browse the "
+"contents of the databases published by MetaBrainz."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:15
+msgid ""
+"You do not have to provide any personally-identifying information if you "
+"choose not to."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:18
+msgid ""
+"We will never reveal your email address on MetaBrainz controlled web "
+"sites."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:22
+msgid ""
+"In order to get maximum value out of the MetaBrainz projects, you may "
+"want to create an account and log in. \n"
+"    Doing so grants you the ability to: edit the databases, contribute "
+"your own data, communicate with other users, and keep track \n"
+"    of recently released music from artists in your MusicBrainz "
+"collection. If you choose to create an account then the minimum we \n"
+"    ask is that you: choose a unique username and password, use a web "
+"browser that accepts \"session\" cookies, and provide a verified \n"
+"    email address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:29
+msgid ""
+"If you do not create an account (or are not logged in) you will not have "
+"access to the above listed features, however, you will \n"
+"    still have full access to browse and examine the databases."
+msgstr ""
 
 #: metabrainz/templates/index/privacy.html:33
 msgid "Applicable to all users"
@@ -1313,39 +2145,197 @@ msgstr "適用於所有使用者"
 msgid "Cookies"
 msgstr "Cookies"
 
+#: metabrainz/templates/index/privacy.html:37
+msgid "We use two cookies that contain sensitive information:"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:42
+msgid ""
+"<b>remember_login</b>: If you choose the \"Log in permanently\" option "
+"when logging in to one of our sites; the cookie will be used to \n"
+"      remember your login details."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:46
+msgid ""
+"<b>musicbrainz_server_session, session, or connect.sid</b>: If you are "
+"logged into one of our sites, your current session ID is stored in this "
+"cookie."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:51
+msgid ""
+"We may store dynamic preference information in other cookies, but these "
+"do not contain any sensitive information."
+msgstr ""
+
 #: metabrainz/templates/index/privacy.html:54
 msgid "Web and FTP access logs"
 msgstr "網絡和FTP訪問紀錄"
+
+#: metabrainz/templates/index/privacy.html:57
+msgid ""
+"In a practice similar to other web sites (and APIs) we keep logs of all "
+"web requests made against our servers. These logs include: your IP\n"
+"    address, your browser's (or API client's) \"User-Agent\" string, and "
+"which page (or API endpoint) you requested with which parameters. "
+"Aggregate information about web and FTP traffic is\n"
+"    made available to the public via our site usage pages."
+msgstr ""
 
 #: metabrainz/templates/index/privacy.html:62
 msgid "Third-Party content"
 msgstr "第三方內容"
 
-#: metabrainz/templates/index/privacy.html:92
+#: metabrainz/templates/index/privacy.html:64
+msgid ""
+"Our projects' web pages may load some third-party content. Some, but "
+"possibly not all sites are listed below:"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:69
+#, python-format
+msgid ""
+"Cover art and other images: These are provided by the various cover art "
+"sites that have given MusicBrainz permission to do so and our own \n"
+"      <a href=\"%(caa_url)s\">Cover Art Archive</a>. This means that the "
+"relevant site will know (if they want to) your IP \n"
+"      address, User-Agent string, etc., and which MusicBrainz web page "
+"you were visiting (the one which included the cover art image)."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:75
+msgid ""
+"AcoustID: Our fingerprints tab loads fingerprint information from "
+"acoustid.org."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:78
+msgid ""
+"MTCaptcha: Our account creation page loads third party content in order "
+"to prevent spammers from creating accounts."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:83
+msgid ""
+"<i>The above information assumes that you are using \"normal\" web "
+"browser settings, whereby images are always loaded and HTTP referrer \n"
+"    information is always sent.</i>"
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:88
+msgid ""
+"It is impractical to constantly modify this privacy policy when "
+"MetaBrainz projects change which third party content they utilize. We "
+"will \n"
+"    aim to use common sense, respect to our community and community "
+"review when adding more content from third party sites. We will also \n"
+"    periodically review our policy to ensure that it remains current."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:93
 msgid "Applicable to account holders"
 msgstr "適用於帳號持有人"
 
-#: metabrainz/templates/index/privacy.html:94
+#: metabrainz/templates/index/privacy.html:95
 msgid "Account creation"
 msgstr "建立帳號"
 
-#: metabrainz/templates/index/privacy.html:108
+#: metabrainz/templates/index/privacy.html:97
+msgid ""
+"When creating an account with a MetaBrainz project you need to pick a "
+"unique username and choose a password, the username you pick is the \n"
+"    only name associated with your account and will be what other "
+"MetaBrainz users know you as. You may optionally also tell us other \n"
+"    information about yourself that will be displayed to other MetaBrainz"
+" users and the public."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:103
+msgid ""
+"Additionally, in order to edit the databases you will need to provide a "
+"confirmed email address. This email address will be held in \n"
+"    confidence, the only method of revealing your email address to "
+"another user is if you choose to send a message to another \n"
+"    user and enable the option to \"reveal my email address\". Changing "
+"the email address stored with your account will require you to \n"
+"    verify the new address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:109
 msgid "Edits and Notes"
 msgstr "編輯和備註"
 
-#: metabrainz/templates/index/privacy.html:114
+#: metabrainz/templates/index/privacy.html:111
+msgid ""
+"If you make any changes to a MetaBrainz project database, such as adding "
+"any data, the details of those changes will be visible to \n"
+"    other logged-in users and the change will be associated with your "
+"username."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:115
 msgid "Subscriptions on MusicBrainz"
 msgstr "MusicBrainz訂閲"
 
-#: metabrainz/templates/index/privacy.html:131
+#: metabrainz/templates/index/privacy.html:117
+msgid ""
+"As a logged-in user you can subscribe to one or more artists, labels, "
+"collections or other editors. The act of subscribing causes \n"
+"    any edits made to (or by in the case of another editor) those "
+"entities to be emailed to you. By default, other users can see your \n"
+"    list of subscriptions, however, you can opt out of this by editing "
+"the appropriate preference."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:123
+msgid ""
+"This does not provide \"perfect\" privacy though, in some cases it will "
+"be possible to infer information about the contents of your \n"
+"    subscription list even though you have disallowed others from viewing"
+" that list directly. This imperfection arises because various \n"
+"    parts of the system behave differently depending on whether or not an"
+" entity has any subscribers; also, the number of users \n"
+"    subscribed to each artist is available via the artist pages. In the "
+"most extreme (possibly contrived) example, imagine that all \n"
+"    users have their subscriptions set to \"public\", except for exactly "
+"one user whose list is \"private\". In that case, any discrepancy \n"
+"    for a given artist between the shown list of subscribers and the "
+"total number of subscribers must be down to that one user. Thus, \n"
+"    you can infer what artists are on that user's list."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:132
 msgid "Third-party sites"
 msgstr "第三方網站"
 
-#: metabrainz/templates/index/privacy.html:145
+#: metabrainz/templates/index/privacy.html:134
+#, python-format
+msgid ""
+"Our code reviews are done on GitHub, which is not under the control of "
+"MetaBrainz. Participating in code reviews or other\n"
+"    tasks carried out on GitHub are subject to <a "
+"href=\"%(github_url)s\">GitHub's privacy policy</a>."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:140
+#, python-format
+msgid ""
+"Our translations platform is provided and hosted by Weblate, which has a "
+"data processing agreement with MetaBrainz.\n"
+"    Participating in translations is subject to <a "
+"href=\"%(weblate_url)s\">dedicated legal terms</a>.\n"
+"    Any translations you make will be submitted to our Git repositories "
+"and publicly associated with your username;\n"
+"    if you so choose, you can also publicly associate them with your own "
+"verified email address."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:147
 msgid "MetaBrainz donors"
 msgstr "MetaBrainz的捐助者"
 
-#: metabrainz/templates/index/privacy.html:147
+#: metabrainz/templates/index/privacy.html:149
 msgid ""
 "When you make a donation to the MetaBrainz Foundation, we are legally\n"
 "    required to collect your personal information and keep it in our "
@@ -1353,11 +2343,9 @@ msgid ""
 "    in case we ever get audited by the IRS. We will not disclose your "
 "personal\n"
 "    information to anyone else, ever."
-msgstr ""
-"當您向MetaBrainz基金會捐款時，法律要求我們收集及記錄您的個人資料，以供美國國"
-"家稅務局審查帳目。我們永遠不會向稅務局以外的人透露您的個人資料。"
+msgstr "當您向MetaBrainz基金會捐款時，法律要求我們收集及記錄您的個人資料，以供美國國家稅務局審查帳目。我們永遠不會向稅務局以外的人透露您的個人資料。"
 
-#: metabrainz/templates/index/privacy.html:153
+#: metabrainz/templates/index/privacy.html:155
 msgid ""
 "We believe in transparent finances, which means that we list all "
 "donations\n"
@@ -1365,15 +2353,36 @@ msgid ""
 "of the\n"
 "    donation, unless you chose to be anonymous during the donation "
 "process."
-msgstr ""
-"我們認為財務狀況應該是透明的。因此，我們會在網站列出所有捐款。除非您選擇保持"
-"匿名，我們只會顯示您的名稱和捐款金額。"
+msgstr "我們認為財務狀況應該是透明的。因此，我們會在網站列出所有捐款。除非您選擇保持匿名，我們只會顯示您的名稱和捐款金額。"
 
-#: metabrainz/templates/index/privacy.html:158
+#: metabrainz/templates/index/privacy.html:160
 msgid "Exceptions"
 msgstr "例外情形"
 
-#: frontend/js/src/Profile.tsx:598
+#: metabrainz/templates/index/privacy.html:162
+msgid ""
+"<i><b>Please note</b>: Reasonable exceptions may apply to the above "
+"policy, for example to comply with applicable laws.\n"
+"    Also, members of the MetaBrainz team and other personnel contracted "
+"to provide services to MetaBrainz may have access to\n"
+"    our infrastructure and could therefore view any information contained"
+" therein. However all personnel are contractually bound\n"
+"    by non-disclosure clauses which prevent them from making any such "
+"information available to others."
+msgstr ""
+
+#: metabrainz/templates/index/privacy.html:171
+#, python-format
+msgid ""
+"If you have any questions about our GDPR statement, please <a "
+"href=\"%(contact_url)s\">contact us</a>. To report\n"
+"   any privacy problems, violations or leaks, our GDPR representative is "
+"our Interim Executive Director Nicolás Tamargo and for\n"
+"   privacy issues contact him at <strong><a "
+"href=\"mailto:gdpr@metabrainz.org\">gdpr@metabrainz.org</a></strong>."
+msgstr ""
+
+#: frontend/js/src/Profile.tsx:603
 #: frontend/js/src/forms/ProfileChangePassword.tsx:22
 #: frontend/js/src/forms/ProfileChangePassword.tsx:111
 #: metabrainz/templates/index/profile-change-password.html:3
@@ -1403,9 +2412,7 @@ msgid ""
 "<a href=\"%(mb_url)s\">MusicBrainz</a> is a community-maintained open "
 "source music encyclopedia that\n"
 "            collects music metadata and makes it available to the public."
-msgstr ""
-"<a href=\"%(mb_url)s\">MusicBrainz</a>是由社群管理的開源音樂百科全書，蒐集音"
-"樂詮釋資料供公眾閱覽和使用。"
+msgstr "<a href=\"%(mb_url)s\">MusicBrainz</a>是由社群管理的開源音樂百科全書，蒐集音樂詮釋資料供公眾閱覽和使用。"
 
 #: metabrainz/templates/index/projects.html:32
 msgid "MusicBrainz Picard"
@@ -1418,8 +2425,8 @@ msgid ""
 "software application for\n"
 "            identifying, tagging, and organizing digital audio recordings."
 msgstr ""
-"<a href=\"%(picard_url)s\">MusicBrainz Picard</a>是一款開源軟件，能讓使用者識"
-"別、標籤和整理數位音訊錄音。"
+"<a href=\"%(picard_url)s\">MusicBrainz "
+"Picard</a>是一款開源軟件，能讓使用者識別、標籤和整理數位音訊錄音。"
 
 #: metabrainz/templates/index/projects.html:47
 msgid "Cover Art Archive"
@@ -1433,9 +2440,9 @@ msgid ""
 "            releases in MusicBrainz. It is a joint project with the <a "
 "href=\"%(archive_org_url)s\">Internet Archive</a>."
 msgstr ""
-"<a href=\"%(caa_url)s\">Cover Art Archive</a>是一個資料庫，存放入列"
-"MusicBrainz專輯的封套圖片。這是一個與<a href=\"%(archive_org_url)s\">"
-"Internet Archive</a>合作的專案。"
+"<a href=\"%(caa_url)s\">Cover Art "
+"Archive</a>是一個資料庫，存放入列MusicBrainz專輯的封套圖片。這是一個與<a "
+"href=\"%(archive_org_url)s\">Internet Archive</a>合作的專案。"
 
 #: metabrainz/templates/index/projects.html:63
 msgid "CritiqueBrainz"
@@ -1448,9 +2455,7 @@ msgid ""
 " book critics and raw data by\n"
 "            providing a platform created for the sole purpose of Creative"
 " Commons licensed reviews."
-msgstr ""
-"<a href=\"%(cb_url)s\">CritiqueBrainz</a>是一個發布創用CC評論的平臺，讓音樂和"
-"文獻評論家能夠接觸原始資料。"
+msgstr "<a href=\"%(cb_url)s\">CritiqueBrainz</a>是一個發布創用CC評論的平臺，讓音樂和文獻評論家能夠接觸原始資料。"
 
 #: metabrainz/templates/index/projects.html:78
 msgid "BookBrainz"
@@ -1464,8 +2469,8 @@ msgid ""
 "            literature. Its aim is to collect and store data about every "
 "publication ever written."
 msgstr ""
-"<a href=\"%(bb_url)s\">BookBrainz</a>是一個載有出版文獻的網路百科全書，目的蒐"
-"集和儲存有史以來所有出版文學的資料。"
+"<a "
+"href=\"%(bb_url)s\">BookBrainz</a>是一個載有出版文獻的網路百科全書，目的蒐集和儲存有史以來所有出版文學的資料。"
 
 #: metabrainz/templates/index/projects.html:93
 msgid "ListenBrainz"
@@ -1479,8 +2484,8 @@ msgid ""
 "            their listen history. One of the goals is for this data to be"
 " used for building open music recommendation systems."
 msgstr ""
-"<a href=\"%(lb_url)s\">ListenBrainz</a>是一個開源的音樂網站，讓使用者導入他們"
-"的聆聽紀錄。專案其中一個目標是使用這些紀錄打造一個開放的音樂推薦系統。"
+"<a "
+"href=\"%(lb_url)s\">ListenBrainz</a>是一個開源的音樂網站，讓使用者導入他們的聆聽紀錄。專案其中一個目標是使用這些紀錄打造一個開放的音樂推薦系統。"
 
 #: metabrainz/templates/index/projects.html:104
 msgid "Past Projects"
@@ -1501,9 +2506,8 @@ msgid ""
 "href=\"%(upf_url)s\">Universitat Pompeu Fabra</a>\n"
 "            in Barcelona."
 msgstr ""
-"<a href=\"%(ab_url)s\">AcousticBrainz</a>眾包和公開世界上所有音樂的聲學資訊。"
-"此專案與巴塞隆納<a href=\"%(upf_url)s\">龐培法布拉大學</a>的<a href=\"%"
-"(mtg_url)s\">音樂科技小組</a>合作。"
+"<a href=\"%(ab_url)s\">AcousticBrainz</a>眾包和公開世界上所有音樂的聲學資訊。此專案與巴塞隆納<a "
+"href=\"%(upf_url)s\">龐培法布拉大學</a>的<a href=\"%(mtg_url)s\">音樂科技小組</a>合作。"
 
 #: metabrainz/templates/index/projects.html:132
 msgid "MessyBrainz"
@@ -1518,9 +2522,8 @@ msgid ""
 "used for AcousticBrainz and is still being\n"
 "            used in ListenBrainz."
 msgstr ""
-"<a href=\"%(messybrainz_url)s\">MessyBrainz</a>找出雜亂的詮釋資料，並儘可能將"
-"它連接至穩定的MusicBrainz識別碼。MessyBrainz目前用於ListenBrainz，曾用於"
-"AcousticBrainz。"
+"<a "
+"href=\"%(messybrainz_url)s\">MessyBrainz</a>找出雜亂的詮釋資料，並儘可能將它連接至穩定的MusicBrainz識別碼。MessyBrainz目前用於ListenBrainz，曾用於AcousticBrainz。"
 
 #: metabrainz/templates/index/shop.html:3
 #: metabrainz/templates/index/shop.html:6
@@ -1543,9 +2546,7 @@ msgid ""
 "    have helped us grow. In either case they played a significant role in"
 " the\n"
 "    success and growth of MusicBrainz."
-msgstr ""
-"以下的組織和個人曾經為我們提供資金或透過提供工具和科技支持我們，對MusicBrainz"
-"的成就和發展扮演重要角色。"
+msgstr "以下的組織和個人曾經為我們提供資金或透過提供工具和科技支持我們，對MusicBrainz的成就和發展扮演重要角色。"
 
 #: metabrainz/templates/index/sponsors.html:18
 msgid "We would not exist without you — <b>Thank You!</b>"
@@ -1557,9 +2558,7 @@ msgid ""
 "<b><a href=\"%(github_url)s\">GitHub</a></b> provides us with a free "
 "Bronze\n"
 "        account for hosting our sysadmin repositories."
-msgstr ""
-"<b><a href=\"%(github_url)s\">GitHub</a></b>為我們提供免費的銅級帳號，寄存我"
-"們的系統管理員倉庫。"
+msgstr "<b><a href=\"%(github_url)s\">GitHub</a></b>為我們提供免費的銅級帳號，寄存我們的系統管理員倉庫。"
 
 #: metabrainz/templates/index/sponsors.html:34
 msgid "Special thanks"
@@ -1574,10 +2573,7 @@ msgid ""
 "    meals. These have become too numerous to list, but we wanted to note "
 "a few individuals\n"
 "    and companies who have made a big difference for us."
-msgstr ""
-"我們在過去得到很多人在各方面的支持，如租借會議場地、支付旅費、作出大量個人捐"
-"款和提供無數次的餐飲服務，等等。這些貢獻雖數之不盡，但我們想在這裡特別感謝為"
-"我們作出巨大貢獻的幾位人士。"
+msgstr "我們在過去得到很多人在各方面的支持，如租借會議場地、支付旅費、作出大量個人捐款和提供無數次的餐飲服務，等等。這些貢獻雖數之不盡，但我們想在這裡特別感謝為我們作出巨大貢獻的幾位人士。"
 
 #: metabrainz/templates/index/sponsors.html:42
 #, python-format
@@ -1603,16 +2599,16 @@ msgid ""
 "    hosting provider between 2006 and 2016 and gave us a discount because"
 " of our non-profit status."
 msgstr ""
-"<a href=\"%(google_url)s\">Google</a></b>一直給予極大支持，作為贊助商多年來累"
-"計捐助超過<b>50萬美元</b>。2010年，<a href=\"%(last_fm_url)s\">Last.fm</a>其"
-"中一位創辦人Richard Jones向MusicBrainz捐助了<b>五萬美元</b>，<a href=\"%"
-"(oracle_url)s\">昇陽電腦</a>和Paul Lamere則捐助了一個資料庫伺服器。<a "
-"href=\"%(oreilly_url)s\">歐萊禮</a>在MetaBrainz基金會尚未成立的時候捐助500美"
-"元，讓MusicBrainz能夠開設銀行賬戶。MetaBrainz基金會不時會遇到有關智慧財產權的"
-"問題，<a href=\"%(ed_url)s\">Ed Cavazos</a>會定期就這些問題提供義務法律諮詢。"
-"此外，<a href=\"%(dan_url)s\">Dan Appleman</a>會定期為我們訂立授權資料使用的"
-"契約。最後，我們要感謝2006年至2016年間的主要寄存服務提供者<a href=\"%(dw_url)"
-"s\">Digital West Networks Inc.</a>，它們考慮到我們並不營利，提供了優惠服務。"
+"<a "
+"href=\"%(google_url)s\">Google</a></b>一直給予極大支持，作為贊助商多年來累計捐助超過<b>50萬美元</b>。2010年，<a"
+" href=\"%(last_fm_url)s\">Last.fm</a>其中一位創辦人Richard "
+"Jones向MusicBrainz捐助了<b>五萬美元</b>，<a href=\"%(oracle_url)s\">昇陽電腦</a>和Paul "
+"Lamere則捐助了一個資料庫伺服器。<a "
+"href=\"%(oreilly_url)s\">歐萊禮</a>在MetaBrainz基金會尚未成立的時候捐助500美元，讓MusicBrainz能夠開設銀行賬戶。MetaBrainz基金會不時會遇到有關智慧財產權的問題，<a"
+" href=\"%(ed_url)s\">Ed Cavazos</a>會定期就這些問題提供義務法律諮詢。此外，<a "
+"href=\"%(dan_url)s\">Dan "
+"Appleman</a>會定期為我們訂立授權資料使用的契約。最後，我們要感謝2006年至2016年間的主要寄存服務提供者<a "
+"href=\"%(dw_url)s\">Digital West Networks Inc.</a>，它們考慮到我們並不營利，提供了優惠服務。"
 
 #: metabrainz/templates/index/sponsors.html:61
 msgid ""
@@ -1641,11 +2637,10 @@ msgid ""
 "working on MusicBrainz, the open music encyclopedia,\n"
 "          and fell in love with Open Source software."
 msgstr ""
-"Robert是<a href=\"%(mb_url)s\">MusicBrainz</a>和MetaBrainz基金會的創辦人和首"
-"席極客。MetaBrainz基金會目標保護和支持MusicBrainz的發展。在加州理工州立大學完"
-"成電腦工程學位後，Robert加入了Xing Technology，鑽研MP3技術。後來，他在網路泡"
-"沫時期加入了EMusic的FreeAmp團隊。Robert在EMusic工作的時候開始建立MusicBrainz"
-"，也同時愛上了開源軟體。"
+"Robert是<a "
+"href=\"%(mb_url)s\">MusicBrainz</a>和MetaBrainz基金會的創辦人和首席極客。MetaBrainz基金會目標保護和支持MusicBrainz的發展。在加州理工州立大學完成電腦工程學位後，Robert加入了Xing"
+" "
+"Technology，鑽研MP3技術。後來，他在網路泡沫時期加入了EMusic的FreeAmp團隊。Robert在EMusic工作的時候開始建立MusicBrainz，也同時愛上了開源軟體。"
 
 #: metabrainz/templates/index/team.html:21
 #, python-format
@@ -1655,13 +2650,17 @@ msgid ""
 "          <a href=\"%(pr_url)s\">Party Robotics</a> where he co-created "
 "Bartendro the open source cocktail robot."
 msgstr ""
-"Robert生前也是一名活躍的硬體駭客，曾在Burning Man和Nowhere展示他的藝術專案。"
-"他是<a href=\"%(pr_url)s\">Party Robotics</a>的創辦人之一，並參與建造開源雞尾"
-"酒機器人Bartendro。"
+"Robert生前也是一名活躍的硬體駭客，曾在Burning Man和Nowhere展示他的藝術專案。他是<a "
+"href=\"%(pr_url)s\">Party Robotics</a>的創辦人之一，並參與建造開源雞尾酒機器人Bartendro。"
 
 #: metabrainz/templates/index/team.html:26
 msgid "He lives on in our hearts and in open source."
 msgstr "他在我們心中和開源世界永垂不朽。"
+
+#: metabrainz/templates/index/team.html:29
+#: metabrainz/templates/index/team.html:315
+msgid "you’re welcome to try"
+msgstr ""
 
 #: metabrainz/templates/index/team.html:39
 msgid ""
@@ -1680,19 +2679,14 @@ msgid ""
 "          ever hear, binge-watching old TV shows, and being the best "
 "drummer in the world on Rock Band 4."
 msgstr ""
-"Michael是MusicBrainz的高級開發者，現住在家鄉芝加哥。他在小學時首次接觸"
-"MusicBrainz，在高中的時候，他開始編輯MusicBrainz，以處理他日漸豐富的音樂珍藏"
-"。到了大學，Michael更參與了三個GSoC專案。在他的空閒時間，Michael會去看演唱會"
-"、製作沒人會聽的音樂、瘋狂觀看舊電視劇和在《搖滾樂團 4》中做世界上最厲害的鼓"
-"手。"
+"Michael是MusicBrainz的高級開發者，現住在家鄉芝加哥。他在小學時首次接觸MusicBrainz，在高中的時候，他開始編輯MusicBrainz，以處理他日漸豐富的音樂珍藏。到了大學，Michael更參與了三個GSoC專案。在他的空閒時間，Michael會去看演唱會、製作沒人會聽的音樂、瘋狂觀看舊電視劇和在《搖滾樂團"
+" 4》中做世界上最厲害的鼓手。"
 
 #: metabrainz/templates/index/team.html:57
 msgid ""
 "<span class=\"name\">Nicolás Tamargo</span> &mdash; Style Leader/Customer"
 " Support/Community Manager/Software Engineer"
-msgstr ""
-"<span class=\"name\">Nicolás Tamargo</span> &mdash; 樣式領袖／客戶聯繫／社群"
-"主管／軟體工程師"
+msgstr "<span class=\"name\">Nicolás Tamargo</span> &mdash; 樣式領袖／客戶聯繫／社群主管／軟體工程師"
 
 #: metabrainz/templates/index/team.html:59
 #, python-format
@@ -1711,11 +2705,8 @@ msgid ""
 "href=\"%(mb_editors_url)s\">editing MusicBrainz</a>\n"
 "          or traveling around trying to watch some wildlife."
 msgstr ""
-"Nicolás初起便是一名勤勞的編輯（他依然以此秘密兼職），因為他非常喜歡整理資料。"
-"不久，他受邀成為樣式領袖，協助社群決定該如何整體各樣資料。後來，他被指派負責"
-"處理技術支援問題，最終也開始撰寫程式碼來解決這些問題（老實說，這些程式有時候"
-"會製造更多錯誤！）公餘時間，他會<a href=\"%(mb_editors_url)s\">編輯"
-"MusicBrainz</a>和四處旅行親近大自然。"
+"Nicolás初起便是一名勤勞的編輯（他依然以此秘密兼職），因為他非常喜歡整理資料。不久，他受邀成為樣式領袖，協助社群決定該如何整體各樣資料。後來，他被指派負責處理技術支援問題，最終也開始撰寫程式碼來解決這些問題（老實說，這些程式有時候會製造更多錯誤！）公餘時間，他會<a"
+" href=\"%(mb_editors_url)s\">編輯MusicBrainz</a>和四處旅行親近大自然。"
 
 #: metabrainz/templates/index/team.html:68
 msgid "Originally from Spain, he now lives in Tartu, Estonia."
@@ -1734,9 +2725,8 @@ msgid ""
 "          more than 1 bit since 1982 and has been an esteemed Linux "
 "system administrator since 1998."
 msgstr ""
-"Laurent Monin是音樂的超級愛好者，在嘗試整理他1500多張CD的時候才了得知"
-"MusicBrainz和Picard的存在。此外，Laurent自1982年開始設計程式，只要是多於一位"
-"元的東西，他都不放過。1998年，他成為了一名受人尊敬的Linux系統管理員。"
+"Laurent "
+"Monin是音樂的超級愛好者，在嘗試整理他1500多張CD的時候才了得知MusicBrainz和Picard的存在。此外，Laurent自1982年開始設計程式，只要是多於一位元的東西，他都不放過。1998年，他成為了一名受人尊敬的Linux系統管理員。"
 
 #: metabrainz/templates/index/team.html:88
 #, python-format
@@ -1753,8 +2743,9 @@ msgid ""
 msgstr ""
 "Laurent興趣和技能種類豐富，曾貢獻於多項開源專案，\n"
 "          其中包括<a href=\"%(elinks_url)s\">ELinks</a>和\n"
-"          <a href=\"%(geeqie_url)s\">Geeqie</a>。他喜歡修補不同音頻硬體，包括"
-"擴大機和揚聲器。Laurent的貢獻不僅如此。他目前在鄰近法國貝桑松的居所\n"
+"          <a "
+"href=\"%(geeqie_url)s\">Geeqie</a>。他喜歡修補不同音頻硬體，包括擴大機和揚聲器。Laurent的貢獻不僅如此。他目前在鄰近法國貝桑松的居所"
+"\n"
 "          維護MetaBrainz的伺服器。"
 
 #: metabrainz/templates/index/team.html:105
@@ -1770,19 +2761,17 @@ msgid ""
 "          in the end. Besides that, he casually plays music, listens to "
 "music, eats music, … music, for an healthy way of life."
 msgstr ""
-"Yvan來自法國南錫，是MusicBrainz的軟體工程師。他以普通使用者的身份接觸"
-"MusicBrainz，\n"
+"Yvan來自法國南錫，是MusicBrainz的軟體工程師。他以普通使用者的身份接觸MusicBrainz，\n"
 "          後來開始編輯、回報錯誤、修正其他人報告的錯誤，最後成為了員工。\n"
-"          此外，他喜歡隨興彈奏音樂、聽音樂、吃音樂、……音樂，他只希望可以健康"
-"地活下去。"
+"          此外，他喜歡隨興彈奏音樂、聽音樂、吃音樂、……音樂，他只希望可以健康地活下去。"
 
 #: metabrainz/templates/index/team.html:120
 msgid ""
 "<span class=\"name\">Nicolas Pelletier</span> &mdash; BookBrainz Lead,  "
 "Software Engineer & Graphic Designer"
 msgstr ""
-"<span class=\"name\">Nicolas Pelletier</span> &mdash; BookBrainz主管、軟體工"
-"程師和平面設計師"
+"<span class=\"name\">Nicolas Pelletier</span> &mdash; "
+"BookBrainz主管、軟體工程師和平面設計師"
 
 #: metabrainz/templates/index/team.html:122
 msgid ""
@@ -1794,8 +2783,7 @@ msgid ""
 "he eventually joined the team."
 msgstr ""
 "Nicolas有平面設計的背景，但卻鍾情電腦和維修電子設備。\n"
-"          他跟隨興趣前往軟體開發的世界，再也沒回頭。他一直對音樂和書感興趣"
-"，\n"
+"          他跟隨興趣前往軟體開發的世界，再也沒回頭。他一直對音樂和書感興趣，\n"
 "          也享受參與MetaBrainz各個專項的工作，最終便加入了團隊。"
 
 #: metabrainz/templates/index/team.html:127
@@ -1816,8 +2804,8 @@ msgid ""
 "ListenBrainz/CritiqueBrainz/Android App Lead &amp; Junior Software "
 "Engineer"
 msgstr ""
-"<span class=\"name\">Kartik Ohri</span> &mdash; ListenBrainz／CritiqueBrainz"
-"／Android程式主管和初級軟體工程師"
+"<span class=\"name\">Kartik Ohri</span> &mdash; "
+"ListenBrainz／CritiqueBrainz／Android程式主管和初級軟體工程師"
 
 #: metabrainz/templates/index/team.html:148
 msgid ""
@@ -1830,8 +2818,7 @@ msgid ""
 msgstr ""
 "Kartik在2018年Google Code-In加入MetaBrainz社群，再也沒有回頭。\n"
 "          Kartik現為MetaBrainz承包者，在主導MusicBrainz Android程式和\n"
-"          CritiqueBrainz專項之外，他也花許多時間在AcousticBrainz和"
-"ListenBrainz專案上。"
+"          CritiqueBrainz專項之外，他也花許多時間在AcousticBrainz和ListenBrainz專案上。"
 
 #: metabrainz/templates/index/team.html:166
 msgid "<span class=\"name\">Adam James</span> &mdash; System Administrator"
@@ -1848,11 +2835,11 @@ msgid ""
 "href=\"https://www.transitiv.co.uk\">Transitiv Technologies</a>,\n"
 "\t  where he is a consultant and technical director."
 msgstr ""
-"Adam是一名系統管理員和業餘開發者，擁有參與Linux和開源軟體15年的經驗。他酷愛音"
-"樂，在整理數字音樂珍藏的時候，成為MusicBrainz的活躍編輯和\n"
+"Adam是一名系統管理員和業餘開發者，擁有參與Linux和開源軟體15年的經驗。他酷愛音樂，在整理數字音樂珍藏的時候，成為MusicBrainz的活躍編輯和"
+"\n"
 "\t  MetaBrainz社群的一分子。\n"
-"\t  Adam是<a href=\"https://www.transitiv.co.uk\">Transitiv Technologies</a>"
-"的\n"
+"\t  Adam是<a href=\"https://www.transitiv.co.uk\">Transitiv "
+"Technologies</a>的\n"
 "\t  顧問和科技長，義務參與本社群的工作。"
 
 #: metabrainz/templates/index/team.html:189
@@ -1878,8 +2865,7 @@ msgid ""
 msgstr ""
 "Julian一接觸終端機就對它產生興趣，在高中時期，他便開始組建、\n"
 "      拆解和重建虛擬機器，來了解它是如何運作的。在之後十年裡，\n"
-"      他不斷精進技能，最終加入資訊科技行業，專注於協助各組織充分使用數位基礎"
-"設施。過程中，他累積了大量音樂，感到須要管理這\n"
+"      他不斷精進技能，最終加入資訊科技行業，專注於協助各組織充分使用數位基礎設施。過程中，他累積了大量音樂，感到須要管理這\n"
 "      個日益龐大的資料庫；就是這樣，他加入了MetaBrainz社群。\n"
 "\n"
 "      除了協助MetaBrainz團隊管理系統，Julian還喜歡聆聽各式各樣的\n"
@@ -1889,9 +2875,7 @@ msgstr ""
 msgid ""
 "<span class=\"name\">Simon Hartman</span> &mdash; Design, UX Consultant &"
 " Social Media Jockey"
-msgstr ""
-"<span class=\"name\">Simon Hartman</span> &mdash; 設計、使用者體驗顧問、社群"
-"媒體高手"
+msgstr "<span class=\"name\">Simon Hartman</span> &mdash; 設計、使用者體驗顧問、社群媒體高手"
 
 #: metabrainz/templates/index/team.html:217
 msgid ""
@@ -1902,10 +2886,8 @@ msgid ""
 "          and has 15 years experience across various graphic "
 "design/comms/marketing roles."
 msgstr ""
-"自2009年起，Simon便持續向MusicBrainz貢獻資料，並針對使用者體驗與設計提出意見"
-"。\n"
-"          2022年，他開始以官方身分針對使用者體驗與設計提出意見。他現居紐西蘭"
-"，\n"
+"自2009年起，Simon便持續向MusicBrainz貢獻資料，並針對使用者體驗與設計提出意見。\n"
+"          2022年，他開始以官方身分針對使用者體驗與設計提出意見。他現居紐西蘭，\n"
 "          並在平面設計、傳播和行銷等領域累積了15年的工作經驗。"
 
 #: metabrainz/templates/index/team.html:236
@@ -1922,10 +2904,9 @@ msgid ""
 "          In his leisure moments, Ansh enjoys binge-watching movies and "
 "listening to music."
 msgstr ""
-"Ansh是一名軟體工程師，目前居住於印度新德里。他於2022年以Google Summer of Code"
-"實習生的身分加入MetaBrainz，自此便成為社群的一員。\n"
-"          他最初貢獻於CritiqueBrainz和BookBrainz，目前也參與開發ListenBrainz"
-"。\n"
+"Ansh是一名軟體工程師，目前居住於印度新德里。他於2022年以Google Summer of "
+"Code實習生的身分加入MetaBrainz，自此便成為社群的一員。\n"
+"          他最初貢獻於CritiqueBrainz和BookBrainz，目前也參與開發ListenBrainz。\n"
 "          閒暇之餘，Ansh喜歡一口氣追看電影和聽音樂。"
 
 #: metabrainz/templates/index/team.html:250
@@ -1950,10 +2931,10 @@ msgid ""
 "          Akshat has always been fascinated by the creativity of people. "
 "He resides in New Delhi, India."
 msgstr ""
-"Akshat出於對MusicBrainz Android應用程式的熱愛，開始為該專案貢獻。在深入了解"
-"MetaBrainz的各項專案後，他決定專注於MusicBrainz。他曾獲選為Google Summer of "
-"Code實習生，目前是MetaBrainz的承包者，致力於改善MusicBrainz的使用者介面與體驗"
-"。Akshat一直受他人的創意啟發。他現居於印度新德里。"
+"Akshat出於對MusicBrainz "
+"Android應用程式的熱愛，開始為該專案貢獻。在深入了解MetaBrainz的各項專案後，他決定專注於MusicBrainz。他曾獲選為Google"
+" Summer of "
+"Code實習生，目前是MetaBrainz的承包者，致力於改善MusicBrainz的使用者介面與體驗。Akshat一直受他人的創意啟發。他現居於印度新德里。"
 
 #: metabrainz/templates/index/team.html:278
 msgid ""
@@ -1972,18 +2953,16 @@ msgid ""
 "          When not staring at a screen, Param plays some chess and tries "
 "to listen to new music."
 msgstr ""
-"Param是一名軟體工程師，也是ListenBrainz專案的前主管。他於2017年以Google "
-"Summer of Code實習生身分加入MetaBrainz，自此便一直是MetaBrainz的一員。Param熱"
-"愛程式設計和音樂，所以MetaBrainz對他而言可說是「一見鍾情」。當不在盯著螢幕的"
-"時候，Param會下下棋，並發掘新音樂。"
+"Param是一名軟體工程師，也是ListenBrainz專案的前主管。他於2017年以Google Summer of "
+"Code實習生身分加入MetaBrainz，自此便一直是MetaBrainz的一員。Param熱愛程式設計和音樂，所以MetaBrainz對他而言可說是「一見鍾情」。當不在盯著螢幕的時候，Param會下下棋，並發掘新音樂。"
 
 #: metabrainz/templates/index/team.html:301
 msgid ""
 "<span class=\"name\">David \"drsaunde\" Saunders</span> &mdash; "
 "MusicBrainz Areas"
 msgstr ""
-"<span class=\"name\">David \"drsaunde\" Saunders</span> &mdash; MusicBrainz地"
-"區"
+"<span class=\"name\">David \"drsaunde\" Saunders</span> &mdash; "
+"MusicBrainz地區"
 
 #: metabrainz/templates/index/team.html:303
 #, python-format
@@ -2000,11 +2979,9 @@ msgid ""
 "href=\"%(gnt_url)s\">GnT's</a>,\n"
 "          as well as cheering for the Toronto Raptors."
 msgstr ""
-"應社群要求，David負責在MusicBrainz中新增地區。他在MusicBrainz活躍超過十年，是"
-"少數幾位修改次數多於100萬的編輯。身為一位引以為傲的加拿大人，當David不在參與"
-"MusicBrainz時，他會享受自己喜愛的東西，例如<a href=\"%(thc_url)s\">THC</a>"
-"、<a href=\"%(tfc_url)s\">TFC</a>、<a href=\"%(cts_url)s\">CTS</a>和<a "
-"href=\"%(gnt_url)s\">GnT's</a>和為多倫多暴龍加油。"
+"應社群要求，David負責在MusicBrainz中新增地區。他在MusicBrainz活躍超過十年，是少數幾位修改次數多於100萬的編輯。身為一位引以為傲的加拿大人，當David不在參與MusicBrainz時，他會享受自己喜愛的東西，例如<a"
+" href=\"%(thc_url)s\">THC</a>、<a href=\"%(tfc_url)s\">TFC</a>、<a "
+"href=\"%(cts_url)s\">CTS</a>和<a href=\"%(gnt_url)s\">GnT's</a>和為多倫多暴龍加油。"
 
 #: metabrainz/templates/index/team.html:328
 msgid "<span class=\"name\">Akira Holm</span> &mdash; MusicBrainz Instruments"
@@ -2022,11 +2999,7 @@ msgid ""
 "listening to all sorts of different music, Lupin \n"
 "          III, colouring, and collecting all sorts of things, from "
 "stickers and stamps to bottlecaps."
-msgstr ""
-"ApeKattQuest（又名MonkeyPython）在2004年成為MusicBrainz編輯，是MusicBrainz的"
-"「樂器新增員」（這個職銜聽起來好像不太嚴肅，但新增及完善樂器資料的人卻是相當"
-"重要的）。當他不在網路上（或在圖書館裡！）四處搜尋樂器資料的時候，他喜歡玩遊"
-"戲、聆聽各式各樣的音樂、看《魯邦三世》、著色和收集貼紙、郵票、瓶蓋等物品。"
+msgstr "ApeKattQuest（又名MonkeyPython）在2004年成為MusicBrainz編輯，是MusicBrainz的「樂器新增員」（這個職銜聽起來好像不太嚴肅，但新增及完善樂器資料的人卻是相當重要的）。當他不在網路上（或在圖書館裡！）四處搜尋樂器資料的時候，他喜歡玩遊戲、聆聽各式各樣的音樂、看《魯邦三世》、著色和收集貼紙、郵票、瓶蓋等物品。"
 
 #: frontend/js/src/Profile.tsx:409
 #: metabrainz/templates/index/datasets/download.html:3
@@ -2082,8 +3055,8 @@ msgid ""
 "name\n"
 "      on the card used to set up the payment."
 msgstr ""
-"如果您使用Stripe，我們會手動取消您的捐款。請<a href=\"%(contact_url)s\">聯絡"
-"我們</a>，並提供您的姓名和最初用於申請捐款的付款卡。"
+"如果您使用Stripe，我們會手動取消您的捐款。請<a "
+"href=\"%(contact_url)s\">聯絡我們</a>，並提供您的姓名和最初用於申請捐款的付款卡。"
 
 #: metabrainz/templates/payments/cancel_recurring.html:20
 #, python-format
@@ -2091,8 +3064,8 @@ msgid ""
 "For PayPal, you will need to cancel from their site.\n"
 "      See <a href=\"%(paypal_cancel_url)s\">their documentation</a>."
 msgstr ""
-"如果您使用PayPal，您要在PayPal網站取消付款。請瀏覽<a href=\"%"
-"(paypal_cancel_url)s\">他們的說明文件</a>。"
+"如果您使用PayPal，您要在PayPal網站取消付款。請瀏覽<a "
+"href=\"%(paypal_cancel_url)s\">他們的說明文件</a>。"
 
 #: metabrainz/templates/payments/donate.html:3
 #: metabrainz/templates/payments/donate.html:7
@@ -2112,10 +3085,8 @@ msgid ""
 "donation off your taxes if you are a\n"
 "      US taxpayer."
 msgstr ""
-"如果您認為我們的專案是值得支持的，請考慮向MetaBrainz基金會捐款。基金會總部位"
-"於美國加州，是一個<a href=\"%(wikipedia_non_profit_url)s\">501(c)(3)免稅非營"
-"利組織</a>。若您是美國納稅人，所有捐款均可抵稅，您將收到一份收據，讓您在報稅"
-"時抵扣捐款金額。"
+"如果您認為我們的專案是值得支持的，請考慮向MetaBrainz基金會捐款。基金會總部位於美國加州，是一個<a "
+"href=\"%(wikipedia_non_profit_url)s\">501(c)(3)免稅非營利組織</a>。若您是美國納稅人，所有捐款均可抵稅，您將收到一份收據，讓您在報稅時抵扣捐款金額。"
 
 #: metabrainz/templates/payments/donate.html:18
 msgid ""
@@ -2133,9 +3104,7 @@ msgstr ""
 msgid ""
 "Where has my contribution gone? See our <a "
 "href=\"%(finance_reports_url)s\">transparent finances</a>."
-msgstr ""
-"我的捐款都去哪裡了？請參見我們透明的<a href=\"%(finance_reports_url)s\">財務"
-"報告</a>。"
+msgstr "我的捐款都去哪裡了？請參見我們透明的<a href=\"%(finance_reports_url)s\">財務報告</a>。"
 
 #: metabrainz/templates/payments/donate.html:24
 #, python-format
@@ -2152,8 +3121,8 @@ msgid ""
 "actual\n"
 "        donation, go to <a href=\"%(mb_url)s\">metabrainz.org</a>."
 msgstr ""
-"<b>注意！</b>本站是網站的開發版，請不要提供您的信用卡資料！如要作出捐款，請前"
-"往<a href=\"%(mb_url)s\">metabrainz.org</a>。"
+"<b>注意！</b>本站是網站的開發版，請不要提供您的信用卡資料！如要作出捐款，請前往<a "
+"href=\"%(mb_url)s\">metabrainz.org</a>。"
 
 #: metabrainz/templates/payments/donate.html:39
 #: metabrainz/templates/payments/payment.html:31
@@ -2167,8 +3136,8 @@ msgid ""
 "            <a href=\"%(mail_link)s\">donations@metabrainz.org</a>\n"
 "            before you do."
 msgstr ""
-"如果您想作出一次大額捐款，請先透過<a href=\"%(mail_link)s\">"
-"donations@metabrainz.org</a>聯絡我們。"
+"如果您想作出一次大額捐款，請先透過<a "
+"href=\"%(mail_link)s\">donations@metabrainz.org</a>聯絡我們。"
 
 #: metabrainz/templates/payments/donate.html:65
 msgid "I want this to be a recurring monthly donation"
@@ -2234,9 +3203,7 @@ msgstr "透過其他方式捐款"
 msgid ""
 "If you use GitHub to sponsor your favourite projects, you can click below"
 " to Sponsor @metabrainz on GitHub Sponsors:"
-msgstr ""
-"如果您在GitHub會贊助喜歡的專案，您可以按一下以下按鈕，在GitHub Sponsors上贊"
-"助@metabrainz："
+msgstr "如果您在GitHub會贊助喜歡的專案，您可以按一下以下按鈕，在GitHub Sponsors上贊助@metabrainz："
 
 #: metabrainz/templates/payments/donate.html:140
 #: metabrainz/templates/payments/payment_base.html:29
@@ -2254,9 +3221,7 @@ msgstr "您可以透過銀行轉賬至以下IBAN，作出定期或一次性的�
 msgid ""
 "Please indicate your name and use the word "
 "<em>%(donation_fixed_string)s</em> in the description field."
-msgstr ""
-"請提供您的姓名，以及在描述欄中使用「<em>%(donation_fixed_string)s</em>」一詞"
-"。"
+msgstr "請提供您的姓名，以及在描述欄中使用「<em>%(donation_fixed_string)s</em>」一詞。"
 
 #: metabrainz/templates/payments/donate.html:145
 msgid "US Check"
@@ -2264,9 +3229,11 @@ msgstr "美國支票"
 
 #: metabrainz/templates/payments/donate.html:146
 msgid ""
-"Due to the increased unreliability of the US Postal Service we have "
-"stopped accepting paper checks. Sorry!"
-msgstr "由於美國郵政署的服務越來越不穩定，我們不再接受支票。抱歉！"
+"Due to the increased unreliability of the US Postal Service and the "
+"relatively large fees involved, we ask you to only send a paper check if "
+"it is the only possible option. Due to the fees, we will not cash checks "
+"for less than $25."
+msgstr ""
 
 #: metabrainz/templates/payments/donate.html:241
 msgid ""
@@ -2335,8 +3302,8 @@ msgid ""
 "actual\n"
 "      payment, go to <a href=\"%(mb_url)s\">metabrainz.org</a>."
 msgstr ""
-"<b>注意！</b>本站是網站的開發版，請不要提供您的信用卡資料！如果您要付款，請前"
-"往<a href=\"%(mb_url)s\">metabrainz.org</a>。"
+"<b>注意！</b>本站是網站的開發版，請不要提供您的信用卡資料！如果您要付款，請前往<a "
+"href=\"%(mb_url)s\">metabrainz.org</a>。"
 
 #: metabrainz/templates/payments/payment.html:17
 msgid "Organization:"
@@ -2353,8 +3320,8 @@ msgid ""
 "          <a href=\"%(mail_link)s\">payments@metabrainz.org</a>\n"
 "          before you do."
 msgstr ""
-"如果您想作出一次大型付款，請先透過<a href=\"%(mail_link)s\">"
-"payments@metabrainz.org</a>聯絡我們。"
+"如果您想作出一次大型付款，請先透過<a "
+"href=\"%(mail_link)s\">payments@metabrainz.org</a>聯絡我們。"
 
 #: metabrainz/templates/payments/payment.html:52
 #: metabrainz/templates/payments/payment.html:159
@@ -2379,8 +3346,8 @@ msgid ""
 "      please take a look at our <a href=\"%(privacy_policy_url)s\">\n"
 "      privacy policy</a>."
 msgstr ""
-"在付款過程中向MetaBrainz基金會提供的個人資料不會向任何人透露。詳情請參見我們"
-"的<a href=\"%(privacy_policy_url)s\">隱私政策</a>。"
+"在付款過程中向MetaBrainz基金會提供的個人資料不會向任何人透露。詳情請參見我們的<a "
+"href=\"%(privacy_policy_url)s\">隱私政策</a>。"
 
 #: metabrainz/templates/payments/payment.html:93
 #, python-format
@@ -3177,8 +4144,8 @@ msgid "Monthly balance sheets"
 msgstr "每月財務狀況表"
 
 #: frontend/js/src/Profile.tsx:520
-#: frontend/js/src/forms/SignupCommercial.tsx:175
-#: frontend/js/src/forms/SignupCommercial.tsx:554
+#: frontend/js/src/forms/SignupCommercial.tsx:180
+#: frontend/js/src/forms/SignupCommercial.tsx:558
 #: frontend/js/src/forms/SignupNonCommercial.tsx:106
 #: frontend/js/src/forms/SignupNonCommercial.tsx:318
 #: metabrainz/templates/supporters/account-type.html:3
@@ -3199,6 +4166,7 @@ msgid "Non-commercial / Personal"
 msgstr "非商業或個人用戶"
 
 #: frontend/js/src/Profile.tsx:235
+#: frontend/js/src/forms/SignupNonCommercial.tsx:107
 #: frontend/js/src/forms/SignupNonCommercial.tsx:151
 #: metabrainz/templates/supporters/account-type.html:42
 msgid "Non-commercial"
@@ -3212,57 +4180,46 @@ msgstr ""
 msgid "Personal or university assignment user."
 msgstr ""
 
-#: metabrainz/templates/supporters/account-type.html:48
-#: metabrainz/templates/supporters/account-type.html:90
-#: metabrainz/templates/supporters/account-type.html:141
-msgid "Upgrade"
-msgstr ""
-
 #: frontend/js/src/Profile.tsx:235
-#: frontend/js/src/forms/SignupCommercial.tsx:176
-#: frontend/js/src/forms/SignupCommercial.tsx:228
-#: metabrainz/templates/supporters/account-type.html:61
+#: frontend/js/src/forms/SignupCommercial.tsx:181
+#: frontend/js/src/forms/SignupCommercial.tsx:233
+#: metabrainz/templates/supporters/account-type.html:56
 msgid "Commercial"
 msgstr "商業用戶"
 
-#: metabrainz/templates/supporters/account-type.html:83
-#: metabrainz/templates/supporters/account-type.html:135
+#: metabrainz/templates/supporters/account-type.html:78
+#: metabrainz/templates/supporters/account-type.html:125
 #, python-format
 msgid "$%(tier_price)s/month and up"
 msgstr "每月$%(tier_price)s或以上"
 
-#: metabrainz/templates/supporters/account-type.html:87
-#: metabrainz/templates/supporters/account-type.html:138
+#: metabrainz/templates/supporters/account-type.html:82
+#: metabrainz/templates/supporters/account-type.html:128
 msgid "More info"
 msgstr "更多資料"
 
-#: metabrainz/templates/supporters/account-type.html:104
+#: metabrainz/templates/supporters/account-type.html:94
 msgid "View all tiers"
 msgstr "檢視所有等級"
 
-#: metabrainz/templates/supporters/account-type.html:112
+#: metabrainz/templates/supporters/account-type.html:102
 msgid "Some of our Unicorn members"
 msgstr "我們一些獨角獸成員"
 
-#: metabrainz/templates/supporters/account-type.html:123
+#: metabrainz/templates/supporters/account-type.html:113
 msgid "See all our supporters"
 msgstr "參見所有支持者"
 
-#: metabrainz/templates/supporters/account-type.html:151
+#: metabrainz/templates/supporters/account-type.html:136
 msgid "View featured tiers"
 msgstr "檢視特色等級"
 
-#: metabrainz/templates/supporters/account-type.html:158
+#: metabrainz/templates/supporters/account-type.html:143
 #, python-format
 msgid ""
 "If you are not sure which tier to pick, please\n"
 "      <a href=\"%(contact_url)s\">contact us</a>."
 msgstr "如果您不確定應該選哪一等級，請<a href=\"%(contact_url)s\">聯繫我們</a>。"
-
-#: metabrainz/templates/supporters/account-type.html:166
-#, fuzzy
-msgid "Back to Profile"
-msgstr "您的帳號"
 
 #: metabrainz/templates/supporters/bad-standing.html:3
 #: metabrainz/templates/supporters/bad-standing.html:6
@@ -3323,9 +4280,9 @@ msgid "Forgot your username"
 msgstr ""
 
 #: frontend/js/src/forms/ResetPassword.tsx:79
-#: frontend/js/src/forms/SignupCommercial.tsx:320
+#: frontend/js/src/forms/SignupCommercial.tsx:325
 #: frontend/js/src/forms/SignupNonCommercial.tsx:227
-#: frontend/js/src/forms/SignupUser.tsx:169
+#: frontend/js/src/forms/SignupUser.tsx:175
 #: metabrainz/templates/users/reauthenticate.html:3
 #: metabrainz/templates/users/reauthenticate.html:6
 msgid "Confirm Password"
@@ -3335,17 +4292,22 @@ msgstr ""
 msgid "Please re-enter your password to continue."
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:108
+#: frontend/js/src/ProfileDelete.tsx:110
 #: frontend/js/src/forms/DeleteApplication.tsx:53
 #: frontend/js/src/forms/OAuthPrompt.tsx:54
 #: frontend/js/src/forms/ProfileChangePassword.tsx:104
 #: frontend/js/src/forms/ProfileEdit.tsx:105
-#: metabrainz/templates/users/reauthenticate.html:23
+#: metabrainz/templates/users/reauthenticate.html:28
 msgid "Cancel"
 msgstr ""
 
-#: metabrainz/templates/users/reauthenticate.html:24
+#: metabrainz/templates/users/reauthenticate.html:29
 msgid "Continue"
+msgstr ""
+
+#: frontend/js/src/forms/utils.tsx:202
+#: metabrainz/templates/users/reauthenticate.html:40
+msgid "Password must not exceed 72 bytes."
 msgstr ""
 
 #: frontend/js/src/forms/ResetPassword.tsx:27
@@ -3353,38 +4315,38 @@ msgstr ""
 msgid "Reset your password"
 msgstr ""
 
-#: frontend/js/src/hooks/useEmailValidation.ts:41 metabrainz/user/forms.py:15
+#: frontend/js/src/hooks/useEmailValidation.ts:41 metabrainz/user/forms.py:16
 msgid "Registration from this email domain is not allowed."
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:50
 #: frontend/js/src/forms/LostPassword.tsx:45
-#: frontend/js/src/forms/SignupCommercial.tsx:270
+#: frontend/js/src/forms/SignupCommercial.tsx:275
 #: frontend/js/src/forms/SignupNonCommercial.tsx:175
-#: frontend/js/src/forms/SignupUser.tsx:114 metabrainz/user/forms.py:20
-#: metabrainz/user/forms.py:45 metabrainz/user/forms.py:62
+#: frontend/js/src/forms/SignupUser.tsx:120 metabrainz/user/forms.py:22
+#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:75
 msgid "Username"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:42
 #: frontend/js/src/forms/LostPassword.tsx:37
-#: frontend/js/src/forms/SignupCommercial.tsx:153
+#: frontend/js/src/forms/SignupCommercial.tsx:158
 #: frontend/js/src/forms/SignupNonCommercial.tsx:84
-#: frontend/js/src/forms/SignupUser.tsx:67 metabrainz/user/forms.py:21
-#: metabrainz/user/forms.py:45 metabrainz/user/forms.py:62
+#: frontend/js/src/forms/SignupUser.tsx:73 metabrainz/user/forms.py:26
+#: metabrainz/user/forms.py:52 metabrainz/user/forms.py:75
 msgid "Username is required!"
 msgstr ""
 
 #: frontend/js/src/forms/LoginUser.tsx:63
 #: frontend/js/src/forms/ResetPassword.tsx:72
-#: frontend/js/src/forms/SignupCommercial.tsx:308
+#: frontend/js/src/forms/SignupCommercial.tsx:313
 #: frontend/js/src/forms/SignupNonCommercial.tsx:214
-#: frontend/js/src/forms/SignupUser.tsx:157 metabrainz/user/forms.py:46
-#: metabrainz/user/forms.py:52
+#: frontend/js/src/forms/SignupUser.tsx:163 metabrainz/user/forms.py:53
+#: metabrainz/user/forms.py:62
 msgid "Password"
 msgstr ""
 
-#: frontend/js/src/forms/LoginUser.tsx:76 metabrainz/user/forms.py:47
+#: frontend/js/src/forms/LoginUser.tsx:76 metabrainz/user/forms.py:57
 msgid "Remember me"
 msgstr ""
 
@@ -3396,11 +4358,11 @@ msgstr ""
 msgid "Username contains invalid or invisible characters."
 msgstr ""
 
-#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:181
+#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:220
 msgid "Hide password"
 msgstr ""
 
-#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:181
+#: frontend/js/src/ApplicationRow.tsx:27 frontend/js/src/forms/utils.tsx:220
 msgid "Show password"
 msgstr ""
 
@@ -3459,11 +4421,11 @@ msgstr ""
 msgid "Revoke access"
 msgstr ""
 
-#: frontend/js/src/OAuthError.tsx:17
+#: frontend/js/src/OAuthError.tsx:18
 msgid "OAuth2 Error"
 msgstr ""
 
-#: frontend/js/src/OAuthError.tsx:18
+#: frontend/js/src/OAuthError.tsx:19
 msgid "An error occurred during OAuth authentication process."
 msgstr ""
 
@@ -3493,8 +4455,8 @@ msgstr ""
 
 #: frontend/js/src/Profile.tsx:109
 msgid ""
-"Are you sure you want to generate new access token? Current token will be"
-" revoked!"
+"Are you sure you want to generate a new access token? The current token "
+"will be revoked!"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:118
@@ -3610,8 +4572,8 @@ msgid "Contact Information"
 msgstr ""
 
 #: frontend/js/src/Profile.tsx:310 frontend/js/src/forms/ProfileEdit.tsx:70
-#: frontend/js/src/forms/SignupCommercial.tsx:284
-#: frontend/js/src/forms/SignupCommercial.tsx:333
+#: frontend/js/src/forms/SignupCommercial.tsx:289
+#: frontend/js/src/forms/SignupCommercial.tsx:338
 #: frontend/js/src/forms/SignupNonCommercial.tsx:189
 #: frontend/js/src/forms/SignupNonCommercial.tsx:241
 msgid "Contact name"
@@ -3727,7 +4689,7 @@ msgstr ""
 msgid "Once you delete your account, there is no going back. Please be certain."
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:550 frontend/js/src/ProfileDelete.tsx:105
+#: frontend/js/src/Profile.tsx:550 frontend/js/src/ProfileDelete.tsx:107
 msgid "Delete My Account"
 msgstr ""
 
@@ -3739,39 +4701,39 @@ msgstr ""
 msgid "Need to delete your account?"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:574
+#: frontend/js/src/Profile.tsx:575
 msgid ""
 "Deletion of supporter accounts requires manual review. Please contact us "
-"at"
+"at <email />."
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:594
+#: frontend/js/src/Profile.tsx:599
 msgid "Security"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:626
+#: frontend/js/src/Profile.tsx:631
 msgid "MetaBrainz Applications"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:630
+#: frontend/js/src/Profile.tsx:635
 msgid ""
 "With your MetaBrainz account, you can access every project in the "
 "MetaBrainz family:"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:643
+#: frontend/js/src/Profile.tsx:648
 msgid "The open-source music encyclopedia"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:655
+#: frontend/js/src/Profile.tsx:660
 msgid "Track, visualise and share the music you listen to"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:667
+#: frontend/js/src/Profile.tsx:672
 msgid "The open-source book database"
 msgstr ""
 
-#: frontend/js/src/Profile.tsx:679
+#: frontend/js/src/Profile.tsx:684
 msgid "Creative Commons licensed reviews"
 msgstr ""
 
@@ -3794,7 +4756,7 @@ msgid "Permanently remove all your account information"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:64
-msgid "Revoke all your API tokens and access"
+msgid "Revoke all your tokens and access to the replication API"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:65
@@ -3806,14 +4768,16 @@ msgid "Log you out of all MetaBrainz services"
 msgstr ""
 
 #: frontend/js/src/ProfileDelete.tsx:70
-msgid "Your username will be reserved and cannot be reused."
+msgid ""
+"Your username will be reserved and cannot be reused without the "
+"intervention of an administrator."
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:82
+#: frontend/js/src/ProfileDelete.tsx:84
 msgid "To confirm, type your username '<username />' below:"
 msgstr ""
 
-#: frontend/js/src/ProfileDelete.tsx:105
+#: frontend/js/src/ProfileDelete.tsx:107
 msgid "Deleting..."
 msgstr "刪除中……"
 
@@ -3825,64 +4789,7 @@ msgstr "個人資料"
 msgid "Close"
 msgstr "關閉"
 
-#: frontend/js/src/forms/ConditionsModal.tsx:23
-msgid "Licensing"
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:25
-msgid ""
-"Any contributions you make to any MetaBrainz service will be released "
-"into the Public Domain and/or licensed under a Creative Commons by-nc-sa "
-"license. Furthermore, you give the MetaBrainz Foundation the right to "
-"license this data for commercial use."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:30
-msgid "Please read our <licenseLink>license page</licenseLink> for more details."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:45
-msgid ""
-"MetaBrainz strongly believes in the privacy of its users. Any personal "
-"information you choose to provide will not be sold or shared with anyone "
-"else."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:50
-msgid ""
-"Please read our <privacyLink>privacy policy</privacyLink> for more "
-"details."
-msgstr "如要了解更多，請參閱我們的<gdprLink>隱私政策</gdprLink>。"
-
-#: frontend/js/src/forms/ConditionsModal.tsx:59
-msgid "GDPR compliance"
-msgstr "GDPR法遵"
-
-#: frontend/js/src/forms/ConditionsModal.tsx:61
-msgid ""
-"You may remove your personal information from our services anytime by "
-"deleting your account."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:66
-msgid ""
-"Please read our <gdprLink>GDPR compliance statement</gdprLink> for more "
-"details."
-msgstr "如要了解更多，請參閱我們的<gdprLink>GDPR法遵聲明</gdprLink>。"
-
-#: frontend/js/src/forms/ConditionsModal.tsx:78
-msgid ""
-"Creating an account on MetaBrainz will give you access to all of our "
-"projects, such as MusicBrainz, ListenBrainz, BookBrainz, and more."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:82
-msgid ""
-"We create a placeholder account for all the MetaBrainz projects when you "
-"sign up, and you are one log-in away from activating them."
-msgstr ""
-
-#: frontend/js/src/forms/ConditionsModal.tsx:91
+#: frontend/js/src/forms/ConditionsModal.tsx:29
 msgid "Sounds good"
 msgstr ""
 
@@ -3968,9 +4875,9 @@ msgstr "忘記使用者名稱？"
 msgid "Forgot your password?"
 msgstr "忘記密碼？"
 
-#: frontend/js/src/forms/LoginUser.tsx:109
-msgid "Don't have an account?"
-msgstr "沒有帳號？"
+#: frontend/js/src/forms/LoginUser.tsx:110
+msgid "Don't have an account? <signupLink>Sign up</signupLink>"
+msgstr ""
 
 #: frontend/js/src/forms/LostPassword.tsx:38
 #: frontend/js/src/forms/LostUsername.tsx:36
@@ -3998,15 +4905,72 @@ msgstr ""
 msgid "Allow access"
 msgstr "批准存取權"
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:71
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:10
+msgid "Licensing"
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:12
+msgid ""
+"Any contributions you make to any MetaBrainz service will be released "
+"into the Public Domain and/or licensed under a Creative Commons by-nc-sa "
+"license. Furthermore, you give the MetaBrainz Foundation the right to "
+"license this data for commercial use."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:17
+msgid "Please read our <licenseLink>license page</licenseLink> for more details."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:34
+msgid ""
+"MetaBrainz strongly believes in the privacy of its users. Any personal "
+"information you choose to provide will not be sold or shared with anyone "
+"else."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:39
+msgid ""
+"Please read our <privacyLink>privacy policy</privacyLink> for more "
+"details."
+msgstr "如要了解更多，請參閱我們的<gdprLink>隱私政策</gdprLink>。"
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:50
+msgid "GDPR compliance"
+msgstr "GDPR法遵"
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:52
+msgid ""
+"You may remove your personal information from our services anytime by "
+"deleting your account."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:57
+msgid ""
+"Please read our <gdprLink>GDPR compliance statement</gdprLink> for more "
+"details."
+msgstr "如要了解更多，請參閱我們的<gdprLink>GDPR法遵聲明</gdprLink>。"
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:71
+msgid ""
+"Creating an account on MetaBrainz will give you access to all of our "
+"projects, such as MusicBrainz, ListenBrainz, BookBrainz, and more."
+msgstr ""
+
+#: frontend/js/src/forms/PrivacySummaryContent.tsx:75
+msgid ""
+"We create a placeholder account for all the MetaBrainz projects when you "
+"sign up, and you are one log-in away from activating them."
+msgstr ""
+
+#: frontend/js/src/forms/ProfileChangePassword.tsx:70
 msgid "Current Password"
 msgstr "目前密碼"
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:80
+#: frontend/js/src/forms/ProfileChangePassword.tsx:79
 msgid "New Password"
 msgstr "新密碼"
 
-#: frontend/js/src/forms/ProfileChangePassword.tsx:89
+#: frontend/js/src/forms/ProfileChangePassword.tsx:88
 msgid "Confirm New Password"
 msgstr "確認新密碼"
 
@@ -4018,205 +4982,189 @@ msgstr "更新"
 msgid "Reset Password"
 msgstr "重設密碼"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:38
-msgid "If you would like to support us with more than $"
+#: frontend/js/src/forms/SignupCommercial.tsx:40
+msgid ""
+"If you would like to support us with more than ${{minPledge}}, please "
+"enter the actual amount here:"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:39
-msgid ", please enter the actual amount here:"
-msgstr ""
-
-#: frontend/js/src/forms/SignupCommercial.tsx:144
+#: frontend/js/src/forms/SignupCommercial.tsx:149
 #: frontend/js/src/forms/SignupNonCommercial.tsx:75
-#: frontend/js/src/forms/SignupUser.tsx:87
+#: frontend/js/src/forms/SignupUser.tsx:93
 msgid "Captcha is required!"
 msgstr "Captcha不能留空！"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:179
+#: frontend/js/src/forms/SignupCommercial.tsx:184
 #: frontend/js/src/forms/SignupNonCommercial.tsx:110
 #: frontend/js/src/forms/SignupUser.tsx:46
 #, fuzzy
 msgid "Access all MetaBrainz projects"
 msgstr "MetaBrainz專案"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:182
+#: frontend/js/src/forms/SignupCommercial.tsx:187
 msgid "Note:"
 msgstr "備註："
 
-#: frontend/js/src/forms/SignupCommercial.tsx:184
+#: frontend/js/src/forms/SignupCommercial.tsx:189
 msgid ""
 "Signing up for any tier other than the <italic>Stealth startup</italic> "
 "tier will publicly list your company on this web site. However, we will "
 "not publish any of your private details."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:221
+#: frontend/js/src/forms/SignupCommercial.tsx:226
 #: frontend/js/src/forms/SignupNonCommercial.tsx:145
 msgid "Account type"
 msgstr "帳號類型"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:234
+#: frontend/js/src/forms/SignupCommercial.tsx:239
 msgid "Selected tier"
 msgstr "已選等級"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:242
-msgid "month and up"
+#: frontend/js/src/forms/SignupCommercial.tsx:247
+msgid "${{tierPrice}}/month and up"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:250
+#: frontend/js/src/forms/SignupCommercial.tsx:255
 msgid "Change account type or tier"
 msgstr "變更帳號類型或分類"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:261
+#: frontend/js/src/forms/SignupCommercial.tsx:266
 #: frontend/js/src/forms/SignupNonCommercial.tsx:166
 msgid "Your account:"
 msgstr "您的帳號："
 
-#: frontend/js/src/forms/SignupCommercial.tsx:271
+#: frontend/js/src/forms/SignupCommercial.tsx:276
 #: frontend/js/src/forms/SignupNonCommercial.tsx:176
-#: frontend/js/src/forms/SignupUser.tsx:114
+#: frontend/js/src/forms/SignupUser.tsx:120
 msgid "(public)"
 msgstr "（公開）"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:291
+#: frontend/js/src/forms/SignupCommercial.tsx:296
 #: frontend/js/src/forms/SignupNonCommercial.tsx:196
-#: frontend/js/src/forms/SignupUser.tsx:127
+#: frontend/js/src/forms/SignupUser.tsx:133
 msgid "E-mail address"
 msgstr "電子信箱地址"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:295
+#: frontend/js/src/forms/SignupCommercial.tsx:300
 #: frontend/js/src/forms/SignupNonCommercial.tsx:200
-#: frontend/js/src/forms/SignupUser.tsx:131
+#: frontend/js/src/forms/SignupUser.tsx:137
 msgid "(checking...)"
 msgstr "（檢查中……）"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:314
+#: frontend/js/src/forms/SignupCommercial.tsx:319
 #: frontend/js/src/forms/SignupNonCommercial.tsx:220
-#: frontend/js/src/forms/SignupUser.tsx:163
+#: frontend/js/src/forms/SignupUser.tsx:169
 msgid "Must be at least 8 characters"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:348
+#: frontend/js/src/forms/SignupCommercial.tsx:353
 msgid ""
 "If you don't have an organization name, you probably want to become a "
 "supporter as a <nonCommercialLink>Non-commercial / "
 "Personal</nonCommercialLink> supporter."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:358
+#: frontend/js/src/forms/SignupCommercial.tsx:363
 msgid ""
 "If you don't have an organization name, you probably want to sign up as a"
 " <nonCommercialLink>Non-commercial / Personal</nonCommercialLink> user."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:378
+#: frontend/js/src/forms/SignupCommercial.tsx:383
 msgid ""
 "Please tell us a little about your company and whether you plan to use "
 "our <apiLink>API</apiLink> or to <hostLink>host your own copy</hostLink> "
 "of the data."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:404
+#: frontend/js/src/forms/SignupCommercial.tsx:408
 msgid "Logo URL"
 msgstr "標誌圖片網址"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:405
+#: frontend/js/src/forms/SignupCommercial.tsx:409
 msgid "(preferably in SVG format)"
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:408
+#: frontend/js/src/forms/SignupCommercial.tsx:412
 msgid ""
 "Image should be about 250 pixels wide on a white or transparent "
 "background. We will host it on our site."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:421
+#: frontend/js/src/forms/SignupCommercial.tsx:425
 msgid ""
 "URL to where developers can use your APIs using MusicBrainz IDs, if "
-"available.."
+"available."
 msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:430
+#: frontend/js/src/forms/SignupCommercial.tsx:434
 msgid "Your project"
 msgstr "您的專案"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:434
+#: frontend/js/src/forms/SignupCommercial.tsx:438
 #: frontend/js/src/forms/SignupNonCommercial.tsx:261
 msgid "(max 150 characters)"
 msgstr "（最多150個字元）"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:451
+#: frontend/js/src/forms/SignupCommercial.tsx:455
 msgid "Billing address"
 msgstr "帳單地址"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:502
+#: frontend/js/src/forms/SignupCommercial.tsx:506
 msgid ""
 "I agree to support the MetaBrainz Foundation when my organization is able"
 " to do so."
-msgstr ""
-"我承諾，當我的組織能夠支持MetaBrainz基金會的時候，我的組織將會支持MetaBrainz"
-"基金會。"
+msgstr "我承諾，當我的組織能夠支持MetaBrainz基金會的時候，我的組織將會支持MetaBrainz基金會。"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:507
+#: frontend/js/src/forms/SignupCommercial.tsx:511
+#: frontend/js/src/forms/SignupNonCommercial.tsx:284
 msgid ""
-"I also agree that if I generate a Live Data Feed access token, that I "
-"treat my access token as a secret and will not share this token publicly "
-"or commit it to a source code repository."
-msgstr ""
-"我也同意，如果我發行實時資料源的存取權杖，我會將存取權杖視作秘密，不會公開分"
-"享此權杖或在原始碼儲存庫發布。"
+"I also agree that if I generate a Live Data Feed access token, then I "
+"will treat my access token as a secret and will not share this token "
+"publicly or commit it to a source code repository."
+msgstr "我也同意，如果我發行存取權杖，我會將存取權杖視作秘密，不會公開分享此權杖或在原始碼儲存庫發布。"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:515
+#: frontend/js/src/forms/SignupCommercial.tsx:519
 msgid ""
 "The following information will be shown publicly: organization name, "
 "logo, website and API URLs, data usage description."
 msgstr "以下資訊將公開展示：組織名稱、標誌、網站、API地址和資料使用的描述。"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:520
+#: frontend/js/src/forms/SignupCommercial.tsx:524
 msgid ""
 "We'll send you more details about payment process once your application "
 "is approved."
 msgstr "您的申請被接納後，我們會為您提供更詳盡的付款教學。"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:552
+#: frontend/js/src/forms/SignupCommercial.tsx:556
 #: frontend/js/src/forms/SignupNonCommercial.tsx:316
-#: frontend/js/src/forms/SignupUser.tsx:224
+#: frontend/js/src/forms/SignupUser.tsx:230
 msgid "Validating..."
 msgstr "核實中……"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:564
+#: frontend/js/src/forms/SignupCommercial.tsx:568
 #: frontend/js/src/forms/SignupNonCommercial.tsx:329
 msgid "Back to profile"
 msgstr "返回個人資料"
 
-#: frontend/js/src/forms/SignupCommercial.tsx:569
-#: frontend/js/src/forms/SignupNonCommercial.tsx:334
-msgid "Not a supporter?"
-msgstr "不是支持者？"
-
-#: frontend/js/src/forms/SignupCommercial.tsx:570
+#: frontend/js/src/forms/SignupCommercial.tsx:574
 #: frontend/js/src/forms/SignupNonCommercial.tsx:335
-msgid "Create a user account"
-msgstr "建立使用者帳號"
+msgid "Not a supporter? <signupLink>Create a user account</signupLink>"
+msgstr ""
 
-#: frontend/js/src/forms/SignupCommercial.tsx:573
-#: frontend/js/src/forms/SignupNonCommercial.tsx:338
-#: frontend/js/src/forms/SignupUser.tsx:231
-msgid "Already have an account?"
-msgstr "您已經有帳號了？"
-
-#: frontend/js/src/forms/SignupNonCommercial.tsx:107
-msgid "non-commercial"
-msgstr "非商業"
+#: frontend/js/src/forms/SignupCommercial.tsx:583
+#: frontend/js/src/forms/SignupNonCommercial.tsx:344
+#: frontend/js/src/forms/SignupUser.tsx:238
+msgid "Already have an account? <loginLink>Sign in</loginLink>"
+msgstr ""
 
 #: frontend/js/src/forms/SignupNonCommercial.tsx:113
 msgid ""
 "Please be aware that misuse of the non-commercial service for commercial "
 "purposes will result in us revoking your access token and then billing "
 "you for your commercial use of our datasets or the Live Data Feed."
-msgstr ""
-"請注意，以商業用途濫用非商業服務會使我們撤銷您的存取權杖，然後收取商業使用資"
-"料集或實時資料源的相關費用。"
+msgstr "請注意，以商業用途濫用非商業服務會使我們撤銷您的存取權杖，然後收取商業使用資料集或實時資料源的相關費用。"
 
 #: frontend/js/src/forms/SignupNonCommercial.tsx:157
 msgid "Change account type"
@@ -4236,50 +5184,40 @@ msgid ""
 "income per year) or personal uses only."
 msgstr "我同意僅以個人或非商業（收入少於每年500美元）用途使用MetaBrainz資料。"
 
-#: frontend/js/src/forms/SignupNonCommercial.tsx:284
-msgid ""
-"I also agree that if I generate a Live Data Feed access token, then I "
-"will treat my access token as a secret and will not share this token "
-"publicly or commit it to a source code repository."
-msgstr ""
-"我也同意，如果我發行存取權杖，我會將存取權杖視作秘密，不會公開分享此權杖或在"
-"原始碼儲存庫發布。"
-
 #: frontend/js/src/forms/SignupUser.tsx:43
 msgid "Create your account"
 msgstr "建立帳號"
 
-#: frontend/js/src/forms/SignupUser.tsx:50
-msgid "Registration started by"
-msgstr "註冊啟動源"
+#: frontend/js/src/forms/SignupUser.tsx:51
+msgid "Registration started by <client />"
+msgstr ""
 
-#: frontend/js/src/forms/SignupUser.tsx:69
+#: frontend/js/src/forms/SignupUser.tsx:75
+#: frontend/js/src/hooks/useEmailValidation.ts:82
 msgid "Invalid email address."
 msgstr "電子信箱地址無效。"
 
-#: frontend/js/src/forms/SignupUser.tsx:150
+#: frontend/js/src/forms/SignupUser.tsx:156
 msgid ""
 "This username and email were provided by the app that started "
 "registration. You can change them later from MetaBrainz settings."
-msgstr ""
-"此使用者名稱和電子信箱地址由啟動註冊的應用程式提供，您可以日後在MetaBrainz設"
-"定中變更。"
+msgstr "此使用者名稱和電子信箱地址由啟動註冊的應用程式提供，您可以日後在MetaBrainz設定中變更。"
 
-#: frontend/js/src/forms/SignupUser.tsx:182
+#: frontend/js/src/forms/SignupUser.tsx:188
 msgid ""
 "I accept that my contributions will be released into the public domain or"
 " licensed for use."
 msgstr "我接收我的貢獻將以公有領域發布或授權使用。"
 
-#: frontend/js/src/forms/SignupUser.tsx:191
+#: frontend/js/src/forms/SignupUser.tsx:197
 msgid "We will never share your personal information."
 msgstr "我們永遠不會分享您的個人資訊。"
 
-#: frontend/js/src/forms/SignupUser.tsx:200
+#: frontend/js/src/forms/SignupUser.tsx:206
 msgid "Click here to read more"
 msgstr "按此了解更多"
 
-#: frontend/js/src/forms/SignupUser.tsx:224
+#: frontend/js/src/forms/SignupUser.tsx:230
 msgid "Create account"
 msgstr "建立帳號"
 
@@ -4290,10 +5228,6 @@ msgstr "此電子信箱地址已經註冊。"
 #: frontend/js/src/hooks/useEmailValidation.ts:47
 msgid "Email validation failed"
 msgstr "未能確認電子信箱"
-
-#: frontend/js/src/hooks/useEmailValidation.ts:82
-msgid "Invalid email address"
-msgstr "電子信箱地址無效"
 
 #~ msgid "You need to specify amount!"
 #~ msgstr "請輸入付款金額！"
@@ -4999,7 +5933,7 @@ msgstr "電子信箱地址無效"
 #~ "Are you sure you want to generate"
 #~ " new access token? Current token will"
 #~ " be revoked!"
-#~ msgstr "您確定要產生新的訪問令牌？您現在的令牌將會被撤銷。"
+#~ msgstr ""
 
 #~ msgid "Sign up <small>Commercial</small>"
 #~ msgstr "<small>商用</small>註冊"
@@ -5044,9 +5978,6 @@ msgstr "電子信箱地址無效"
 #~ "your APIs using MusicBrainz IDs, if "
 #~ "available.."
 #~ msgstr ""
-#~ "URL to where developers can use "
-#~ "your APIs using MusicBrainz IDs, if "
-#~ "available.."
 
 #~ msgid "(max 150 characters)"
 #~ msgstr "（最多150個字元）"
@@ -5349,3 +6280,96 @@ msgstr "電子信箱地址無效"
 
 #~ msgid "Privacy policy"
 #~ msgstr "隱私政策"
+
+#~ msgid "You need to specify website of the organization."
+#~ msgstr "請提供組織網址。"
+
+#~ msgid ""
+#~ "We are currently evaluating our overall"
+#~ " online advertising strategy. We are "
+#~ "evaluating advertising, traffic optimization,\n"
+#~ ""
+#~ "    search engine optimization and "
+#~ "software monitization technologies. If you "
+#~ "provide these professional services, please"
+#~ " provide a detailed\n"
+#~ "    deck of your comprehensive services"
+#~ " to the following email address. "
+#~ "<em>Please respect our other non-media"
+#~ " teams and do not contact us \n"
+#~ "    regarding these services on any "
+#~ "other of our email addresses. We "
+#~ "will disregard the entirety of your "
+#~ "submissions if you contact us any "
+#~ "other way!</em>"
+#~ msgstr "我們正在評估網路廣告的整體策略，包括廣告投放、流量優化、搜尋引擎優化和軟體獲利科技等方面。如果您能就上述方面提供專業服務，請向以下電子信箱寄出關於該服務的詳盡簡報。<em>請尊重我們的非媒體部門，不要向我們其他郵箱寄出有關於廣告服務的電子郵件，否則我們將不會理會您公司的所有來函。</em>"
+
+#~ msgid ""
+#~ "Please come ask your questions at "
+#~ "our <a href=\"%(forums_url)s\">forums</a>! We "
+#~ "would love to\n"
+#~ "    answer any questions you may have."
+#~ msgstr "歡迎到我們的<a href=\"%(forums_url)s\">討論區</a>發問！我們非常樂意解答您的疑問。"
+
+#~ msgid ""
+#~ "Due to the increased unreliability of"
+#~ " the US Postal Service we have "
+#~ "stopped accepting paper checks. Sorry!"
+#~ msgstr "由於美國郵政署的服務越來越不穩定，我們不再接受支票。抱歉！"
+
+#~ msgid "Upgrade"
+#~ msgstr ""
+
+#~ msgid "Back to Profile"
+#~ msgstr "您的帳號"
+
+#~ msgid ""
+#~ "Deletion of supporter accounts requires "
+#~ "manual review. Please contact us at"
+#~ msgstr ""
+
+#~ msgid "Revoke all your API tokens and access"
+#~ msgstr ""
+
+#~ msgid "Your username will be reserved and cannot be reused."
+#~ msgstr ""
+
+#~ msgid "Don't have an account?"
+#~ msgstr "沒有帳號？"
+
+#~ msgid "If you would like to support us with more than $"
+#~ msgstr ""
+
+#~ msgid ", please enter the actual amount here:"
+#~ msgstr ""
+
+#~ msgid "month and up"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "I also agree that if I generate"
+#~ " a Live Data Feed access token, "
+#~ "that I treat my access token as"
+#~ " a secret and will not share "
+#~ "this token publicly or commit it "
+#~ "to a source code repository."
+#~ msgstr "我也同意，如果我發行實時資料源的存取權杖，我會將存取權杖視作秘密，不會公開分享此權杖或在原始碼儲存庫發布。"
+
+#~ msgid "Not a supporter?"
+#~ msgstr "不是支持者？"
+
+#~ msgid "Create a user account"
+#~ msgstr "建立使用者帳號"
+
+#~ msgid "Already have an account?"
+#~ msgstr "您已經有帳號了？"
+
+#~ msgid "non-commercial"
+#~ msgstr "非商業"
+
+#~ msgid "Registration started by"
+#~ msgstr "註冊啟動源"
+
+#~ msgid "Invalid email address"
+#~ msgstr "電子信箱地址無效"
+

--- a/metabrainz/utils.py
+++ b/metabrainz/utils.py
@@ -5,6 +5,7 @@ import random
 import string
 
 from flask import request
+from markupsafe import Markup
 
 from metabrainz.i18n import get_locale
 
@@ -53,3 +54,29 @@ def get_int_query_param(key: str, default: int):
 
 def get_global_props():
     return json.dumps({"locale": get_locale()})
+
+
+# Characters that must never appear raw inside a <script> element. In
+# particular "<" can begin the "</script" that ends the block early, after
+# which the rest of the value is parsed as HTML: an error description echoing
+# an attacker-controlled query parameter is enough to inject a script tag.
+# Escaping them as JSON \u sequences leaves the value unchanged after
+# JSON.parse(). U+2028/U+2029 are escaped too, as they are line terminators
+# in JavaScript source but legal raw in JSON.
+_SCRIPT_UNSAFE_CHARACTERS = {
+    "<": "\\u003c",
+    ">": "\\u003e",
+    "&": "\\u0026",
+    "\u2028": "\\u2028",
+    "\u2029": "\\u2029",
+}
+
+
+def react_props(value):
+    """Escape an already serialised JSON string for embedding in a script tag."""
+    if not value:
+        return Markup("{}")
+    value = str(value)
+    for character, escaped in _SCRIPT_UNSAFE_CHARACTERS.items():
+        value = value.replace(character, escaped)
+    return Markup(value)

--- a/metabrainz/utils_test.py
+++ b/metabrainz/utils_test.py
@@ -1,5 +1,7 @@
+import json
 from unittest import TestCase
 from metabrainz import utils
+from metabrainz.utils import react_props
 from datetime import datetime
 
 
@@ -17,3 +19,24 @@ class UtilsTestCase(TestCase):
         self.assertEqual(len(str_1), length)
         self.assertEqual(len(str_2), length)
         self.assertNotEqual(str_1, str_2)  # Generated strings shouldn't be the same
+
+
+class ReactPropsTestCase(TestCase):
+    """Props are embedded raw in a <script> block, so they must not be able to
+    close it. Descriptions echoed back by authlib can contain any character an
+    OAuth client puts in the query string."""
+
+    def test_script_tag_cannot_break_out(self):
+        payload = "</script><img src=x onerror=alert(1)>"
+        escaped = react_props(json.dumps({"description": payload}))
+        self.assertNotIn("<", escaped)
+        self.assertNotIn(">", escaped)
+        self.assertNotIn("&", escaped)
+
+    def test_value_survives_the_round_trip(self):
+        props = {"description": "</script> & <b>a</b> \u2028 \u2029"}
+        self.assertEqual(json.loads(react_props(json.dumps(props))), props)
+
+    def test_missing_props_render_an_empty_object(self):
+        self.assertEqual(react_props(None), "{}")
+        self.assertEqual(react_props(""), "{}")


### PR DESCRIPTION
## Problem

The OAuth2/OIDC authorization and error pages are rendered only in the language
selected via the website's `lang` cookie (`get_locale()`, wired through
`Babel(app, locale_selector=get_locale)`). OAuth clients such as MusicBrainz
Picard open the authorization URL in an **external browser** where no `lang`
cookie exists, so a user whose client is configured for another language (e.g.
French) always sees the authorization and error pages in English.

## Changes

**1. Honor the OpenID Connect `ui_locales` request parameter**

`get_locale()` now falls back to `ui_locales` (a space-separated,
preference-ordered list of BCP 47 tags, per OIDC Core 1.0 §3.1.2.1) when no
supported `lang` cookie is present, matching on the primary language subtag
against the supported locales (`en`, `es`, `fr`, `de`). An explicit cookie still
takes precedence, and unsupported/unknown locales fall back to the default
(never an error, as the spec requires).

**2. Localize OAuth authorization error messages by error code**

OAuth error pages previously showed only the untranslated English
`error_description`. Per RFC 6749 §4.1.2.1, `error_description` is a
developer-facing, ASCII-only field and must not carry localized text, so the
user-facing message is instead derived from the stable OAuth/OIDC error *code*
(`access_denied`, `invalid_scope`, etc.) via gettext. The error handler passes a
translated `message` prop chosen by code (None for unknown codes); the
`OAuthError` React component shows it prominently and keeps the raw
`code: description` as secondary technical detail.

## Testing

- New unit tests: `metabrainz/i18n_test.py` (12 cases: `match_ui_locales` +
  `get_locale` precedence) and `metabrainz/errors_test.py` (3 cases: error-code
  message map). All pass via `./test.sh`.
- Frontend `npm run type-check` and `eslint` clean on the changed component.

## Notes

- New gettext strings will be picked up by the normal translation workflow
  (Weblate / `messages.pot` regeneration) — not included here.
- Scope descriptions on the consent page are still English; that is a separate,
  larger change (DB-stored descriptions) tracked in its own ticket.

Ticket: MEB-190
