### PR TITLE
Fix support page tier cards overlapping due to unequal heights

### DIFF
--- a/frontend/css/main.less
+++ b/frontend/css/main.less
@@ -125,8 +125,24 @@ img.pull-right {
 #tiers {
   margin-top: 40px;
   #primary-tiers {
+    .row {
+      display: flex;
+      flex-wrap: wrap;
+    }
     .tier {
+      display: flex;
+      @media (max-width: @screen-sm-max) {
+        width: 100%;
+      }
       .thumbnail {
+        display: flex;
+        flex-direction: column;
+        width: 100%;
+        .caption {
+          flex: 1;
+          display: grid;
+          grid-template-rows: auto auto 1fr auto;
+        }
         h3 {
           margin-top: 8px;
           font-size: 20px;


### PR DESCRIPTION
# Problem

## What is the issue?
On the Support Us page, the Silver tier card wraps underneath the Bronze card instead of starting on a new row.

<img width="1195" height="916" alt="image" src="https://github.com/user-attachments/assets/f6c6d858-7e7d-40e0-b7d4-fea78ea13f80" />


## Why does it happen?
The tier cards use Bootstrap's float-based grid. When cards in a row have unequal heights, the float clearing breaks. A tall card prevents the next card from clearing past it, causing it to snag and wrap into the wrong position.

<!-- screenshots of current (broken) state to be attached -->

* [x] I have reviewed the code and tested it locally

# AI usage

* [ ] I did not use any AI
* [x] I have used AI in this PR (add more details below)

#### If you did use AI:
* [ ] I used AI tools for communication
* [x] I used AI tools for coding
* [x] I understand all the changes made in this PR