### PR TITLE
Trim usernames and emails in login/edit/donation forms

### DIFF
--- a/admin/schema_updates/2026-09-11-normalize-user-emails.sql
+++ b/admin/schema_updates/2026-09-11-normalize-user-emails.sql
@@ -1,0 +1,12 @@
+BEGIN;
+
+-- Normalize stored addresses for the lowercase email lookups in recovery forms.
+-- Verification and password-reset links tied to changed addresses must be requested
+-- again because their checksums include the stored email address.
+UPDATE "user"
+SET email = LOWER(TRIM(email)),
+    unconfirmed_email = LOWER(TRIM(unconfirmed_email))
+WHERE email IS DISTINCT FROM LOWER(TRIM(email))
+   OR unconfirmed_email IS DISTINCT FROM LOWER(TRIM(unconfirmed_email));
+
+COMMIT;

--- a/metabrainz/admin/forms.py
+++ b/metabrainz/admin/forms.py
@@ -32,7 +32,7 @@ class SupporterEditForm(FlaskForm):
     # The email address is deliberately not editable here. It is changed from the
     # supporter page through ChangeEmailForm, which is the same path the user page
     # uses, so an admin cannot confirm an address without saying that is what they meant.
-    username = StringField("Username", default="", filters=[str.strip], validators=[validate_username])
+    username = StringField("Username", default="", filters=[lambda value: (value or "").strip()], validators=[validate_username])
 
     contact_name = StringField("Name")
 
@@ -86,7 +86,7 @@ class ChangeEmailForm(FlaskForm):
     email = EmailField(
         "New email address",
         default="",
-        filters=[str.strip, str.lower],
+        filters=[lambda value: (value or "").strip().lower()],
         validators=[
             DataRequired(message="Email cannot be empty"),
             Email(message="This is not a valid email address"),
@@ -111,7 +111,7 @@ class EditUsernameForm(FlaskForm):
     username = StringField(
         "New Username",
         default="",
-        filters=[str.strip],
+        filters=[lambda value: (value or "").strip()],
         validators=[
             DataRequired(message="Username cannot be empty"),
             Length(min=1, max=255, message="Username must be between 1 and 255 characters"),

--- a/metabrainz/admin/forms.py
+++ b/metabrainz/admin/forms.py
@@ -32,7 +32,7 @@ class SupporterEditForm(FlaskForm):
     # The email address is deliberately not editable here. It is changed from the
     # supporter page through ChangeEmailForm, which is the same path the user page
     # uses, so an admin cannot confirm an address without saying that is what they meant.
-    username = StringField("Username", validators=[validate_username])
+    username = StringField("Username", default="", filters=[str.strip], validators=[validate_username])
 
     contact_name = StringField("Name")
 
@@ -85,6 +85,8 @@ class ChangeEmailForm(FlaskForm):
     """
     email = EmailField(
         "New email address",
+        default="",
+        filters=[str.strip, str.lower],
         validators=[
             DataRequired(message="Email cannot be empty"),
             Email(message="This is not a valid email address"),
@@ -108,6 +110,8 @@ class EditUsernameForm(FlaskForm):
     """Form for editing a user's username."""
     username = StringField(
         "New Username",
+        default="",
+        filters=[str.strip],
         validators=[
             DataRequired(message="Username cannot be empty"),
             Length(min=1, max=255, message="Username must be between 1 and 255 characters"),

--- a/metabrainz/admin/views_test.py
+++ b/metabrainz/admin/views_test.py
@@ -438,11 +438,13 @@ class AdminViewsTestCase(FlaskTestCase):
 
         response = self._edit_username(
             user,
-            "RenamedUser",
+            " RenamedUser \t",
             reason="  Requested by the account owner.  ",
         )
 
         self.assertEqual(response.status_code, 302)
+        db.session.refresh(user)
+        self.assertEqual(user.name, "RenamedUser")
         log = ModerationLog.query.filter_by(
             user_id=user.id,
             action="edit_username",
@@ -495,7 +497,7 @@ class AdminViewsTestCase(FlaskTestCase):
     def test_admin_supporter_edit_reserves_previous_username(self):
         supporter = self.create_supporter()
 
-        response = self._edit_supporter_username(supporter, "RenamedUser")
+        response = self._edit_supporter_username(supporter, " RenamedUser \t")
 
         self.assertEqual(response.status_code, 302)
         db.session.refresh(supporter.user)
@@ -770,7 +772,10 @@ class AdminViewsTestCase(FlaskTestCase):
         user_id = user.id
 
         response = self._change_email_from_user_page(
-            user_id, "new@example.com", confirmed=True, reason="Owner asked over the phone."
+            user_id,
+            " NEW@EXAMPLE.COM \t",
+            confirmed=True,
+            reason="Owner asked over the phone.",
         )
         self.assertEqual(response.status_code, 302)
 

--- a/metabrainz/index/forms.py
+++ b/metabrainz/index/forms.py
@@ -58,7 +58,7 @@ class UserEditForm(MeBFlaskForm):
     """ Login form for existing users. """
     email = EmailField(
         default="",
-        filters=[str.strip, str.lower],
+        filters=[lambda value: (value or "").strip().lower()],
         validators=[DataRequired(gettext("Email address is required!"))],
     )
 
@@ -86,7 +86,7 @@ class SupporterEditForm(UserEditForm):
     contact_name = StringField(
         gettext("Name"),
         default="",
-        filters=[str.strip],
+        filters=[lambda value: (value or "").strip()],
         validators=[
             validators.DataRequired(message=gettext("Contact name field is empty.")),
         ],

--- a/metabrainz/index/forms.py
+++ b/metabrainz/index/forms.py
@@ -56,7 +56,11 @@ class DatasetsField(SelectMultipleField):
 
 class UserEditForm(MeBFlaskForm):
     """ Login form for existing users. """
-    email = EmailField(validators=[DataRequired(gettext("Email address is required!"))])
+    email = EmailField(
+        default="",
+        filters=[str.strip, str.lower],
+        validators=[DataRequired(gettext("Email address is required!"))],
+    )
 
 
 class UserChangePasswordForm(MeBFlaskForm):
@@ -79,9 +83,14 @@ class UserChangePasswordForm(MeBFlaskForm):
 
 class SupporterEditForm(UserEditForm):
     """Supporter profile editing form."""
-    contact_name = StringField(gettext("Name"), [
-        validators.DataRequired(message=gettext("Contact name field is empty.")),
-    ])
+    contact_name = StringField(
+        gettext("Name"),
+        default="",
+        filters=[str.strip],
+        validators=[
+            validators.DataRequired(message=gettext("Contact name field is empty.")),
+        ],
+    )
 
 class NonCommercialSupporterEditForm(SupporterEditForm):
     datasets = DatasetsField()

--- a/metabrainz/payments/forms.py
+++ b/metabrainz/payments/forms.py
@@ -21,7 +21,7 @@ class BasePaymentForm(FlaskForm):
 
 
 class DonationForm(BasePaymentForm):
-    editor = StringField(default="", filters=[str.strip])  # MusicBrainz username
+    editor = StringField(default="", filters=[lambda value: (value or "").strip()])  # MusicBrainz username
     can_contact = BooleanField()
     anonymous = BooleanField()
 

--- a/metabrainz/payments/forms.py
+++ b/metabrainz/payments/forms.py
@@ -21,7 +21,7 @@ class BasePaymentForm(FlaskForm):
 
 
 class DonationForm(BasePaymentForm):
-    editor = StringField()  # MusicBrainz username
+    editor = StringField(default="", filters=[str.strip])  # MusicBrainz username
     can_contact = BooleanField()
     anonymous = BooleanField()
 

--- a/metabrainz/payments/stripe/views_test.py
+++ b/metabrainz/payments/stripe/views_test.py
@@ -141,13 +141,14 @@ class StripePayViewTestCase(FlaskTestCase):
             data={
                 "amount": "100",
                 "currency": "usd",
-                "editor": "tester",
+                "editor": " tester \t",
             },
         )
 
         call_kwargs = mock_session.create.call_args[1]
         metadata = call_kwargs["payment_intent_data"]["metadata"]
         self.assertNotIn("supporter_id", metadata)
+        self.assertEqual(metadata["editor"], "tester")
 
 
 class StripeWebhookViewTestCase(FlaskTestCase):

--- a/metabrainz/payments/views.py
+++ b/metabrainz/payments/views.py
@@ -28,6 +28,7 @@ def donate():
     form = DonationForm()
 
     if editor := request.args.get('editor'):
+        editor = editor.strip()
         form.editor.data = editor
     else:
         if current_user is not None and not current_user.is_anonymous:
@@ -134,10 +135,11 @@ def check_editor():
     editor = request.args.get('q')
     if editor is None:
         return jsonify({'error': 'Editor not specified.'}), 400
+    editor = editor.strip()
 
     try:
         resp = requests.get(current_app.config['MUSICBRAINZ_BASE_URL'] +
-                            'ws/js/editor/?q=' + request.args.get('q')).json()
+                            'ws/js/editor/?q=' + editor).json()
     except RequestException as e:
         return jsonify({'error': e})
 

--- a/metabrainz/payments/views_test.py
+++ b/metabrainz/payments/views_test.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from metabrainz.testing import FlaskTestCase
 from metabrainz.model import db
 from metabrainz.model.supporter import Supporter
@@ -9,6 +11,24 @@ class PaymentsViewsTestCase(FlaskTestCase):
 
     def test_donate(self):
         self.assert200(self.client.get(url_for('payments.donate')))
+
+    def test_donate_prefills_trimmed_editor_query_param(self):
+        self.assert200(self.client.get(url_for("payments.donate", editor=" tester \t")))
+
+        form = self.get_context_variable("form")
+        self.assertEqual(form.editor.data, "tester")
+
+    @patch("metabrainz.payments.views.requests.get")
+    def test_check_editor_trims_editor_query_param(self, mock_get):
+        mock_get.return_value.json.return_value = [{"name": "tester"}]
+
+        response = self.client.get(url_for("payments.check_editor", q=" tester \t"))
+
+        self.assert200(response)
+        self.assertEqual(response.json, {"editor": "tester", "found": True})
+        mock_get.assert_called_once_with(
+            self.app.config["MUSICBRAINZ_BASE_URL"] + "ws/js/editor/?q=tester"
+        )
 
     def test_payment_selector_is_public(self):
         self.assert200(self.client.get(url_for('payments.payment_selector')))

--- a/metabrainz/supporter/views_test.py
+++ b/metabrainz/supporter/views_test.py
@@ -484,7 +484,7 @@ class SupportersViewsTestCase(FlaskTestCase):
             url_for('supporters.signup_commercial', tier_id=self.tier.id),
             data={
                 "username": "new_commercial_user",
-                "email": "commercial@example.com",
+                "email": " COMMERCIAL@EXAMPLE.COM \t",
                 "password": "securepassword123",
                 "confirm_password": "securepassword123",
                 "contact_name": "New Commercial Contact",
@@ -596,7 +596,7 @@ class SupportersViewsTestCase(FlaskTestCase):
             url_for('supporters.signup_noncommercial'),
             data={
                 "username": "new_noncommercial_user",
-                "email": "noncommercial@example.com",
+                "email": " NONCOMMERCIAL@EXAMPLE.COM \t",
                 "password": "securepassword123",
                 "confirm_password": "securepassword123",
                 "contact_name": "New NonCommercial Contact",

--- a/metabrainz/supporter/views_test.py
+++ b/metabrainz/supporter/views_test.py
@@ -805,6 +805,25 @@ class SupportersViewsTestCase(FlaskTestCase):
     def test_signup_noncommercial_rate_limit(self):
         self._test_signup_rate_limit(is_commercial=False)
 
+    def test_user_profile_edit_normalizes_email(self):
+        self.temporary_login(self.existing_user)
+
+        new_email = "updated-existing-user@gmail.com"
+        self.client.get(url_for("index.profile_edit"))
+        response = self.client.post(
+            url_for("index.profile_edit"),
+            data={
+                "email": " UPDATED-EXISTING-USER@GMAIL.COM \t",
+                "csrf_token": g.csrf_token,
+            },
+            follow_redirects=False,
+        )
+        self.assertRedirects(response, url_for("index.profile"))
+
+        self.assertIsNone(self.existing_user.email)
+        self.assertEqual(self.existing_user.unconfirmed_email, new_email)
+        self.assertMessageFlashed(f"Email verification link sent to {new_email}", "success")
+
     def test_noncommercial_supporter_profile_edit(self):
         """Test that non-commercial supporters can update only contact_name, contact_email
          and dataset via profile edit."""
@@ -830,8 +849,8 @@ class SupportersViewsTestCase(FlaskTestCase):
         response = self.client.post(
             url_for('index.profile_edit'),
             data={
-                "contact_name": "Updated Contact Name",
-                "email": new_email,
+                "contact_name": " Updated Contact Name \t",
+                "email": " UPDATED-EXISTING-USER@GMAIL.COM \t",
                 "usage_desc": "Trying to change usage description",
                 "datasets": dataset2.id,
                 "csrf_token": g.csrf_token,
@@ -948,13 +967,14 @@ class SupportersViewsTestCase(FlaskTestCase):
         original_website_url = supporter.website_url
         original_amount_pledged = supporter.amount_pledged
         original_good_standing = supporter.good_standing
+        original_contact_name = supporter.contact_name
 
         self.client.get(url_for("index.profile_edit"))
         response = self.client.post(
             url_for("index.profile_edit"),
             data={
-                "contact_name": supporter.contact_name,
-                "email": "updated@example.com",
+                "contact_name": f" {supporter.contact_name} \t",
+                "email": " UPDATED@EXAMPLE.COM \t",
                 "org_name": "Trying to change org name",
                 "website_url": "https://malicious.com",
                 "amount_pledged": "125",
@@ -970,6 +990,7 @@ class SupportersViewsTestCase(FlaskTestCase):
         self.assertEqual(supporter.website_url, original_website_url)
         self.assertEqual(supporter.amount_pledged, original_amount_pledged)
         self.assertEqual(supporter.good_standing, original_good_standing)
+        self.assertEqual(supporter.contact_name, original_contact_name)
         self.assertEqual(self.existing_user.email, original_email)
         self.assertEqual(self.existing_user.unconfirmed_email, "updated@example.com")
         self.assertEqual(supporter.state, original_state)

--- a/metabrainz/user/forms.py
+++ b/metabrainz/user/forms.py
@@ -72,13 +72,26 @@ class UserReauthenticationForm(MeBFlaskForm):
 
 class ForgotUsernameForm(MeBFlaskForm):
     """ Form to request lost username email. """
-    email = EmailField(validators=[DataRequired(gettext("Email address is required!"))])
+    email = EmailField(
+        default="",
+        filters=[str.strip, str.lower],
+        validators=[DataRequired(gettext("Email address is required!"))]
+    )
 
 
 class ForgotPasswordForm(MeBFlaskForm):
     """ Form to request reset password link. """
-    username = StringField(gettext("Username"), validators=[DataRequired(gettext("Username is required!"))])
-    email = EmailField(validators=[DataRequired(gettext("Email address is required!"))])
+    username = StringField(
+        gettext("Username"),
+        default="",
+        filters=[str.strip],
+        validators=[DataRequired(gettext("Username is required!"))]
+    )
+    email = EmailField(
+        default="",
+        filters=[str.strip, str.lower],
+        validators=[DataRequired(gettext("Email address is required!"))]
+    )
 
 
 class ResetPasswordForm(MeBFlaskForm):

--- a/metabrainz/user/forms.py
+++ b/metabrainz/user/forms.py
@@ -27,10 +27,14 @@ class UserSignupForm(MeBFlaskForm):
             validate_username,
         ],
     )
-    email = EmailField(validators=[
-        DataRequired(gettext("Email address is required!")),
-        validate_email_domain
-    ])
+    email = EmailField(
+        default="",
+        filters=[str.strip, str.lower],
+        validators=[
+            DataRequired(gettext("Email address is required!")),
+            validate_email_domain
+        ],
+    )
     password = PasswordField(validators=[
         DataRequired(gettext("Password is required!")),
         Length(min=8, max=64),

--- a/metabrainz/user/forms.py
+++ b/metabrainz/user/forms.py
@@ -49,7 +49,12 @@ class UserSignupForm(MeBFlaskForm):
 
 class UserLoginForm(MeBFlaskForm):
     """ Login form for existing users. """
-    username = StringField(gettext("Username"), validators=[DataRequired(gettext("Username is required!"))])
+    username = StringField(
+        gettext("Username"),
+        default="",
+        filters=[str.strip],
+        validators=[DataRequired(gettext("Username is required!"))]
+    )
     password = PasswordField(gettext("Password"), validators=[
         DataRequired(gettext("Password is required!")),
         validate_bcrypt_password_length,

--- a/metabrainz/user/forms.py
+++ b/metabrainz/user/forms.py
@@ -21,7 +21,7 @@ class UserSignupForm(MeBFlaskForm):
     username = StringField(
         gettext("Username"),
         default="",
-        filters=[str.strip],
+        filters=[lambda value: (value or "").strip()],
         validators=[
             DataRequired(gettext("Username is required!")),
             validate_username,
@@ -29,7 +29,7 @@ class UserSignupForm(MeBFlaskForm):
     )
     email = EmailField(
         default="",
-        filters=[str.strip, str.lower],
+        filters=[lambda value: (value or "").strip().lower()],
         validators=[
             DataRequired(gettext("Email address is required!")),
             validate_email_domain
@@ -56,7 +56,7 @@ class UserLoginForm(MeBFlaskForm):
     username = StringField(
         gettext("Username"),
         default="",
-        filters=[str.strip],
+        filters=[lambda value: (value or "").strip()],
         validators=[DataRequired(gettext("Username is required!"))]
     )
     password = PasswordField(gettext("Password"), validators=[
@@ -78,7 +78,7 @@ class ForgotUsernameForm(MeBFlaskForm):
     """ Form to request lost username email. """
     email = EmailField(
         default="",
-        filters=[str.strip, str.lower],
+        filters=[lambda value: (value or "").strip().lower()],
         validators=[DataRequired(gettext("Email address is required!"))]
     )
 
@@ -88,12 +88,12 @@ class ForgotPasswordForm(MeBFlaskForm):
     username = StringField(
         gettext("Username"),
         default="",
-        filters=[str.strip],
+        filters=[lambda value: (value or "").strip()],
         validators=[DataRequired(gettext("Username is required!"))]
     )
     email = EmailField(
         default="",
-        filters=[str.strip, str.lower],
+        filters=[lambda value: (value or "").strip().lower()],
         validators=[DataRequired(gettext("Email address is required!"))]
     )
 

--- a/metabrainz/user/views_test.py
+++ b/metabrainz/user/views_test.py
@@ -128,6 +128,18 @@ class UsersViewsTestCase(FlaskTestCase):
         self.assertIsNotNone(user)
         self.assertEqual(user.name, "test_user_1")
 
+    def test_user_signup_normalizes_email(self):
+        self._test_user_signup_helper({
+            "username": "test_user_1",
+            "email": " TEST@EXAMPLE.COM \t",
+            "password": "<PASSWORD>",
+            "confirm_password": "<PASSWORD>",
+        }, 302)
+
+        user = User.get(name="test_user_1")
+        self.assertIsNotNone(user)
+        self.assertEqual(user.unconfirmed_email, "test@example.com")
+
     def test_user_signup_regular_flow_is_not_registration_request_signup(self):
         self.client.get("/signup")
         props = json.loads(self.get_context_variable("props"))

--- a/metabrainz/user/views_test.py
+++ b/metabrainz/user/views_test.py
@@ -286,6 +286,15 @@ class UsersViewsTestCase(FlaskTestCase):
         self.client.get("/logout")
         self.assertTrue(current_user.is_anonymous)
 
+    def test_user_login_trims_username_whitespace(self):
+        self.create_user()
+
+        self._test_user_login_helper({
+            "username": " \ttest_user_1  ",
+            "password": "<PASSWORD>",
+        }, 302)
+        self.assertEqual(current_user.name, "test_user_1")
+
     def test_user_login_records_remember_me(self):
         self.create_user()
 
@@ -774,6 +783,18 @@ class UsersViewsTestCase(FlaskTestCase):
         response = self.client.post("/lost-password", data={
             "username": "test_user_1",
             "email": "test@example.com",
+            "csrf_token": g.csrf_token
+        })
+        self.assertEqual(response.status_code, 302)
+        self.assertMessageFlashed("Password reset link sent!", "success")
+
+    def test_forgot_password_normalizes_username_and_email(self):
+        self.create_user()
+
+        self.client.get("/lost-password")
+        response = self.client.post("/lost-password", data={
+            "username": " \ttest_user_1  ",
+            "email": " TEST@EXAMPLE.COM  ",
             "csrf_token": g.csrf_token
         })
         self.assertEqual(response.status_code, 302)

--- a/metabrainz/user/views_test.py
+++ b/metabrainz/user/views_test.py
@@ -689,6 +689,18 @@ class UsersViewsTestCase(FlaskTestCase):
         self.assertEqual(self.get_context_variable("username"), "test_user_1")
         self.assertMessageFlashed("Username recovery email sent!", "success")
 
+    def test_forgot_username_normalizes_email(self):
+        self.create_user()
+
+        self.client.get("/lost-username")
+        response = self.client.post("/lost-username", data={
+            "email": " TEST@EXAMPLE.COM  ",
+            "csrf_token": g.csrf_token
+        })
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(self.get_context_variable("username"), "test_user_1")
+        self.assertMessageFlashed("Username recovery email sent!", "success")
+
     def test_forgot_username_delivery_failure(self):
         self.create_user()
         self.client.get("/lost-username")

--- a/metabrainz/user/views_test.py
+++ b/metabrainz/user/views_test.py
@@ -364,6 +364,19 @@ class UsersViewsTestCase(FlaskTestCase):
         }, {"password": "Password is required!"})
         self.assertTrue(current_user.is_anonymous)
 
+    def test_user_login_null_username(self):
+        self.client.get("/login")
+        response = self.client.post("/login", json={
+            "username": None,
+            "password": "<PASSWORD>",
+            "csrf_token": g.csrf_token,
+        })
+
+        self.assert200(response)
+        props = json.loads(self.get_context_variable("props"))
+        self.assertEqual(props["initial_errors"], {"username": "Username is required!"})
+        self.assertTrue(current_user.is_anonymous)
+
     def test_user_login_missing_csrf_token(self):
         self.create_user()
 


### PR DESCRIPTION
As reported, there is a mismatch between some input forms and how usernames are sanitized, causing some confusing errors when an untrimmed username is inputed.
While in there I also sanitized email inputs, and while doing so figured we should lowercase them for the same reasons.
Did the same for usernames in the donation forms as I seem to remember this issue being reported at support@.

Trims usernames and emails, and lowercases emails in all user and supporter forms that are missing it.
Had to add `default=""` to a few fields so that an unexpected None instead of a string does not crash on `str.strip`.

Used Codex to modify or generate regression tests for all the modifications I made.